### PR TITLE
Follow conventions for Conan 2.0 CLI output

### DIFF
--- a/conan/api/output.py
+++ b/conan/api/output.py
@@ -58,8 +58,8 @@ if get_env("CONAN_COLOR_DARK", 0):
 
 
 class ConanOutput:
-    def __init__(self, scope="", stream=sys.stderr):
-        self.stream = stream
+    def __init__(self, scope="", stream=None):
+        self.stream = stream or sys.stderr
         self._scope = scope
         # FIXME:  This is needed because in testing we are redirecting the sys.stderr to a buffer
         #         stream to capture it, so colorama is not there to strip the color bytes

--- a/conan/api/output.py
+++ b/conan/api/output.py
@@ -187,3 +187,18 @@ class ConanOutput:
 
     def flush(self):
         self.stream.flush()
+
+
+def cli_out_write(data, fg=None, bg=None, endline="\n", indentation=0):
+    """
+    Output to be used by formatters to dump information to stdout
+    """
+
+    fg_ = fg or ''
+    bg_ = bg or ''
+    if color_enabled(sys.stdout):
+        data = f"{' ' * indentation}{fg_}{bg_}{data}{Style.RESET_ALL}{endline}"
+    else:
+        data = f"{' ' * indentation}{data}{endline}"
+
+    sys.stdout.write(data)

--- a/conan/api/output.py
+++ b/conan/api/output.py
@@ -58,8 +58,8 @@ if get_env("CONAN_COLOR_DARK", 0):
 
 
 class ConanOutput:
-    def __init__(self, scope="", stream=None):
-        self.stream = stream or sys.stderr
+    def __init__(self, scope=""):
+        self.stream = sys.stderr
         self._scope = scope
         # FIXME:  This is needed because in testing we are redirecting the sys.stderr to a buffer
         #         stream to capture it, so colorama is not there to strip the color bytes

--- a/conan/api/output.py
+++ b/conan/api/output.py
@@ -58,8 +58,8 @@ if get_env("CONAN_COLOR_DARK", 0):
 
 
 class ConanOutput:
-    def __init__(self, scope=""):
-        self.stream = sys.stderr
+    def __init__(self, scope="", stream=sys.stderr):
+        self.stream = stream
         self._scope = scope
         # FIXME:  This is needed because in testing we are redirecting the sys.stderr to a buffer
         #         stream to capture it, so colorama is not there to strip the color bytes

--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -9,8 +9,8 @@ from difflib import get_close_matches
 from inspect import getmembers
 
 from conan.api.conan_api import ConanAPIV2
-from conan.api.output import ConanOutput, Color
-from conan.cli.command import ConanSubCommand, cli_out_write
+from conan.api.output import ConanOutput, Color, cli_out_write
+from conan.cli.command import ConanSubCommand
 from conan.cli.exit_codes import SUCCESS, ERROR_MIGRATION, ERROR_GENERAL, USER_CTRL_C, \
     ERROR_SIGTERM, USER_CTRL_BREAK, ERROR_INVALID_CONFIGURATION, ERROR_INVALID_SYSTEM_REQUIREMENTS
 from conans import __version__ as client_version

--- a/conan/cli/command.py
+++ b/conan/cli/command.py
@@ -225,14 +225,3 @@ def conan_subcommand(formatters=None):
         return cmd
 
     return decorator
-
-
-def cli_out_write(data, fg=None, bg=None, endline="\n", indentation=0):
-    fg_ = fg or ''
-    bg_ = bg or ''
-    if color_enabled(sys.stdout):
-        data = f"{' ' * indentation}{fg_}{bg_}{data}{Style.RESET_ALL}{endline}"
-    else:
-        data = f"{' ' * indentation}{data}{endline}"
-
-    sys.stdout.write(data)

--- a/conan/cli/command.py
+++ b/conan/cli/command.py
@@ -98,6 +98,10 @@ class BaseConanCommand(object):
 
     @property
     def _help_formatters(self):
+        """
+        Formatters that are shown as available in help, 'text' formatter
+        should not appear
+        """
         return [formatter for formatter in list(self._formatters) if formatter != "text"]
 
     def _init_formatters(self):

--- a/conan/cli/commands/__init__.py
+++ b/conan/cli/commands/__init__.py
@@ -1,11 +1,13 @@
 import json
 import os
+import sys
 from json import JSONEncoder
 
 from conan.api.model import Remote
 from conans.errors import ConanException
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
+from conan.api.output import ConanOutput
 
 
 def make_abs_path(path, cwd=None):
@@ -32,7 +34,11 @@ class ConanJSONEncoder(JSONEncoder):
 
 def json_formatter(data):
     myjson = json.dumps(data, indent=4, cls=ConanJSONEncoder)
-    return myjson
+    ConanOutput(stream=sys.stdout).writeln(myjson)
+
+
+def text_formatter(data):
+    ConanOutput(stream=sys.stdout).info(data)
 
 
 def add_log_level_args(subparser):

--- a/conan/cli/commands/__init__.py
+++ b/conan/cli/commands/__init__.py
@@ -32,12 +32,12 @@ class ConanJSONEncoder(JSONEncoder):
         return JSONEncoder.default(self, o)
 
 
-def json_formatter(data):
+def default_json_formatter(data):
     myjson = json.dumps(data, indent=4, cls=ConanJSONEncoder)
     ConanOutput(stream=sys.stdout).writeln(myjson)
 
 
-def text_formatter(data):
+def default_text_formatter(data):
     ConanOutput(stream=sys.stdout).info(data)
 
 

--- a/conan/cli/commands/__init__.py
+++ b/conan/cli/commands/__init__.py
@@ -38,7 +38,7 @@ def default_json_formatter(data):
 
 
 def default_text_formatter(data):
-    ConanOutput(stream=sys.stdout).info(data)
+    ConanOutput(stream=sys.stdout).writeln(data)
 
 
 def add_log_level_args(subparser):

--- a/conan/cli/commands/__init__.py
+++ b/conan/cli/commands/__init__.py
@@ -1,6 +1,5 @@
 import json
 import os
-import sys
 from json import JSONEncoder
 
 from conan.api.model import Remote
@@ -8,7 +7,6 @@ from conan.api.output import cli_out_write
 from conans.errors import ConanException
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
-from conan.api.output import ConanOutput
 
 
 def make_abs_path(path, cwd=None):

--- a/conan/cli/commands/__init__.py
+++ b/conan/cli/commands/__init__.py
@@ -4,6 +4,7 @@ import sys
 from json import JSONEncoder
 
 from conan.api.model import Remote
+from conan.api.output import cli_out_write
 from conans.errors import ConanException
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
@@ -34,11 +35,11 @@ class ConanJSONEncoder(JSONEncoder):
 
 def default_json_formatter(data):
     myjson = json.dumps(data, indent=4, cls=ConanJSONEncoder)
-    ConanOutput(stream=sys.stdout).writeln(myjson)
+    cli_out_write(myjson)
 
 
 def default_text_formatter(data):
-    ConanOutput(stream=sys.stdout).writeln(data)
+    cli_out_write(data)
 
 
 def add_log_level_args(subparser):

--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -1,6 +1,6 @@
 from conan.api.conan_api import ConanAPIV2
 from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand
-from conan.cli.commands import default_text_formatter, default_json_formatter
+from conan.cli.commands import default_text_formatter
 from conans.errors import ConanException
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference

--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -1,7 +1,6 @@
 from conan.api.conan_api import ConanAPIV2
-from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand, cli_out_write
-from conan.cli.commands import text_formatter
-from conan.cli.commands.list import json_formatter
+from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand
+from conan.cli.commands import default_text_formatter, default_json_formatter
 from conans.errors import ConanException
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
@@ -13,7 +12,7 @@ def cache(conan_api: ConanAPIV2, parser, *args):
     pass
 
 
-@conan_subcommand(formatters={"text": text_formatter})
+@conan_subcommand(formatters={"text": default_text_formatter})
 def cache_path(conan_api: ConanAPIV2, parser, subparser, *args):
     """
         Shows the path af a given reference

--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -1,18 +1,19 @@
 from conan.api.conan_api import ConanAPIV2
 from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand, cli_out_write
+from conan.cli.commands import text_formatter
 from conan.cli.commands.list import json_formatter
 from conans.errors import ConanException
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
 
 
-@conan_command(group=COMMAND_GROUPS['consumer'], formatters={"json": json_formatter})
+@conan_command(group=COMMAND_GROUPS['consumer'])
 def cache(conan_api: ConanAPIV2, parser, *args):
     """Performs file operations in the local cache (of recipes and packages)"""
     pass
 
 
-@conan_subcommand()
+@conan_subcommand(formatters={"text": text_formatter})
 def cache_path(conan_api: ConanAPIV2, parser, subparser, *args):
     """
         Shows the path af a given reference
@@ -48,8 +49,7 @@ def cache_path(conan_api: ConanAPIV2, parser, subparser, *args):
             path = method(pref.ref)
         else:
             path = method(pref)
-
-    cli_out_write(path)
+    return path
 
 
 def _get_recipe_reference(reference):

--- a/conan/cli/commands/config.py
+++ b/conan/cli/commands/config.py
@@ -2,7 +2,7 @@ import sys
 
 from conan.api.output import ConanOutput
 from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand
-from conan.cli.commands import json_formatter, text_formatter
+from conan.cli.commands import default_json_formatter, default_text_formatter
 from conans.model.conf import BUILT_IN_CONFS
 from conans.util.config_parser import get_bool_from_text
 
@@ -42,13 +42,13 @@ def config_install(conan_api, parser, subparser, *args):
                              target_folder=args.target_folder)
 
 
-def _list_text(confs):
+def list_text_formatter(confs):
     out = ConanOutput(stream=sys.stdout)
     for k, v in confs.items():
         out.writeln(f"{k}: {v}")
 
 
-@conan_subcommand(formatters={"text": text_formatter})
+@conan_subcommand(formatters={"text": default_text_formatter})
 def config_home(conan_api, parser, subparser, *args):
     """
     Gets the Conan home folder
@@ -56,7 +56,7 @@ def config_home(conan_api, parser, subparser, *args):
     return conan_api.config.home()
 
 
-@conan_subcommand(formatters={"text": _list_text, "json": json_formatter})
+@conan_subcommand(formatters={"text": list_text_formatter, "json": default_json_formatter})
 def config_list(conan_api, parser, subparser, *args):
     """
     Prints all the Conan available configurations: core and tools.

--- a/conan/cli/commands/config.py
+++ b/conan/cli/commands/config.py
@@ -1,6 +1,6 @@
 import sys
 
-from conan.api.output import ConanOutput
+from conan.api.output import ConanOutput, cli_out_write
 from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand
 from conan.cli.commands import default_json_formatter, default_text_formatter
 from conans.model.conf import BUILT_IN_CONFS
@@ -43,9 +43,8 @@ def config_install(conan_api, parser, subparser, *args):
 
 
 def list_text_formatter(confs):
-    out = ConanOutput(stream=sys.stdout)
     for k, v in confs.items():
-        out.writeln(f"{k}: {v}")
+        cli_out_write(f"{k}: {v}")
 
 
 @conan_subcommand(formatters={"text": default_text_formatter})

--- a/conan/cli/commands/config.py
+++ b/conan/cli/commands/config.py
@@ -1,6 +1,6 @@
 import sys
 
-from conan.api.output import ConanOutput, cli_out_write
+from conan.api.output import cli_out_write
 from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand
 from conan.cli.commands import default_json_formatter, default_text_formatter
 from conans.model.conf import BUILT_IN_CONFS

--- a/conan/cli/commands/config.py
+++ b/conan/cli/commands/config.py
@@ -1,6 +1,8 @@
-from conan.api.output import ConanOutput, Color
+import sys
+
+from conan.api.output import ConanOutput
 from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand
-from conan.cli.commands import json_formatter
+from conan.cli.commands import json_formatter, text_formatter
 from conans.model.conf import BUILT_IN_CONFS
 from conans.util.config_parser import get_bool_from_text
 
@@ -40,25 +42,23 @@ def config_install(conan_api, parser, subparser, *args):
                              target_folder=args.target_folder)
 
 
-@conan_subcommand(formatters={"text": lambda x: x})
+def _list_text(confs):
+    out = ConanOutput(stream=sys.stdout)
+    for k, v in confs.items():
+        out.writeln(f"{k}: {v}")
+
+
+@conan_subcommand(formatters={"text": text_formatter})
 def config_home(conan_api, parser, subparser, *args):
     """
     Gets the Conan home folder
     """
-    home = conan_api.config.home()
-    ConanOutput().info(f"Current Conan home: {home}")
-    return home
+    return conan_api.config.home()
 
 
-@conan_subcommand(formatters={"json": json_formatter})
+@conan_subcommand(formatters={"text": _list_text, "json": json_formatter})
 def config_list(conan_api, parser, subparser, *args):
     """
     Prints all the Conan available configurations: core and tools.
     """
-    out = ConanOutput()
-    confs = BUILT_IN_CONFS
-    out.writeln(f"Supported Conan global.conf and [conf] properties:",
-                fg=Color.BRIGHT_CYAN)
-    for k, v in confs.items():
-        out.writeln(f"{k}: {v}")
-    return confs
+    return BUILT_IN_CONFS

--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import sys
 
-from conan.api.output import ConanOutput
+from conan.api.output import ConanOutput, cli_out_write
 from conan.cli.command import conan_command, COMMAND_GROUPS, OnceArgument
 from conan.cli.commands.export import common_args_export
 from conan.cli.commands.install import _get_conanfile_path
@@ -18,9 +18,8 @@ from conans.util.files import chdir, mkdir
 
 
 def json_create(info):
-    out = ConanOutput(stream=sys.stdout)
     deps_graph = info
-    out.writeln(json.dumps({"graph": deps_graph.serialize()}, indent=4))
+    cli_out_write(json.dumps({"graph": deps_graph.serialize()}, indent=4))
 
 
 @conan_command(group=COMMAND_GROUPS['creator'], formatters={"json": json_create})

--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -1,7 +1,6 @@
 import json
 import os
 import shutil
-import sys
 
 from conan.api.output import ConanOutput, cli_out_write
 from conan.cli.command import conan_command, COMMAND_GROUPS, OnceArgument
@@ -13,7 +12,6 @@ from conan.api.conan_app import ConanApp
 from conan.cli.formatters.graph import print_graph_basic, print_graph_packages
 from conans.client.conanfile.build import run_build_method
 from conans.errors import ConanException, conanfile_exception_formatter
-from conans.model.graph_lock import Lockfile
 from conans.util.files import chdir, mkdir
 
 

--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -1,6 +1,7 @@
 import json
 import os
 import shutil
+import sys
 
 from conan.api.output import ConanOutput
 from conan.cli.command import conan_command, COMMAND_GROUPS, OnceArgument
@@ -17,8 +18,9 @@ from conans.util.files import chdir, mkdir
 
 
 def json_create(info):
+    out = ConanOutput(stream=sys.stdout)
     deps_graph = info
-    return json.dumps({"graph": deps_graph.serialize()}, indent=4)
+    out.writeln(json.dumps({"graph": deps_graph.serialize()}, indent=4))
 
 
 @conan_command(group=COMMAND_GROUPS['creator'], formatters={"json": json_create})

--- a/conan/cli/commands/export.py
+++ b/conan/cli/commands/export.py
@@ -2,7 +2,7 @@ import json
 import os
 import sys
 
-from conan.api.output import ConanOutput
+from conan.api.output import ConanOutput, cli_out_write
 from conan.cli.command import conan_command, COMMAND_GROUPS, OnceArgument
 from conan.cli.commands.install import _get_conanfile_path
 from conan.cli.common import get_lockfile, add_reference_args
@@ -14,8 +14,7 @@ def common_args_export(parser):
 
 
 def json_export(ref):
-    out = ConanOutput(stream=sys.stdout)
-    out.write(json.dumps({"reference": ref.repr_notime()}))
+    cli_out_write(json.dumps({"reference": ref.repr_notime()}))
 
 
 @conan_command(group=COMMAND_GROUPS['creator'], formatters={"json": json_export})

--- a/conan/cli/commands/export.py
+++ b/conan/cli/commands/export.py
@@ -1,6 +1,5 @@
 import json
 import os
-import sys
 
 from conan.api.output import ConanOutput, cli_out_write
 from conan.cli.command import conan_command, COMMAND_GROUPS, OnceArgument

--- a/conan/cli/commands/export.py
+++ b/conan/cli/commands/export.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 
 from conan.api.output import ConanOutput
 from conan.cli.command import conan_command, COMMAND_GROUPS, OnceArgument
@@ -13,7 +14,8 @@ def common_args_export(parser):
 
 
 def json_export(ref):
-    return json.dumps({"reference": ref.repr_notime()})
+    out = ConanOutput(stream=sys.stdout)
+    out.write(json.dumps({"reference": ref.repr_notime()}))
 
 
 @conan_command(group=COMMAND_GROUPS['creator'], formatters={"json": json_export})

--- a/conan/cli/commands/export_pkg.py
+++ b/conan/cli/commands/export_pkg.py
@@ -1,8 +1,7 @@
 import json
 import os
-import sys
 
-from conan.api.output import ConanOutput, cli_out_write
+from conan.api.output import cli_out_write
 from conan.cli.command import conan_command, COMMAND_GROUPS
 from conan.cli.commands.install import _get_conanfile_path
 from conan.cli.common import get_lockfile, add_profiles_args, get_profiles_from_args, \

--- a/conan/cli/commands/export_pkg.py
+++ b/conan/cli/commands/export_pkg.py
@@ -2,7 +2,7 @@ import json
 import os
 import sys
 
-from conan.api.output import ConanOutput
+from conan.api.output import ConanOutput, cli_out_write
 from conan.cli.command import conan_command, COMMAND_GROUPS
 from conan.cli.commands.install import _get_conanfile_path
 from conan.cli.common import get_lockfile, add_profiles_args, get_profiles_from_args, \
@@ -10,9 +10,8 @@ from conan.cli.common import get_lockfile, add_profiles_args, get_profiles_from_
 
 
 def json_export_pkg(info):
-    out = ConanOutput(stream=sys.stdout)
     deps_graph = info
-    out.writeln(json.dumps({"graph": deps_graph.serialize()}, indent=4))
+    cli_out_write(json.dumps({"graph": deps_graph.serialize()}, indent=4))
 
 
 @conan_command(group=COMMAND_GROUPS['creator'], formatters={"json": json_export_pkg})

--- a/conan/cli/commands/export_pkg.py
+++ b/conan/cli/commands/export_pkg.py
@@ -1,6 +1,8 @@
 import json
 import os
+import sys
 
+from conan.api.output import ConanOutput
 from conan.cli.command import conan_command, COMMAND_GROUPS
 from conan.cli.commands.install import _get_conanfile_path
 from conan.cli.common import get_lockfile, add_profiles_args, get_profiles_from_args, \
@@ -8,8 +10,9 @@ from conan.cli.common import get_lockfile, add_profiles_args, get_profiles_from_
 
 
 def json_export_pkg(info):
+    out = ConanOutput(stream=sys.stdout)
     deps_graph = info
-    return json.dumps({"graph": deps_graph.serialize()}, indent=4)
+    out.writeln(json.dumps({"graph": deps_graph.serialize()}, indent=4))
 
 
 @conan_command(group=COMMAND_GROUPS['creator'], formatters={"json": json_export_pkg})

--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -2,7 +2,7 @@ import json
 import os
 import sys
 
-from conan.api.output import ConanOutput
+from conan.api.output import ConanOutput, cli_out_write
 from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand, \
     Extender
 from conan.cli.commands import make_abs_path
@@ -23,17 +23,15 @@ def graph(conan_api, parser, *args):
 
 def cli_build_order(build_order):
     # TODO: Very simple cli output, probably needs to be improved
-    output = ConanOutput(stream=sys.stdout)
     for level in build_order:
         for item in level:
             for package_level in item['packages']:
                 for package in package_level:
-                    output.writeln(f"{item['ref']}:{package['package_id']} - {package['binary']}")
+                    cli_out_write(f"{item['ref']}:{package['package_id']} - {package['binary']}")
 
 
 def json_build_order(build_order):
-    output = ConanOutput(stream=sys.stdout)
-    output.writeln(json.dumps(build_order, indent=4))
+    cli_out_write(json.dumps(build_order, indent=4))
 
 
 @conan_subcommand(formatters={"text": cli_build_order, "json": json_build_order})

--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 
 from conan.api.output import ConanOutput
 from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand, \
@@ -22,7 +23,7 @@ def graph(conan_api, parser, *args):
 
 def cli_build_order(build_order):
     # TODO: Very simple cli output, probably needs to be improved
-    output = ConanOutput()
+    output = ConanOutput(stream=sys.stdout)
     for level in build_order:
         for item in level:
             for package_level in item['packages']:
@@ -31,10 +32,11 @@ def cli_build_order(build_order):
 
 
 def json_build_order(build_order):
-    return json.dumps(build_order, indent=4)
+    output = ConanOutput(stream=sys.stdout)
+    output.writeln(json.dumps(build_order, indent=4))
 
 
-@conan_subcommand(formatters={"json": json_build_order})
+@conan_subcommand(formatters={"text": cli_build_order, "json": json_build_order})
 def graph_build_order(conan_api, parser, subparser, *args):
     """
     Computes the build order of a dependency graph
@@ -53,11 +55,10 @@ def graph_build_order(conan_api, parser, subparser, *args):
     out.title("Computing the build order")
     install_graph = InstallGraph(deps_graph)
     install_order_serialized = install_graph.install_build_order()
-    cli_build_order(install_order_serialized)
     return install_order_serialized
 
 
-@conan_subcommand(formatters={"json": json_build_order})
+@conan_subcommand(formatters={"text": cli_build_order, "json": json_build_order})
 def graph_build_order_merge(conan_api, parser, subparser, *args):
     """
     Merges more than 1 build-order file
@@ -72,7 +73,6 @@ def graph_build_order_merge(conan_api, parser, subparser, *args):
         result.merge(install_graph)
 
     install_order_serialized = result.install_build_order()
-    cli_build_order(install_order_serialized)
     return install_order_serialized
 
 

--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -1,6 +1,5 @@
 import json
 import os
-import sys
 
 from conan.api.output import ConanOutput, cli_out_write
 from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand, \

--- a/conan/cli/commands/inspect.py
+++ b/conan/cli/commands/inspect.py
@@ -3,40 +3,29 @@ import inspect as python_inspect
 import sys
 
 from conan.api.output import ConanOutput
-from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand
-from conan.cli.commands import default_json_formatter, default_text_formatter
+from conan.cli.command import conan_command, COMMAND_GROUPS
+from conan.cli.commands import default_json_formatter
 
 
-@conan_command(group=COMMAND_GROUPS['consumer'])
+def inspect_text_formatter(data):
+    out = ConanOutput(stream=sys.stdout)
+    for name, value in data.items():
+        if value is None:
+            continue
+        if isinstance(value, dict):
+            out.writeln(f"{name}:")
+            for k, v in value.items():
+                out.writeln(f"    {k}: {v}")
+        else:
+            out.writeln("{}: {}".format(name, value))
+
+
+@conan_command(group=COMMAND_GROUPS['consumer'], formatters={"text": inspect_text_formatter, "json": default_json_formatter})
 def inspect(conan_api, parser, *args):
     """
     Inspect a conanfile.py to return the public fields
     """
-
-
-# def inspect_text_formatter(data):
-#     out = ConanOutput(stream=sys.stdout)
-#     for name, value in python_inspect.getmembers(conanfile):
-#         if name.startswith('_') or python_inspect.ismethod(value) \
-#            or python_inspect.isfunction(value) or isinstance(value, property):
-#             continue
-#         ret[name] = value
-#         if value is None:
-#             continue
-#         if isinstance(value, dict):
-#             out.writeln(f"{name}:")
-#             for k, v in value.items():
-#                 out.writeln(f"    {k}: {v}")
-#         else:
-#             out.writeln("{}: {}".format(name, value))
-
-
-@conan_subcommand(formatters={"text": default_text_formatter, "json": default_json_formatter})
-def inspect_path(conan_api, parser, subparser, *args, **kwargs):
-    """
-    Returns the specified attribute/s of a conanfile
-    """
-    subparser.add_argument("path", help="Path to a folder containing a recipe (conanfile.py)")
+    parser.add_argument("path", help="Path to a folder containing a recipe (conanfile.py)")
 
     args = parser.parse_args(*args)
     conanfile = conan_api.graph.load_conanfile_class(args.path)

--- a/conan/cli/commands/inspect.py
+++ b/conan/cli/commands/inspect.py
@@ -3,7 +3,7 @@ import inspect as python_inspect
 import sys
 
 from conan.api.output import ConanOutput
-from conan.cli.command import conan_command, COMMAND_GROUPS
+from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand
 from conan.cli.commands import default_json_formatter
 
 
@@ -20,12 +20,19 @@ def inspect_text_formatter(data):
             out.writeln("{}: {}".format(name, value))
 
 
-@conan_command(group=COMMAND_GROUPS['consumer'], formatters={"text": inspect_text_formatter, "json": default_json_formatter})
+@conan_command(group=COMMAND_GROUPS['consumer'])
 def inspect(conan_api, parser, *args):
     """
     Inspect a conanfile.py to return the public fields
     """
-    parser.add_argument("path", help="Path to a folder containing a recipe (conanfile.py)")
+
+
+@conan_subcommand(formatters={"text": inspect_text_formatter, "json": default_json_formatter})
+def inspect_path(conan_api, parser, subparser, *args, **kwargs):
+    """
+    Returns the specified attribute/s of a conanfile
+    """
+    subparser.add_argument("path", help="Path to a folder containing a recipe (conanfile.py)")
 
     args = parser.parse_args(*args)
     conanfile = conan_api.graph.load_conanfile_class(args.path)

--- a/conan/cli/commands/inspect.py
+++ b/conan/cli/commands/inspect.py
@@ -2,22 +2,21 @@ import json
 import inspect as python_inspect
 import sys
 
-from conan.api.output import ConanOutput
+from conan.api.output import ConanOutput, cli_out_write
 from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand
 from conan.cli.commands import default_json_formatter
 
 
 def inspect_text_formatter(data):
-    out = ConanOutput(stream=sys.stdout)
     for name, value in data.items():
         if value is None:
             continue
         if isinstance(value, dict):
-            out.writeln(f"{name}:")
+            cli_out_write(f"{name}:")
             for k, v in value.items():
-                out.writeln(f"    {k}: {v}")
+                cli_out_write(f"    {k}: {v}")
         else:
-            out.writeln("{}: {}".format(name, value))
+            cli_out_write("{}: {}".format(name, value))
 
 
 @conan_command(group=COMMAND_GROUPS['consumer'])

--- a/conan/cli/commands/inspect.py
+++ b/conan/cli/commands/inspect.py
@@ -1,12 +1,10 @@
 import json
 import inspect as python_inspect
+import sys
 
 from conan.api.output import ConanOutput
 from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand
-
-
-def _inspect_json_formatter(data):
-    return json.dumps(data, indent=4)
+from conan.cli.commands import default_json_formatter, default_text_formatter
 
 
 @conan_command(group=COMMAND_GROUPS['consumer'])
@@ -16,7 +14,24 @@ def inspect(conan_api, parser, *args):
     """
 
 
-@conan_subcommand(formatters={"json": _inspect_json_formatter})
+# def inspect_text_formatter(data):
+#     out = ConanOutput(stream=sys.stdout)
+#     for name, value in python_inspect.getmembers(conanfile):
+#         if name.startswith('_') or python_inspect.ismethod(value) \
+#            or python_inspect.isfunction(value) or isinstance(value, property):
+#             continue
+#         ret[name] = value
+#         if value is None:
+#             continue
+#         if isinstance(value, dict):
+#             out.writeln(f"{name}:")
+#             for k, v in value.items():
+#                 out.writeln(f"    {k}: {v}")
+#         else:
+#             out.writeln("{}: {}".format(name, value))
+
+
+@conan_subcommand(formatters={"text": default_text_formatter, "json": default_json_formatter})
 def inspect_path(conan_api, parser, subparser, *args, **kwargs):
     """
     Returns the specified attribute/s of a conanfile
@@ -24,7 +39,6 @@ def inspect_path(conan_api, parser, subparser, *args, **kwargs):
     subparser.add_argument("path", help="Path to a folder containing a recipe (conanfile.py)")
 
     args = parser.parse_args(*args)
-    out = ConanOutput()
     conanfile = conan_api.graph.load_conanfile_class(args.path)
     ret = {}
 
@@ -35,11 +49,5 @@ def inspect_path(conan_api, parser, subparser, *args, **kwargs):
         ret[name] = value
         if value is None:
             continue
-        if isinstance(value, dict):
-            out.writeln(f"{name}:")
-            for k, v in value.items():
-                out.writeln(f"    {k}: {v}")
-        else:
-            out.writeln("{}: {}".format(name, value))
 
     return ret

--- a/conan/cli/commands/inspect.py
+++ b/conan/cli/commands/inspect.py
@@ -1,8 +1,7 @@
-import json
 import inspect as python_inspect
-import sys
 
-from conan.api.output import ConanOutput, cli_out_write
+
+from conan.api.output import cli_out_write
 from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand
 from conan.cli.commands import default_json_formatter
 

--- a/conan/cli/commands/install.py
+++ b/conan/cli/commands/install.py
@@ -1,6 +1,5 @@
 import json
 import os
-import sys
 
 from conan.api.output import ConanOutput, cli_out_write
 from conan.cli.command import conan_command, Extender, COMMAND_GROUPS

--- a/conan/cli/commands/install.py
+++ b/conan/cli/commands/install.py
@@ -2,7 +2,7 @@ import json
 import os
 import sys
 
-from conan.api.output import ConanOutput
+from conan.api.output import ConanOutput, cli_out_write
 from conan.cli.command import conan_command, Extender, COMMAND_GROUPS
 from conan.cli.commands import make_abs_path
 from conan.cli.common import _add_common_install_arguments, _help_build_policies, \
@@ -14,9 +14,8 @@ from conans.model.recipe_ref import RecipeReference
 
 
 def json_install(info):
-    out = ConanOutput(stream=sys.stdout)
     deps_graph = info
-    out.writeln(json.dumps({"graph": deps_graph.serialize()}, indent=4))
+    cli_out_write(json.dumps({"graph": deps_graph.serialize()}, indent=4))
 
 
 def _get_conanfile_path(path, cwd, py):

--- a/conan/cli/commands/install.py
+++ b/conan/cli/commands/install.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 
 from conan.api.output import ConanOutput
 from conan.cli.command import conan_command, Extender, COMMAND_GROUPS
@@ -13,8 +14,9 @@ from conans.model.recipe_ref import RecipeReference
 
 
 def json_install(info):
+    out = ConanOutput(stream=sys.stdout)
     deps_graph = info
-    return json.dumps({"graph": deps_graph.serialize()}, indent=4)
+    out.writeln(json.dumps({"graph": deps_graph.serialize()}, indent=4))
 
 
 def _get_conanfile_path(path, cwd, py):

--- a/conan/cli/commands/list.py
+++ b/conan/cli/commands/list.py
@@ -1,8 +1,7 @@
 import json
-import sys
 from collections import OrderedDict
 
-from conan.api.output import ConanOutput, Color, cli_out_write
+from conan.api.output import Color, cli_out_write
 from conan.cli.command import conan_command, conan_subcommand, Extender, COMMAND_GROUPS
 from conan.cli.commands import default_json_formatter
 from conan.cli.common import get_remote_selection

--- a/conan/cli/commands/list.py
+++ b/conan/cli/commands/list.py
@@ -2,7 +2,7 @@ import json
 import sys
 from collections import OrderedDict
 
-from conan.api.output import ConanOutput, Color
+from conan.api.output import ConanOutput, Color, cli_out_write
 from conan.cli.command import conan_command, conan_subcommand, Extender, COMMAND_GROUPS
 from conan.cli.commands import default_json_formatter
 from conan.cli.common import get_remote_selection
@@ -19,85 +19,81 @@ value_color = Color.CYAN
 
 
 def print_list_recipes(results):
-    out = ConanOutput(stream=sys.stdout)
     for remote, result in results.items():
-        out.writeln(f"{remote}:", fg=remote_color)
+        cli_out_write(f"{remote}:", fg=remote_color)
         if result.get("error"):
-            out.writeln(f"  ERROR: {result.get('error')}", fg=error_color)
+            cli_out_write(f"  ERROR: {result.get('error')}", fg=error_color)
         else:
             recipes = result.get("recipes", [])
             if not recipes:
                 # FIXME: this should be an error message, NOT FOUND
-                out.writeln("  There are no matching recipe references")
+                cli_out_write("  There are no matching recipe references")
             else:
                 current_recipe = None
                 for ref in recipes:
                     if ref.name != current_recipe:
                         current_recipe = ref.name
-                        out.writeln(f"  {current_recipe}", fg=recipe_color)
+                        cli_out_write(f"  {current_recipe}", fg=recipe_color)
 
-                    out.writeln(f"    {ref}", fg=reference_color)
+                    cli_out_write(f"    {ref}", fg=reference_color)
 
 
 def print_list_recipe_revisions(results):
-    out = ConanOutput(stream=sys.stdout)
     for remote, result in results.items():
         name = remote if remote is not None else "Local Cache"
-        out.writeln(f"{name}:", fg=remote_color)
+        cli_out_write(f"{name}:", fg=remote_color)
         if result.get("error"):
-            out.writeln(f"  ERROR: {result.get('error')}", fg=error_color)
+            cli_out_write(f"  ERROR: {result.get('error')}", fg=error_color)
         else:
             revisions = result.get("revisions", [])
             if not revisions:
                 # FIXME: this should be an error message, NOT FOUND
-                out.writeln("  There are no matching recipe references")
+                cli_out_write("  There are no matching recipe references")
             else:
                 for ref in revisions:
-                    out.writeln(f"  {ref.repr_humantime()}", fg=recipe_color)
+                    cli_out_write(f"  {ref.repr_humantime()}", fg=recipe_color)
 
 
 def print_list_package_revisions(results):
-    out = ConanOutput(stream=sys.stdout)
     for remote, result in results.items():
         name = remote if remote is not None else "Local Cache"
-        out.writeln(f"{name}:", fg=remote_color)
+        cli_out_write(f"{name}:", fg=remote_color)
         if result.get("error"):
-            out.writeln(f"  ERROR: {result.get('error')}", fg=error_color)
+            cli_out_write(f"  ERROR: {result.get('error')}", fg=error_color)
         else:
             revisions = result.get("revisions", [])
             if not revisions:
                 # FIXME: this should be an error message, NOT FOUND
-                out.writeln(f"  There are no matching package references")
+                cli_out_write(f"  There are no matching package references")
             else:
                 for pref in revisions:
-                    out.writeln(f"  {pref.repr_humantime()}", fg=recipe_color)
+                    cli_out_write(f"  {pref.repr_humantime()}", fg=recipe_color)
 
 
 def print_list_package_ids(results):
-    out = ConanOutput(stream=sys.stdout)
     for remote, result in results.items():
         name = remote if remote is not None else "Local Cache"
-        out.writeln(f"{name}:", fg=remote_color)
+        cli_out_write(f"{name}:", fg=remote_color)
         if result.get("error"):
-            out.writeln(f"  ERROR: {result.get('error')}", fg=error_color)
+            cli_out_write(f"  ERROR: {result.get('error')}", fg=error_color)
         else:
             packages = result.get("packages", [])
             if not packages:
                 # It is legal not to have binaries
-                out.writeln("  There are no packages")
+                cli_out_write("  There are no packages")
             else:
                 for pref, binary_info in packages.items():
-                    out.writeln(f"  {pref.repr_notime()}", fg=reference_color)
+                    cli_out_write(f"  {pref.repr_notime()}", fg=reference_color)
                     for item, contents in binary_info.items():
                         if not contents:
                             continue
-                        out.writeln(f"    {item}:", fg=field_color)
+                        cli_out_write(f"    {item}:", fg=field_color)
                         if not isinstance(contents, dict):
                             for c in contents:
-                                out.writeln(f"      {c}", fg=value_color)
+                                cli_out_write(f"      {c}", fg=value_color)
                         else:
                             for k, v in contents.items():
-                                out.writeln(f"      {k}={v}", fg=value_color)
+                                cli_out_write(f"      {k}={v}", fg=value_color)
 
 
 def _add_remotes_and_cache_options(subparser):
@@ -211,7 +207,6 @@ def list_package_revisions(conan_api, parser, subparser, *args):
 
 
 def _list_packages_json(data):
-    out = ConanOutput(stream=sys.stdout)
     for remote, d in data.items():
         d["reference"] = repr(d["reference"])
         try:
@@ -219,7 +214,7 @@ def _list_packages_json(data):
         except KeyError:
             pass
     myjson = json.dumps(data, indent=4)
-    out.writeln(myjson)
+    cli_out_write(myjson)
 
 
 @conan_subcommand(formatters={"text": print_list_package_ids, "json": _list_packages_json})

--- a/conan/cli/commands/profile.py
+++ b/conan/cli/commands/profile.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 from conan.api.output import ConanOutput, cli_out_write
 from conan.cli.command import conan_command, conan_subcommand, COMMAND_GROUPS

--- a/conan/cli/commands/profile.py
+++ b/conan/cli/commands/profile.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from conan.api.output import ConanOutput
+from conan.api.output import ConanOutput, cli_out_write
 from conan.cli.command import conan_command, conan_subcommand, COMMAND_GROUPS
 from conan.cli.commands import default_text_formatter, default_json_formatter
 from conan.cli.common import add_profiles_args, get_profiles_from_args
@@ -11,24 +11,21 @@ from conans.util.files import save
 
 def print_profiles(profiles):
     host, build = profiles
-    out = ConanOutput(stream=sys.stdout)
-    out.writeln("Host profile:")
-    out.writeln(host.dumps())
-    out.writeln("Build profile:")
-    out.writeln(build.dumps())
+    cli_out_write("Host profile:")
+    cli_out_write(host.dumps())
+    cli_out_write("Build profile:")
+    cli_out_write(build.dumps())
 
 
 def profiles_list_cli_output(profiles):
-    out = ConanOutput(stream=sys.stdout)
-    out.writeln("Profiles found in the cache:")
+    cli_out_write("Profiles found in the cache:")
     for p in profiles:
-        out.writeln(p)
+        cli_out_write(p)
 
 
 def detected_profile_cli_output(detect_profile):
-    out = ConanOutput(stream=sys.stdout)
-    out.writeln("Detected profile:")
-    out.writeln(detect_profile.dumps())
+    cli_out_write("Detected profile:")
+    cli_out_write(detect_profile.dumps())
 
 
 @conan_subcommand(formatters={"text": print_profiles})

--- a/conan/cli/commands/remote.py
+++ b/conan/cli/commands/remote.py
@@ -29,7 +29,7 @@ def print_remote_user_list(results):
         if result["user_name"] is None:
             cli_out_write("  No user", fg=error_color)
         else:
-            cli_out_write("  Username: ", fg=recipe_color,)
+            cli_out_write("  Username: ", fg=recipe_color, endline="")
             cli_out_write(result["user_name"], fg=reference_color)
             cli_out_write("  authenticated: ", fg=recipe_color, endline="")
             cli_out_write(result["authenticated"], fg=reference_color)

--- a/conan/cli/commands/remote.py
+++ b/conan/cli/commands/remote.py
@@ -1,5 +1,4 @@
 import json
-import sys
 from collections import OrderedDict
 
 from conan.api.output import cli_out_write

--- a/conan/cli/commands/remote.py
+++ b/conan/cli/commands/remote.py
@@ -2,7 +2,7 @@ import json
 import sys
 from collections import OrderedDict
 
-from conan.api.output import ConanOutput
+from conan.api.output import cli_out_write
 from conan.api.conan_api import ConanAPIV2
 from conan.api.model import Remote
 from conan.cli.command import conan_command, conan_subcommand, OnceArgument
@@ -13,34 +13,30 @@ from conans.errors import ConanException
 
 
 def formatter_remote_list_json(remotes):
-    output = ConanOutput(stream=sys.stdout)
     info = [{"name": r.name, "url": r.url, "verify_ssl": r.verify_ssl, "enabled": not r.disabled}
             for r in remotes]
-    output.writeln(json.dumps(info, indent=4))
+    cli_out_write(json.dumps(info, indent=4))
 
 
 def print_remote_list(remotes):
-    output = ConanOutput(stream=sys.stdout)
     for r in remotes:
         output_str = str(r)
-        output.writeln(output_str)
+        cli_out_write(output_str)
 
 
 def print_remote_user_list(results):
-    output = ConanOutput(stream=sys.stdout)
     for remote_name, result in results.items():
-        output.writeln(f"{remote_name}:", fg=remote_color)
+        cli_out_write(f"{remote_name}:", fg=remote_color)
         if result["user_name"] is None:
-            output.writeln("  No user", fg=error_color)
+            cli_out_write("  No user", fg=error_color)
         else:
-            output.write("  Username: ", fg=recipe_color,)
-            output.writeln(result["user_name"], fg=reference_color)
-            output.write("  authenticated: ", fg=recipe_color)
-            output.writeln(result["authenticated"], fg=reference_color)
+            cli_out_write("  Username: ", fg=recipe_color,)
+            cli_out_write(result["user_name"], fg=reference_color)
+            cli_out_write("  authenticated: ", fg=recipe_color, endline="")
+            cli_out_write(result["authenticated"], fg=reference_color)
 
 
 def print_remote_user_set(results):
-    output = ConanOutput(stream=sys.stdout)
     for remote_name, result in results.items():
         from_user = "'{}'".format(result["previous_info"]["user_name"])
         from_user += " (anonymous)" \
@@ -49,12 +45,11 @@ def print_remote_user_set(results):
         to_user += " (anonymous)" \
             if not result["info"]["authenticated"] else " (authenticated)"
         message = "Changed user of remote '{}' from {} to {}".format(remote_name, from_user, to_user)
-        output.writeln(message)
+        cli_out_write(message)
 
 
 def output_remotes_json(results):
-    output = ConanOutput(stream=sys.stdout)
-    output.writeln(json.dumps(list(results.values())))
+    cli_out_write(json.dumps(list(results.values())))
 
 
 @conan_subcommand(formatters={"text": print_remote_list, "json": formatter_remote_list_json})

--- a/conan/cli/commands/search.py
+++ b/conan/cli/commands/search.py
@@ -2,12 +2,12 @@ from collections import OrderedDict
 
 from conan.api.conan_api import ConanAPIV2
 from conan.cli.command import conan_command, Extender, COMMAND_GROUPS
-from conan.cli.commands.list import print_list_recipes, json_formatter
+from conan.cli.commands.list import print_list_recipes, default_json_formatter
 from conan.cli.common import get_remote_selection
 
 
 # FIXME: "conan search" == "conan list recipes -r="*" -c" --> implement @conan_alias_command??
-@conan_command(group=COMMAND_GROUPS['consumer'], formatters={"json": json_formatter})
+@conan_command(group=COMMAND_GROUPS['consumer'], formatters={"json": default_json_formatter})
 def search(conan_api: ConanAPIV2, parser, *args):
     """
     Searches for package recipes in a remote or remotes

--- a/conan/cli/commands/search.py
+++ b/conan/cli/commands/search.py
@@ -7,7 +7,7 @@ from conan.cli.common import get_remote_selection
 
 
 # FIXME: "conan search" == "conan list recipes -r="*" -c" --> implement @conan_alias_command??
-@conan_command(group=COMMAND_GROUPS['consumer'], formatters={"json": default_json_formatter})
+@conan_command(group=COMMAND_GROUPS['consumer'], formatters={"text": print_list_recipes, "json": default_json_formatter})
 def search(conan_api: ConanAPIV2, parser, *args):
     """
     Searches for package recipes in a remote or remotes
@@ -28,5 +28,4 @@ def search(conan_api: ConanAPIV2, parser, *args):
             results[name] = {"recipes": conan_api.search.recipes(args.query, remote)}
         except Exception as e:
             results[name] = {"error": str(e)}
-    print_list_recipes(results)
     return results

--- a/conan/cli/formatters/graph.py
+++ b/conan/cli/formatters/graph.py
@@ -1,5 +1,6 @@
 import fnmatch
 import json
+import sys
 
 from conan.api.output import ConanOutput, Color
 from conan.cli.formatters import get_template
@@ -103,7 +104,7 @@ def print_graph_info(deps_graph, field_filter, package_filter):
     """ More complete graph output, including information for every node in the graph
     Used for 'graph info' command
     """
-    out = ConanOutput()
+    out = ConanOutput(stream=sys.stdout)
     out.title("Basic graph information")
     serial = deps_graph.serialize()
     for n in serial["nodes"]:
@@ -215,19 +216,22 @@ def _render_graph(graph, template, template_folder):
 
 
 def format_graph_html(info):
+    out = ConanOutput(stream=sys.stdout)
     graph, template_folder = info
     template = get_template(templates.INFO_GRAPH_HTML, template_folder=template_folder)
-    return _render_graph(graph, template, template_folder)
+    out.writeln(_render_graph(graph, template, template_folder))
 
 
 def format_graph_dot(info):
+    out = ConanOutput(stream=sys.stdout)
     graph, template_folder = info
     template = get_template(templates.INFO_GRAPH_DOT, template_folder=template_folder)
-    return _render_graph(graph, template, template_folder)
+    out.writeln(_render_graph(graph, template, template_folder))
 
 
 def format_graph_json(info):
+    out = ConanOutput(stream=sys.stdout)
     deps_graph, _ = info
     serialized = deps_graph.serialize()
     json_result = json.dumps(serialized, indent=4)
-    return json_result
+    out.writeln(json_result)

--- a/conan/cli/formatters/graph.py
+++ b/conan/cli/formatters/graph.py
@@ -3,6 +3,7 @@ import json
 import sys
 
 from conan.api.output import ConanOutput, Color
+from conan.api.output import cli_out_write
 from conan.cli.formatters import get_template
 from conans.assets import templates
 from conans.client.graph.graph import CONTEXT_BUILD, RECIPE_CONSUMER, RECIPE_VIRTUAL, BINARY_CACHE, \
@@ -104,7 +105,7 @@ def print_graph_info(deps_graph, field_filter, package_filter):
     """ More complete graph output, including information for every node in the graph
     Used for 'graph info' command
     """
-    out = ConanOutput(stream=sys.stdout)
+    out = ConanOutput()
     out.title("Basic graph information")
     serial = deps_graph.serialize()
     for n in serial["nodes"]:
@@ -121,7 +122,7 @@ def print_graph_info(deps_graph, field_filter, package_filter):
 
 
 def _serial_pretty_printer(data, field_filter, indent=""):
-    out = ConanOutput(stream=sys.stdout)
+    out = ConanOutput()
     for k, v in data.items():
         if field_filter is not None and k not in field_filter:
             continue
@@ -216,22 +217,19 @@ def _render_graph(graph, template, template_folder):
 
 
 def format_graph_html(info):
-    out = ConanOutput(stream=sys.stdout)
     graph, template_folder = info
     template = get_template(templates.INFO_GRAPH_HTML, template_folder=template_folder)
-    out.writeln(_render_graph(graph, template, template_folder))
+    cli_out_write(_render_graph(graph, template, template_folder))
 
 
 def format_graph_dot(info):
-    out = ConanOutput(stream=sys.stdout)
     graph, template_folder = info
     template = get_template(templates.INFO_GRAPH_DOT, template_folder=template_folder)
-    out.writeln(_render_graph(graph, template, template_folder))
+    cli_out_write(_render_graph(graph, template, template_folder))
 
 
 def format_graph_json(info):
-    out = ConanOutput(stream=sys.stdout)
     deps_graph, _ = info
     serialized = deps_graph.serialize()
     json_result = json.dumps(serialized, indent=4)
-    out.writeln(json_result)
+    cli_out_write(json_result)

--- a/conan/cli/formatters/graph.py
+++ b/conan/cli/formatters/graph.py
@@ -121,7 +121,7 @@ def print_graph_info(deps_graph, field_filter, package_filter):
 
 
 def _serial_pretty_printer(data, field_filter, indent=""):
-    out = ConanOutput()
+    out = ConanOutput(stream=sys.stdout)
     for k, v in data.items():
         if field_filter is not None and k not in field_filter:
             continue

--- a/conans/test/integration/command/config_test.py
+++ b/conans/test/integration/command/config_test.py
@@ -21,9 +21,7 @@ def test_config_home_default():
     """
     client = TestClient()
     client.run("config home")
-    assert client.cache.cache_folder in client.out
-    client.run("config home --format=text")
-    assert client.cache.cache_folder == client.stdout
+    assert f"{client.cache.cache_folder}\n" == client.stdout
 
 
 def test_config_home_custom_home_dir():

--- a/conans/test/integration/command/config_test.py
+++ b/conans/test/integration/command/config_test.py
@@ -33,7 +33,7 @@ def test_config_home_custom_home_dir():
         client.run("config home")
         assert cache_folder in client.out
         client.run("config home --format=text")
-        assert client.cache.cache_folder == client.stdout
+        assert f"{client.cache.cache_folder}\n" == client.stdout
 
 
 def test_config_home_custom_install():
@@ -56,4 +56,4 @@ def test_config_list():
     for k, v in BUILT_IN_CONFS.items():
         assert f"{k}: {v}" in client.out
     client.run("config list --format=json")
-    assert json.dumps(BUILT_IN_CONFS, indent=4) == client.stdout
+    assert f"{json.dumps(BUILT_IN_CONFS, indent=4)}\n" == client.stdout

--- a/conans/test/integration/command_v2/custom_commands_test.py
+++ b/conans/test/integration/command_v2/custom_commands_test.py
@@ -25,13 +25,14 @@ class TestCustomCommands:
             import json
             import os
 
-            from conan.cli.command import conan_command, cli_out_write
+            from conan.cli.command import conan_command
+            from conan.api.output import ConanOutput
 
             def output_mycommand_cli(info):
-                return f"Conan cache folder is: {info.get('cache_folder')}"
+                ConanOutput().writeln(f"Conan cache folder is: {info.get('cache_folder')}")
 
             def output_mycommand_json(info):
-                return json.dumps(info)
+                ConanOutput().writeln(json.dumps(info))
 
             @conan_command(group="custom commands",
                            formatters={"cli": output_mycommand_cli,
@@ -103,13 +104,14 @@ class TestCustomCommands:
         complex_command = textwrap.dedent("""
             import json
 
-            from conan.cli.command import conan_command, conan_subcommand, cli_out_write
+            from conan.cli.command import conan_command, conan_subcommand
+            from conan.api.output import ConanOutput
 
             def output_cli(info):
-                return f"{info.get('argument1')}"
+                ConanOutput().writeln(f"{info.get('argument1')}")
 
             def output_json(info):
-                return json.dumps(info)
+                 ConanOutput().writeln(json.dumps(info))
 
             @conan_subcommand(formatters={"cli": output_cli, "json": output_json})
             def complex_sub1(conan_api, parser, subparser, *args):

--- a/conans/test/integration/command_v2/custom_commands_test.py
+++ b/conans/test/integration/command_v2/custom_commands_test.py
@@ -26,13 +26,13 @@ class TestCustomCommands:
             import os
 
             from conan.cli.command import conan_command
-            from conan.api.output import ConanOutput
+            from conan.api.output import cli_out_write
 
             def output_mycommand_cli(info):
-                ConanOutput().writeln(f"Conan cache folder is: {info.get('cache_folder')}")
+                cli_out_write(f"Conan cache folder is: {info.get('cache_folder')}")
 
             def output_mycommand_json(info):
-                ConanOutput().writeln(json.dumps(info))
+                cli_out_write(json.dumps(info))
 
             @conan_command(group="custom commands",
                            formatters={"cli": output_mycommand_cli,
@@ -57,7 +57,7 @@ class TestCustomCommands:
 
     def test_command_layer(self):
         myhello = textwrap.dedent("""
-            from conan.api.output import ConanOutput
+            from conan.api.output import cli_out_write
             from conan.cli.command import conan_command
 
             @conan_command(group="custom commands")
@@ -65,10 +65,10 @@ class TestCustomCommands:
                 '''
                 My Hello doc
                 '''
-                ConanOutput().info("Hello {}!")
+                cli_out_write("Hello {}!")
             """)
         mybye = textwrap.dedent("""
-            from conan.api.output import ConanOutput
+            from conan.api.output import cli_out_write
             from conan.cli.command import conan_command, conan_subcommand
 
             @conan_command(group="custom commands")
@@ -82,7 +82,7 @@ class TestCustomCommands:
                 '''
                 My bye say doc
                 '''
-                ConanOutput().info("Bye!")
+                cli_out_write("Bye!")
             """)
 
         client = TestClient()
@@ -105,13 +105,13 @@ class TestCustomCommands:
             import json
 
             from conan.cli.command import conan_command, conan_subcommand
-            from conan.api.output import ConanOutput
+            from conan.api.output import cli_out_write
 
             def output_cli(info):
-                ConanOutput().writeln(f"{info.get('argument1')}")
+                cli_out_write(f"{info.get('argument1')}")
 
             def output_json(info):
-                 ConanOutput().writeln(json.dumps(info))
+                 cli_out_write(json.dumps(info))
 
             @conan_subcommand(formatters={"cli": output_cli, "json": output_json})
             def complex_sub1(conan_api, parser, subparser, *args):

--- a/conans/test/integration/templates/test_user_overrides.py
+++ b/conans/test/integration/templates/test_user_overrides.py
@@ -33,11 +33,11 @@ class UserOverridesTemplatesTestCase(unittest.TestCase):
         save(table_template_path, content='{{ base_template_path }}')
         self.t.run("graph info --requires=app/0.1 --format=html")
         content = self.t.stdout
-        self.assertEqual(os.path.join(self.t.cache_folder, 'templates'), content)
+        self.assertEqual(os.path.join(self.t.cache_folder, 'templates\n'), content)
 
     def test_graph_dot(self):
         table_template_path = os.path.join(self.t.cache_folder, 'templates', INFO_GRAPH_DOT)
         save(table_template_path, content='{{ base_template_path }}')
         self.t.run("graph info --requires=app/0.1 --format=dot")
         content = self.t.stdout
-        self.assertEqual(os.path.join(self.t.cache_folder, 'templates'), content)
+        self.assertEqual(os.path.join(self.t.cache_folder, 'templates\n'), content)


### PR DESCRIPTION
Still working on it ...

Following the convention for Conan 2.0 that the results for the commands are dumped to the stdout. Rest of operations while running the command are dumped to stderr.

Several fixes in the output for the CLI:
- All commands must define a `text` formatter if they have to output something to the stdout. 
- The `text` formatter is not shown in the help and is used by default in case the command defined it.

I think that the formatters were not correctly used in the code because they only formatted the output and not write anything and maybe that was a bit confusing, so now the formatters are changed to also do the actual output to stdout using `cli_out_write()`