### PR TITLE
[feature] Detect if running clang compiler on Windows

### DIFF
--- a/conan/tools/microsoft/__init__.py
+++ b/conan/tools/microsoft/__init__.py
@@ -5,3 +5,4 @@ from conan.tools.microsoft.subsystems import unix_path
 from conan.tools.microsoft.toolchain import MSBuildToolchain
 from conan.tools.microsoft.visual import msvc_runtime_flag, VCVars, is_msvc, \
     is_msvc_static_runtime, check_min_vs
+from conan.tools.microsoft.clang import is_clang_cl

--- a/conan/tools/microsoft/clang.py
+++ b/conan/tools/microsoft/clang.py
@@ -1,0 +1,14 @@
+
+def is_clang_cl(conanfile, build_context=False):
+    """ Validate if current compiler in settings is 'clang' and running on Windows
+    :param conanfile: ConanFile instance
+    :param build_context: If True, will use the settings from the build context, not host ones
+    :return: True, if the host compiler is related to Clang on Windows, otherwise, False.
+    """
+    # FIXME: 2.0: remove "hasattr()" condition
+    if not build_context or not hasattr(conanfile, "settings_build"):
+        settings = conanfile.settings
+    else:
+        settings = conanfile.settings_build
+    return (settings.get_safe("os") == "Windows" and settings.get_safe("compiler") == "clang") or \
+        settings.get_safe("compiler.toolset") == "ClangCL"


### PR DESCRIPTION
Changelog: Feature: `conan.tools.microsoft.is_clang_cl` detects if running Clang on Windows
Docs: https://github.com/conan-io/docs/pull/2774

close #12175

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
