### PR TITLE
Add --deploy to graph-info

### DIFF
--- a/conan/api/subapi/install.py
+++ b/conan/api/subapi/install.py
@@ -49,7 +49,7 @@ class InstallAPI:
         if deploy:
             base_folder = conanfile.folders.base_build
             mkdir(base_folder)
-            _do_deploys(self.conan_api, deps_graph, deploy, base_folder)
+            do_deploys(self.conan_api, deps_graph, deploy, base_folder)
 
         conanfile.generators = list(set(conanfile.generators).union(generators or []))
         app = ConanApp(self.conan_api.cache_folder)
@@ -87,17 +87,16 @@ def _find_deployer(d, cache_deploy_folder):
     raise ConanException(f"Cannot find deployer '{d}'")
 
 
-def _do_deploys(conan_api, graph, deploy, deploy_folder):
+def do_deploys(conan_api, graph, deploy, deploy_folder):
     # Handle the deploys
     cache = ClientCache(conan_api.cache_folder)
     for d in deploy or []:
         deployer = _find_deployer(d, cache.deployers_path)
         # IMPORTANT: Use always kwargs to not break if it changes in the future
-        conanfile = graph.root.conanfile
-        deployer(conanfile=conanfile, output_folder=deploy_folder)
+        deployer(graph=graph, output_folder=deploy_folder)
 
 
-def full_deploy(conanfile, output_folder):
+def full_deploy(graph, output_folder):
     """
     Deploys to output_folder + host/dep/0.1/Release/x86_64 subfolder
     """
@@ -106,6 +105,7 @@ def full_deploy(conanfile, output_folder):
     import os
     import shutil
 
+    conanfile = graph.root.conanfile
     conanfile.output.info(f"Conan built-in full deployer to {output_folder}")
     for dep in conanfile.dependencies.values():
         if dep.package_folder is None:
@@ -123,7 +123,7 @@ def full_deploy(conanfile, output_folder):
         dep.set_deploy_folder(new_folder)
 
 
-def direct_deploy(conanfile, output_folder):
+def direct_deploy(graph, output_folder):
     """
     Deploys to output_folder a single package,
     """
@@ -132,6 +132,7 @@ def direct_deploy(conanfile, output_folder):
     import os
     import shutil
 
+    conanfile = graph.root.conanfile
     conanfile.output.info(f"Conan built-in pkg deployer to {output_folder}")
     # If the argument is --requires, the current conanfile is a virtual one with 1 single
     # dependency, the "reference" package. If the argument is a local path, then all direct

--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -2,7 +2,7 @@ import json
 import os
 
 from conan.api.output import ConanOutput
-from conan.api.subapi.install import _do_deploys
+from conan.api.subapi.install import do_deploys
 from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand, \
     Extender
 from conan.cli.commands import make_abs_path
@@ -111,6 +111,6 @@ def graph_info(conan_api, parser, subparser, *args):
     save_lockfile_out(args, deps_graph, lockfile, os.getcwd())
     if args.deploy:
         base_folder = os.getcwd()
-        _do_deploys(conan_api, deps_graph, args.deploy, base_folder)
+        do_deploys(conan_api, deps_graph, args.deploy, base_folder)
 
     return deps_graph, os.path.join(conan_api.cache_folder, "templates")

--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -2,6 +2,7 @@ import json
 import os
 
 from conan.api.output import ConanOutput
+from conan.api.subapi.install import _do_deploys
 from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand, \
     Extender
 from conan.cli.commands import make_abs_path
@@ -11,6 +12,7 @@ from conan.cli.formatters.graph import format_graph_html, format_graph_json, for
     print_graph_info
 from conans.client.graph.install_graph import InstallGraph
 from conans.errors import ConanException
+from conans.util.files import mkdir
 
 
 @conan_command(group=COMMAND_GROUPS['consumer'])
@@ -89,6 +91,8 @@ def graph_info(conan_api, parser, subparser, *args):
                            help="Show only the specified fields")
     subparser.add_argument("--package-filter", nargs=1, action=Extender,
                            help='Print information only for packages that match the patterns')
+    subparser.add_argument("--deploy", action=Extender,
+                           help='Deploy using the provided deployer to the output folder')
     args = parser.parse_args(*args)
 
     # parameter validation
@@ -105,6 +109,8 @@ def graph_info(conan_api, parser, subparser, *args):
         print_graph_info(deps_graph, args.filter, args.package_filter)
 
     save_lockfile_out(args, deps_graph, lockfile, os.getcwd())
+    if args.deploy:
+        base_folder = os.getcwd()
+        _do_deploys(conan_api, deps_graph, args.deploy, base_folder)
 
     return deps_graph, os.path.join(conan_api.cache_folder, "templates")
-

--- a/conans/test/functional/command/test_install_deploy.py
+++ b/conans/test/functional/command/test_install_deploy.py
@@ -21,7 +21,8 @@ def test_install_deploy():
         import os, shutil
 
         # USE **KWARGS to be robust against changes
-        def deploy(conanfile, output_folder, **kwargs):
+        def deploy(graph, output_folder, **kwargs):
+            conanfile = graph.root.conanfile
             for r, d in conanfile.dependencies.items():
                 new_folder = os.path.join(output_folder, d.ref.name)
                 shutil.copytree(d.package_folder, new_folder)
@@ -51,7 +52,8 @@ def test_copy_files_deploy():
     deploy = textwrap.dedent("""
         import os, shutil
 
-        def deploy(conanfile, output_folder, **kwargs):
+        def deploy(graph, output_folder, **kwargs):
+            conanfile = graph.root.conanfile
             for r, d in conanfile.dependencies.items():
                 bindir = os.path.join(d.package_folder, "bin")
                 for f in os.listdir(bindir):
@@ -73,15 +75,18 @@ def test_multi_deploy():
     """
     c = TestClient()
     deploy1 = textwrap.dedent("""
-        def deploy(conanfile, output_folder, **kwargs):
+        def deploy(graph, output_folder, **kwargs):
+            conanfile = graph.root.conanfile
             conanfile.output.info("deploy1!!")
         """)
     deploy2 = textwrap.dedent("""
-        def deploy(conanfile, output_folder, **kwargs):
+        def deploy(graph, output_folder, **kwargs):
+            conanfile = graph.root.conanfile
             conanfile.output.info("sub/deploy2!!")
         """)
     deploy_cache = textwrap.dedent("""
-        def deploy(conanfile, output_folder, **kwargs):
+        def deploy(graph, output_folder, **kwargs):
+            conanfile = graph.root.conanfile
             conanfile.output.info("deploy cache!!")
         """)
     save(os.path.join(c.cache_folder, "extensions", "deploy", "deploy_cache.py"), deploy_cache)


### PR DESCRIPTION
How to do some quick ``graph info``, and extract custom information from the graph, in an extensible way?

- Formatters at the moment are very built-in, and seems difficult to change it
- ``--deploy`` only applies to ``install``, so it is necessary to install the binaries, which can be slow
- There are no more global custom generators, only as ``python_requires``
- It could be possible to fork the ``graph_info`` command, but seems a bit too much to just do something equivalent to the deployers

On the other hand, I don't love the ``deploy`` name, but I don't want to create yet another name for something that is mostly identical
