### PR TITLE
Fix library install names in packaged executables

### DIFF
--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -204,8 +204,7 @@ def fix_apple_shared_install_name(conanfile):
         for libdir in libdirs:
             full_folder = os.path.join(conanfile.package_folder, libdir)
             if not os.path.exists(full_folder):
-                # as method package is running before package_info, the cpp.package might be
-                # wrong
+                # Should this be an error?
                 continue
             shared_libs = _darwin_collect_dylibs(full_folder)
             # fix LC_ID_DYLIB in first pass
@@ -231,8 +230,8 @@ def fix_apple_shared_install_name(conanfile):
         for bindir in bindirs:
             full_folder = os.path.join(conanfile.package_folder, bindir)
             if not os.path.exists(full_folder):
-                # as method package is running before package_info, the cpp.package might be
-                # wrong
+                # Skip if the folder does not exist inside the package
+                # (e.g. package does not contain executables but bindirs is defined)
                 continue
             executables = _darwin_collect_executables(full_folder)
             for executable in executables:
@@ -258,4 +257,8 @@ def fix_apple_shared_install_name(conanfile):
 
     if is_apple_os(conanfile) and conanfile.options.get_safe("shared", False):
         substitutions = _fix_dylib_files(conanfile)
+
+        # Only "fix" executables if dylib files were patched, otherwise 
+        # there is nothing to do.
+        if substitutions:
         _fix_executables(conanfile, substitutions)

--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -4,6 +4,7 @@ import os
 
 from conans.util.runners import check_output_runner
 from conans.client.tools.apple import to_apple_arch as _to_apple_arch
+from conans.errors import ConanException
 
 
 def is_apple_os(conanfile):
@@ -204,8 +205,8 @@ def fix_apple_shared_install_name(conanfile):
         for libdir in libdirs:
             full_folder = os.path.join(conanfile.package_folder, libdir)
             if not os.path.exists(full_folder):
-                # Should this be an error?
-                continue
+                raise ConanException(f"Trying to locate shared libraries, but `{libdir}` "
+                                     f" not found inside package folder {conanfile.package_folder}")
             shared_libs = _darwin_collect_dylibs(full_folder)
             # fix LC_ID_DYLIB in first pass
             for shared_lib in shared_libs:
@@ -261,4 +262,4 @@ def fix_apple_shared_install_name(conanfile):
         # Only "fix" executables if dylib files were patched, otherwise 
         # there is nothing to do.
         if substitutions:
-        _fix_executables(conanfile, substitutions)
+            _fix_executables(conanfile, substitutions)

--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -203,6 +203,10 @@ def fix_apple_shared_install_name(conanfile):
         libdirs = getattr(conanfile.cpp.package, "libdirs")
         for libdir in libdirs:
             full_folder = os.path.join(conanfile.package_folder, libdir)
+            if not os.path.exists(full_folder):
+                # as method package is running before package_info, the cpp.package might be
+                # wrong
+                continue
             shared_libs = _darwin_collect_dylibs(full_folder)
             # fix LC_ID_DYLIB in first pass
             for shared_lib in shared_libs:
@@ -226,6 +230,10 @@ def fix_apple_shared_install_name(conanfile):
         bindirs = getattr(conanfile.cpp.package, "bindirs")
         for bindir in bindirs:
             full_folder = os.path.join(conanfile.package_folder, bindir)
+            if not os.path.exists(full_folder):
+                # as method package is running before package_info, the cpp.package might be
+                # wrong
+                continue
             executables = _darwin_collect_executables(full_folder)
             for executable in executables:
 

--- a/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
+++ b/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
@@ -269,6 +269,10 @@ def test_autotools_fix_shared_libs():
         libbye_la_HEADERS = bye.h
         libbye_ladir = $(includedir)
         libbye_la_LIBADD = libhello.la
+
+        bin_PROGRAMS = main
+        main_SOURCES = main.cpp
+        main_LDADD = libhello.la libbye.la
     """)
 
     test_src = textwrap.dedent("""
@@ -280,6 +284,7 @@ def test_autotools_fix_shared_libs():
         "src/makefile.am": makefile_am,
         "src/bye.cpp": bye_cpp,
         "src/bye.h": bye_h,
+        "src/main.cpp": test_src,
         "test_package/main.cpp": test_src,
         "conanfile.py": conanfile,
     })
@@ -304,5 +309,13 @@ def test_autotools_fix_shared_libs():
     assert "@rpath/libhello.dylib (compatibility version 1.0.0, current version 1.0.0)" in client.out
     assert "@rpath/libbye.dylib (compatibility version 1.0.0, current version 1.0.0)" in client.out
 
+    # app rpath fixed in executable
+    exe_path = os.path.join(package_folder, "bin", "main")
+    client.run_command("otool -L {}".format(exe_path))
+    assert "@rpath/libhello.dylib" in client.out
+    client.run_command(exe_path)
+    assert "Bye, bye!" in client.out
+
+    # Running the test-package also works
     client.run("test test_package hello/0.1@ -o hello:shared=True")
     assert "Bye, bye!" in client.out

--- a/conans/test/unittests/tools/apple/test_apple_tools.py
+++ b/conans/test/unittests/tools/apple/test_apple_tools.py
@@ -1,5 +1,8 @@
+import pytest
+
 from conans.test.utils.mocks import ConanFileMock, MockSettings
-from conan.tools.apple import is_apple_os, to_apple_arch
+from conans.test.utils.test_files import temp_folder
+from conan.tools.apple import is_apple_os, to_apple_arch, fix_apple_shared_install_name
 
 def test_tools_apple_is_apple_os():
     conanfile = ConanFileMock()
@@ -22,3 +25,14 @@ def test_tools_apple_to_apple_arch():
 
     conanfile.settings = MockSettings({"arch": "x86_64"})
     assert to_apple_arch(conanfile) == "x86_64"
+
+def test_fix_shared_install_name_no_libraries():
+    conanfile = ConanFileMock(
+        options="""{"shared": [True, False]}""",
+        options_values={"shared": True})
+    conanfile.settings = MockSettings({"os": "Macos"})
+    conanfile.folders.set_base_package(temp_folder())
+
+    with pytest.raises(Exception) as e:
+        fix_apple_shared_install_name(conanfile)
+        assert "not found inside package folder" in str(e.value)


### PR DESCRIPTION
Changelog: Feature: The tool `fix_apple_shared_install_name` now also patches the `<package_id>/bin` executables found to point to the libraries at `../lib/xxx.dylib`.
Docs: https://github.com/conan-io/docs/pull/2806

This PR is built upon: https://github.com/conan-io/conan/pull/12133

Main differences from the earlier PR:
* To locate executables inside the binfolders, call `otool -hv` which prints a summary of the Mach-O header:
```
Mach header
      magic  cputype cpusubtype  caps    filetype ncmds sizeofcmds      flags
MH_MAGIC_64    ARM64        ALL  0x00     EXECUTE    20       1120   NOUNDEFS DYLDLINK TWOLEVEL PIE
```
Where `EXECUTE` is what we're after. This simplifies things as we no longer need to check for the executable flag or make other assumptions.

* After retrieving the library dependencies from the executable (with `otool -L`), work out which entries need patching by comparing the entries with the `substitutions` dictionary - this dictionary already includes a list of which libraries in the package were packaged, so we know exactly which ones to patch. This fixes logic to not rely on other reasonings such as checking if install names start with `/lib`

* If the executable references a dependency on `/lib/libfoo.dylib`, and this library is inside the package and we have patched the install name to `@rpath/libfoo.dylib`, then the executable has the reference replaced to exactly that (rather than `@executable_path/../lib/libfoo.dylib` - this is because one typically expects the reference of the dependency to match the install name of the dependency. 

* To support the two points above, and to overcome some inconsistency of libtool - had to add some logic to handle a reference to `/lib/libfoo.1.dylib` even if the install name did not include this originally. 

* Add explicit rpath entries to the executables that are patched. In the typical case, the executable will contain an entry to `@rpath/../lib` - relative paths are computed for this. 

Co-authored with @lasote 

Close https://github.com/conan-io/conan/issues/12107