### PR TITLE
new upload_policy='skip' feature

### DIFF
--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -109,12 +109,12 @@ class _UploadCollecter(object):
 
                 # TODO: This search of binary packages has to be improved, more robust
                 # So only real packages are retrieved
-                if conanfile.build_policy == "installer":
+                if conanfile.upload_policy == "skip":
                     # TODO: This build_policy CANNOT be conditional, so all binaries will be skipped
                     #   this could be a future feature, but will require annotating/metadata of the
                     #   binaries created with this policy value for each binary
                     self._output.info("{}: Skipping upload of binaries, because "
-                                      "build_policy='installer'".format(ref))
+                                      "upload_policy='skip'".format(ref))
                     packages_ids = []
                 elif all_packages or query:
                     if all_packages:

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -109,7 +109,14 @@ class _UploadCollecter(object):
 
                 # TODO: This search of binary packages has to be improved, more robust
                 # So only real packages are retrieved
-                if all_packages or query:
+                if conanfile.build_policy == "installer":
+                    # TODO: This build_policy CANNOT be conditional, so all binaries will be skipped
+                    #   this could be a future feature, but will require annotating/metadata of the
+                    #   binaries created with this policy value for each binary
+                    self._output.info("{}: Skipping upload of binaries, because "
+                                      "build_policy='installer'".format(ref))
+                    packages_ids = []
+                elif all_packages or query:
                     if all_packages:
                         query = None
                     # better to do a search, that will retrieve real packages with ConanInfo

--- a/conans/client/graph/build_mode.py
+++ b/conans/client/graph/build_mode.py
@@ -97,10 +97,6 @@ class BuildMode(object):
             return False
         if self.missing or self.outdated:
             return True
-        if conan_file.build_policy == "installer":
-            conan_file.output.info("Building package from source as defined by "
-                                   "build_policy='installer'")
-            return True
         if conan_file.build_policy_missing:
             conan_file.output.info("Building package from source as defined by "
                                    "build_policy='missing'")

--- a/conans/client/graph/build_mode.py
+++ b/conans/client/graph/build_mode.py
@@ -97,6 +97,10 @@ class BuildMode(object):
             return False
         if self.missing or self.outdated:
             return True
+        if conan_file.build_policy == "installer":
+            conan_file.output.info("Building package from source as defined by "
+                                   "build_policy='installer'")
+            return True
         if conan_file.build_policy_missing:
             conan_file.output.info("Building package from source as defined by "
                                    "build_policy='missing'")

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -110,6 +110,7 @@ class ConanFile(object):
     topics = None
     homepage = None
     build_policy = None
+    upload_policy = None
     short_paths = False
     apply_env = True  # Apply environment variables from requires deps_env_info and profiles
     exports = None

--- a/conans/test/functional/only_source_test.py
+++ b/conans/test/functional/only_source_test.py
@@ -163,3 +163,22 @@ class MyPackage(ConanFile):
 
         other_client.run("install %s" % str(ref))
         self.assertNotIn("Copying sources to build folder", other_client.out)
+
+
+def test_build_policy_installer():
+    c = TestClient(default_server_user=True)
+    conanfile = GenConanfile("pkg", "1.0").with_class_attribute('build_policy = "installer"')
+    c.save({"conanfile.py": conanfile})
+    c.run("export .")
+    c.run("install pkg/1.0@")
+    assert "pkg/1.0: Calling build()" in c.out
+    assert "pkg/1.0: Building package from source as defined by build_policy='installer'" in c.out
+
+    # If binary already there it should do nothing
+    c.run("install pkg/1.0@")
+    assert "pkg/1.0: Calling build()" not in c.out
+    assert "pkg/1.0: Building package from source" not in c.out
+
+    c.run("upload * -r=default -c --all")
+    assert "Uploading package" not in c.out
+    assert "pkg/1.0: Skipping upload of binaries, because build_policy='installer'" in c.out

--- a/conans/test/functional/only_source_test.py
+++ b/conans/test/functional/only_source_test.py
@@ -167,12 +167,13 @@ class MyPackage(ConanFile):
 
 def test_build_policy_installer():
     c = TestClient(default_server_user=True)
-    conanfile = GenConanfile("pkg", "1.0").with_class_attribute('build_policy = "installer"')
+    conanfile = GenConanfile("pkg", "1.0").with_class_attribute('build_policy = "missing"')\
+                                          .with_class_attribute('upload_policy = "skip"')
     c.save({"conanfile.py": conanfile})
     c.run("export .")
     c.run("install pkg/1.0@")
     assert "pkg/1.0: Calling build()" in c.out
-    assert "pkg/1.0: Building package from source as defined by build_policy='installer'" in c.out
+    assert "pkg/1.0: Building package from source as defined by build_policy='missing'" in c.out
 
     # If binary already there it should do nothing
     c.run("install pkg/1.0@")
@@ -181,4 +182,4 @@ def test_build_policy_installer():
 
     c.run("upload * -r=default -c --all")
     assert "Uploading package" not in c.out
-    assert "pkg/1.0: Skipping upload of binaries, because build_policy='installer'" in c.out
+    assert "pkg/1.0: Skipping upload of binaries, because upload_policy='skip'" in c.out


### PR DESCRIPTION
Changelog: Feature: New `upload_policy='skip'` that not upload binaries (without raising an Exception, simply skip the binaries).
Docs: https://github.com/conan-io/docs/pull/2802

Close https://github.com/conan-io/conan/issues/11731
