### PR TITLE
Simplify conan inspect command, removing path subcommand.

### DIFF
--- a/conan/cli/commands/inspect.py
+++ b/conan/cli/commands/inspect.py
@@ -1,9 +1,10 @@
 import inspect as python_inspect
-
+import os
 
 from conan.api.output import cli_out_write
 from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand
 from conan.cli.commands import default_json_formatter
+from conan.cli.commands.install import _get_conanfile_path
 
 
 def inspect_text_formatter(data):
@@ -18,22 +19,18 @@ def inspect_text_formatter(data):
             cli_out_write("{}: {}".format(name, value))
 
 
-@conan_command(group=COMMAND_GROUPS['consumer'])
+@conan_command(group=COMMAND_GROUPS['consumer'], formatters={"text": inspect_text_formatter, "json": default_json_formatter})
 def inspect(conan_api, parser, *args):
     """
     Inspect a conanfile.py to return the public fields
     """
-
-
-@conan_subcommand(formatters={"text": inspect_text_formatter, "json": default_json_formatter})
-def inspect_path(conan_api, parser, subparser, *args, **kwargs):
-    """
-    Returns the specified attribute/s of a conanfile
-    """
-    subparser.add_argument("path", help="Path to a folder containing a recipe (conanfile.py)")
+    parser.add_argument("path", help="Path to a folder containing a recipe (conanfile.py)")
 
     args = parser.parse_args(*args)
-    conanfile = conan_api.graph.load_conanfile_class(args.path)
+
+    path = _get_conanfile_path(args.path, os.getcwd(), py=True)
+
+    conanfile = conan_api.graph.load_conanfile_class(path)
     ret = {}
 
     for name, value in python_inspect.getmembers(conanfile):

--- a/conans/test/integration/command_v2/test_inspect.py
+++ b/conans/test/integration/command_v2/test_inspect.py
@@ -8,7 +8,7 @@ from conans.test.utils.tools import TestClient
 def test_basic_inspect():
     t = TestClient()
     t.save({"foo/conanfile.py": GenConanfile().with_name("foo").with_shared_option()})
-    t.run("inspect path foo/conanfile.py")
+    t.run("inspect foo/conanfile.py")
     lines = t.out.splitlines()
     assert lines == ["default_options:",
                      "    shared: False",
@@ -32,21 +32,22 @@ def test_options_description():
                                    "fpic": "Yet another long explanation of fpic"}
             """)
     t.save({"foo/conanfile.py": conanfile})
-    t.run("inspect path foo/conanfile.py")
+    t.run("inspect foo/conanfile.py")
     assert "shared: Some long explanation about shared option" in t.out
     assert "fpic: Yet another long explanation of fpic" in t.out
 
 
-
 def test_missing_conanfile():
     t = TestClient()
-    t.run("inspect path missing/conanfile.py", assert_error=True)
-    assert "conanfile.py not found!" in t.out
+    t.run("inspect missing/conanfile.py", assert_error=True)
+    assert "Conanfile not found at" in t.out
 
 
-def test_json():
+def test_dot_and_folder_conanfile():
     t = TestClient()
-    t.save({"foo/conanfile.py": GenConanfile().with_name("foo").with_shared_option()})
-    t.run("inspect path foo/conanfile.py --format json")
-    assert json.loads(t.stdout)["name"] == "foo"
-    assert json.loads(t.stdout)["options"] == {"shared": [True, False]}
+    t.save({"conanfile.py": GenConanfile().with_name("foo")})
+    t.run("inspect .")
+    assert 'name: foo' in t.out
+    t.save({"foo/conanfile.py": GenConanfile().with_name("foo")}, clean_first=True)
+    t.run("inspect foo")
+    assert 'name: foo' in t.out


### PR DESCRIPTION
Changelog: Simplify conan inspect command, removing path subcommand.
Closes: https://github.com/conan-io/conan/issues/12247

TODO: consider to add inspection of references in local cache and remotes, some ideas:

```
conan inspect conanfile.py
conan inspect --requires=zlib/1.2.11 --> goes to the local cache
```

I would leave the inspect on remote case for users to implement their own using custom commands or maybe:

```
conan inspect --requires=zlib/1.2.11 --cache --> goes to the local cache
conan inspect --requires=zlib/1.2.11 --remote=remote --> goes to the remote
```
