### PR TITLE
Do not allow doing conan create/export with uncommitted changes using revision_mode=scm

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -101,6 +101,11 @@ def calc_revision(scoped_output, path, manifest, revision_mode):
                         "'{}'".format(revision_mode, path)
             raise ConanException("{}: {}".format(error_msg, exc))
 
+        with chdir(path):
+            if bool(check_output_runner('git status -s').strip()):
+                raise ConanException("Can't have a dirty repository using revision_mode='scm' and doing"
+                                     " 'conan export', please commit the changes and run again.")
+
         revision = rev_detected
 
         scoped_output.info("Using git commit as the recipe revision: %s" % revision)

--- a/conans/test/functional/revisions_test.py
+++ b/conans/test/functional/revisions_test.py
@@ -806,23 +806,22 @@ class UploadPackagesWithRevisions(unittest.TestCase):
 
 class SCMRevisions(unittest.TestCase):
 
-    @pytest.mark.xfail(reason="reconsider this case for Conan 2.0")
     def test_auto_revision_even_without_scm_git(self):
-        """Even without using the scm feature, the revision is detected from repo.
-         Also while we continue working in local, the revision doesn't change, so the packages
-         can be found"""
+        """
+        Can't do conan create/export with uncommited changes if using revision_mode=scm
+        """
         ref = RecipeReference.loads("lib/1.0@conan/testing")
         client = TurboTestClient()
         conanfile = GenConanfile().with_revision_mode("scm")
-        commit = client.init_git_repo(files={"file.txt": "hey"}, origin_url="http://myrepo.git")
+        commit = client.init_git_repo(files={"file.txt": "hey", "conanfile.py": str(conanfile)},
+                                      origin_url="http://myrepo.git")
         client.create(ref, conanfile=conanfile)
         self.assertEqual(client.recipe_revision(ref), commit)
 
         # Change the conanfile and make another create, the revision should be the same
         client.save({"conanfile.py": str(conanfile.with_build_msg("New changes!"))})
-        client.create(ref, conanfile=conanfile)
-        self.assertEqual(client.recipe_revision(ref), commit)
-        self.assertIn("New changes!", client.out)
+        client.create(ref, conanfile=conanfile, assert_error=True)
+        self.assertIn("Can't have a dirty repository using revision_mode='scm' and doing", client.out)
 
     def test_auto_revision_without_commits(self):
         """If we have a repo but without commits, it has to fail when the revision_mode=scm"""


### PR DESCRIPTION
Changelog: Do not allow doing conan create/export with uncommitted changes using revision_mode=scm
Closes: https://github.com/conan-io/conan/issues/12069