### PR TITLE
Add stdcpp_library to conan.tools.build

### DIFF
--- a/conan/tools/build/__init__.py
+++ b/conan/tools/build/__init__.py
@@ -2,3 +2,4 @@ from conan.tools.build.cpu import build_jobs
 from conan.tools.build.cross_building import cross_building, can_run
 from conan.tools.build.cppstd import check_min_cppstd, valid_min_cppstd, default_cppstd, \
     supported_cppstd
+from conan.tools.build.stdcpp_library import stdcpp_library

--- a/conan/tools/build/stdcpp_library.py
+++ b/conan/tools/build/stdcpp_library.py
@@ -1,5 +1,9 @@
 
 def stdcpp_library(conanfile):
+    """ Returns the name of the C++ standard library that can be passed
+    to the linker, based on the current settings. Returs None if the name 
+    of the C++ standard library file is not known.
+    """
     libcxx = conanfile.settings.get_safe("compiler.libcxx")
     if libcxx in ["libstdc++", "libstdc++11"]:
         return "stdc++"

--- a/conan/tools/build/stdcpp_library.py
+++ b/conan/tools/build/stdcpp_library.py
@@ -1,0 +1,12 @@
+
+def stdcpp_library(conanfile):
+    libcxx = conanfile.settings.get_safe("compiler.libcxx")
+    if libcxx in ["libstdc++", "libstdc++11"]:
+        return "stdc++"
+    elif libcxx in ["libc++"]:
+        return "c++"
+    elif libcxx in ["c++_shared"]:
+        return "c++_shared"
+    elif libcxx in ["c++_static"]:
+        return "c++_static"
+    return None

--- a/conans/test/unittests/tools/build/test_stdcpp_library.py
+++ b/conans/test/unittests/tools/build/test_stdcpp_library.py
@@ -1,0 +1,18 @@
+import pytest
+from conan.tools.build import stdcpp_library
+from conans.test.utils.mocks import MockSettings, MockConanfile
+
+
+@pytest.mark.parametrize("libcxx,expected_library", [
+    ("libstdc++", "stdc++"),
+    ("libstdc++11", "stdc++"),
+    ("libc++", "c++"),
+    ("c++_shared", "c++_shared"), 
+    ("c++_static", "c++_static"),
+    ("foobar", None)
+])
+def test_stdcpp_library(libcxx, expected_library):
+    settings = MockSettings({"compiler.libcxx": libcxx})
+    conanfile = MockConanfile(settings)
+
+    assert stdcpp_library(conanfile) == expected_library


### PR DESCRIPTION
Changelog: Feature: Add `stdcpp_library` to `conan.tools.build` to get name of C++ standard library to be linked.
Docs: https://github.com/conan-io/docs/pull/2804
Close https://github.com/conan-io/conan/issues/11912