### PR TITLE
[develop2] components checks

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -379,3 +379,5 @@ class BinaryInstaller:
                     conanfile.cpp_info.merge(full_editable_cppinfo, overwrite=True)
 
                 self._hook_manager.execute("post_package_info", conanfile=conanfile)
+
+        conanfile.cpp_info.check_component_requires(conanfile)

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -504,6 +504,7 @@ class CppInfo(object):
           component requires
         - Check that component external dep::comp dependency "dep" is a recipe "requires"
         - Check that every internal component require actually exist
+        It doesn't check that external components do exist
         """
         # Accumulate all external requires
         external = set()

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -182,7 +182,6 @@ class _Component(object):
         assert len(includedirs) == 1
         return includedirs[0]
 
-
     @property
     def system_libs(self):
         if self._system_libs is None:
@@ -506,9 +505,12 @@ class CppInfo(object):
         - Check that every internal component require actually exist
         It doesn't check that external components do exist
         """
+        if not self.has_components and not self.requires:
+            return
         # Accumulate all external requires
         external = set()
         internal = set()
+        # TODO: Cache this, this is computed in different places
         for key, comp in self.components.items():
             external.update(r.split("::")[0] for r in comp.requires if "::" in r)
             internal.update(r for r in comp.requires if "::" not in r)
@@ -518,8 +520,10 @@ class CppInfo(object):
             raise ConanException(f"{conanfile}: Internal components not found: {missing_internal}")
         if not external:
             return
+        # Only direct host dependencies can be used with components
         direct_dependencies = [d.ref.name
-                               for d, _ in conanfile.dependencies.filter({"direct": True}).items()]
+                               for d, _ in conanfile.dependencies.filter({"direct": True,
+                                                                          "build": False}).items()]
         for e in external:
             if e not in direct_dependencies:
                 raise ConanException(
@@ -543,10 +547,14 @@ class CppInfo(object):
         """Returns a list of tuples with (require, component_name) required by the package
         If the require is internal (to another component), the require will be None"""
         # FIXME: Cache the value
+        # First aggregate without repetition, respecting the order
         ret = []
-        for key, comp in self.components.items():
-            ret.extend([r.split("::") for r in comp.requires if "::" in r and r not in ret])
-            ret.extend([(None, r) for r in comp.requires if "::" not in r and r not in ret])
+        for comp in self.components.values():
+            for r in comp.requires:
+                if r not in ret:
+                    ret.append(r)
+        # Then split the names
+        ret = [r.split("::") if "::" in r else (None, r) for r in ret]
         return ret
 
     def __str__(self):

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
@@ -138,6 +138,28 @@ def test_unused_requirement(top_conanfile):
 
 
 # TODO: This is CMakeDeps Independent, move it out of here
+def test_unused_tool_requirement(top_conanfile):
+    """ Requires should include all listed requirements
+        This error is known when creating the package if the requirement is consumed.
+    """
+    consumer = textwrap.dedent("""
+        from conan import ConanFile
+
+        class Recipe(ConanFile):
+            requires = "top/version"
+            tool_requires = "top2/version"
+            def package_info(self):
+                self.cpp_info.requires = ["top::other"]
+    """)
+    t = TestClient()
+    t.save({'top.py': top_conanfile, 'consumer.py': consumer})
+    t.run('create top.py --name=top --version=version')
+    t.run('create top.py --name=top2 --version=version')
+    t.run('create consumer.py --name=wrong --version=version')
+    # This runs without crashing, because it is not chcking that top::other doesn't exist
+
+
+# TODO: This is CMakeDeps Independent, move it out of here
 def test_wrong_requirement(top_conanfile):
     """ If we require a wrong requirement, we get a meaninful error.
         This error is known when creating the package if the requirement is not there.


### PR DESCRIPTION
The "quality" checks for components were removed in 2.0 because they were a bit complicated.
Recent work on SKIPPED binaries dependencies in https://github.com/conan-io/conan/pull/12033, show that it could be useful to recover them, but it is not completely clear what are the semantics of the global vs component ``cpp_info.requires`` vs ``cpp_info.component[].requires``, needs to be checked.