### PR TITLE
Add ability to set custom host triplet passed by Autotools toolchain

### DIFF
--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -56,7 +56,8 @@ class AutotoolsToolchain:
         if cross_building(self._conanfile):
             os_build, arch_build, os_host, arch_host = get_cross_building_settings(self._conanfile)
             compiler = self._conanfile.settings.get_safe("compiler")
-            self._host = _get_gnu_triplet(os_host, arch_host, compiler=compiler) if self._host is None else self._host
+            if not self._host:
+                self._host = _get_gnu_triplet(os_host, arch_host, compiler=compiler)
             self._build = _get_gnu_triplet(os_build, arch_build, compiler=compiler)
 
             # Apple Stuff

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -43,8 +43,8 @@ class AutotoolsToolchain:
         self.fpic = self._conanfile.options.get_safe("fPIC")
         self.msvc_runtime_flag = self._get_msvc_runtime_flag()
 
-        # Cross build
-        self._host = None
+        # Cross build triplets
+        self._host = self._conanfile.conf.get("tools.gnu:host_triplet")
         self._build = None
         self._target = None
 
@@ -56,7 +56,7 @@ class AutotoolsToolchain:
         if cross_building(self._conanfile):
             os_build, arch_build, os_host, arch_host = get_cross_building_settings(self._conanfile)
             compiler = self._conanfile.settings.get_safe("compiler")
-            self._host = _get_gnu_triplet(os_host, arch_host, compiler=compiler)
+            self._host = _get_gnu_triplet(os_host, arch_host, compiler=compiler) if self._host is None else self._host
             self._build = _get_gnu_triplet(os_build, arch_build, compiler=compiler)
 
             # Apple Stuff

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -28,6 +28,7 @@ BUILT_IN_CONFS = {
     "tools.files.download:retry_wait": "Seconds to wait between download attempts",
     "tools.gnu:make_program": "Indicate path to make program",
     "tools.gnu:define_libcxx11_abi": "Force definition of GLIBCXX_USE_CXX11_ABI=1 for libstdc++11",
+    "tools.gnu:host_triplet": "Custom host triplet to pass to Autotools scripts",
     "tools.google.bazel:configs": "Define Bazel config file",
     "tools.google.bazel:bazelrc_path": "Defines Bazel rc-path",
     "tools.microsoft.msbuild:verbosity": "Verbosity level for MSBuild: 'Quiet', 'Minimal', 'Normal', 'Detailed', 'Diagnostic'",

--- a/conans/test/functional/toolchains/gnu/autotools/test_crossbuild_triplet.py
+++ b/conans/test/functional/toolchains/gnu/autotools/test_crossbuild_triplet.py
@@ -11,7 +11,7 @@ def test_crossbuild_triplet_from_conf():
         os:
             Linux:
             Windows:
-        arch: [x86_64, moxie]
+        arch: [x86_64, hexagon]
         compiler:
             gcc:
                 version: ["10", "11"]
@@ -22,13 +22,13 @@ def test_crossbuild_triplet_from_conf():
     host_profile = textwrap.dedent("""
         [settings]
         os=Linux
-        arch=moxie
+        arch=hexagon
         compiler=gcc
         compiler.version=10
         compiler.libcxx=libstdc++11
         build_type=Release
         [conf]
-        tools.gnu:host_triplet=moxie-acme-linux-gnu
+        tools.gnu:host_triplet=hexagon-acme-linux-gnu
     """)
 
     build_profile = textwrap.dedent("""
@@ -49,5 +49,5 @@ def test_crossbuild_triplet_from_conf():
     client.run("new hello/0.1 --template=autotools_lib")
     client.run("create . --profile:build=build_profile --profile:host=host_profile -tf None")
 
-    assert "--host=moxie-acme-linux-gnu" in client.out
-    assert "checking host system type... moxie-acme-linux-gnu" in client.out
+    assert "--host=hexagon-acme-linux-gnu" in client.out
+    assert "checking host system type... hexagon-acme-linux-gnu" in client.out

--- a/conans/test/functional/toolchains/gnu/autotools/test_crossbuild_triplet.py
+++ b/conans/test/functional/toolchains/gnu/autotools/test_crossbuild_triplet.py
@@ -1,0 +1,53 @@
+import platform
+import pytest
+import textwrap
+
+from conans.test.utils.tools import TestClient
+
+@pytest.mark.skipif(platform.system() not in  ["Darwin", "Linux"], reason="Autotools on Linux or macOS")
+def test_crossbuild_triplet_from_conf():
+
+    settings_yml = textwrap.dedent("""
+        os:
+            Linux:
+            Windows:
+        arch: [x86_64, moxie]
+        compiler:
+            gcc:
+                version: ["10", "11"]
+                libcxx: [libstdc++11]
+        build_type: [None, Debug, Release]
+        """)
+    
+    host_profile = textwrap.dedent("""
+        [settings]
+        os=Linux
+        arch=moxie
+        compiler=gcc
+        compiler.version=10
+        compiler.libcxx=libstdc++11
+        build_type=Release
+        [conf]
+        tools.gnu:host_triplet=moxie-acme-linux-gnu
+    """)
+
+    build_profile = textwrap.dedent("""
+        [settings]
+        os=Linux
+        arch=x86_64
+        compiler=gcc
+        compiler.version=11
+        compiler.libcxx=libstdc++11
+        build_type=Release   
+    """)
+
+    client = TestClient(path_with_spaces=False)
+    client.save({client.cache.settings_path: settings_yml})
+    client.save({"host_profile": host_profile})
+    client.save({"build_profile": build_profile})
+
+    client.run("new hello/0.1 --template=autotools_lib")
+    client.run("create . --profile:build=build_profile --profile:host=host_profile -tf None")
+
+    assert "--host=moxie-acme-linux-gnu" in client.out
+    assert "checking host system type... moxie-acme-linux-gnu" in client.out

--- a/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -58,6 +58,15 @@ def test_invalid_target_triple():
     assert "Unknown 'UNKNOWN_ARCH' machine, Conan doesn't know how " \
            "to translate it to the GNU triplet," in str(excinfo)
 
+def test_custom_host_triple():
+    conanfile = ConanFileMock()
+    conanfile.settings = MockSettings({"os": "Linux", "arch": "x86"})
+    conanfile.settings_build = MockSettings({"os": "Linux", "arch": "x86_64"})
+    conanfile.conf.define("tools.gnu:host_triplet", "i686-pc-linux-gnu")
+    tc = AutotoolsToolchain(conanfile)
+    tc.generate_args()
+    obj = load_toolchain_args()
+    assert "--host=i686-pc-linux-gnu" in obj["configure_args"]
 
 def test_cppstd():
     # Using "cppstd" is discarded


### PR DESCRIPTION
Changelog: Feature:  Add `tools.gnu:host_triplet` conf setting to customise the host triplet set by the AutoTools toolchain
Docs:  TODO

This setting can be useful in the following situations:

- When the user is using a combination of `os`/`arch` for which Conan does not know how to construct the GNU host triplet. In this situation, an exception would be thrown upon constructing the `AutotoolsToolchain()` toolchain object, leaving the user without much recourse.  This can happen if the user is using custom architectures in `settings.yml`, or if Conan doesn't know which triplet to use for the specific `os`/`arch` combination.
- When Conan _can_ produce a valid triplet based on `os`/`arch`, but the specific target platform has a different convention. E.g. for some embedded devices one may want to specify the CPU in a more comprehensive way, or actually specify the vendor (rather than the implicit `unknown`).

In a way, this is analogous to being able to define `system_name`, `system_version`, `system_processor` via the `tools.cmake.cmaketoolchain:` conf settings.

Close: https://github.com/conan-io/conan/issues/12217