### PR TITLE
fix virtual envs with dots

### DIFF
--- a/conan/tools/env/virtualbuildenv.py
+++ b/conan/tools/env/virtualbuildenv.py
@@ -23,9 +23,9 @@ class VirtualBuildEnv:
     def _filename(self):
         f = self.basename
         if self.configuration:
-            f += "-" + self.configuration
+            f += "-" + self.configuration.replace(".", "_")
         if self.arch:
-            f += "-" + self.arch
+            f += "-" + self.arch.replace(".", "_")
         return f
 
     def environment(self):

--- a/conan/tools/env/virtualrunenv.py
+++ b/conan/tools/env/virtualrunenv.py
@@ -45,9 +45,9 @@ class VirtualRunEnv:
     def _filename(self):
         f = self.basename
         if self.configuration:
-            f += "-" + self.configuration
+            f += "-" + self.configuration.replace(".", "_")
         if self.arch:
-            f += "-" + self.arch
+            f += "-" + self.arch.replace(".", "_")
         return f
 
     def environment(self):

--- a/conans/test/integration/environment/test_env.py
+++ b/conans/test/integration/environment/test_env.py
@@ -681,3 +681,41 @@ def test_files_always_created():
     assert os.path.isfile(os.path.join(c.current_folder, f"conanrun.{ext}"))
     assert os.path.isfile(os.path.join(c.current_folder, f"conanbuildenv-release-{arch}.{ext}"))
     assert os.path.isfile(os.path.join(c.current_folder, f"conanbuildenv-release-{arch}.{ext}"))
+
+
+def test_error_with_dots_virtualenv():
+    # https://github.com/conan-io/conan/issues/12163
+    tool = textwrap.dedent(r"""
+        from conan import ConanFile
+        class ToolConan(ConanFile):
+            name = "tool"
+            version = "0.1"
+            settings = "arch", "os"
+
+            def package_info(self):
+                self.buildenv_info.define("DUMMY", "123456")
+        """)
+    test_package = textwrap.dedent(r"""
+        from conan import ConanFile
+        import os
+
+        class ToolTestConan(ConanFile):
+            name = "app"
+            version = "0.1"
+            settings = "os", "compiler", "build_type", "arch"
+            generators = "VirtualBuildEnv"
+
+            def build_requirements(self):
+                self.tool_requires("tool/0.1")
+
+            def build(self):
+                self.run("echo DUMMY=$DUMMY")
+                self.run("set")
+            """)
+    client = TestClient()
+    client.save({"dep/conanfile.py": tool,
+                 "consumer/conanfile.py": test_package})
+
+    client.run("create dep -s arch=armv8.3")
+    client.run("create consumer -s arch=armv8.3")
+    assert "DUMMY=123456" in client.out


### PR DESCRIPTION
Changelog: Bugfix: Fix new ``VirtualBuildEnv`` and ``VirtualRunEnv`` generators problems with dots in architecture or config.
Docs: Omit

Close https://github.com/conan-io/conan/issues/12163