### PR TITLE
backporting Git.included_files()

### DIFF
--- a/conan/tools/scm/git.py
+++ b/conan/tools/scm/git.py
@@ -87,3 +87,8 @@ class Git(object):
     def checkout(self, commit):
         self._conanfile.output.info("Checkout: {}".format(commit))
         self.run('checkout {}'.format(commit))
+
+    def included_files(self):
+        files = self.run("ls-files --full-name --others --cached --exclude-standard")
+        files = files.splitlines()
+        return files


### PR DESCRIPTION
Changelog: Feature: New ``included_files()`` method in ``from conan.tools.scm import Git``.
Docs: https://github.com/conan-io/docs/pull/2799

Close https://github.com/conan-io/conan/issues/12265
