### PR TITLE
Fix bug with generated pkgconfig files and apple frameworks

### DIFF
--- a/conan/tools/gnu/gnudeps_flags.py
+++ b/conan/tools/gnu/gnudeps_flags.py
@@ -52,7 +52,7 @@ class GnuDepsFlags(object):
         if str(compiler) not in self._GCC_LIKE:
             return []
         if is_path:
-            return ["-F %s" % self._adjust_path(framework_path) for framework_path in frameworks]
+            return ["-F\"%s\"" % self._adjust_path(framework_path) for framework_path in frameworks]
         else:
             return ["-framework %s" % framework for framework in frameworks]
 

--- a/conans/client/build/compiler_flags.py
+++ b/conans/client/build/compiler_flags.py
@@ -280,4 +280,4 @@ def format_framework_paths(framework_paths, settings):
     compiler_base = settings.get_safe("compiler.base")
     if (str(compiler) not in GCC_LIKE) and (str(compiler_base) not in GCC_LIKE):
         return []
-    return ["-F %s" % adjust_path(framework_path, settings) for framework_path in framework_paths]
+    return ["-F\"%s\"" % adjust_path(framework_path, settings) for framework_path in framework_paths]

--- a/conans/test/functional/toolchains/gnu/test_pkgconfigdeps_autotools.py
+++ b/conans/test/functional/toolchains/gnu/test_pkgconfigdeps_autotools.py
@@ -1,0 +1,103 @@
+import platform
+import textwrap
+
+import pytest
+
+from conans.test.utils.tools import TestClient
+
+
+@pytest.mark.tool_pkg_config
+@pytest.mark.tool_autotools
+@pytest.mark.skipif(platform.system() == "Windows", reason="Needs pkg-config")
+def test_pkg_configdeps_definitions_escape():
+    client = TestClient(path_with_spaces=False)
+    # client.run("new autotools_lib -d name=pkg -d version=1.0")
+    conanfile_pkg = textwrap.dedent("""
+    from conan import ConanFile
+    from conan.tools.gnu import Autotools
+    from conan.tools.layout import basic_layout
+    from conan.tools.apple import fix_apple_shared_install_name
+
+
+    class PkgConan(ConanFile):
+        name = "pkg"
+        version = "1.0"
+        settings = "os", "compiler", "build_type", "arch"
+        exports_sources = "configure.ac", "Makefile.am", "src/*"
+        generators = "AutotoolsToolchain"
+
+        def layout(self):
+            basic_layout(self)
+
+        def build(self):
+            autotools = Autotools(self)
+            autotools.autoreconf()
+            autotools.configure()
+            autotools.make()
+
+        def package(self):
+            autotools = Autotools(self)
+            autotools.install()
+            fix_apple_shared_install_name(self)
+
+        def package_info(self):
+            self.cpp_info.libs = ["pkg"]
+            self.cpp_info.frameworkdirs = ["/my/framework/file1", "/my/framework/file2"]
+    """)
+    conanfile_test = textwrap.dedent("""
+    import os
+    from conan import ConanFile
+    from conan.tools.gnu import Autotools
+    from conan.tools.layout import basic_layout
+    from conan.tools.build import cross_building
+    class PkgTestConan(ConanFile):
+        settings = "os", "compiler", "build_type", "arch"
+        generators = "PkgConfigDeps", "AutotoolsToolchain", "VirtualBuildEnv", "VirtualRunEnv"
+        apply_env = False
+        test_type = "explicit"
+
+        def requirements(self):
+            self.requires(self.tested_reference_str)
+
+        def build(self):
+            autotools = Autotools(self)
+            autotools.autoreconf()
+            autotools.configure()
+            autotools.make()
+
+        def layout(self):
+            basic_layout(self)
+
+        def test(self):
+            if not cross_building(self):
+                cmd = os.path.join(self.cpp.build.bindirs[0], "main")
+                self.run(cmd, env="conanrun")
+    """)
+    configure_test = textwrap.dedent("""
+    AC_INIT([main], [1.0], [])
+    AM_INIT_AUTOMAKE([-Wall -Werror foreign])
+    AC_PROG_CXX
+    PKG_PROG_PKG_CONFIG
+    PKG_CHECK_MODULES([pkg], [pkg >= 1.0])
+    AC_CONFIG_FILES([Makefile])
+    AC_OUTPUT
+    """)
+    makefile_test = textwrap.dedent("""
+    bin_PROGRAMS = main
+    main_SOURCES = main.cpp
+    AM_CXXFLAGS = $(pkg_CFLAGS)
+    main_LDADD = $(pkg_LIBS)
+    """)
+    client.run("new pkg/1.0 -m autotools_lib")
+    client.save({"conanfile.py": conanfile_pkg,
+                 "test_package/conanfile.py": conanfile_test,
+                 "test_package/configure.ac": configure_test,
+                 "test_package/Makefile.am": makefile_test,
+                 })
+    client.run("create .")
+    if platform.system() == "Darwin":
+        # Checking that frameworkdirs appear all together instead of "-F /whatever/f1"
+        assert '-F/my/framework/file1' in client.out
+        assert '-F/my/framework/file2' in client.out
+        assert "warning: directory not found for option '-F/my/framework/file1'" in client.out
+        assert "warning: directory not found for option '-F/my/framework/file2'" in client.out

--- a/conans/test/unittests/client/build/autotools_environment_test.py
+++ b/conans/test/unittests/client/build/autotools_environment_test.py
@@ -236,7 +236,7 @@ class AutoToolsConfigureTest(unittest.TestCase):
                                 '-D_GLIBCXX_USE_CXX11_ABI=0',
                     'CXXFLAGS': 'a_c_flag -m32 -O3 -s --sysroot=/path/to/folder a_cxx_flag',
                     'LDFLAGS': 'shared_link_flag exe_link_flag -framework oneframework -framework twoframework '
-                               '-F one/framework/path -m32 --sysroot=/path/to/folder -Lone/lib/path',
+                               '-F\"one/framework/path\" -m32 --sysroot=/path/to/folder -Lone/lib/path',
                     'LIBS': '-lonelib -ltwolib -lonesystemlib -ltwosystemlib'}
 
         self.assertEqual(be.vars, expected)
@@ -254,7 +254,7 @@ class AutoToolsConfigureTest(unittest.TestCase):
                                 ' -D_GLIBCXX_USE_CXX11_ABI=0',
                     'CXXFLAGS': 'a_c_flag -m64 -g --sysroot=/path/to/folder a_cxx_flag',
                     'LDFLAGS': 'shared_link_flag exe_link_flag -framework oneframework -framework twoframework '
-                               '-F one/framework/path -m64 --sysroot=/path/to/folder -Lone/lib/path',
+                               '-F\"one/framework/path\" -m64 --sysroot=/path/to/folder -Lone/lib/path',
                     'LIBS': '-lonelib -ltwolib -lonesystemlib -ltwosystemlib'}
         be = AutoToolsBuildEnvironment(conanfile)
         self.assertEqual(be.vars, expected)
@@ -272,7 +272,7 @@ class AutoToolsConfigureTest(unittest.TestCase):
                                 ' -DNDEBUG -D_GLIBCXX_USE_CXX11_ABI=0',
                     'CXXFLAGS': 'a_c_flag -m64 -O3 --sysroot=/path/to/folder a_cxx_flag -stdlib=libstdc++',
                     'LDFLAGS': 'shared_link_flag exe_link_flag -framework oneframework -framework twoframework '
-                               '-F one/framework/path -m64 --sysroot=/path/to/folder -Lone/lib/path',
+                               '-F\"one/framework/path\" -m64 --sysroot=/path/to/folder -Lone/lib/path',
                     'LIBS': '-lonelib -ltwolib -lonesystemlib -ltwosystemlib'}
         be = AutoToolsBuildEnvironment(conanfile)
         self.assertEqual(be.vars, expected)
@@ -289,7 +289,7 @@ class AutoToolsConfigureTest(unittest.TestCase):
                     'CPPFLAGS': '-Ipath/includes -Iother/include/path -Donedefinition -Dtwodefinition -DNDEBUG',
                     'CXXFLAGS': 'a_c_flag -m64 -O3 --sysroot=/path/to/folder a_cxx_flag -stdlib=libc++',
                     'LDFLAGS': 'shared_link_flag exe_link_flag -framework oneframework -framework twoframework '
-                               '-F one/framework/path -m64 --sysroot=/path/to/folder -Lone/lib/path',
+                               '-F\"one/framework/path\" -m64 --sysroot=/path/to/folder -Lone/lib/path',
                     'LIBS': '-lonelib -ltwolib -lonesystemlib -ltwosystemlib'}
         be = AutoToolsBuildEnvironment(conanfile)
         self.assertEqual(be.vars, expected)
@@ -307,7 +307,7 @@ class AutoToolsConfigureTest(unittest.TestCase):
                                 '-D_GLIBCXX_USE_CXX11_ABI=1',
                     'CXXFLAGS': 'a_c_flag -m64 -O3 -s --sysroot=/path/to/folder a_cxx_flag',
                     'LDFLAGS': 'shared_link_flag exe_link_flag -framework oneframework -framework twoframework '
-                               '-F one/framework/path -m64 --sysroot=/path/to/folder -Lone/lib/path',
+                               '-F\"one/framework/path\" -m64 --sysroot=/path/to/folder -Lone/lib/path',
                     'LIBS': '-lonelib -ltwolib -lonesystemlib -ltwosystemlib'}
         be = AutoToolsBuildEnvironment(conanfile)
         self.assertEqual(be.vars, expected)
@@ -387,7 +387,7 @@ class AutoToolsConfigureTest(unittest.TestCase):
                                 '-D_GLIBCXX_USE_CXX11_ABI=1',
                     'CXXFLAGS': 'a_c_flag -m64 -O3 -s --sysroot=/path/to/folder a_cxx_flag',
                     'LDFLAGS': 'shared_link_flag exe_link_flag -framework oneframework -framework twoframework '
-                               '-F one/framework/path -m64 --sysroot=/path/to/folder '
+                               '-F\"one/framework/path\" -m64 --sysroot=/path/to/folder '
                                '-Wl,-rpath,"one/lib/path" -Lone/lib/path',
                     'LIBS': '-lonelib -ltwolib -lonesystemlib -ltwosystemlib'}
         be = AutoToolsBuildEnvironment(conanfile, include_rpath_flags=True)
@@ -414,7 +414,7 @@ class AutoToolsConfigureTest(unittest.TestCase):
                         'CXXFLAGS': 'a_c_flag -m64 -g --sysroot=/path/to/folder a_cxx_flag -additionalcxxflag',
                         'LIBS': '-lonelib -ltwolib -lonesystemlib -ltwosystemlib -additionallibs',
                         'LDFLAGS': 'shared_link_flag exe_link_flag -framework oneframework '
-                                   '-framework twoframework -F one/framework/path -m64 '
+                                   '-framework twoframework -F\"one/framework/path\" -m64 '
                                    '--sysroot=/path/to/folder -Lone/lib/path -additionalldflag',
                         'CFLAGS': 'a_c_flag -m64 -g --sysroot=/path/to/folder -additionalcflag'}
             self.assertEqual(be.vars, expected)

--- a/conans/test/unittests/client/generators/compiler_args_test.py
+++ b/conans/test/unittests/client/generators/compiler_args_test.py
@@ -78,7 +78,7 @@ class CompilerArgsTest(unittest.TestCase):
                          ' cxx_flag1 c_flag1 -m32 -O3 -s -DNDEBUG'
                          ' -Wl,-rpath,"/root/lib" -Wl,-rpath,"/root/path/to/lib1"'
                          ' -L/root/lib -L/root/path/to/lib1 -lmylib'
-                         ' -F /root/Frameworks -std=gnu++17', gcc.content)
+                         ' -F"/root/Frameworks" -std=gnu++17', gcc.content)
 
         settings.arch = "x86_64"
         settings.build_type = "Debug"
@@ -89,7 +89,7 @@ class CompilerArgsTest(unittest.TestCase):
                          ' cxx_flag1 c_flag1 -m64 -g'
                          ' -Wl,-rpath,"/root/lib" -Wl,-rpath,"/root/path/to/lib1"'
                          ' -L/root/lib -L/root/path/to/lib1 -lmylib'
-                         ' -D_GLIBCXX_USE_CXX11_ABI=1 -F /root/Frameworks -std=gnu++17',
+                         ' -D_GLIBCXX_USE_CXX11_ABI=1 -F"/root/Frameworks" -std=gnu++17',
                          gcc.content)
 
         settings.compiler.libcxx = "libstdc++"
@@ -98,7 +98,7 @@ class CompilerArgsTest(unittest.TestCase):
                          ' cxx_flag1 c_flag1 -m64 -g'
                          ' -Wl,-rpath,"/root/lib" -Wl,-rpath,"/root/path/to/lib1"'
                          ' -L/root/lib -L/root/path/to/lib1 -lmylib'
-                         ' -D_GLIBCXX_USE_CXX11_ABI=0 -F /root/Frameworks -std=gnu++17',
+                         ' -D_GLIBCXX_USE_CXX11_ABI=0 -F"/root/Frameworks" -std=gnu++17',
                          gcc.content)
 
         settings.os = "Windows"
@@ -112,7 +112,7 @@ class CompilerArgsTest(unittest.TestCase):
                          ' cxx_flag1 c_flag1 -m32 -O3 -s -DNDEBUG'
                          ' -Wl,-rpath,"/root/lib" -Wl,-rpath,"/root/path/to/lib1"'
                          ' -L/root/lib -L/root/path/to/lib1 -lmylib'
-                         ' -D_GLIBCXX_USE_CXX11_ABI=0 -F /root/Frameworks -std=gnu++17',
+                         ' -D_GLIBCXX_USE_CXX11_ABI=0 -F"/root/Frameworks" -std=gnu++17',
                          gcc.content)
 
     def test_compiler_args(self):
@@ -142,7 +142,7 @@ class CompilerArgsTest(unittest.TestCase):
                          ' cxx_flag1 c_flag1 -m32 -O3 -DNDEBUG'
                          ' -Wl,-rpath,"/root/lib" -Wl,-rpath,"/root/path/to/lib1"'
                          ' -L/root/lib -L/root/path/to/lib1 -lmylib'
-                         ' -F /root/Frameworks', gen.content)
+                         ' -F"/root/Frameworks"', gen.content)
 
         settings = Settings.loads(get_default_settings_yml())
         settings.os = "Linux"
@@ -158,7 +158,7 @@ class CompilerArgsTest(unittest.TestCase):
                          ' cxx_flag1 c_flag1 -m32 -O3 -DNDEBUG'
                          ' -Wl,-rpath,"/root/lib" -Wl,-rpath,"/root/path/to/lib1"'
                          ' -L/root/lib -L/root/path/to/lib1 -lmylib'
-                         ' -F /root/Frameworks', args.content)
+                         ' -F"/root/Frameworks"', args.content)
 
     def test_apple_frameworks(self):
         settings = Settings.loads(get_default_settings_yml())
@@ -175,8 +175,8 @@ class CompilerArgsTest(unittest.TestCase):
                          ' -Wl,-rpath,"/root/lib" -Wl,-rpath,"/root/path/to/lib1"'
                          ' -L/root/lib -L/root/path/to/lib1 -lmylib'
                          ' -framework AVFoundation -framework VideoToolbox'
-                         ' -F /root/Frameworks -F /root/path/to/Frameworks1'
-                         ' -F /root/path/to/Frameworks2', args.content)
+                         ' -F"/root/Frameworks" -F"/root/path/to/Frameworks1"'
+                         ' -F"/root/path/to/Frameworks2"', args.content)
 
     def test_system_libs(self):
         settings = Settings.loads(get_default_settings_yml())
@@ -192,4 +192,4 @@ class CompilerArgsTest(unittest.TestCase):
                          ' cxx_flag1 c_flag1 -m64 -O3 -s -DNDEBUG'
                          ' -Wl,-rpath,"/root/lib" -Wl,-rpath,"/root/path/to/lib1"'
                          ' -L/root/lib -L/root/path/to/lib1 -lmylib -lsystem_lib1'
-                         ' -F /root/Frameworks', args.content)
+                         ' -F"/root/Frameworks"', args.content)

--- a/conans/test/unittests/client/generators/pkg_config_test.py
+++ b/conans/test/unittests/client/generators/pkg_config_test.py
@@ -214,6 +214,6 @@ includedir=${prefix}/include
 Name: MyPkg
 Description: My cool description
 Version: 1.3
-Libs: -L"${libdir}" -Wl,-rpath,"${libdir}" -framework AudioUnit -framework AudioToolbox -F /dummy_root_folder1/Frameworks
+Libs: -L"${libdir}" -Wl,-rpath,"${libdir}" -framework AudioUnit -framework AudioToolbox -F"/dummy_root_folder1/Frameworks"
 Cflags: -I"${includedir}"
 """)

--- a/conans/test/unittests/tools/gnu/gnudepsflags_test.py
+++ b/conans/test/unittests/tools/gnu/gnudepsflags_test.py
@@ -28,6 +28,6 @@ def test_framework_flags_only_for_apple_os(os_):
     expected_framework_path = []
     if is_apple_os(conanfile):
         expected_framework = ["-framework Foundation"]
-        expected_framework_path = ["-F Framework"]
+        expected_framework_path = ["-F\"Framework\""]
     assert gnudepsflags.frameworks == expected_framework
     assert gnudepsflags.framework_paths == expected_framework_path


### PR DESCRIPTION
Changelog: Fix: omit
Docs: omit

I faced this bug in this PR https://github.com/conan-io/conan-center-index/pull/12371
> The cause of the error on Mac is the generated pkgconfig files. As can be seen in the log files:
> ```
> imagemagick/7.1.0-45: 
> ld: warning: directory not found for option '-F-F'
> ld: warning: directory not found for option '-F-F'
> ld: warning: directory not found for option '-F-F'
> ld: warning: directory not found for option '-F-F'
> ld: warning: directory not found for option '-F-F'
> ld: warning: directory not found for option '-F-Wl,-rpath'
> ld: warning: directory not found for option '-F-F'
> ld: warning: directory not found for option '-F-F'
> ld: warning: directory not found for option '-F-pthread'
> ```
> Now why would we have two "-F" flags following each other? It turns out it's because the generated pkgconfig files happen to have something like
> ```
> Libs: -L"${libdir1}" -F <framework-path> // notice the whitespace in between
> ```
> For some reason pkgconf decides to reorder the libs, which causes several "-F" flags following each other.
> 
> For a minimal example try
> 
> testlib1.pc:
> ```
> Name: testlib1
> Description: test library 1
> Version: 1.0
> Libs: -ltestlib1 -F /some-directory
> ```
> testlib2.pc:
> ```
> Name: testlib2
> Description: test library 2
> Version: 1.0
> Libs: -ltestlib2 -F /some-directory
> Requires: testlib1
> ```
> 
> Now if we run `pkgconf --libs testlib2` we get
> ```
> -ltestlib2 -F -ltestlib1 /some-directory
> ```
> which is of course incorrect.

I also found out that autotools' libtool reorders passed LDFLAGS, causing the same error.

Fixes #11867 and probably #12106