### PR TITLE
Use settings_target in xcrun instead of settings

### DIFF
--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -79,14 +79,14 @@ def apple_sdk_path(conanfile):
 
 class XCRun(object):
 
-    def __init__(self, conanfile, sdk=None, use_target_settings=False):
+    def __init__(self, conanfile, sdk=None, use_settings_target=False):
         """sdk=False will skip the flag
            sdk=None will try to adjust it automatically
            target_settings=True try to use settings_target in case they exist"""
 
         # FIXME: 2.0: remove "hasattr()" condition
         settings = conanfile.settings
-        if use_target_settings and hasattr(conanfile, "settings_target") and conanfile.settings_target is not None:
+        if use_settings_target and hasattr(conanfile, "settings_target") and conanfile.settings_target is not None:
             settings = conanfile.settings_target
 
         if sdk is None and settings:

--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -83,13 +83,10 @@ class XCRun(object):
         """sdk=False will skip the flag
            sdk=None will try to adjust it automatically"""
 
-        if hasattr(conanfile, "settings_target"):
-            settings_target = conanfile.settings_target
-        else:
-            settings_target = conanfile.settings
+        settings = conanfile.settings_target if hasattr(conanfile, "settings_target") else conanfile.settings
 
-        if sdk is None and settings_target:
-            sdk = apple_sdk_name(settings_target)
+        if sdk is None and settings:
+            sdk = apple_sdk_name(settings)
         self.sdk = sdk
 
     def _invoke(self, args):

--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -79,14 +79,15 @@ def apple_sdk_path(conanfile):
 
 class XCRun(object):
 
-    def __init__(self, conanfile, sdk=None):
+    def __init__(self, conanfile, sdk=None, use_target_settings=True):
         """sdk=False will skip the flag
-           sdk=None will try to adjust it automatically"""
+           sdk=None will try to adjust it automatically
+           target_settings=True try to use settings_target in case they exist"""
 
-        if hasattr(conanfile, "settings_target") and conanfile.settings_target is not None:
+        # FIXME: 2.0: remove "hasattr()" condition
+        settings = conanfile.settings
+        if use_target_settings and hasattr(conanfile, "settings_target") and conanfile.settings_target is not None:
             settings = conanfile.settings_target
-        else:
-            settings = conanfile.settings
 
         if sdk is None and settings:
             sdk = apple_sdk_name(settings)

--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -83,10 +83,13 @@ class XCRun(object):
         """sdk=False will skip the flag
            sdk=None will try to adjust it automatically"""
 
-        settings = conanfile.settings_target if hasattr(conanfile, "settings_target") else conanfile.settings
+        if hasattr(conanfile, "settings_target") and conanfile.settings_target is not None:
+            settings_target = conanfile.settings_target
+        else:
+            settings_target = conanfile.settings
 
-        if sdk is None and settings:
-            sdk = apple_sdk_name(settings)
+        if sdk is None and settings_target:
+            sdk = apple_sdk_name(settings_target)
         self.sdk = sdk
 
     def _invoke(self, args):

--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -79,7 +79,7 @@ def apple_sdk_path(conanfile):
 
 class XCRun(object):
 
-    def __init__(self, conanfile, sdk=None, use_target_settings=True):
+    def __init__(self, conanfile, sdk=None, use_target_settings=False):
         """sdk=False will skip the flag
            sdk=None will try to adjust it automatically
            target_settings=True try to use settings_target in case they exist"""

--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -82,8 +82,14 @@ class XCRun(object):
     def __init__(self, conanfile, sdk=None):
         """sdk=False will skip the flag
            sdk=None will try to adjust it automatically"""
-        if sdk is None and conanfile.settings:
-            sdk = apple_sdk_name(conanfile.settings)
+
+        if hasattr(conanfile, "settings_target"):
+            settings_target = conanfile.settings_target
+        else:
+            settings_target = conanfile.settings
+
+        if sdk is None and settings_target:
+            sdk = apple_sdk_name(settings_target)
         self.sdk = sdk
 
     def _invoke(self, args):

--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -84,12 +84,12 @@ class XCRun(object):
            sdk=None will try to adjust it automatically"""
 
         if hasattr(conanfile, "settings_target") and conanfile.settings_target is not None:
-            settings_target = conanfile.settings_target
+            settings = conanfile.settings_target
         else:
-            settings_target = conanfile.settings
+            settings = conanfile.settings
 
-        if sdk is None and settings_target:
-            sdk = apple_sdk_name(settings_target)
+        if sdk is None and settings:
+            sdk = apple_sdk_name(settings)
         self.sdk = sdk
 
     def _invoke(self, args):

--- a/conans/test/functional/tools/test_apple_tools.py
+++ b/conans/test/functional/tools/test_apple_tools.py
@@ -45,7 +45,7 @@ def test_xcrun_in_tool_requires():
     client.run("export br.py br/0.1@")
 
     conanfile = textwrap.dedent("""
-        from conans import ConanFile
+        from conan import ConanFile
         class Pkg(ConanFile):
             settings = "os", "compiler", "build_type", "arch"
             tool_requires = "br/0.1"

--- a/conans/test/functional/tools/test_apple_tools.py
+++ b/conans/test/functional/tools/test_apple_tools.py
@@ -83,7 +83,7 @@ def test_xcrun_in_required_by_tool_requires():
     client = TestClient()
 
     openssl = textwrap.dedent("""
-        from conans import ConanFile
+        from conan import ConanFile
         from conan.tools.apple import XCRun
         class Pkg(ConanFile):
             settings = "os", "compiler", "build_type", "arch"

--- a/conans/test/functional/tools/test_apple_tools.py
+++ b/conans/test/functional/tools/test_apple_tools.py
@@ -75,6 +75,11 @@ def test_xcrun_in_tool_requires():
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Requires Xcode")
 def test_xcrun_in_required_by_tool_requires():
+    """
+    ConanCenter case, most typical, openssl builds with autotools so needs the sysroot
+    and is a require by cmake so in the build context it needs the settings_build, not
+    the settings_target, that's why the use_target_settings default is False
+    """
     client = TestClient()
 
     openssl = textwrap.dedent("""

--- a/conans/test/functional/tools/test_apple_tools.py
+++ b/conans/test/functional/tools/test_apple_tools.py
@@ -41,7 +41,7 @@ def test_xcrun_in_tool_requires():
                 xcrun = XCRun(self{})
                 self.output.info("sdk: %s" % xcrun.sdk)
         """)
-    client.save({"br.py": tool.format(", use_target_settings=True")})
+    client.save({"br.py": tool.format(", use_settings_target=True")})
     client.run("export br.py br/0.1@")
 
     conanfile = textwrap.dedent("""
@@ -78,7 +78,7 @@ def test_xcrun_in_required_by_tool_requires():
     """
     ConanCenter case, most typical, openssl builds with autotools so needs the sysroot
     and is a require by cmake so in the build context it needs the settings_build, not
-    the settings_target, that's why the use_target_settings default is False
+    the settings_target, that's why the use_settings_target default is False
     """
     client = TestClient()
 

--- a/conans/test/functional/tools/test_apple_tools.py
+++ b/conans/test/functional/tools/test_apple_tools.py
@@ -93,7 +93,7 @@ def test_xcrun_in_required_by_tool_requires():
         """)
 
     consumer = textwrap.dedent("""
-        from conans import ConanFile
+        from conan import ConanFile
         class Pkg(ConanFile):
             settings = "os", "compiler", "build_type", "arch"
             tool_requires = "cmake/1.0"

--- a/conans/test/functional/tools/test_apple_tools.py
+++ b/conans/test/functional/tools/test_apple_tools.py
@@ -40,7 +40,7 @@ def test_xcrun_in_tool_requires():
                 xcrun = XCRun(self{})
                 self.output.info("sdk: %s" % xcrun.sdk)
         """)
-    client.save({"br.py": tool.format("")})
+    client.save({"br.py": tool.format(", use_target_settings=True")})
     client.run("export br.py br/0.1@")
 
     conanfile = textwrap.dedent("""
@@ -66,7 +66,7 @@ def test_xcrun_in_tool_requires():
     assert "br/0.1: sdk: iphoneos15.0" in client.out
     assert "br/0.1: sdk: macosx" not in client.out
 
-    client.save({"br.py": tool.format(", use_target_settings=False")})
+    client.save({"br.py": tool.format("")})
     client.run("export br.py br/0.1@")
     client.run("create . pkg/1.0@ -pr:h=./profile_ios -pr:b=default --build")
     assert "br/0.1: sdk: iphoneos15.0" not in client.out

--- a/conans/test/functional/tools/test_apple_tools.py
+++ b/conans/test/functional/tools/test_apple_tools.py
@@ -116,5 +116,5 @@ def test_xcrun_in_required_by_tool_requires():
 
     client.run("export openssl.py openssl/1.0@")
     client.run("export cmake.py")
-    client.run("create consumer.py consumer/1.0@ --build -pr:h=./profile_ios -pr:b=default --build")
+    client.run("create consumer.py consumer/1.0@ -pr:h=./profile_ios -pr:b=default --build")
     assert "sdk for building openssl: macosx" in client.out

--- a/conans/test/functional/tools/test_apple_tools.py
+++ b/conans/test/functional/tools/test_apple_tools.py
@@ -37,11 +37,11 @@ def test_xcrun_in_tool_requires():
             settings = "os", "compiler", "build_type", "arch"
 
             def package_info(self):
-                xcrun = XCRun(self)
-                self.output.info(f"sdk: {xcrun.sdk}")
+                xcrun = XCRun(self{})
+                self.output.info("sdk: %s" % xcrun.sdk)
         """)
-    client.save({"conanfile.py": tool})
-    client.run("export . br/0.1@")
+    client.save({"br.py": tool.format("")})
+    client.run("export br.py br/0.1@")
 
     conanfile = textwrap.dedent("""
         from conans import ConanFile
@@ -62,6 +62,12 @@ def test_xcrun_in_tool_requires():
     """)
 
     client.save({"conanfile.py": conanfile, "profile_ios": profile_ios})
-    client.run("create . pkg/1.0@ -pr:h=./profile_ios -pr:b=default --build=missing")
+    client.run("create . pkg/1.0@ -pr:h=./profile_ios -pr:b=default --build")
     assert "br/0.1: sdk: iphoneos15.0" in client.out
     assert "br/0.1: sdk: macosx" not in client.out
+
+    client.save({"br.py": tool.format(", use_target_settings=False")})
+    client.run("export br.py br/0.1@")
+    client.run("create . pkg/1.0@ -pr:h=./profile_ios -pr:b=default --build")
+    assert "br/0.1: sdk: iphoneos15.0" not in client.out
+    assert "br/0.1: sdk: macosx" in client.out

--- a/conans/test/functional/tools/test_apple_tools.py
+++ b/conans/test/functional/tools/test_apple_tools.py
@@ -32,7 +32,7 @@ def test_xcrun_in_tool_requires():
     # https://github.com/conan-io/conan/issues/12260
     client = TestClient()
     tool = textwrap.dedent("""
-        from conans import ConanFile
+        from conan import ConanFile
         from conan.tools.apple import XCRun
         class Pkg(ConanFile):
             settings = "os", "compiler", "build_type", "arch"


### PR DESCRIPTION
Changelog: Fix: Use `settings_target` in XCRun instead of settings as default and provide argument `use_settings_target ` to select using the active context settings.
Docs: https://github.com/conan-io/docs/pull/2797

`use_settings_target` is `False` by default because because of the use of this tool in ConanCenter, for example _openssl_ builds with _AutoTools_ so needs the **sysroot** (uses _XCRun.sdk_) and is a require by _CMake_ so in the **build context** it needs the `settings_build`, not the `settings_target`

To discuss: `use_settings_target ` default and name.

TODO: Check other tools that may need this fix too

Closes: https://github.com/conan-io/conan/issues/12260


