### PR TITLE
Do not add architecture to system packages by default, only when cross-compiling

### DIFF
--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -1,5 +1,6 @@
 import platform
 
+from conan.tools.build import cross_building
 from conans.client.graph.graph import CONTEXT_BUILD
 from conans.errors import ConanException
 
@@ -57,7 +58,7 @@ class _SystemPackageManagerTool(object):
 
     def get_package_name(self, package):
         # TODO: should we only add the arch if cross-building?
-        if self._arch in self._arch_names:
+        if self._arch in self._arch_names and cross_building(self._conanfile):
             return "{}{}{}".format(package, self._arch_separator,
                                    self._arch_names.get(self._arch))
         return package

--- a/conans/test/functional/tools/system/package_manager_test.py
+++ b/conans/test/functional/tools/system/package_manager_test.py
@@ -50,11 +50,11 @@ def test_apt_install_substitutes():
     client.save({"conanfile.py": conanfile_py.format(installs)})
     client.run("create . test/1.0@ -c tools.system.package_manager:mode=install "
                "-c tools.system.package_manager:sudo=True", assert_error=True)
-
-    assert "dpkg-query: no packages found matching non-existing1:amd64" in client.out
-    assert "dpkg-query: no packages found matching non-existing2:amd64" in client.out
-    assert "dpkg-query: no packages found matching non-existing3:amd64" in client.out
-    assert "dpkg-query: no packages found matching non-existing4:amd64" in client.out
+    print(client.out)
+    assert "dpkg-query: no packages found matching non-existing1" in client.out
+    assert "dpkg-query: no packages found matching non-existing2" in client.out
+    assert "dpkg-query: no packages found matching non-existing3" in client.out
+    assert "dpkg-query: no packages found matching non-existing4" in client.out
     assert "ERROR: while executing system_requirements(): " \
            "None of the installs for the package substitutes succeeded." in client.out
 
@@ -88,6 +88,7 @@ def test_build_require():
             tool_requires = "tool_require/1.0"
         """)})
     client.run("create consumer.py consumer/1.0@ -s:b arch=armv8 -s:h arch=x86 --build=missing")
+    print(client.out)
     assert "dpkg-query: no packages found matching non-existing1:arm64" in client.out
     assert "dpkg-query: no packages found matching non-existing2:arm64" in client.out
     assert "missing: ['non-existing1', 'non-existing2']" in client.out

--- a/conans/test/functional/tools/system/package_manager_test.py
+++ b/conans/test/functional/tools/system/package_manager_test.py
@@ -50,7 +50,6 @@ def test_apt_install_substitutes():
     client.save({"conanfile.py": conanfile_py.format(installs)})
     client.run("create . test/1.0@ -c tools.system.package_manager:mode=install "
                "-c tools.system.package_manager:sudo=True", assert_error=True)
-    print(client.out)
     assert "dpkg-query: no packages found matching non-existing1" in client.out
     assert "dpkg-query: no packages found matching non-existing2" in client.out
     assert "dpkg-query: no packages found matching non-existing3" in client.out
@@ -88,9 +87,8 @@ def test_build_require():
             tool_requires = "tool_require/1.0"
         """)})
     client.run("create consumer.py consumer/1.0@ -s:b arch=armv8 -s:h arch=x86 --build=missing")
-    print(client.out)
-    assert "dpkg-query: no packages found matching non-existing1:arm64" in client.out
-    assert "dpkg-query: no packages found matching non-existing2:arm64" in client.out
+    assert "dpkg-query: no packages found matching non-existing1" in client.out
+    assert "dpkg-query: no packages found matching non-existing2" in client.out
     assert "missing: ['non-existing1', 'non-existing2']" in client.out
 
 


### PR DESCRIPTION
Changelog: Feature: Do not add architecture to system packages by default, only when cross-compiling.
Docs: omit

The most common situation when installing system packages is that you don't use the architecture in the package name unless you are cross-compiling, so this defaults to that behaviour.
Also it's testing how to install archless packages even with cross-compilation, but that's something we probably want to change as the code would look a bit ugly. You can workaround that with an empty dictionary as arch_names in classes that accept the argument:

```
Apt(self).install(["libudev-dev"], update=True, check=True)
Apt(self, arch_names={}).install(["archless-package"], update=True, check=True)
```



Closes: https://github.com/conan-io/conan/issues/12320