### PR TITLE
removed the unnecessary mutually exclusive group in "conan list" command

### DIFF
--- a/conan/cli/commands/list.py
+++ b/conan/cli/commands/list.py
@@ -97,9 +97,8 @@ def print_list_package_ids(results):
 
 
 def _add_remotes_and_cache_options(subparser):
-    remotes_group = subparser.add_mutually_exclusive_group()
-    remotes_group.add_argument("-r", "--remote", default=None, action=Extender,
-                               help="Remote names. Accepts wildcards")
+    subparser.add_argument("-r", "--remote", default=None, action=Extender,
+                           help="Remote names. Accepts wildcards")
     subparser.add_argument("-c", "--cache", action='store_true', help="Search in the local cache")
 
 


### PR DESCRIPTION
Changelog: (Fix): removed the unnecessary mutually exclusive group  from "conan list" command arguments parser

fixes #12346

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
