### PR TITLE
Implement `env_info` and `user_info` as fake attributes in Conan 2.0 so the error is not thrown

### DIFF
--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -30,6 +30,15 @@ class DefaultOrderedDict(OrderedDict):
         return the_copy
 
 
+class MockInfoProperty(dict):
+    """
+    # TODO: Remove in 2.X
+    to mock user_info and env_info
+    """
+    __getattr__ = dict.get
+    __setattr__ = dict.__setitem__
+
+
 class _Component(object):
 
     def __init__(self, set_defaults=False):
@@ -62,6 +71,8 @@ class _Component(object):
         # LEGACY 1.X fields, can be removed in 2.X
         self.names = {}
         self.filenames = {}
+        self.user_info = MockInfoProperty()
+        self.env_info = MockInfoProperty()
 
         if set_defaults:
             self.includedirs = ["include"]

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -52,7 +52,8 @@ class MockInfoProperty(object):
             ConanOutput().warning(self._message)
 
     def __setattr__(self, attr, value):
-        ConanOutput().warning(self._message)
+        if attr != "_message":
+            ConanOutput().warning(self._message)
         return super(MockInfoProperty, self).__setattr__(attr, value)
 
 

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -1,9 +1,11 @@
 import os
+from collections import defaultdict
 from pathlib import Path
 
 from conan.api.output import ConanOutput
 from conans.client.subsystems import command_env_wrapper
 from conans.errors import ConanException
+from conans.model.build_info import MockInfoProperty
 from conans.model.conf import Conf
 from conans.model.dependencies import ConanFileDependencies
 from conans.model.layout import Folders, Infos
@@ -212,6 +214,11 @@ class ConanFile:
     #: Configuration variables to be passed to the dependant recipes.
     #: Should be only filled in the ``package_info()`` method.
     conf_info = None
+
+    # LEGACY 1.X fields, can be removed in 2.X
+    deps_cpp_info = defaultdict(MockInfoProperty)
+    deps_env_info = defaultdict(MockInfoProperty)
+
 
     def __init__(self, display_name=""):
         self.display_name = display_name

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -215,7 +215,6 @@ class ConanFile:
     #: Should be only filled in the ``package_info()`` method.
     conf_info = None
 
-
     def __init__(self, display_name=""):
         self.display_name = display_name
         # something that can run commands, as os.sytem

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -259,8 +259,8 @@ class ConanFile:
         self.cpp = Infos()
 
         # LEGACY 1.X fields, can be removed in 2.X
-        self.deps_cpp_info = defaultdict(MockInfoProperty)
-        self.deps_env_info = defaultdict(MockInfoProperty)
+        self.deps_cpp_info = defaultdict(lambda: MockInfoProperty("ConanFile.deps_cpp_info"))
+        self.deps_env_info = defaultdict(lambda: MockInfoProperty("ConanFile.deps_env_info"))
 
 
 

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -258,12 +258,6 @@ class ConanFile:
         self.folders = Folders()
         self.cpp = Infos()
 
-        # LEGACY 1.X fields, can be removed in 2.X
-        self.deps_cpp_info = defaultdict(lambda: MockInfoProperty("ConanFile.deps_cpp_info"))
-        self.deps_env_info = defaultdict(lambda: MockInfoProperty("ConanFile.deps_env_info"))
-
-
-
     def serialize(self):
         result = {}
         for a in ("url", "license", "author", "description", "topics", "homepage", "build_policy",

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -1,11 +1,9 @@
 import os
-from collections import defaultdict
 from pathlib import Path
 
 from conan.api.output import ConanOutput
 from conans.client.subsystems import command_env_wrapper
 from conans.errors import ConanException
-from conans.model.build_info import MockInfoProperty
 from conans.model.conf import Conf
 from conans.model.dependencies import ConanFileDependencies
 from conans.model.layout import Folders, Infos

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -215,10 +215,6 @@ class ConanFile:
     #: Should be only filled in the ``package_info()`` method.
     conf_info = None
 
-    # LEGACY 1.X fields, can be removed in 2.X
-    deps_cpp_info = defaultdict(MockInfoProperty)
-    deps_env_info = defaultdict(MockInfoProperty)
-
 
     def __init__(self, display_name=""):
         self.display_name = display_name
@@ -261,6 +257,12 @@ class ConanFile:
         # layout() method related variables:
         self.folders = Folders()
         self.cpp = Infos()
+
+        # LEGACY 1.X fields, can be removed in 2.X
+        self.deps_cpp_info = defaultdict(MockInfoProperty)
+        self.deps_env_info = defaultdict(MockInfoProperty)
+
+
 
     def serialize(self):
         result = {}

--- a/conans/test/integration/conan_v2/test_legacy_cpp_info.py
+++ b/conans/test/integration/conan_v2/test_legacy_cpp_info.py
@@ -27,3 +27,10 @@ def test_legacy_names_filenames():
         """)
     c.save({"conanfile.py": conanfile})
     c.run("create .")
+    message = "WARN: The use of '{}' is deprecated in Conan 2.0 and will be removed in " \
+              "Conan 2.X. Please, update your recipes unless you are maintaining compatibility " \
+              "with Conan 1.X"
+
+    for name in ["cpp_info.names", "cpp_info.filenames", "cpp_info.env_info", "cpp_info.user_info",
+                 "ConanFile.deps_cpp_info", "ConanFile.deps_env_info"]:
+        assert message.format(name) in c.out

--- a/conans/test/integration/conan_v2/test_legacy_cpp_info.py
+++ b/conans/test/integration/conan_v2/test_legacy_cpp_info.py
@@ -18,6 +18,12 @@ def test_legacy_names_filenames():
                 self.cpp_info.names["cmake_find_package_multi"] = "absl"
                 self.cpp_info.filenames["cmake_find_package"] = "tensorflowlite"
                 self.cpp_info.filenames["cmake_find_package_multi"] = "tensorflowlite"
+
+                self.cpp_info.env_info.whatever = "whatever-env_info"
+                self.cpp_info.user_info.whatever = "whatever-user_info"
+
+                fake_user_info = self.deps_cpp_info["fake_dependency"].does_not_exist
+                fake_env_info = self.deps_env_info["fake_dependency"].does_not_exist
         """)
     c.save({"conanfile.py": conanfile})
     c.run("create .")

--- a/conans/test/integration/conan_v2/test_legacy_cpp_info.py
+++ b/conans/test/integration/conan_v2/test_legacy_cpp_info.py
@@ -21,9 +21,6 @@ def test_legacy_names_filenames():
 
                 self.cpp_info.env_info.whatever = "whatever-env_info"
                 self.cpp_info.user_info.whatever = "whatever-user_info"
-
-                fake_user_info = self.deps_cpp_info["fake_dependency"].does_not_exist
-                fake_env_info = self.deps_env_info["fake_dependency"].does_not_exist
         """)
     c.save({"conanfile.py": conanfile})
     c.run("create .")
@@ -31,6 +28,5 @@ def test_legacy_names_filenames():
               "Conan 2.X. Please, update your recipes unless you are maintaining compatibility " \
               "with Conan 1.X"
 
-    for name in ["cpp_info.names", "cpp_info.filenames", "cpp_info.env_info", "cpp_info.user_info",
-                 "ConanFile.deps_cpp_info", "ConanFile.deps_env_info"]:
+    for name in ["cpp_info.names", "cpp_info.filenames", "cpp_info.env_info", "cpp_info.user_info"]:
         assert message.format(name) in c.out


### PR DESCRIPTION
Changelog: Implement `env_info` and `user_info` as fake attributes in Conan 2.0 so the error is not thrown
Docs: add note to migration guide

Closes: https://github.com/conan-io/conan/issues/12334

TODO: [Output a warning message](https://github.com/conan-io/conan/issues/12345) in 2.0 to inform users that those attributes are deprecated (we should also include other things like .names that are still there to provide compatibility). This is in order to reduce the risk of breaking users when we pass from Conan 2.0 to 2.X
