### PR TITLE
Overwrite deactivate script to unset only the last activated virtual environment (#12344)

### DIFF
--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -350,7 +350,7 @@ class EnvVars:
         filepath, filename = os.path.split(file_location)
         deactivate_file = os.path.join(filepath, "deactivate_{}".format(filename))
         deactivate = textwrap.dedent("""\
-           echo "echo Restoring environment" >> "{deactivate_file}"
+           echo "echo Restoring environment" > "{deactivate_file}"
            for v in {vars}
            do
                is_defined="true"

--- a/conans/test/integration/environment/test_env.py
+++ b/conans/test/integration/environment/test_env.py
@@ -483,18 +483,19 @@ def test_multiple_deactivate():
     os.chmod(os.path.join(client.current_folder, "display.sh"), 0o777)
     client.run("install .")
 
-    if platform.system() == "Windows":
-        cmd = "conanbuild.bat && display.bat && deactivate_conanbuild.bat && display.bat"
-    else:
-        cmd = '. ./conanbuild.sh && ./display.sh && . ./deactivate_conanbuild.sh && ./display.sh'
-    out, _ = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                              shell=True, cwd=client.current_folder).communicate()
-    out = out.decode()
-    assert "VAR1=Value1!!" in out
-    assert "VAR2=Value2!!" in out
-    assert 2 == str(out).count("Restoring environment")
-    assert "VAR1=!!" in out
-    assert "VAR2=!!" in out
+    for _ in range(2):  # Just repeat it, so we can check things keep working
+        if platform.system() == "Windows":
+            cmd = "conanbuild.bat && display.bat && deactivate_conanbuild.bat && display.bat"
+        else:
+            cmd = '. ./conanbuild.sh && ./display.sh && . ./deactivate_conanbuild.sh && ./display.sh'
+        out, _ = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                  shell=True, cwd=client.current_folder).communicate()
+        out = out.decode()
+        assert "VAR1=Value1!!" in out
+        assert "VAR2=Value2!!" in out
+        assert 2 == str(out).count("Restoring environment")
+        assert "VAR1=!!" in out
+        assert "VAR2=!!" in out
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Path problem in Windows only")


### PR DESCRIPTION
Changelog: Fix: Overwrite deactivate script to unset only the last activated virtual environment.
Docs: omit

fixes #12344 

* Align with Windows behavior (save_bat())

No idea how to add a unit test to check that there is no duplication of the echo message.
I had a look at:
- https://github.com/conan-io/conan/blob/develop/conans/test/integration/environment/test_env.py
- https://github.com/conan-io/conan/blob/develop/conans/test/integration/build_requires/test_install_test_build_require.py#L183-L190

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 