### PR TITLE
fix auto_use=True crash with no generate()

### DIFF
--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -254,6 +254,7 @@ def write_toolchain(conanfile, path, output):
 
     # tools.env.virtualenv:auto_use will be always True in Conan 2.0
     if conanfile.conf["tools.env.virtualenv:auto_use"]:
+        mkdir(path)
         with chdir(path):
             if conanfile.virtualbuildenv:
                 from conan.tools.env.virtualbuildenv import VirtualBuildEnv

--- a/conans/test/integration/toolchains/gnu/test_basic_layout.py
+++ b/conans/test/integration/toolchains/gnu/test_basic_layout.py
@@ -23,3 +23,25 @@ def test_basic_layout_subproject():
     ext = "sh" if platform.system() != "Windows" else "bat"
     assert os.path.isfile(os.path.join(c.current_folder, "pkg", "build-release", "conan",
                                        "conanautotoolstoolchain.{}".format(ext)))
+
+
+# TODO: Remove this test in 2.0
+def test_basic_layout_no_generators():
+    """ test that conan doesn't crash for auto_use=True
+    because generator folder doesn't exist
+    # https://github.com/conan-io/conan/issues/12383
+    """
+    c = TestClient()
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.layout import basic_layout
+        class Pkg(ConanFile):
+            name = "pkg"
+            version = "0.1"
+            settings = "os", "compiler", "build_type", "arch"
+            def layout(self):
+                basic_layout(self)
+        """)
+    c.save({"conanfile.py": conanfile})
+    c.run("create . -c tools.env.virtualenv:auto_use=True")
+    # It used to fail, if it doesn't crash, it is good


### PR DESCRIPTION
Changelog: Bugfix: Avoid Conan crash when ``tools.env.environment:auto_use=True`` is enabled and no ``generate()`` method.
Docs: Omit

Close https://github.com/conan-io/conan/issues/12383