### PR TITLE
Bug/requires aggregation with transitive deps

### DIFF
--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -232,7 +232,7 @@ class Requirement:
         self.run = self.run or other.run
         self.visible |= other.visible
         self.force |= other.force
-        # self.direct |= other.direct
+        self.direct |= other.direct
         if not other.test:
             self.test = False  # it it was previously a test, but also required by non-test
         # TODO: self.package_id_mode => Choose more restrictive?

--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -232,7 +232,7 @@ class Requirement:
         self.run = self.run or other.run
         self.visible |= other.visible
         self.force |= other.force
-        self.direct |= other.direct
+        # self.direct |= other.direct
         if not other.test:
             self.test = False  # it it was previously a test, but also required by non-test
         # TODO: self.package_id_mode => Choose more restrictive?

--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -232,6 +232,7 @@ class Requirement:
         self.run = self.run or other.run
         self.visible |= other.visible
         self.force |= other.force
+        self.direct |= other.direct
         if not other.test:
             self.test = False  # it it was previously a test, but also required by non-test
         # TODO: self.package_id_mode => Choose more restrictive?

--- a/conans/test/integration/test_components_error.py
+++ b/conans/test/integration/test_components_error.py
@@ -51,5 +51,4 @@ def test_component_error():
     c.run("install t3")
 
     arch = c.get_default_host_profile().settings['arch']
-    assert 'list(APPEND t2_FIND_DEPENDENCY_NAMES T1)' in c.load(f"t3/t2-release-{arch}-data.cmake")
-    assert not os.path.exists(os.path.join(c.current_folder, "t3/t1-config.cmake"))
+    assert 'list(APPEND t2_FIND_DEPENDENCY_NAMES t1)' in c.load(f"t3/t2-release-{arch}-data.cmake")

--- a/conans/test/integration/test_components_error.py
+++ b/conans/test/integration/test_components_error.py
@@ -37,7 +37,7 @@ def test_component_error():
         class t3Conan(ConanFile):
             name = "t3"
             version = "0.1.0"
-            requires = "t2/0.1.0"
+            requires = "t1/0.1.0", "t2/0.1.0"
             package_type = "application"
             generators = "CMakeDeps"
             settings = "os", "arch", "compiler", "build_type"

--- a/conans/test/integration/test_components_error.py
+++ b/conans/test/integration/test_components_error.py
@@ -51,5 +51,5 @@ def test_component_error():
     c.run("install t3")
 
     arch = c.get_default_host_profile().settings['arch']
-    assert 'set(t2_FIND_DEPENDENCY_NAMES T1)' in c.load(f"t3/t2-release-{arch}-data.cmake")
+    assert 'list(APPEND t2_FIND_DEPENDENCY_NAMES T1)' in c.load(f"t3/t2-release-{arch}-data.cmake")
     assert not os.path.exists(os.path.join(c.current_folder, "t3/t1-config.cmake"))

--- a/conans/test/integration/test_components_error.py
+++ b/conans/test/integration/test_components_error.py
@@ -53,21 +53,3 @@ def test_component_error():
     arch = c.get_default_host_profile().settings['arch']
     assert 'set(t2_FIND_DEPENDENCY_NAMES "")' in c.load(f"t3/t2-release-{arch}-data.cmake")
     assert not os.path.exists(os.path.join(c.current_folder, "t3/t1-config.cmake"))
-
-    t4 = textwrap.dedent("""
-        from conan import ConanFile
-
-        class t4Conan(ConanFile):
-            name = "t4"
-            version = "0.1.0"
-            requires = "t1/0.1.0", "t2/0.1.0"
-            package_type = "application"
-            generators = "CMakeDeps"
-            settings = "os", "arch", "compiler", "build_type"
-        """)
-
-    c.save({"t4/conanfile.py": t4})
-    c.run("install t4")
-
-    arch = c.get_default_host_profile().settings['arch']
-    assert 'list(APPEND t2_FIND_DEPENDENCY_NAMES t1)' in c.load(f"t4/t2-release-{arch}-data.cmake")

--- a/conans/test/integration/test_components_error.py
+++ b/conans/test/integration/test_components_error.py
@@ -51,5 +51,5 @@ def test_component_error():
     c.run("install t3")
 
     arch = c.get_default_host_profile().settings['arch']
-    assert 'set(t2_FIND_DEPENDENCY_NAMES "")' in c.load(f"t3/t2-release-{arch}-data.cmake")
+    assert 'set(t2_FIND_DEPENDENCY_NAMES T1)' in c.load(f"t3/t2-release-{arch}-data.cmake")
     assert not os.path.exists(os.path.join(c.current_folder, "t3/t1-config.cmake"))

--- a/conans/test/integration/test_components_error.py
+++ b/conans/test/integration/test_components_error.py
@@ -1,4 +1,4 @@
-import os.path
+import os
 import textwrap
 
 from conans.test.utils.tools import TestClient
@@ -37,7 +37,7 @@ def test_component_error():
         class t3Conan(ConanFile):
             name = "t3"
             version = "0.1.0"
-            requires = "t1/0.1.0", "t2/0.1.0"
+            requires = "t2/0.1.0"
             package_type = "application"
             generators = "CMakeDeps"
             settings = "os", "arch", "compiler", "build_type"
@@ -51,4 +51,23 @@ def test_component_error():
     c.run("install t3")
 
     arch = c.get_default_host_profile().settings['arch']
-    assert 'list(APPEND t2_FIND_DEPENDENCY_NAMES t1)' in c.load(f"t3/t2-release-{arch}-data.cmake")
+    assert 'set(t2_FIND_DEPENDENCY_NAMES "")' in c.load(f"t3/t2-release-{arch}-data.cmake")
+    assert not os.path.exists(os.path.join(c.current_folder, "t3/t1-config.cmake"))
+
+    t4 = textwrap.dedent("""
+        from conan import ConanFile
+
+        class t4Conan(ConanFile):
+            name = "t4"
+            version = "0.1.0"
+            requires = "t1/0.1.0", "t2/0.1.0"
+            package_type = "application"
+            generators = "CMakeDeps"
+            settings = "os", "arch", "compiler", "build_type"
+        """)
+
+    c.save({"t4/conanfile.py": t4})
+    c.run("install t4")
+
+    arch = c.get_default_host_profile().settings['arch']
+    assert 'list(APPEND t2_FIND_DEPENDENCY_NAMES t1)' in c.load(f"t4/t2-release-{arch}-data.cmake")


### PR DESCRIPTION
Changelog: Bugfix: Fix an issue with requires.direct being overwritten based on requirement ordering in recipe.
Docs: https://github.com/conan-io/docs/pull/XXXX (TBD)

See: https://github.com/conan-io/conan/issues/12372

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 
