### PR TITLE
Make build_folder available in generate() for test_package

### DIFF
--- a/conans/client/manager.py
+++ b/conans/client/manager.py
@@ -84,6 +84,7 @@ def deps_install(app, ref_or_path, install_folder, base_folder, graph_info, remo
         conanfile.folders.set_base_imports(install_folder)
         conanfile.folders.set_base_generators(base_folder)
         conanfile.folders.set_base_source(base_folder)
+        conanfile.folders.set_base_build(base_folder)
 
     if hasattr(conanfile, "layout") and test:
         install_folder = conanfile.generators_folder

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -69,7 +69,8 @@ def test_cmake_toolchain_custom_toolchain():
     assert not os.path.exists(os.path.join(client.current_folder, "conan_toolchain.cmake"))
     presets = load_cmake_presets(client.current_folder)
     assert "mytoolchain.cmake" in presets["configurePresets"][0]["toolchainFile"]
-    assert "binaryDir" not in presets["configurePresets"][0]
+    # Now that we define the build_folder even if not layout() binaryDir is defined
+    assert "binaryDir" in presets["configurePresets"][0]
 
 
 @pytest.mark.skipif(platform.system() != "Darwin",

--- a/conans/test/integration/layout/test_layout_generate.py
+++ b/conans/test/integration/layout/test_layout_generate.py
@@ -125,4 +125,4 @@ def test_generate_build_folder_test_package():
             "test_package/conanfile.py": conanfile})
     c.run("create .")
     build_folder = os.path.join(c.current_folder, "test_package", "build", "Release")
-    assert f"build_folder: {build_folder}" in c.out
+    assert f"build_folder in test_package: {build_folder}" in c.out

--- a/conans/test/integration/layout/test_layout_generate.py
+++ b/conans/test/integration/layout/test_layout_generate.py
@@ -115,7 +115,7 @@ def test_generate_build_folder_test_package():
                 cmake_layout(self)
 
             def generate(self):
-                self.output.info(f"build_folder in test_package: {self.build_folder}")
+                self.output.info(f"build_folder in test_package: {bool(self.build_folder)}")
 
             def test(self):
                 pass
@@ -124,5 +124,4 @@ def test_generate_build_folder_test_package():
     c.save({"conanfile.py": GenConanfile("pkg", "1.0"),
             "test_package/conanfile.py": conanfile})
     c.run("create .")
-    build_folder = os.path.join(c.current_folder, "test_package", "build", "Release")
-    assert f"build_folder in test_package: {build_folder}" in c.out
+    assert f"build_folder in test_package: True" in c.out

--- a/conans/test/integration/layout/test_layout_generate.py
+++ b/conans/test/integration/layout/test_layout_generate.py
@@ -96,3 +96,33 @@ def test_generate_source_folder_test_package():
             "test_package/conanfile.py": conanfile})
     c.run("create .")
     assert "PKG_CONFIG_PATH True!" in c.out
+
+
+def test_generate_build_folder_test_package():
+    c = TestClient()
+    conanfile = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+        from conan.tools.cmake import cmake_layout
+
+        class Pkg(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+
+            def requirements(self):
+                self.requires(self.tested_reference_str)
+
+            def layout(self):
+                cmake_layout(self)
+
+            def generate(self):
+                self.output.info(f"build_folder in test_package: {self.build_folder}")
+
+            def test(self):
+                pass
+        """)
+
+    c.save({"conanfile.py": GenConanfile("pkg", "1.0"),
+            "test_package/conanfile.py": conanfile})
+    c.run("create .")
+    build_folder = os.path.join(c.current_folder, "test_package", "build", "Release")
+    assert f"build_folder: {build_folder}" in c.out


### PR DESCRIPTION
Changelog: Feature: Make `conanfile.build_folder` available in `generate()` for test_package.
Docs: omit

Closes: https://github.com/conan-io/conan/issues/12393
