### PR TITLE
Do not include build-context dependencies in Bazel BUILD file

### DIFF
--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -147,7 +147,8 @@ class BazelDeps(object):
 
         dependencies = []
         for req, dep in dependency.dependencies.items():
-            dependencies.append(dep.ref.name)
+            if not dep.is_build_context:
+                dependencies.append(dep.ref.name)
 
         shared_library = dependency.options.get_safe("shared") if dependency.options else False
 


### PR DESCRIPTION
Changelog: Bugfix: Do not include build-context dependencies in Bazel BUILD file
Docs: omit

Fixes #12444 
