### PR TITLE
automatically add msys2/usr/bin path

### DIFF
--- a/conans/client/subsystems.py
+++ b/conans/client/subsystems.py
@@ -75,6 +75,9 @@ def _windows_bash_wrapper(conanfile, command, env, envfiles_folder):
         # Configure MSYS2 to inherith the PATH
         msys2_mode_env = Environment()
         _msystem = {"x86": "MINGW32"}.get(conanfile.settings.get_safe("arch"), "MINGW64")
+        # https://www.msys2.org/wiki/Launchers/ dictates that the shell should be launched with
+        # - MSYSTEM defined
+        # - CHERE_INVOKING is necessary to keep the CWD and not change automatically to the user home
         msys2_mode_env.define("MSYSTEM", _msystem)
         msys2_mode_env.define("MSYS2_PATH_TYPE", "inherit")
         # So --login do not change automatically to the user home
@@ -96,6 +99,8 @@ def _windows_bash_wrapper(conanfile, command, env, envfiles_folder):
                                                 accepted_extensions=("sh", ))
     wrapped_user_cmd = _escape_windows_cmd(wrapped_user_cmd)
 
+    # according to https://www.msys2.org/wiki/Launchers/, it is necessary to use --login shell
+    # running without it is discouraged
     final_command = '{} --login -c {}'.format(wrapped_shell, wrapped_user_cmd)
     return final_command
 

--- a/conans/client/subsystems.py
+++ b/conans/client/subsystems.py
@@ -77,6 +77,8 @@ def _windows_bash_wrapper(conanfile, command, env, envfiles_folder):
         _msystem = {"x86": "MINGW32"}.get(conanfile.settings.get_safe("arch"), "MINGW64")
         msys2_mode_env.define("MSYSTEM", _msystem)
         msys2_mode_env.define("MSYS2_PATH_TYPE", "inherit")
+        # So --login do not change automatically to the user home
+        msys2_mode_env.define("CHERE_INVOKING", "1")
         path = os.path.join(conanfile.generators_folder, "msys2_mode.bat")
         # Make sure we save pure .bat files, without sh stuff
         wb, conanfile.win_bash = conanfile.win_bash, None

--- a/conans/client/subsystems.py
+++ b/conans/client/subsystems.py
@@ -77,6 +77,9 @@ def _windows_bash_wrapper(conanfile, command, env, envfiles_folder):
         _msystem = {"x86": "MINGW32"}.get(conanfile.settings.get_safe("arch"), "MINGW64")
         msys2_mode_env.define("MSYSTEM", _msystem)
         msys2_mode_env.define("MSYS2_PATH_TYPE", "inherit")
+        # Automatically add the current bash.exe path to the PATH
+        if os.path.isabs(shell_path):
+            msys2_mode_env.prepend_path("PATH", os.path.dirname(shell_path))
         path = os.path.join(conanfile.generators_folder, "msys2_mode.bat")
         msys2_mode_env.vars(conanfile, "build").save_bat(path)
         env.append(path)

--- a/conans/client/subsystems.py
+++ b/conans/client/subsystems.py
@@ -81,7 +81,10 @@ def _windows_bash_wrapper(conanfile, command, env, envfiles_folder):
         if os.path.isabs(shell_path):
             msys2_mode_env.prepend_path("PATH", os.path.dirname(shell_path))
         path = os.path.join(conanfile.generators_folder, "msys2_mode.bat")
+        # Make sure we save pure .bat files, without sh stuff
+        wb, conanfile.win_bash = conanfile.win_bash, None
         msys2_mode_env.vars(conanfile, "build").save_bat(path)
+        conanfile.win_bash = wb
         env.append(path)
 
     wrapped_shell = '"%s"' % shell_path if " " in shell_path else shell_path

--- a/conans/test/functional/toolchains/gnu/autotools/test_win_bash.py
+++ b/conans/test/functional/toolchains/gnu/autotools/test_win_bash.py
@@ -61,3 +61,40 @@ def test_autotools_bash_complete():
     bat_contents = client.load("conanbuild.bat")
     assert "conanvcvars.bat" in bat_contents
 
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows")
+def test_add_msys2_path_automatically():
+    """ Check that commands like ar, autoconf, etc, that are in the /usr/bin folder together
+    with the bash.exe, can be automaticallly used when running in windows bash, without user
+    extra addition to [buildenv] of that msys64/usr/bin path
+
+    # https://github.com/conan-io/conan/issues/12110
+    """
+    client = TestClient(path_with_spaces=False)
+    try:
+        bash_path = tools_locations["msys2"]["system"]["path"]["Windows"] + "/bash.exe"
+    except KeyError:
+        pytest.skip("msys2 path not defined")
+
+    save(client.cache.new_config_path, textwrap.dedent("""
+            tools.microsoft.bash:subsystem=msys2
+            tools.microsoft.bash:path={}
+            """.format(bash_path)))
+
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+
+        class HelloConan(ConanFile):
+            name = "hello"
+            version = "0.1"
+
+            win_bash = True
+
+            def build(self):
+                self.run("ar -h")
+                """)
+
+    client.save({"conanfile.py": conanfile})
+    client.run("create .")
+    assert "Usage: ar" in client.out
+


### PR DESCRIPTION
Changelog: Feature: Automatically add the msys2 ``usr/bin`` folder where ``bash.exe`` is to the PATH.
Docs: Omit

Close https://github.com/conan-io/conan/issues/12110
