### PR TITLE
Stop mutating CMAKE_PREFIX_PATH in config file generated by CMakeDeps

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -88,7 +88,6 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
 
         # FIXME: What is the result of this for multi-config? All configs adding themselves to path?
         set(CMAKE_MODULE_PATH {{ '${' }}{{ pkg_name }}_BUILD_DIRS{{ config_suffix }}} {{ '${' }}CMAKE_MODULE_PATH})
-        set(CMAKE_PREFIX_PATH {{ '${' }}{{ pkg_name }}_BUILD_DIRS{{ config_suffix }}} {{ '${' }}CMAKE_PREFIX_PATH})
 
         {% if not components_names %}
 

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1141,7 +1141,10 @@ def test_find_program_for_tool_requires():
     client = TestClient()
 
     conanfile = textwrap.dedent("""
+        import os
+
         from conan import ConanFile
+        from conan.tools.files import copy
         class TestConan(ConanFile):
             name = "foobar"
             version = "1.0"
@@ -1150,8 +1153,8 @@ def test_find_program_for_tool_requires():
             def layout(self):
                 pass
             def package(self):
-                self.copy(pattern="lib*", dst="lib")
-                self.copy(pattern="*bin", dst="bin")
+                copy(self, pattern="lib*", src=self.build_folder, dst=os.path.join(self.package_folder, "lib"))
+                copy(self, pattern="*bin", src=self.build_folder, dst=os.path.join(self.package_folder, "bin"))
     """)
 
     host_profile = textwrap.dedent("""
@@ -1181,6 +1184,8 @@ def test_find_program_for_tool_requires():
                 "build_profile": build_profile
                 })
 
+    xxx = client.get_default_build_profile()
+
     client.run("create . -pr:b build_profile -pr:h build_profile")
     client.run("create . -pr:b build_profile -pr:h host_profile")
 
@@ -1201,9 +1206,8 @@ def test_find_program_for_tool_requires():
     """)
 
     cmakelists_consumer = textwrap.dedent("""
-        set(CMAKE_CXX_COMPILER_WORKS 1)
         cmake_minimum_required(VERSION 3.15)
-        project(Hello LANGUAGES CXX)
+        project(Hello LANGUAGES NONE)
         find_package(foobar CONFIG REQUIRED)
         find_program(FOOBIN_EXECUTABLE foobin)
         message("foobin executable: ${FOOBIN_EXECUTABLE}")

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1185,7 +1185,7 @@ def test_find_program_for_tool_requires():
     client.run("create . -pr:b default -pr:h host_profile")
 
     conanfile_consumer = textwrap.dedent("""
-        from conans import ConanFile
+        from conan import ConanFile
         from conan.tools.cmake import cmake_layout
         class PkgConan(ConanFile):
             settings = "os", "arch", "compiler", "build_type"

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1131,7 +1131,7 @@ def test_cmake_toolchain_vars_when_option_declared():
     assert "mylib position independent code: ON" in t.out
 
 
-#@pytest.mark.tool_cmake()
+@pytest.mark.tool_cmake
 def test_find_program_for_tool_requires():
     """Test that the same reference can be both a tool_requires and a regular requires,
     and that find_program (executables) and find_package (libraries) find the correct ones

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1141,7 +1141,7 @@ def test_find_program_for_tool_requires():
     client = TestClient()
 
     conanfile = textwrap.dedent("""
-        from conans import ConanFile
+        from conan import ConanFile
         class TestConan(ConanFile):
             name = "foobar"
             version = "1.0"

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1178,11 +1178,11 @@ def test_find_program_for_tool_requires():
                 "libfoo.so": "",
                 "foobin": "",
                 "host_profile": host_profile,
-                "default": build_profile
+                "build_profile": build_profile
                 })
 
-    client.run("create . -pr:b default -pr:h default")
-    client.run("create . -pr:b default -pr:h host_profile")
+    client.run("create . -pr:b build_profile -pr:h build_profile")
+    client.run("create . -pr:b build_profile -pr:h host_profile")
 
     conanfile_consumer = textwrap.dedent("""
         from conan import ConanFile
@@ -1214,10 +1214,10 @@ def test_find_program_for_tool_requires():
         "conanfile_consumer.py": conanfile_consumer,
         "CMakeLists.txt": cmakelists_consumer,
         "host_profile": host_profile,
-        "default": build_profile}, clean_first=True)
-    client.run("install conanfile_consumer.py pkg/0.1@ -g CMakeToolchain -g CMakeDeps -pr:b default -pr:h host_profile")
+        "build_profile": build_profile}, clean_first=True)
+    client.run("install conanfile_consumer.py pkg/0.1@ -g CMakeToolchain -g CMakeDeps -pr:b build_profile -pr:h host_profile")
 
-    build_context_package_id = "87a1781cf3e271d7a6db8e73b9c785c0edbe76dc"
+    build_context_package_id = "581814504b2e960b35df487e5bdb32b1ecf02253"
     host_context_package_id = "bf544cd3bc20b82121fd76b82eacbb36d75fa167"
 
     with client.chdir("build"):


### PR DESCRIPTION
Changelog: Bugfix: Fix issue where find_program does not work for a tool requirement in the build context, when the dependency is also a regular requirement in the host context. 
Docs: Omit

Close https://github.com/conan-io/conan/issues/12237

### Notes
This fixes a bug where the following two invocations were dependent on the order of the calls. As investigated in https://github.com/conan-io/conan/issues/12237, there does not appear to be a case where the generated config files by `CMakeDeps` need to alter the value of `CMAKE_PREFIX_PATH` - where needed, that is handled by `CMakeToolchain`.

For the following, when cross building, in both instances the following two invocations should find the binary executable from the package in the build context. Before this fix, calling `find_program` after `find_package` would result in the binary executable being found in the host context (which may not run at all).

```
        find_package(foobar CONFIG REQUIRED)
        find_program(FOOBIN_EXECUTABLE foobin)
```
and this
```
        find_program(FOOBIN_EXECUTABLE foobin)
        find_package(foobar CONFIG REQUIRED)
```
 

