### PR TITLE
Improvements in the remotes management and API

### DIFF
--- a/conan/api/conan_app.py
+++ b/conan/api/conan_app.py
@@ -60,14 +60,10 @@ class ConanApp(object):
 
         # Remotes
         self.selected_remotes = []
-        self.enabled_remotes = []
-        self.all_remotes = []
         self.update = False
         self.check_updates = False
 
     def load_remotes(self, remotes=None, update=False, check_updates=False):
-        self.all_remotes = self.cache.remotes_registry.list()
-        self.enabled_remotes = [r for r in self.all_remotes if not r.disabled]
         self.update = update
         self.check_updates = check_updates
         self.selected_remotes = []

--- a/conan/api/conan_app.py
+++ b/conan/api/conan_app.py
@@ -10,7 +10,6 @@ from conans.client.remote_manager import RemoteManager
 from conans.client.rest.auth_manager import ConanApiAuthManager
 from conans.client.rest.conan_requester import ConanRequester
 from conans.client.rest.rest_client import RestApiClientFactory
-from conans.errors import ConanException
 
 
 class CmdWrapper:
@@ -59,21 +58,9 @@ class ConanApp(object):
         self.loader = ConanFileLoader(self.pyreq_loader, conanfile_helpers)
 
         # Remotes
-        self.selected_remotes = []
         self.update = False
         self.check_updates = False
 
-    def load_remotes(self, remotes=None, update=False, check_updates=False):
+    def load_remotes(self, update=False, check_updates=False):
         self.update = update
         self.check_updates = check_updates
-        self.selected_remotes = []
-        if remotes:
-            for r in remotes:
-                if r.name is not None:  # FIXME: Remove this when we pass always remote objects
-                    tmp = self.cache.remotes_registry.read(r.name)
-                    if tmp.disabled:
-                        raise ConanException("Remote '{}' is disabled".format(tmp.name))
-                    self.selected_remotes.append(tmp)
-            # sort the list based on the index preference in the remotes list
-            if self.selected_remotes:
-                self.selected_remotes.sort(key=lambda remote: self.cache.remotes_registry.get_remote_index(remote))

--- a/conan/api/subapi/download.py
+++ b/conan/api/subapi/download.py
@@ -17,7 +17,6 @@ class DownloadAPI:
     def recipe(self, ref: RecipeReference, remote: Remote):
         output = ConanOutput()
         app = ConanApp(self.conan_api.cache_folder)
-        app.load_remotes([remote])
         skip_download = app.cache.exists_rrev(ref)
         if skip_download:
             output.info(f"Skip {ref.repr_notime()} download, already in cache")
@@ -39,7 +38,6 @@ class DownloadAPI:
     def package(self, pref: PkgReference, remote: Remote):
         output = ConanOutput()
         app = ConanApp(self.conan_api.cache_folder)
-        app.load_remotes([remote])
         if not app.cache.exists_rrev(pref.ref):
             raise ConanException("The recipe of the specified package "
                                  "doesn't exist, download it first")

--- a/conan/api/subapi/download.py
+++ b/conan/api/subapi/download.py
@@ -27,7 +27,7 @@ class DownloadAPI:
 
         layout = app.cache.ref_layout(ref)
         conan_file_path = layout.conanfile()
-        conanfile = app.loader.load_basic(conan_file_path, display=ref)
+        conanfile = app.loader.load_basic(conan_file_path, display=ref, remotes=[remote])
 
         # Download the sources too, don't be lazy
         output.info(f"Downloading '{str(ref)}' sources")

--- a/conan/api/subapi/graph.py
+++ b/conan/api/subapi/graph.py
@@ -24,7 +24,7 @@ class GraphAPI:
                                      update=None, remotes=None, lockfile=None):
         app = ConanApp(self.conan_api.cache_folder)
         # necessary for correct resolution and update of remote python_requires
-        app.load_remotes(remotes, update=update)
+        app.load_remotes(update=update)
 
         if path.endswith(".py"):
             conanfile = app.loader.load_consumer(path,
@@ -32,7 +32,8 @@ class GraphAPI:
                                                  version=version,
                                                  user=user,
                                                  channel=channel,
-                                                 graph_lock=lockfile)
+                                                 graph_lock=lockfile,
+                                                 remotes=remotes)
             ref = RecipeReference(conanfile.name, conanfile.version,
                                   conanfile.user, conanfile.channel)
             initialize_conanfile_profile(conanfile, profile_build, profile_host, CONTEXT_HOST,
@@ -64,7 +65,7 @@ class GraphAPI:
 
         app = ConanApp(self.conan_api.cache_folder)
         # necessary for correct resolution and update of remote python_requires
-        app.load_remotes(remotes, update=update)
+        app.load_remotes(update=update)
 
         loader = app.loader
         profile_host.options.scope(tested_reference)
@@ -72,7 +73,7 @@ class GraphAPI:
         # do not try apply lock_python_requires for test_package/conanfile.py consumer
         conanfile = loader.load_consumer(path, user=tested_reference.user,
                                          channel=tested_reference.channel,
-                                         graph_lock=lockfile)
+                                         graph_lock=lockfile, remotes=remotes)
         initialize_conanfile_profile(conanfile, profile_build, profile_host, CONTEXT_HOST, False)
         conanfile.display_name = "%s (test package)" % str(tested_reference)
         conanfile.output.scope = conanfile.display_name
@@ -114,12 +115,13 @@ class GraphAPI:
         """
         app = ConanApp(self.conan_api.cache_folder)
 
-        app.load_remotes(remotes, update=update, check_updates=check_update)
+        app.load_remotes(update=update, check_updates=check_update)
 
         assert profile_host is not None
         assert profile_build is not None
 
-        builder = DepsGraphBuilder(app.proxy, app.loader, app.range_resolver)
+        remotes = remotes or []
+        builder = DepsGraphBuilder(app.proxy, app.loader, app.range_resolver, remotes)
         deps_graph = builder.load_graph(root_node, profile_host, profile_build, lockfile)
 
         if lockfile:
@@ -141,9 +143,9 @@ class GraphAPI:
             revisions for already existing recipes in the Conan cache
         """
         conan_app = ConanApp(self.conan_api.cache_folder)
-        conan_app.load_remotes(remotes, update=update)
+        conan_app.load_remotes(update=update)
         binaries_analyzer = GraphBinariesAnalyzer(conan_app)
-        binaries_analyzer.evaluate_graph(graph, build_mode, lockfile)
+        binaries_analyzer.evaluate_graph(graph, build_mode, lockfile, remotes)
 
     @api_method
     def load_conanfile_class(self, path):

--- a/conan/api/subapi/install.py
+++ b/conan/api/subapi/install.py
@@ -23,10 +23,10 @@ class InstallAPI:
         :param update:
         """
         app = ConanApp(self.conan_api.cache_folder)
-        app.load_remotes(remotes, update=update)
+        app.load_remotes(update=update)
         installer = BinaryInstaller(app)
         # TODO: Extract this from the GraphManager, reuse same object, check args earlier
-        installer.install(deps_graph)
+        installer.install(deps_graph, remotes)
 
     # TODO: Look for a better name
     def install_consumer(self, deps_graph, generators=None, source_folder=None, output_folder=None,

--- a/conan/api/subapi/remotes.py
+++ b/conan/api/subapi/remotes.py
@@ -16,7 +16,7 @@ def get_remote_selection(conan_api, remote_patterns):
     """
     ret_remotes = []
     for pattern in remote_patterns:
-        tmp = conan_api.remotes.list(pattern=pattern, only_active=True)
+        tmp = conan_api.remotes.list(pattern=pattern, only_enabled=True)
         if not tmp:
             raise ConanException("Remotes for pattern '{}' can't be found or are "
                                  "disabled".format(pattern))
@@ -30,7 +30,7 @@ def get_multiple_remotes(conan_api, remote_names=None):
         return [conan_api.remotes.get(remote_name) for remote_name in remote_names]
     elif remote_names is None:
         # if we don't pass any remotes we want to retrieve only the enabled ones
-        return conan_api.remotes.list(only_active=True)
+        return conan_api.remotes.list(only_enabled=True)
 
 
 class RemotesAPI:
@@ -39,7 +39,7 @@ class RemotesAPI:
         self.conan_api = conan_api
 
     @api_method
-    def list(self, pattern=None, only_active=False):
+    def list(self, pattern=None, only_enabled=False):
         app = ConanApp(self.conan_api.cache_folder)
         remotes = app.cache.remotes_registry.list()
         if pattern:
@@ -52,7 +52,7 @@ class RemotesAPI:
                 raise ConanException(f"Remote '{pattern}' not found in remotes")
 
             remotes = filtered_remotes
-        if only_active:
+        if only_enabled:
             remotes = [r for r in remotes if not r.disabled]
         return remotes
 

--- a/conan/api/subapi/upload.py
+++ b/conan/api/subapi/upload.py
@@ -62,20 +62,16 @@ class UploadAPI:
         """Check if the artifacts are already in the specified remote, skipping them from
         the upload_bundle in that case"""
         app = ConanApp(self.conan_api.cache_folder)
-        app.load_remotes([remote])
         UploadUpstreamChecker(app).check(upload_bundle, remote, force)
 
     @api_method
-    def prepare(self, upload_bundle):
+    def prepare(self, upload_bundle, enabled_remotes):
         """Compress the recipes and packages and fill the upload_data objects
         with the complete information. It doesn't perform the upload nor checks upstream to see
         if the recipe is still there"""
         app = ConanApp(self.conan_api.cache_folder)
-        # Necessary to load remotes, as exports_sources might need to be retrieved to
-        # prepare the artifacts
-        app.load_remotes()
         preparator = PackagePreparator(app)
-        preparator.prepare(upload_bundle)
+        preparator.prepare(upload_bundle, enabled_remotes)
         signer = PkgSignaturesPlugin(app.cache)
         # This might add files entries to upload_bundle with signatures
         signer.sign(upload_bundle)
@@ -83,7 +79,6 @@ class UploadAPI:
     @api_method
     def upload_bundle(self, upload_bundle, remote):
         app = ConanApp(self.conan_api.cache_folder)
-        app.load_remotes([remote])
         app.remote_manager.check_credentials(remote)
         executor = UploadExecutor(app)
         executor.upload(upload_bundle, remote)

--- a/conan/cli/commands/build.py
+++ b/conan/cli/commands/build.py
@@ -5,7 +5,6 @@ from conan.cli.command import conan_command, COMMAND_GROUPS
 from conan.cli.commands import make_abs_path
 from conan.cli.commands.install import graph_compute, _get_conanfile_path
 from conan.cli.common import save_lockfile_out
-from conan.api.subapi.remotes import get_multiple_remotes
 from conan.cli.args import add_lockfile_args, _add_common_install_arguments, add_reference_args, \
     _help_build_policies
 from conan.api.conan_app import ConanApp
@@ -31,13 +30,13 @@ def build(conan_api, parser, *args):
     cwd = os.getcwd()
     path = _get_conanfile_path(args.path, cwd, py=True)
     folder = os.path.dirname(path)
-    remote = get_multiple_remotes(conan_api, args.remote)
+    remotes = conan_api.remotes.list(args.remote)
 
     deps_graph, lockfile = graph_compute(args, conan_api, partial=args.lockfile_partial)
 
     out = ConanOutput()
     out.title("Installing packages")
-    conan_api.install.install_binaries(deps_graph=deps_graph, remotes=remote, update=args.update)
+    conan_api.install.install_binaries(deps_graph=deps_graph, remotes=remotes, update=args.update)
 
     source_folder = folder
     output_folder = make_abs_path(args.output_folder, cwd) if args.output_folder else None

--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -7,7 +7,6 @@ from conan.cli.command import conan_command, COMMAND_GROUPS, OnceArgument
 from conan.cli.commands.export import common_args_export
 from conan.cli.commands.install import _get_conanfile_path
 from conan.cli.common import get_lockfile, get_profiles_from_args, scope_options, save_lockfile_out
-from conan.api.subapi.remotes import get_multiple_remotes
 from conan.cli.args import add_lockfile_args, _add_common_install_arguments, _help_build_policies
 from conan.api.conan_app import ConanApp
 from conan.cli.printers.graph import print_graph_basic, print_graph_packages
@@ -40,7 +39,7 @@ def create(conan_api, parser, *args):
     path = _get_conanfile_path(args.path, cwd, py=True)
     lockfile = get_lockfile(lockfile_path=args.lockfile, cwd=cwd, conanfile_path=path,
                             partial=args.lockfile_partial)
-    remotes = get_multiple_remotes(conan_api, args.remote)
+    remotes = conan_api.remotes.list(args.remote)
     profile_host, profile_build = get_profiles_from_args(conan_api, args)
 
     out = ConanOutput()

--- a/conan/cli/commands/install.py
+++ b/conan/cli/commands/install.py
@@ -5,7 +5,6 @@ from conan.api.output import ConanOutput, cli_out_write
 from conan.cli.command import conan_command, Extender, COMMAND_GROUPS
 from conan.cli.commands import make_abs_path
 from conan.cli.common import get_profiles_from_args, get_lockfile, scope_options, save_lockfile_out
-from conan.api.subapi.remotes import get_multiple_remotes
 from conan.cli.args import add_lockfile_args, _add_common_install_arguments, add_reference_args, \
     _help_build_policies
 from conan.cli.printers.graph import print_graph_basic, print_graph_packages
@@ -66,7 +65,7 @@ def graph_compute(args, conan_api, partial=False, allow_error=False):
         raise ConanException("Please specify at least a path to a conanfile or a valid reference.")
 
     # Basic collaborators, remotes, lockfile, profiles
-    remotes = get_multiple_remotes(conan_api, args.remote)
+    remotes = conan_api.remotes.list(args.remote)
     lockfile = get_lockfile(lockfile_path=args.lockfile, cwd=cwd, conanfile_path=path,
                             partial=partial)
     profile_host, profile_build = get_profiles_from_args(conan_api, args)
@@ -169,13 +168,13 @@ def install(conan_api, parser, *args):
     else:
         output_folder = None
 
-    remote = get_multiple_remotes(conan_api, args.remote)
+    remotes = conan_api.remotes.list(args.remote)
 
     deps_graph, lockfile = graph_compute(args, conan_api, partial=args.lockfile_partial)
 
     out = ConanOutput()
     out.title("Installing packages")
-    conan_api.install.install_binaries(deps_graph=deps_graph, remotes=remote, update=args.update)
+    conan_api.install.install_binaries(deps_graph=deps_graph, remotes=remotes, update=args.update)
 
     out.title("Finalizing install (deploy, generators)")
     conan_api.install.install_consumer(deps_graph=deps_graph,

--- a/conan/cli/commands/list.py
+++ b/conan/cli/commands/list.py
@@ -4,7 +4,6 @@ from collections import OrderedDict
 from conan.api.output import Color, cli_out_write
 from conan.cli.command import conan_command, conan_subcommand, Extender, COMMAND_GROUPS
 from conan.cli.commands import default_json_formatter
-from conan.api.subapi.remotes import get_remote_selection
 from conan.cli.formatters.list import list_packages_html
 from conans.errors import ConanException, InvalidNameException, NotFoundException
 from conans.model.package_ref import PkgReference
@@ -108,7 +107,7 @@ def _selected_cache_remotes(conan_api, args):
     if args.cache or not args.remote:
         remotes.append(None)
     if args.remote:
-        remotes.extend(get_remote_selection(conan_api, args.remote))
+        remotes.extend(conan_api.remotes.list(args.remote))
     return remotes
 
 

--- a/conan/cli/commands/remote.py
+++ b/conan/cli/commands/remote.py
@@ -160,10 +160,7 @@ def remote_enable(conan_api, parser, subparser, *args):
     subparser.add_argument("remote", help="Pattern of the remote/s to enable. "
                                           "The pattern uses 'fnmatch' style wildcards.")
     args = parser.parse_args(*args)
-    remotes = conan_api.remotes.list(pattern=args.remote)
-    for r in remotes:
-        r.disabled = False
-        conan_api.remotes.update(r)
+    conan_api.remotes.enable(args.remote)
 
 
 @conan_subcommand()
@@ -174,10 +171,7 @@ def remote_disable(conan_api, parser, subparser, *args):
     subparser.add_argument("remote", help="Pattern of the remote/s to disable. "
                                           "The pattern uses 'fnmatch' style wildcards.")
     args = parser.parse_args(*args)
-    remotes = conan_api.remotes.list(pattern=args.remote)
-    for r in remotes:
-        r.disabled = True
-        conan_api.remotes.update(r)
+    conan_api.remotes.disable(args.remote)
 
 
 # ### User related commands

--- a/conan/cli/commands/search.py
+++ b/conan/cli/commands/search.py
@@ -3,7 +3,6 @@ from collections import OrderedDict
 from conan.api.conan_api import ConanAPIV2
 from conan.cli.command import conan_command, Extender, COMMAND_GROUPS
 from conan.cli.commands.list import print_list_recipes, default_json_formatter
-from conan.api.subapi.remotes import get_remote_selection
 
 
 # FIXME: "conan search" == "conan list recipes -r="*" -c" --> implement @conan_alias_command??
@@ -19,7 +18,7 @@ def search(conan_api: ConanAPIV2, parser, *args):
                              "in all remotes")
     args = parser.parse_args(*args)
 
-    remotes = get_remote_selection(conan_api, args.remote)
+    remotes = conan_api.remotes.list(args.remote)
 
     results = OrderedDict()
     for remote in remotes:

--- a/conan/cli/commands/test.py
+++ b/conan/cli/commands/test.py
@@ -5,7 +5,6 @@ from conan.cli.command import conan_command, COMMAND_GROUPS, OnceArgument
 from conan.cli.commands.create import test_package, _check_tested_reference_matches
 from conan.cli.commands.install import _get_conanfile_path
 from conan.cli.common import get_lockfile, get_profiles_from_args, save_lockfile_out
-from conan.api.subapi.remotes import get_multiple_remotes
 from conan.cli.args import add_lockfile_args, _add_common_install_arguments
 from conan.cli.printers.graph import print_graph_basic, print_graph_packages
 from conans.model.recipe_ref import RecipeReference
@@ -29,7 +28,7 @@ def test(conan_api, parser, *args):
     path = _get_conanfile_path(args.path, cwd, py=True)
     lockfile = get_lockfile(lockfile_path=args.lockfile, cwd=cwd, conanfile_path=path,
                             partial=args.lockfile_partial)
-    remotes = get_multiple_remotes(conan_api, args.remote)
+    remotes = conan_api.remotes.list(args.remote)
     profile_host, profile_build = get_profiles_from_args(conan_api, args)
 
     out = ConanOutput()

--- a/conan/cli/commands/upload.py
+++ b/conan/cli/commands/upload.py
@@ -1,5 +1,3 @@
-from pprint import pprint
-
 from conan.api.conan_api import ConanAPIV2
 from conan.cli.command import conan_command, COMMAND_GROUPS, OnceArgument
 from conans.client.userio import UserInput
@@ -39,6 +37,7 @@ def upload(conan_api: ConanAPIV2, parser, *args):
     args = parser.parse_args(*args)
 
     remote = conan_api.remotes.get(args.remote)
+    enabled_remotes = conan_api.remotes.list()
 
     upload_bundle = conan_api.upload.get_bundle(args.reference, args.package_query, args.only_recipe)
     if not upload_bundle.recipes:
@@ -57,7 +56,7 @@ def upload(conan_api: ConanAPIV2, parser, *args):
     if not upload_bundle.any_upload:
         return
 
-    conan_api.upload.prepare(upload_bundle)
+    conan_api.upload.prepare(upload_bundle, enabled_remotes)
     conan_api.upload.upload_bundle(upload_bundle, remote)
 
 

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -137,7 +137,7 @@ class PackagePreparator:
         self._app = app
         self._output = ConanOutput()
 
-    def prepare(self, upload_bundle):
+    def prepare(self, upload_bundle, enabled_remotes):
         self._output.info("Preparing artifacts to upload")
         for recipe in upload_bundle.recipes:
             layout = self._app.cache.ref_layout(recipe.ref)
@@ -145,7 +145,7 @@ class PackagePreparator:
             conanfile = self._app.loader.load_basic(conanfile_path)
 
             if recipe.upload:
-                self._prepare_recipe(recipe, conanfile, self._app.enabled_remotes)
+                self._prepare_recipe(recipe, conanfile, enabled_remotes)
             for package in recipe.packages:
                 if package.upload:
                     self._prepare_package(package)

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -63,8 +63,8 @@ class GraphBinariesAnalyzer(object):
             except NotFoundException:
                 pass
 
-        if not self._app.enabled_remotes and self._app.update:
-            node.conanfile.output.warning("Can't update, there are no remotes configured or enabled")
+        if not self._app.selected_remotes and self._app.update:
+            node.conanfile.output.warning("Can't update, there are no remotes defined")
 
         if len(results) > 0:
             remotes_results = sorted(results, key=lambda k: k['pref'].timestamp, reverse=True)

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -54,7 +54,7 @@ class GraphBinariesAnalyzer(object):
     def _get_package_from_remotes(self, node):
         results = []
         pref = node.pref
-        for r in self._app.selected_remotes:
+        for r in self._selected_remotes:
             try:
                 latest_pref = self._remote_manager.get_latest_package_reference(pref, r)
                 results.append({'pref': latest_pref, 'remote': r})
@@ -63,7 +63,7 @@ class GraphBinariesAnalyzer(object):
             except NotFoundException:
                 pass
 
-        if not self._app.selected_remotes and self._app.update:
+        if not self._selected_remotes and self._app.update:
             node.conanfile.output.warning("Can't update, there are no remotes defined")
 
         if len(results) > 0:
@@ -292,7 +292,8 @@ class GraphBinariesAnalyzer(object):
             with conanfile_exception_formatter(conanfile, "layout"):
                 conanfile.layout()
 
-    def evaluate_graph(self, deps_graph, build_mode, lockfile):
+    def evaluate_graph(self, deps_graph, build_mode, lockfile, remotes):
+        self._selected_remotes = remotes or []# TODO: A bit dirty interfaz, pass as arg instead
         build_mode = BuildMode(build_mode)
         for node in deps_graph.ordered_iterate():
             if node.recipe in (RECIPE_CONSUMER, RECIPE_VIRTUAL):

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -15,10 +15,11 @@ from conans.model.requires import Requirement
 
 class DepsGraphBuilder(object):
 
-    def __init__(self, proxy, loader, resolver):
+    def __init__(self, proxy, loader, resolver, remotes):
         self._proxy = proxy
         self._loader = loader
         self._resolver = resolver
+        self._remotes = remotes  # TODO: pass as arg to load_graph()
 
     def load_graph(self, root_node, profile_host, profile_build, graph_lock=None):
         assert profile_host is not None
@@ -181,7 +182,7 @@ class DepsGraphBuilder(object):
         while alias is not None:
             # if not cached, then resolve
             try:
-                result = self._proxy.get_recipe(alias)
+                result = self._proxy.get_recipe(alias, self._remotes)
                 conanfile_path, recipe_status, remote, new_ref = result
             except ConanException as e:
                 raise GraphError.missing(node, require, str(e))
@@ -199,9 +200,10 @@ class DepsGraphBuilder(object):
             alias = new_req.alias
 
     def _resolve_recipe(self, ref, graph_lock):
-        result = self._proxy.get_recipe(ref)
+        result = self._proxy.get_recipe(ref, self._remotes)
         conanfile_path, recipe_status, remote, new_ref = result
-        dep_conanfile = self._loader.load_conanfile(conanfile_path, ref=ref, graph_lock=graph_lock)
+        dep_conanfile = self._loader.load_conanfile(conanfile_path, ref=ref, graph_lock=graph_lock,
+                                                    remotes=self._remotes)
         return new_ref, dep_conanfile, recipe_status, remote
 
     def _create_new_node(self, node, require, graph, profile_host, profile_build, graph_lock):
@@ -210,7 +212,7 @@ class DepsGraphBuilder(object):
             #  if not require.locked_id:  # if it is locked, nothing to resolved
             # TODO: This range-resolve might resolve in a given remote or cache
             # Make sure next _resolve_recipe use it
-            resolved_ref = self._resolver.resolve(require, str(node.ref))
+            resolved_ref = self._resolver.resolve(require, str(node.ref), self._remotes)
 
             # This accounts for alias too
             resolved = self._resolve_recipe(resolved_ref, graph_lock)

--- a/conans/client/graph/proxy.py
+++ b/conans/client/graph/proxy.py
@@ -13,10 +13,10 @@ class ConanProxy(object):
         self._remote_manager = conan_app.remote_manager
         self._conan_app = conan_app
 
-    def get_recipe(self, ref):
+    def get_recipe(self, ref, remotes):
         # TODO: cache2.0 Check with new locks
         # with layout.conanfile_write_lock(self._out):
-        result = self._get_recipe(ref)
+        result = self._get_recipe(ref, remotes)
         conanfile_path, status, remote, new_ref = result
 
         if status not in (RECIPE_DOWNLOADED, RECIPE_UPDATED):
@@ -25,7 +25,7 @@ class ConanProxy(object):
         return conanfile_path, status, remote, new_ref
 
     # return the remote where the recipe was found or None if the recipe was not found
-    def _get_recipe(self, reference):
+    def _get_recipe(self, reference, remotes):
         output = ConanOutput(scope=str(reference))
 
         conanfile_path = self._cache.editable_packages.get_path(reference)
@@ -38,7 +38,7 @@ class ConanProxy(object):
         # NOT in disk, must be retrieved from remotes
         if not ref:
             # we will only check all servers for latest revision if we did a --update
-            remote, new_ref = self._download_recipe(reference, output)
+            remote, new_ref = self._download_recipe(reference, remotes, output)
             recipe_layout = self._cache.ref_layout(new_ref)
             status = RECIPE_DOWNLOADED
             conanfile_path = recipe_layout.conanfile()
@@ -51,7 +51,7 @@ class ConanProxy(object):
         # TODO: If the revision is given, then we don't need to check for updates?
         if self._conan_app.check_updates or self._conan_app.update:
 
-            remote, remote_ref = self._find_newest_recipe_in_remotes(reference)
+            remote, remote_ref = self._find_newest_recipe_in_remotes(reference, remotes)
             if remote_ref:
                 # check if we already have the latest in local cache
                 # TODO: cache2.0 here if we already have a revision in the cache but we add the
@@ -65,7 +65,7 @@ class ConanProxy(object):
                         # the remote one is newer
                         if self._conan_app.update:
                             output.info("Retrieving from remote '%s'..." % remote.name)
-                            remote, new_ref = self._download_recipe(remote_ref, output)
+                            remote, new_ref = self._download_recipe(remote_ref, remotes, output)
                             new_recipe_layout = self._cache.ref_layout(new_ref)
                             new_conanfile_path = new_recipe_layout.conanfile()
                             status = RECIPE_UPDATED
@@ -92,11 +92,11 @@ class ConanProxy(object):
             status = RECIPE_INCACHE
             return conanfile_path, status, None, ref
 
-    def _find_newest_recipe_in_remotes(self, reference):
+    def _find_newest_recipe_in_remotes(self, reference, remotes):
         output = ConanOutput(scope=str(reference))
 
         results = []
-        for remote in self._conan_app.selected_remotes:
+        for remote in remotes:
             output.info(f"Checking remote: {remote.name}")
             if not reference.revision:
                 try:
@@ -123,7 +123,7 @@ class ConanProxy(object):
         return found_rrev.get("remote"), found_rrev.get("ref")
 
     # searches in all the remotes and downloads the latest from all of them
-    def _download_recipe(self, ref, scoped_output):
+    def _download_recipe(self, ref, remotes, scoped_output):
         def _retrieve_from_remote(the_remote, reference):
             scoped_output.info("Trying with '%s'..." % the_remote.name)
             # If incomplete, resolve the latest in server
@@ -135,11 +135,10 @@ class ConanProxy(object):
             return reference
 
         scoped_output.info("Not found in local cache, looking in remotes...")
-        remotes = self._conan_app.selected_remotes
         if not remotes:
             raise ConanException("No remote defined")
 
-        remote, latest_rref = self._find_newest_recipe_in_remotes(ref)
+        remote, latest_rref = self._find_newest_recipe_in_remotes(ref, remotes)
 
         if not latest_rref:
             msg = "Unable to find '%s' in remotes" % repr(ref)

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -23,7 +23,7 @@ class RangeResolver(object):
             pattern_cached.update({remote.name: results})
         return results
 
-    def resolve(self, require, base_conanref):
+    def resolve(self, require, base_conanref, remotes):
         version_range = require.version_range
         if version_range is None:
             return require.ref
@@ -40,7 +40,7 @@ class RangeResolver(object):
 
         resolved_ref = self._resolve_local(search_ref, version_range)
         if resolved_ref is None or self._conan_app.update:
-            remote_resolved_ref = self._resolve_remote(search_ref, version_range)
+            remote_resolved_ref = self._resolve_remote(search_ref, version_range, remotes)
             if resolved_ref is None or (remote_resolved_ref is not None and
                                         resolved_ref.version < remote_resolved_ref.version):
                 resolved_ref = remote_resolved_ref
@@ -64,9 +64,9 @@ class RangeResolver(object):
         if local_found:
             return self._resolve_version(version_range, local_found)
 
-    def _search_and_resolve_remotes(self, search_ref, version_range):
+    def _search_and_resolve_remotes(self, search_ref, version_range, remotes):
         results = []
-        for remote in self._conan_app.selected_remotes:
+        for remote in remotes:
             remote_results = self._search_remote_recipes(remote, search_ref)
             remote_results = [ref for ref in remote_results
                               if ref.user == search_ref.user
@@ -86,9 +86,9 @@ class RangeResolver(object):
         else:
             return None
 
-    def _resolve_remote(self, search_ref, version_range):
+    def _resolve_remote(self, search_ref, version_range, remotes):
         # Searching for just the name is much faster in remotes like Artifactory
-        resolved_ref  = self._search_and_resolve_remotes(search_ref, version_range)
+        resolved_ref  = self._search_and_resolve_remotes(search_ref, version_range, remotes)
         # We don't want here to resolve the revision that should be done in the proxy
         # as any other regular flow
         # FIXME: refactor all this and update for 2.0

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -35,8 +35,9 @@ def build_id(conan_file):
 
 class _PackageBuilder(object):
 
-    def __init__(self, app):
+    def __init__(self, app, conan_api):
         self._app = app
+        self._conan_api = conan_api
         self._cache = app.cache
         self._hook_manager = app.hook_manager
         self._remote_manager = app.remote_manager
@@ -77,7 +78,6 @@ class _PackageBuilder(object):
 
     def _prepare_sources(self, conanfile, pref, recipe_layout):
         export_source_folder = recipe_layout.export_sources()
-        conanfile_path = recipe_layout.conanfile()
         source_folder = recipe_layout.source()
 
         remotes = self._app.enabled_remotes
@@ -192,8 +192,9 @@ class BinaryInstaller:
     """ main responsible of retrieving binary packages or building them from source
     locally in case they are not found in remotes
     """
-    def __init__(self, app):
+    def __init__(self, app, conan_api):
         self._app = app
+        self._conan_api = conan_api
         self._cache = app.cache
         self._remote_manager = app.remote_manager
         self._hook_manager = app.hook_manager
@@ -333,7 +334,7 @@ class BinaryInstaller:
         with pkg_layout.package_lock():
             pkg_layout.package_remove()
             with pkg_layout.set_dirty_context_manager():
-                builder = _PackageBuilder(self._app)
+                builder = _PackageBuilder(self._app, self._conan_api)
                 pref = builder.build_package(node, pkg_layout)
             assert node.prev, "Node PREV shouldn't be empty"
             assert node.pref.revision, "Node PREF revision shouldn't be empty"

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -89,7 +89,7 @@ class ConanFileLoader:
                    remotes=None):
         """ loads the basic conanfile object and evaluates its name and version
         """
-        conanfile, _ = self.load_basic_module(conanfile_path, graph_lock, remotes)
+        conanfile, _ = self.load_basic_module(conanfile_path, graph_lock, remotes=remotes)
 
         # Export does a check on existing name & version
         if name:

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -31,12 +31,12 @@ class ConanFileLoader:
         self._conanfile_helpers = conanfile_helpers
         invalidate_caches()
 
-    def load_basic(self, conanfile_path, graph_lock=None, display=""):
+    def load_basic(self, conanfile_path, graph_lock=None, display="", remotes=None):
         """ loads a conanfile basic object without evaluating anything
         """
-        return self.load_basic_module(conanfile_path, graph_lock, display)[0]
+        return self.load_basic_module(conanfile_path, graph_lock, display, remotes)[0]
 
-    def load_basic_module(self, conanfile_path, graph_lock=None, display=""):
+    def load_basic_module(self, conanfile_path, graph_lock=None, display="", remotes=None):
         """ loads a conanfile basic object without evaluating anything, returns the module too
         """
         cached = self._cached_conanfile_classes.get(conanfile_path)
@@ -52,7 +52,7 @@ class ConanFileLoader:
             module, conanfile = parse_conanfile(conanfile_path)
 
             if self._pyreq_loader:
-                self._pyreq_loader.load_py_requires(conanfile, self, graph_lock)
+                self._pyreq_loader.load_py_requires(conanfile, self, graph_lock, remotes)
 
             conanfile.recipe_folder = os.path.dirname(conanfile_path)
             conanfile.recipe_path = Path(conanfile.recipe_folder)
@@ -85,10 +85,11 @@ class ConanFileLoader:
 
         return data or {}
 
-    def load_named(self, conanfile_path, name, version, user, channel, graph_lock=None):
+    def load_named(self, conanfile_path, name, version, user, channel, graph_lock=None,
+                   remotes=None):
         """ loads the basic conanfile object and evaluates its name and version
         """
-        conanfile, _ = self.load_basic_module(conanfile_path, graph_lock)
+        conanfile, _ = self.load_basic_module(conanfile_path, graph_lock, remotes)
 
         # Export does a check on existing name & version
         if name:
@@ -143,10 +144,11 @@ class ConanFileLoader:
         return conanfile
 
     def load_consumer(self, conanfile_path, name=None, version=None, user=None,
-                      channel=None, graph_lock=None):
+                      channel=None, graph_lock=None, remotes=None):
         """ loads a conanfile.py in user space. Might have name/version or not
         """
-        conanfile = self.load_named(conanfile_path, name, version, user, channel, graph_lock)
+        conanfile = self.load_named(conanfile_path, name, version, user, channel, graph_lock,
+                                    remotes)
 
         ref = RecipeReference(conanfile.name, conanfile.version, user, channel)
         if str(ref):
@@ -160,12 +162,12 @@ class ConanFileLoader:
         except Exception as e:  # re-raise with file name
             raise ConanException("%s: %s" % (conanfile_path, str(e)))
 
-    def load_conanfile(self, conanfile_path, ref, graph_lock=None):
+    def load_conanfile(self, conanfile_path, ref, graph_lock=None, remotes=None):
         """ load a conanfile with a full reference, name, version, user and channel are obtained
         from the reference, not evaluated. Main way to load from the cache
         """
         try:
-            conanfile, _ = self.load_basic_module(conanfile_path, graph_lock, str(ref))
+            conanfile, _ = self.load_basic_module(conanfile_path, graph_lock, str(ref), remotes)
         except Exception as e:
             raise ConanException("%s: Cannot load recipe.\n%s" % (str(ref), str(e)))
 

--- a/conans/test/integration/command/install/install_test.py
+++ b/conans/test/integration/command/install/install_test.py
@@ -281,12 +281,12 @@ def test_install_disabled_remote(client):
     client.run("upload * --confirm -r default")
     client.run("remote disable default")
     client.run("install --requires=pkg/0.1@lasote/testing -r default", assert_error=True)
-    assert "Remote 'default' is disabled" in client.out
+    assert "ERROR: Remote 'default' can't be found or is disabled" in client.out
     client.run("remote enable default")
     client.run("install --requires=pkg/0.1@lasote/testing -r default")
     client.run("remote disable default")
     client.run("install --requires=pkg/0.1@lasote/testing --update -r default", assert_error=True)
-    assert "Remote 'default' is disabled" in client.out
+    assert "ERROR: Remote 'default' can't be found or is disabled" in client.out
 
 
 def test_install_skip_disabled_remote():

--- a/conans/test/integration/command/install/install_update_test.py
+++ b/conans/test/integration/command/install/install_update_test.py
@@ -148,5 +148,4 @@ def test_update_binaries_failed():
     client.save({"conanfile.py": GenConanfile()})
     client.run("create . --name=pkg --version=0.1 --user=lasote --channel=testing")
     client.run("install --requires=pkg/0.1@lasote/testing --update")
-    assert "pkg/0.1@lasote/testing: WARN: Can't update, there are no remotes configured or " \
-           "enabled" in client.out
+    assert "WARN: Can't update, there are no remotes defined" in client.out

--- a/conans/test/integration/command/remote_test.py
+++ b/conans/test/integration/command/remote_test.py
@@ -195,10 +195,11 @@ class RemoteTest(unittest.TestCase):
         client = TestClient()
 
         client.run("remote disable invalid_remote", assert_error=True)
-        self.assertIn("ERROR: Remote 'invalid_remote' not found in remotes", client.out)
+        msg = "ERROR: Remote 'invalid_remote' can't be found or is disabled"
+        self.assertIn(msg, client.out)
 
         client.run("remote enable invalid_remote", assert_error=True)
-        self.assertIn("ERROR: Remote 'invalid_remote' not found in remotes", client.out)
+        self.assertIn(msg, client.out)
 
         client.run("remote disable invalid_wildcard_*")
 

--- a/conans/test/integration/command/user_test.py
+++ b/conans/test/integration/command/user_test.py
@@ -18,7 +18,7 @@ class UserTest(unittest.TestCase):
 
         with self.assertRaises(Exception):
             client.run("remote login wrong_remote foo -p bar")
-        self.assertIn("ERROR: Remote 'wrong_remote' not found in remotes", client.out)
+        self.assertIn("ERROR: Remote 'wrong_remote' can't be found or is disabled", client.out)
 
     def test_command_user_list(self):
         """ Test list of user is reported for all remotes or queried remote
@@ -31,7 +31,7 @@ class UserTest(unittest.TestCase):
         # Test with wrong remote right error is reported
         with self.assertRaises(Exception):
             client.run("remote login Test_Wrong_Remote foo")
-        self.assertIn("ERROR: Remote 'Test_Wrong_Remote' not found in remotes", client.out)
+        self.assertIn("ERROR: Remote 'Test_Wrong_Remote' can't be found or is disabled", client.out)
 
         # Test user list for all remotes is reported
         client.run("remote list-users")

--- a/conans/test/integration/command_v2/list_package_ids_test.py
+++ b/conans/test/integration/command_v2/list_package_ids_test.py
@@ -175,7 +175,7 @@ class TestListPackagesFromRemotes(TestListPackageIdsBase):
         # He have to put both remotes instead of using "-a" because of the
         # disbaled remote won't appear
         self.client.run("list packages whatever/1.0#123 -r remote1 -r remote2", assert_error=True)
-        assert "Remotes for pattern 'remote1' can't be found or are disabled" in self.client.out
+        assert "ERROR: Remote 'remote1' can't be found or is disabled" in self.client.out
 
     @pytest.mark.parametrize("exc,output", [
         (ConanConnectionError("Review your network!"), "ERROR: Review your network!"),
@@ -335,7 +335,7 @@ class TestRemotes(TestListPackageIdsBase):
         remote1_recipe1 = "test_recipe/1.0.0@user/channel"
         remote1_recipe2 = "test_recipe/1.1.0@user/channel"
 
-        expected_output = "ERROR: Remotes for pattern 'wrong_remote' can't be found or are disabled"
+        expected_output = "ERROR: Remote 'wrong_remote' can't be found or is disabled"
 
         self._add_remote(remote1)
         self._upload_recipe(remote1, remote1_recipe1)

--- a/conans/test/integration/command_v2/list_package_ids_test.py
+++ b/conans/test/integration/command_v2/list_package_ids_test.py
@@ -335,7 +335,7 @@ class TestRemotes(TestListPackageIdsBase):
         remote1_recipe1 = "test_recipe/1.0.0@user/channel"
         remote1_recipe2 = "test_recipe/1.1.0@user/channel"
 
-        expected_output = "Remote 'wrong_remote' not found in remotes"
+        expected_output = "ERROR: Remotes for pattern 'wrong_remote' can't be found or are disabled"
 
         self._add_remote(remote1)
         self._upload_recipe(remote1, remote1_recipe1)

--- a/conans/test/integration/command_v2/list_package_revisions_test.py
+++ b/conans/test/integration/command_v2/list_package_revisions_test.py
@@ -193,7 +193,7 @@ class TestRemotes(TestListPackageRevisionsBase):
         remote1_recipe1 = "test_recipe/1.0.0@user/channel"
         remote1_recipe2 = "test_recipe/1.1.0@user/channel"
 
-        expected_output = "ERROR: Remote 'wrong_remote' not found in remotes"
+        expected_output = "ERROR: Remotes for pattern 'wrong_remote' can't be found or are disabled"
 
         self._add_remote(remote1)
         self._upload_recipe(remote1, remote1_recipe1)

--- a/conans/test/integration/command_v2/list_package_revisions_test.py
+++ b/conans/test/integration/command_v2/list_package_revisions_test.py
@@ -123,7 +123,7 @@ class TestListPackagesFromRemotes(TestListPackageRevisionsBase):
         # disbaled remote won't appear
         pref = self._get_fake_package_refence('whatever/0.1')
         self.client.run(f"list package-revisions {pref} -r remote1 -r remote2", assert_error=True)
-        assert "Remotes for pattern 'remote1' can't be found or are disabled" in self.client.out
+        assert "ERROR: Remote 'remote1' can't be found or is disabled" in self.client.out
 
     @pytest.mark.parametrize("exc,output", [
         (ConanConnectionError("Review your network!"),
@@ -193,7 +193,7 @@ class TestRemotes(TestListPackageRevisionsBase):
         remote1_recipe1 = "test_recipe/1.0.0@user/channel"
         remote1_recipe2 = "test_recipe/1.1.0@user/channel"
 
-        expected_output = "ERROR: Remotes for pattern 'wrong_remote' can't be found or are disabled"
+        expected_output = "ERROR: Remote 'wrong_remote' can't be found or is disabled"
 
         self._add_remote(remote1)
         self._upload_recipe(remote1, remote1_recipe1)

--- a/conans/test/integration/command_v2/list_recipe_revisions_test.py
+++ b/conans/test/integration/command_v2/list_recipe_revisions_test.py
@@ -101,7 +101,7 @@ class TestListRecipesFromRemotes(TestListRecipeRevisionsBase):
         # disbaled remote won't appear
         self.client.run("list recipe-revisions whatever/1.0 -r remote1 -r remote2",
                         assert_error=True)
-        assert "Remotes for pattern 'remote1' can't be found or are disabled" in self.client.out
+        assert "ERROR: Remote 'remote1' can't be found or is disabled" in self.client.out
 
     @pytest.mark.parametrize("exc,output", [
         (ConanConnectionError("Review your network!"),
@@ -187,7 +187,7 @@ class TestRemotes(TestListRecipeRevisionsBase):
         remote1_recipe1 = "test_recipe/1.0.0@user/channel"
         remote1_recipe2 = "test_recipe/1.1.0@user/channel"
 
-        expected_output = "ERROR: Remotes for pattern 'wrong_remote' can't be found or are disabled"
+        expected_output = "ERROR: Remote 'wrong_remote' can't be found or is disabled"
 
         self._add_remote(remote1)
         self._upload_recipe(remote1, remote1_recipe1)

--- a/conans/test/integration/command_v2/list_recipe_revisions_test.py
+++ b/conans/test/integration/command_v2/list_recipe_revisions_test.py
@@ -187,7 +187,7 @@ class TestRemotes(TestListRecipeRevisionsBase):
         remote1_recipe1 = "test_recipe/1.0.0@user/channel"
         remote1_recipe2 = "test_recipe/1.1.0@user/channel"
 
-        expected_output = "ERROR: Remote 'wrong_remote' not found in remotes"
+        expected_output = "ERROR: Remotes for pattern 'wrong_remote' can't be found or are disabled"
 
         self._add_remote(remote1)
         self._upload_recipe(remote1, remote1_recipe1)

--- a/conans/test/integration/command_v2/list_recipes_test.py
+++ b/conans/test/integration/command_v2/list_recipes_test.py
@@ -35,7 +35,7 @@ class TestListRecipesBase:
 class TestParams(TestListRecipesBase):
     def test_fail_if_remote_list_is_empty(self):
         self.client.run("list recipes -r whatever *", assert_error=True)
-        assert "Remote 'whatever' not found in remotes" in self.client.out
+        assert "ERROR: Remotes for pattern 'whatever' can't be found or are disabled" in self.client.out
 
     def test_query_param_is_required(self):
         self._add_remote("remote1")
@@ -268,7 +268,7 @@ class TestRemotes(TestListRecipesBase):
         remote1_recipe1 = "test_recipe/1.0.0@user/channel"
         remote1_recipe2 = "test_recipe/1.1.0@user/channel"
 
-        expected_output = "Remote 'wrong_remote' not found in remotes"
+        expected_output = "ERROR: Remotes for pattern 'wrong_remote' can't be found or are disabled"
 
         self._add_remote(remote1)
         self._upload_recipe(remote1, remote1_recipe1)

--- a/conans/test/integration/command_v2/list_recipes_test.py
+++ b/conans/test/integration/command_v2/list_recipes_test.py
@@ -35,7 +35,7 @@ class TestListRecipesBase:
 class TestParams(TestListRecipesBase):
     def test_fail_if_remote_list_is_empty(self):
         self.client.run("list recipes -r whatever *", assert_error=True)
-        assert "ERROR: Remotes for pattern 'whatever' can't be found or are disabled" in self.client.out
+        assert "ERROR: Remote 'whatever' can't be found or is disabled" in self.client.out
 
     def test_query_param_is_required(self):
         self._add_remote("remote1")
@@ -89,7 +89,7 @@ class TestListRecipesFromRemotes(TestListRecipesBase):
         # He have to put both remotes instead of using "-a" because of the
         # disbaled remote won't appear
         self.client.run("list recipes whatever -r remote1 -r remote2", assert_error=True)
-        assert "Remotes for pattern 'remote1' can't be found or are disabled" in self.client.out
+        assert "ERROR: Remote 'remote1' can't be found or is disabled" in self.client.out
 
     @pytest.mark.parametrize("exc,output", [
         (ConanConnectionError("Review your network!"),
@@ -268,7 +268,7 @@ class TestRemotes(TestListRecipesBase):
         remote1_recipe1 = "test_recipe/1.0.0@user/channel"
         remote1_recipe2 = "test_recipe/1.1.0@user/channel"
 
-        expected_output = "ERROR: Remotes for pattern 'wrong_remote' can't be found or are disabled"
+        expected_output = "ERROR: Remote 'wrong_remote' can't be found or is disabled"
 
         self._add_remote(remote1)
         self._upload_recipe(remote1, remote1_recipe1)

--- a/conans/test/integration/command_v2/search_test.py
+++ b/conans/test/integration/command_v2/search_test.py
@@ -45,7 +45,7 @@ class TestSearch:
     def test_search_disabled_remote(self, remotes):
         self.client.run("remote disable remote1")
         self.client.run("search whatever -r remote1", assert_error=True)
-        expected_output = "ERROR: Remotes for pattern 'remote1' can't be found or are disabled"
+        expected_output = "ERROR: Remote 'remote1' can't be found or is disabled"
         assert expected_output in self.client.out
 
 
@@ -212,7 +212,7 @@ class TestRemotes:
         self._add_recipe(remote1, remote1_recipe2)
 
         self.client.run("search -r wrong_remote test_recipe", assert_error=True)
-        expected_output = "ERROR: Remotes for pattern 'wrong_remote' can't be found or are disabled"
+        expected_output = "ERROR: Remote 'wrong_remote' can't be found or is disabled"
         assert expected_output in self.client.out
 
     def test_search_wildcard(self):

--- a/conans/test/integration/command_v2/search_test.py
+++ b/conans/test/integration/command_v2/search_test.py
@@ -212,7 +212,7 @@ class TestRemotes:
         self._add_recipe(remote1, remote1_recipe2)
 
         self.client.run("search -r wrong_remote test_recipe", assert_error=True)
-        expected_output = "Remote 'wrong_remote' not found in remotes"
+        expected_output = "ERROR: Remotes for pattern 'wrong_remote' can't be found or are disabled"
         assert expected_output in self.client.out
 
     def test_search_wildcard(self):

--- a/conans/test/integration/remote/selected_remotes_test.py
+++ b/conans/test/integration/remote/selected_remotes_test.py
@@ -30,9 +30,9 @@ class TestSelectedRemotesInstall:
         assert "OLDREV" in self.client.out
         self.client.run("remove * -f")
         self.client.run("install --requires=liba/1.0 -r server1 -r server0 --build='*'")
-        # changing the order of the remotes in the arguments does not change the result
+        # changing the order of the remotes in the arguments does change the result
         # we install the revision from the server with more preference
-        assert "OLDREV" in self.client.out
+        assert "NEWER_REV" in self.client.out
         # select two remotes, just one has liba, will install the rev from that one
         self.client.run("remove * -f")
         self.client.run("install --requires=liba/1.0 -r server2 -r server1 --build='*'")


### PR DESCRIPTION
- Removing external methods related to removes, centralized in RemotesAPI
- Dropping global state ``ConanApp.selected_remotes`` and ``ConanApp.enabled_remotes``
- Leaving legacy ``ConanApp.load_remotes()`` with only ``update`` things, to be cleaned in another PR, this is only about the remotes
- ``conan install`` will only use "enabled_remotes" those selected, so sources will not be retrieved from other repos not passed in ``-r=xxx`` arguments
- Order of arguments in ``conan install -r=remote1 -r=remote2`` matters now