### PR TITLE
Add target argument to Autotools.install()

### DIFF
--- a/conan/tools/gnu/autotools.py
+++ b/conan/tools/gnu/autotools.py
@@ -55,10 +55,10 @@ class Autotools(object):
         command = join_arguments([make_program, target, str_args, str_extra_args, jobs])
         self._conanfile.run(command)
 
-    def install(self, args=None):
+    def install(self, args=None, target="install"):
         args = args if args is not None else \
             ["DESTDIR={}".format(unix_path(self._conanfile, self._conanfile.package_folder))]
-        self.make(target="install", args=args)
+        self.make(target=target, args=args)
 
     def autoreconf(self, args=None):
         args = args or []

--- a/conans/test/unittests/client/toolchain/autotools/autotools_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_test.py
@@ -34,3 +34,10 @@ def test_configure_arguments():
     ab.make()
     assert "my_make my_make_args -j23" in runner.command_called
 
+    # test install target argument
+
+    ab.install()
+    assert 'my_make install my_make_args DESTDIR=None -j23' in runner.command_called
+
+    ab.install(target="install_other")
+    assert 'my_make install_other my_make_args DESTDIR=None -j23' in runner.command_called


### PR DESCRIPTION
Changelog: Feature: Add `target` argument to `Autotools.install()`.
Docs: https://github.com/conan-io/docs/pull/2823

Closes: https://github.com/conan-io/conan/issues/12470
