### PR TITLE
Fix passing build jobs number (-j) to Autotools build helper

### DIFF
--- a/conan/tools/gnu/autotools.py
+++ b/conan/tools/gnu/autotools.py
@@ -49,7 +49,7 @@ class Autotools(object):
         str_args = self._make_args
         str_extra_args = " ".join(args) if args is not None else ""
         jobs = ""
-        jobs_already_passed = re.search(r"-j\d+", join_arguments([str_args, str_extra_args]))
+        jobs_already_passed = re.search(r"-j(\d+)", join_arguments([str_args, str_extra_args]))
         if not jobs_already_passed and "nmake" not in make_program.lower():
             njobs = build_jobs(self._conanfile)
             if njobs:

--- a/conan/tools/gnu/autotools.py
+++ b/conan/tools/gnu/autotools.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from conan.tools.build import build_jobs
 from conan.tools.files.files import load_toolchain_args
@@ -48,7 +49,8 @@ class Autotools(object):
         str_args = self._make_args
         str_extra_args = " ".join(args) if args is not None else ""
         jobs = ""
-        if "-j" not in (str_args + str_extra_args) and "nmake" not in make_program.lower():
+        jobs_already_passed = re.search(r"-j\d+", join_arguments([str_args, str_extra_args]))
+        if not jobs_already_passed and "nmake" not in make_program.lower():
             njobs = build_jobs(self._conanfile)
             if njobs:
                 jobs = "-j{}".format(njobs)
@@ -58,7 +60,7 @@ class Autotools(object):
     def install(self, args=None, target="install"):
         args = args if args else []
         str_args = " ".join(args)
-        if "DESTDIR" not in str_args:
+        if "DESTDIR=" not in str_args:
             args.insert(0, "DESTDIR={}".format(unix_path(self._conanfile, self._conanfile.package_folder)))
         self.make(target=target, args=args)
 

--- a/conan/tools/gnu/autotools.py
+++ b/conan/tools/gnu/autotools.py
@@ -49,7 +49,7 @@ class Autotools(object):
         str_args = self._make_args
         str_extra_args = " ".join(args) if args is not None else ""
         jobs = ""
-        jobs_already_passed = re.search(r"(^-j\d+\s+)|(\W-j\d+\s*)", join_arguments([str_args, str_extra_args]))
+        jobs_already_passed = re.search(r"(^-j\d+)|(\W-j\d+\s*)", join_arguments([str_args, str_extra_args]))
         if not jobs_already_passed and "nmake" not in make_program.lower():
             njobs = build_jobs(self._conanfile)
             if njobs:

--- a/conan/tools/gnu/autotools.py
+++ b/conan/tools/gnu/autotools.py
@@ -49,7 +49,7 @@ class Autotools(object):
         str_args = self._make_args
         str_extra_args = " ".join(args) if args is not None else ""
         jobs = ""
-        jobs_already_passed = re.search(r"-j(\d+)", join_arguments([str_args, str_extra_args]))
+        jobs_already_passed = re.search(r"(^-j\d+\s+)|(\W-j\d+\s*)", join_arguments([str_args, str_extra_args]))
         if not jobs_already_passed and "nmake" not in make_program.lower():
             njobs = build_jobs(self._conanfile)
             if njobs:

--- a/conan/tools/gnu/autotools.py
+++ b/conan/tools/gnu/autotools.py
@@ -48,7 +48,7 @@ class Autotools(object):
         str_args = self._make_args
         str_extra_args = " ".join(args) if args is not None else ""
         jobs = ""
-        if "-j" not in str_args and "nmake" not in make_program.lower():
+        if "-j" not in (str_args + str_extra_args) and "nmake" not in make_program.lower():
             njobs = build_jobs(self._conanfile)
             if njobs:
                 jobs = "-j{}".format(njobs)
@@ -56,8 +56,10 @@ class Autotools(object):
         self._conanfile.run(command)
 
     def install(self, args=None, target="install"):
-        args = args if args is not None else \
-            ["DESTDIR={}".format(unix_path(self._conanfile, self._conanfile.package_folder))]
+        args = args if args else []
+        str_args = " ".join(args)
+        if "DESTDIR" not in str_args:
+            args.insert(0, "DESTDIR={}".format(unix_path(self._conanfile, self._conanfile.package_folder)))
         self.make(target=target, args=args)
 
     def autoreconf(self, args=None):

--- a/conans/test/unittests/client/toolchain/autotools/autotools_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_test.py
@@ -56,6 +56,14 @@ def test_configure_arguments():
     assert "-j23" not in runner.command_called
     assert "my_make install my_make_args DESTDIR=whatever -j1" == runner.command_called
 
+    ab.install(args=["DESTDIR=whatever", "-arg1 -j1 -arg2"])
+    assert "-j23" not in runner.command_called
+    assert "my_make install my_make_args DESTDIR=whatever -arg1 -j1 -arg2" == runner.command_called
+
     # check that we don't detect -j in an argument as number of jobs
     ab.install(args=["DESTDIR=/user/smith-john/whatever"])
     assert "my_make install my_make_args DESTDIR=/user/smith-john/whatever -j23" == runner.command_called
+
+    # check that we don't detect -j in an argument as number of jobs
+    ab.install(args=["DESTDIR=/user/smith-j47/whatever"])
+    assert "my_make install my_make_args DESTDIR=/user/smith-j47/whatever -j23" == runner.command_called

--- a/conans/test/unittests/client/toolchain/autotools/autotools_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_test.py
@@ -42,28 +42,33 @@ def test_configure_arguments():
     ab.install(target="install_other")
     assert 'my_make install_other my_make_args DESTDIR=None -j23' == runner.command_called
 
-    # we can override the number of jobs in the recipe
+    save_toolchain_args({
+        "configure_args": "my_configure_args",
+        "make_args": ""}
+    )
+
+    ab = Autotools(conanfile)
 
     ab.make(args=["-j1"])
     assert "-j23" not in runner.command_called
-    assert "my_make my_make_args -j1" == runner.command_called
+    assert "my_make -j1" == runner.command_called
 
     ab.install(args=["-j1"])
     assert "-j23" not in runner.command_called
-    assert "my_make install my_make_args DESTDIR=None -j1" == runner.command_called
+    assert "my_make install DESTDIR=None -j1" == runner.command_called
 
     ab.install(args=["DESTDIR=whatever", "-j1"])
     assert "-j23" not in runner.command_called
-    assert "my_make install my_make_args DESTDIR=whatever -j1" == runner.command_called
+    assert "my_make install DESTDIR=whatever -j1" == runner.command_called
 
     ab.install(args=["DESTDIR=whatever", "-arg1 -j1 -arg2"])
     assert "-j23" not in runner.command_called
-    assert "my_make install my_make_args DESTDIR=whatever -arg1 -j1 -arg2" == runner.command_called
+    assert "my_make install DESTDIR=whatever -arg1 -j1 -arg2" == runner.command_called
 
     # check that we don't detect -j in an argument as number of jobs
     ab.install(args=["DESTDIR=/user/smith-john/whatever"])
-    assert "my_make install my_make_args DESTDIR=/user/smith-john/whatever -j23" == runner.command_called
+    assert "my_make install DESTDIR=/user/smith-john/whatever -j23" == runner.command_called
 
     # check that we don't detect -j in an argument as number of jobs
     ab.install(args=["DESTDIR=/user/smith-j47/whatever"])
-    assert "my_make install my_make_args DESTDIR=/user/smith-j47/whatever -j23" == runner.command_called
+    assert "my_make install DESTDIR=/user/smith-j47/whatever -j23" == runner.command_called

--- a/conans/test/unittests/client/toolchain/autotools/autotools_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_test.py
@@ -42,33 +42,37 @@ def test_configure_arguments():
     ab.install(target="install_other")
     assert 'my_make install_other my_make_args DESTDIR=None -j23' == runner.command_called
 
-    save_toolchain_args({
-        "configure_args": "my_configure_args",
-        "make_args": ""}
-    )
+    for make_args in ["my_make_args", ""]:
 
-    ab = Autotools(conanfile)
+        save_toolchain_args({
+            "configure_args": "my_configure_args",
+            "make_args": f"{make_args}"}
+        )
 
-    ab.make(args=["-j1"])
-    assert "-j23" not in runner.command_called
-    assert "my_make -j1" == runner.command_called
+        ab = Autotools(conanfile)
 
-    ab.install(args=["-j1"])
-    assert "-j23" not in runner.command_called
-    assert "my_make install DESTDIR=None -j1" == runner.command_called
+        make_args_str = f" {make_args}" if make_args else ""
 
-    ab.install(args=["DESTDIR=whatever", "-j1"])
-    assert "-j23" not in runner.command_called
-    assert "my_make install DESTDIR=whatever -j1" == runner.command_called
+        ab.make(args=["-j1"])
+        assert "-j23" not in runner.command_called
+        assert f"my_make{make_args_str} -j1" == runner.command_called
 
-    ab.install(args=["DESTDIR=whatever", "-arg1 -j1 -arg2"])
-    assert "-j23" not in runner.command_called
-    assert "my_make install DESTDIR=whatever -arg1 -j1 -arg2" == runner.command_called
+        ab.install(args=["-j1"])
+        assert "-j23" not in runner.command_called
+        assert f"my_make install{make_args_str} DESTDIR=None -j1" == runner.command_called
 
-    # check that we don't detect -j in an argument as number of jobs
-    ab.install(args=["DESTDIR=/user/smith-john/whatever"])
-    assert "my_make install DESTDIR=/user/smith-john/whatever -j23" == runner.command_called
+        ab.install(args=["DESTDIR=whatever", "-j1"])
+        assert "-j23" not in runner.command_called
+        assert f"my_make install{make_args_str} DESTDIR=whatever -j1" == runner.command_called
 
-    # check that we don't detect -j in an argument as number of jobs
-    ab.install(args=["DESTDIR=/user/smith-j47/whatever"])
-    assert "my_make install DESTDIR=/user/smith-j47/whatever -j23" == runner.command_called
+        ab.install(args=["DESTDIR=whatever", "-arg1 -j1 -arg2"])
+        assert "-j23" not in runner.command_called
+        assert f"my_make install{make_args_str} DESTDIR=whatever -arg1 -j1 -arg2" == runner.command_called
+
+        # check that we don't detect -j in an argument as number of jobs
+        ab.install(args=["DESTDIR=/user/smith-john/whatever"])
+        assert f"my_make install{make_args_str} DESTDIR=/user/smith-john/whatever -j23" == runner.command_called
+
+        # check that we don't detect -j in an argument as number of jobs
+        ab.install(args=["DESTDIR=/user/smith-j47/whatever"])
+        assert f"my_make install{make_args_str} DESTDIR=/user/smith-j47/whatever -j23" == runner.command_called

--- a/conans/test/unittests/client/toolchain/autotools/autotools_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_test.py
@@ -32,12 +32,26 @@ def test_configure_arguments():
 
     ab = Autotools(conanfile)
     ab.make()
-    assert "my_make my_make_args -j23" in runner.command_called
+    assert "my_make my_make_args -j23" == runner.command_called
 
     # test install target argument
 
     ab.install()
-    assert 'my_make install my_make_args DESTDIR=None -j23' in runner.command_called
+    assert 'my_make install my_make_args DESTDIR=None -j23' == runner.command_called
 
     ab.install(target="install_other")
-    assert 'my_make install_other my_make_args DESTDIR=None -j23' in runner.command_called
+    assert 'my_make install_other my_make_args DESTDIR=None -j23' == runner.command_called
+
+    # we can override the number of jobs in the recipe
+
+    ab.make(args=["-j1"])
+    assert "-j23" not in runner.command_called
+    assert "my_make my_make_args -j1" == runner.command_called
+
+    ab.install(args=["-j1"])
+    assert "-j23" not in runner.command_called
+    assert "my_make install my_make_args DESTDIR=None -j1" == runner.command_called
+
+    ab.install(args=["DESTDIR=whatever", "-j1"])
+    assert "-j23" not in runner.command_called
+    assert "my_make install my_make_args DESTDIR=whatever -j1" == runner.command_called

--- a/conans/test/unittests/client/toolchain/autotools/autotools_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_test.py
@@ -55,3 +55,7 @@ def test_configure_arguments():
     ab.install(args=["DESTDIR=whatever", "-j1"])
     assert "-j23" not in runner.command_called
     assert "my_make install my_make_args DESTDIR=whatever -j1" == runner.command_called
+
+    # check that we don't detect -j in an argument as number of jobs
+    ab.install(args=["DESTDIR=/user/smith-john/whatever"])
+    assert "my_make install my_make_args DESTDIR=/user/smith-john/whatever -j23" == runner.command_called


### PR DESCRIPTION
Changelog: Fix: Give priority to `-j` argument set by user in recipe over the default set by conan in `Autotools` build helper.
Docs: omit

Closes: https://github.com/conan-io/conan/issues/12494
Closes: https://github.com/conan-io/conan/issues/12296
