### PR TITLE
second approach to correct require equality

### DIFF
--- a/conans/model/recipe_ref.py
+++ b/conans/model/recipe_ref.py
@@ -81,6 +81,15 @@ class RecipeReference:
         return (self.name, self.version, self.user, self.channel, self.revision) == \
                (ref.name, ref.version, ref.user, ref.channel, ref.revision)
 
+    def require_equal(self, ref):
+        # Timestamp doesn't affect equality.
+        # This is necessary for building an ordered list of UNIQUE recipe_references for Lockfile
+        if self.revision is not None and ref.revision is not None:
+            return (self.name, self.version, self.user, self.channel, self.revision) == \
+                   (ref.name, ref.version, ref.user, ref.channel, ref.revision)
+        return (self.name, self.version, self.user, self.channel) == \
+               (ref.name, ref.version, ref.user, ref.channel)
+
     def __hash__(self):
         # This is necessary for building an ordered list of UNIQUE recipe_references for Lockfile
         return hash((self.name, self.version, self.user, self.channel, self.revision))

--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -211,7 +211,7 @@ class Requirement:
                  (self.libs and other.libs) or
                  (self.run and other.run) or
                  (self.visible and other.visible) or
-                 (self.ref == other.ref)))
+                 (self.ref.require_equal(other.ref))))
 
     def aggregate(self, other):
         """ when closing loop and finding the same dependency on a node, the information needs

--- a/conans/test/integration/lockfile/test_lock_requires.py
+++ b/conans/test/integration/lockfile/test_lock_requires.py
@@ -450,3 +450,81 @@ class TestLockTestPackage:
             assert "dep/1.0" in c.out
             assert "dep/2.0" not in c.out
             assert "package tested" in c.out
+
+
+class TestErrorDuplicates:
+    def test_error_duplicates(self):
+        """ the problem is having 2 different, almost identical requires that will point to the same
+        thing, with different traits and not colliding.
+        Lockfiles do a ``require.ref`` update and that alters some dictionaries iteration, producing
+        an infinite loop and blocking
+        """
+        c = TestClient()
+        pkg = textwrap.dedent("""
+            from conan import ConanFile
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "0.1"
+                def requirements(self):
+                    self.requires("dep/0.1#f8c2264d0b32a4c33f251fe2944bb642", headers=False, libs=False,
+                                visible=False)
+                    self.requires("dep/0.1", headers=True, libs=False, visible=False)
+                """)
+        c.save({"dep/conanfile.py": GenConanfile("dep", "0.1"),
+                "pkg/conanfile.py": pkg})
+        c.run("create dep --lockfile-out=conan.lock")
+        c.run("create pkg", assert_error=True)
+        assert "Duplicated requirement: dep/0.1" in c.out
+        c.run("create pkg --lockfile=conan.lock", assert_error=True)
+        assert "Duplicated requirement: dep/0.1" in c.out
+
+    def test_error_duplicates_reverse(self):
+        """ Same as above, but order requires changed
+        """
+        c = TestClient()
+        pkg = textwrap.dedent("""
+            from conan import ConanFile
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "0.1"
+                def requirements(self):
+                    self.requires("dep/0.1", headers=True, libs=False, visible=False)
+                    self.requires("dep/0.1#f8c2264d0b32a4c33f251fe2944bb642", headers=False, libs=False,
+                                visible=False)
+                """)
+        c.save({"dep/conanfile.py": GenConanfile("dep", "0.1"),
+                "pkg/conanfile.py": pkg})
+        c.run("create dep --lockfile-out=conan.lock")
+        c.run("create pkg", assert_error=True)
+        assert "Duplicated requirement: dep/0.1" in c.out
+        c.run("create pkg --lockfile=conan.lock", assert_error=True)
+        assert "Duplicated requirement: dep/0.1" in c.out
+
+    def test_error_duplicates_revisions(self):
+        """ 2 different revisions can be added without conflict, if they are not visible and not
+        other conflicting traits
+        """
+        c = TestClient()
+        pkg = textwrap.dedent("""
+            from conan import ConanFile
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "0.1"
+                def requirements(self):
+                    self.requires("dep/0.1#f8c2264d0b32a4c33f251fe2944bb642", headers=False,
+                                  libs=False, visible=False)
+                    self.requires("dep/0.1#7b91e6100797b8b012eb3cdc5544800b", headers=True,
+                                  libs=False, visible=False)
+                """)
+        c.save({"dep/conanfile.py": GenConanfile("dep", "0.1"),
+                "dep2/conanfile.py": GenConanfile("dep", "0.1").with_class_attribute("potato=42"),
+                "pkg/conanfile.py": pkg})
+        c.run("create dep --lockfile-out=conan.lock")
+        c.run("create dep2 --lockfile=conan.lock --lockfile-out=conan.lock")
+
+        c.run("create pkg")
+        assert "dep/0.1#f8c2264d0b32a4c33f251fe2944bb642 - Cache" in c.out
+        assert "dep/0.1#7b91e6100797b8b012eb3cdc5544800b - Cache" in c.out
+        c.run("create pkg --lockfile=conan.lock")
+        assert "dep/0.1#f8c2264d0b32a4c33f251fe2944bb642 - Cache" in c.out
+        assert "dep/0.1#7b91e6100797b8b012eb3cdc5544800b - Cache" in c.out


### PR DESCRIPTION
Complement to https://github.com/conan-io/conan/pull/12506, implementing the approach of changing the equality of ``Requirement``, but not ``RecipeReference``
