### PR TITLE
Add cli_args argument to CMake build helper configure method

### DIFF
--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -61,7 +61,7 @@ class CMake(object):
 
         self._cmake_program = "cmake"  # Path to CMake should be handled by environment
 
-    def configure(self, variables=None, build_script_folder=None):
+    def configure(self, variables=None, build_script_folder=None, cli_args=None):
         cmakelist_folder = self._conanfile.source_folder
         if build_script_folder:
             cmakelist_folder = os.path.join(self._conanfile.source_folder, build_script_folder)
@@ -90,6 +90,9 @@ class CMake(object):
 
         arg_list.extend(['-D{}="{}"'.format(k, v) for k, v in self._cache_variables.items()])
         arg_list.append('"{}"'.format(cmakelist_folder))
+
+        if cli_args:
+            arg_list.extend(cli_args)
 
         command = " ".join(arg_list)
         self._conanfile.output.info("CMake command: %s" % command)

--- a/conans/test/unittests/tools/cmake/test_cmake_test.py
+++ b/conans/test/unittests/tools/cmake/test_cmake_test.py
@@ -43,3 +43,18 @@ def test_run_tests(generator, target):
 
     search_pattern = "--target {}" if platform.system() == "Windows" else "'--target' '{}'"
     assert search_pattern.format(target) in conanfile.command
+
+
+def test_cli_args_configure():
+    settings = Settings.loads(get_default_settings_yml())
+
+    conanfile = ConanFileMock()
+    conanfile.conf = Conf()
+    conanfile.folders.generators = "."
+    conanfile.folders.set_base_generators(temp_folder())
+    conanfile.settings = settings
+
+    write_cmake_presets(conanfile, "toolchain", "Unix Makefiles", {})
+    cmake = CMake(conanfile)
+    cmake.configure(cli_args=["--graphviz=foo.dot"])
+    assert "--graphviz=foo.dot" in conanfile.command


### PR DESCRIPTION
Changelog: Feature: Add `cli_args` argument to CMake build helper configure method.
Docs: https://github.com/conan-io/docs/pull/2822

Closes: https://github.com/conan-io/conan/issues/12496