### PR TITLE
[CMakeToolchain][env] Added PKG_CONFIG_PATH env variable and PKG_CONFIG_EXECUTABLE one

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -559,6 +559,20 @@ class FindFiles(Block):
         }
 
 
+class PkgConfigBlock(Block):
+    template = textwrap.dedent("""
+        {% if pkg_config %}
+        set(PKG_CONFIG_EXECUTABLE {{ pkg_config }} CACHE FILEPATH "pkg-config executable")
+        {% endif %}
+        """)
+
+    def context(self):
+        pkg_config = self._conanfile.conf.get("tools.gnu:pkg_config", default=False, check_type=str)
+        if pkg_config:
+            pkg_config = pkg_config.replace("\\", "/")
+        return pkg_config
+
+
 class UserToolchain(Block):
     template = textwrap.dedent("""
         {% for user_toolchain in paths %}

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -575,7 +575,11 @@ class PkgConfigBlock(Block):
             pkg_config = pkg_config.replace("\\", "/")
         pkg_config_path = self._conanfile.generators_folder
         if pkg_config_path:
-            pkg_config_path += os.pathsep
+            # Path sep based on "os" host settings (as it's done
+            # for "fpic" calculation for instance)
+            os_ = self._conanfile.settings.get_safe("os")
+            pathsep = ":" if os_ != "Windows" else ";"
+            pkg_config_path = pkg_config_path.replace("\\", "/") + pathsep
         return {"pkg_config": pkg_config,
                 "pkg_config_path": pkg_config_path}
 

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -565,7 +565,11 @@ class PkgConfigBlock(Block):
         set(PKG_CONFIG_EXECUTABLE {{ pkg_config }} CACHE FILEPATH "pkg-config executable")
         {% endif %}
         {% if pkg_config_path %}
+        if (DEFINED ENV{PKG_CONFIG_PATH})
         set(ENV{PKG_CONFIG_PATH} "{{ pkg_config_path }}$ENV{PKG_CONFIG_PATH}")
+        else()
+        set(ENV{PKG_CONFIG_PATH} "{{ pkg_config_path }}")
+        endif()
         {% endif %}
         """)
 

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -12,6 +12,7 @@ from conan.tools.build.cross_building import cross_building
 from conan.tools.cmake.toolchain import CONAN_TOOLCHAIN_FILENAME
 from conan.tools.intel import IntelCC
 from conan.tools.microsoft.visual import is_msvc, msvc_version_to_toolset_version
+from conans.client.subsystems import deduce_subsystem, WINDOWS
 from conans.errors import ConanException
 from conans.util.files import load
 
@@ -579,10 +580,9 @@ class PkgConfigBlock(Block):
             pkg_config = pkg_config.replace("\\", "/")
         pkg_config_path = self._conanfile.generators_folder
         if pkg_config_path:
-            # Path sep based on "os" host settings (as it's done
-            # for "fpic" calculation for instance)
-            os_ = self._conanfile.settings.get_safe("os")
-            pathsep = ":" if os_ != "Windows" else ";"
+            # hardcoding scope as "build"
+            subsystem = deduce_subsystem(self._conanfile, "build")
+            pathsep = ":" if subsystem != WINDOWS else ";"
             pkg_config_path = pkg_config_path.replace("\\", "/") + pathsep
         return {"pkg_config": pkg_config,
                 "pkg_config_path": pkg_config_path}

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -570,7 +570,7 @@ class PkgConfigBlock(Block):
         pkg_config = self._conanfile.conf.get("tools.gnu:pkg_config", default=False, check_type=str)
         if pkg_config:
             pkg_config = pkg_config.replace("\\", "/")
-        return pkg_config
+        return {"pkg_config": pkg_config}
 
 
 class UserToolchain(Block):

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -567,7 +567,7 @@ class PkgConfigBlock(Block):
         """)
 
     def context(self):
-        pkg_config = self._conanfile.conf.get("tools.gnu:pkg_config", default=False, check_type=str)
+        pkg_config = self._conanfile.conf.get("tools.gnu:pkg_config", check_type=str)
         if pkg_config:
             pkg_config = pkg_config.replace("\\", "/")
         return {"pkg_config": pkg_config}

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -153,7 +153,7 @@ class FPicBlock(Block):
     template = textwrap.dedent("""
         {% if fpic %}
         message(STATUS "Conan toolchain: Setting CMAKE_POSITION_INDEPENDENT_CODE={{ fpic }} (options.fPIC)")
-        set(CMAKE_POSITION_INDEPENDENT_CODE {{ fpic }} CACHE BOOL "Position independent code") 
+        set(CMAKE_POSITION_INDEPENDENT_CODE {{ fpic }} CACHE BOOL "Position independent code")
         {% endif %}
         """)
 
@@ -564,13 +564,24 @@ class PkgConfigBlock(Block):
         {% if pkg_config %}
         set(PKG_CONFIG_EXECUTABLE {{ pkg_config }} CACHE FILEPATH "pkg-config executable")
         {% endif %}
+        {% if pkg_config_path %}
+        set(ENV{PKG_CONFIG_PATH} "{{ pkg_config_path }}")
+        {% endif %}
         """)
 
     def context(self):
         pkg_config = self._conanfile.conf.get("tools.gnu:pkg_config", check_type=str)
         if pkg_config:
             pkg_config = pkg_config.replace("\\", "/")
-        return {"pkg_config": pkg_config}
+        pkg_config_path = self._conanfile.generators_folder
+        if pkg_config_path:
+            # Check if user has already defined their own PKG_CONFIG_PATH variable
+            user_pkg_config_path = os.getenv("PKG_CONFIG_PATH")
+            if user_pkg_config_path:
+                # Prepending the Conan one
+                pkg_config_path = pkg_config_path + os.pathsep + user_pkg_config_path
+        return {"pkg_config": pkg_config,
+                "pkg_config_path": pkg_config_path}
 
 
 class UserToolchain(Block):

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -565,7 +565,7 @@ class PkgConfigBlock(Block):
         set(PKG_CONFIG_EXECUTABLE {{ pkg_config }} CACHE FILEPATH "pkg-config executable")
         {% endif %}
         {% if pkg_config_path %}
-        set(ENV{PKG_CONFIG_PATH} "{{ pkg_config_path }}")
+        set(ENV{PKG_CONFIG_PATH} "{{ pkg_config_path }}$ENV{PKG_CONFIG_PATH}")
         {% endif %}
         """)
 
@@ -575,11 +575,7 @@ class PkgConfigBlock(Block):
             pkg_config = pkg_config.replace("\\", "/")
         pkg_config_path = self._conanfile.generators_folder
         if pkg_config_path:
-            # Check if user has already defined their own PKG_CONFIG_PATH variable
-            user_pkg_config_path = os.getenv("PKG_CONFIG_PATH")
-            if user_pkg_config_path:
-                # Prepending the Conan one
-                pkg_config_path = pkg_config_path + os.pathsep + user_pkg_config_path
+            pkg_config_path += os.pathsep
         return {"pkg_config": pkg_config,
                 "pkg_config_path": pkg_config_path}
 

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -11,7 +11,7 @@ from conan.tools.cmake.presets import write_cmake_presets
 from conan.tools.cmake.toolchain import CONAN_TOOLCHAIN_FILENAME
 from conan.tools.cmake.toolchain.blocks import ToolchainBlocks, UserToolchain, GenericSystemBlock, \
     AndroidSystemBlock, AppleSystemBlock, FPicBlock, ArchitectureBlock, GLibCXXBlock, VSRuntimeBlock, \
-    CppStdBlock, ParallelBlock, CMakeFlagsInitBlock, TryCompileBlock, FindFiles, SkipRPath, \
+    CppStdBlock, ParallelBlock, CMakeFlagsInitBlock, TryCompileBlock, FindFiles, PkgConfigBlock, SkipRPath, \
     SharedLibBock, OutputDirsBlock, ExtraFlagsBlock
 from conan.tools.intel import IntelCC
 from conan.tools.microsoft import VCVars
@@ -139,6 +139,7 @@ class CMakeToolchain(object):
                                        ("cmake_flags_init", CMakeFlagsInitBlock),
                                        ("try_compile", TryCompileBlock),
                                        ("find_paths", FindFiles),
+                                       ("pkg_config", PkgConfigBlock),
                                        ("rpath", SkipRPath),
                                        ("shared", SharedLibBock),
                                        ("output_dirs", OutputDirsBlock)])

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -11,9 +11,8 @@ from conan.tools.cmake.presets import write_cmake_presets
 from conan.tools.cmake.toolchain import CONAN_TOOLCHAIN_FILENAME
 from conan.tools.cmake.toolchain.blocks import ToolchainBlocks, UserToolchain, GenericSystemBlock, \
     AndroidSystemBlock, AppleSystemBlock, FPicBlock, ArchitectureBlock, GLibCXXBlock, VSRuntimeBlock, \
-    CppStdBlock, ParallelBlock, CMakeFlagsInitBlock, TryCompileBlock, FindFiles, PkgConfigBlock, SkipRPath, \
-    SharedLibBock, OutputDirsBlock, ExtraFlagsBlock
-from conan.tools.env import Environment
+    CppStdBlock, ParallelBlock, CMakeFlagsInitBlock, TryCompileBlock, FindFiles, PkgConfigBlock, \
+    SkipRPath, SharedLibBock, OutputDirsBlock, ExtraFlagsBlock
 from conan.tools.intel import IntelCC
 from conan.tools.microsoft import VCVars
 from conan.tools.microsoft.visual import vs_ide_version
@@ -169,18 +168,7 @@ class CMakeToolchain(object):
         content = Template(self._template, trim_blocks=True, lstrip_blocks=True).render(**context)
         return content
 
-    def environment(self):
-        env = Environment()
-        env.prepend_path("PKG_CONFIG_PATH", self._conanfile.generators_folder)
-        return env
-
-    def vars(self):
-        return self.environment().vars(self._conanfile, scope="build")
-
-    def generate(self, env=None, scope="build"):
-        env = env or self.environment()
-        env = env.vars(self._conanfile, scope=scope)
-        env.save_script("conan_toolchain_env")
+    def generate(self):
         toolchain_file = self._conanfile.conf.get("tools.cmake.cmaketoolchain:toolchain_file")
         if toolchain_file is None:  # The main toolchain file generated only if user dont define
             save(os.path.join(self._conanfile.generators_folder, self.filename), self.content)

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -13,6 +13,7 @@ from conan.tools.cmake.toolchain.blocks import ToolchainBlocks, UserToolchain, G
     AndroidSystemBlock, AppleSystemBlock, FPicBlock, ArchitectureBlock, GLibCXXBlock, VSRuntimeBlock, \
     CppStdBlock, ParallelBlock, CMakeFlagsInitBlock, TryCompileBlock, FindFiles, PkgConfigBlock, SkipRPath, \
     SharedLibBock, OutputDirsBlock, ExtraFlagsBlock
+from conan.tools.env import Environment
 from conan.tools.intel import IntelCC
 from conan.tools.microsoft import VCVars
 from conan.tools.microsoft.visual import vs_ide_version
@@ -168,7 +169,18 @@ class CMakeToolchain(object):
         content = Template(self._template, trim_blocks=True, lstrip_blocks=True).render(**context)
         return content
 
-    def generate(self):
+    def environment(self):
+        env = Environment()
+        env.prepend_path("PKG_CONFIG_PATH", self._conanfile.generators_folder)
+        return env
+
+    def vars(self):
+        return self.environment().vars(self._conanfile, scope="build")
+
+    def generate(self, env=None, scope="build"):
+        env = env or self.environment()
+        env = env.vars(self._conanfile, scope=scope)
+        env.save_script("conan_toolchain_env")
         toolchain_file = self._conanfile.conf.get("tools.cmake.cmaketoolchain:toolchain_file")
         if toolchain_file is None:  # The main toolchain file generated only if user dont define
             save(os.path.join(self._conanfile.generators_folder, self.filename), self.content)

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1099,7 +1099,7 @@ def test_cmake_toolchain_vars_when_option_declared():
 
     t.run("new mylib/1.0 --template cmake_lib")
     t.save({"CMakeLists.txt": cmakelists})
-    
+
     # The generated toolchain should set `BUILD_SHARED_LIBS` to `OFF`,
     # and `CMAKE_POSITION_INDEPENDENT_CODE` to `ON` and the calls to
     # `option()` in the CMakeLists.txt should respect the existing values.
@@ -1112,7 +1112,7 @@ def test_cmake_toolchain_vars_when_option_declared():
     assert "mylib target type: STATIC_LIBRARY" in t.out
     assert f"mylib position independent code: {fpic_cmake_value}" in t.out
 
-    # When building manually, ensure the value passed by the toolchain overrides the ones in 
+    # When building manually, ensure the value passed by the toolchain overrides the ones in
     # the CMakeLists
     fpic_option = "-o mylib:fPIC=False" if platform.system() != "Windows" else ""
     t.run(f"install . -o mylib:shared=False {fpic_option}")
@@ -1198,10 +1198,10 @@ def test_find_program_for_tool_requires():
 
             def layout(self):
                 cmake_layout(self)
-            
+
             def requirements(self):
                 self.requires("foobar/1.0")
-            
+
             def build_requirements(self):
                 self.tool_requires("foobar/1.0")
     """)
@@ -1227,7 +1227,63 @@ def test_find_program_for_tool_requires():
 
     with client.chdir("build"):
         client.run_command("cmake .. -DCMAKE_TOOLCHAIN_FILE=generators/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release")
-        # Verify binary executable is found from build context package, 
+        # Verify binary executable is found from build context package,
         # and library comes from host context package
         assert f"package/{build_context_package_id}/bin/foobin" in client.out
         assert f"package/{host_context_package_id}/include" in client.out
+
+
+@pytest.mark.tool_pkg_config
+def test_cmaketoolchain_and_pkg_config_path():
+    """
+    Lightweight test which is loading a dependency as a *.pc file through
+    CMake thanks to pkg_check_modules macro.
+    It's working because PKG_CONFIG_PATH env variable is being loaded automatically
+    by the VirtualBuildEnv generator.
+    """
+    client = TestClient()
+    dep = textwrap.dedent("""
+    from conan import ConanFile
+    class DepConan(ConanFile):
+        name = "dep"
+        version = "1.0"
+        def package_info(self):
+            self.cpp_info.libs = ["dep"]
+    """)
+    pkg = textwrap.dedent("""
+    from conan import ConanFile
+    from conan.tools.cmake import CMake, cmake_layout
+    class HelloConan(ConanFile):
+        name = "pkg"
+        version = "1.0"
+        settings = "os", "compiler", "build_type", "arch"
+        generators = "PkgConfigDeps", "CMakeToolchain", "VirtualBuildEnv"
+        exports_sources = "CMakeLists.txt"
+
+        def requirements(self):
+            self.requires("dep/1.0")
+
+        def layout(self):
+            cmake_layout(self)
+
+        def build(self):
+            cmake = CMake(self)
+            cmake.configure()
+            cmake.build()
+    """)
+    cmakelists = textwrap.dedent("""
+    cmake_minimum_required(VERSION 3.15)
+    project(pkg CXX)
+
+    find_package(PkgConfig REQUIRED)
+    # We should have PKG_CONFIG_PATH created in the current environment
+    pkg_check_modules(DEP REQUIRED IMPORTED_TARGET dep)
+    """)
+    client.save({
+        "dep/conanfile.py": dep,
+        "pkg/conanfile.py": pkg,
+        "pkg/CMakeLists.txt": cmakelists
+    })
+    client.run("create dep/conanfile.py")
+    client.run("create pkg/conanfile.py")
+    assert "Found dep, version 1.0" in client.out

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1239,7 +1239,7 @@ def test_cmaketoolchain_and_pkg_config_path():
     Lightweight test which is loading a dependency as a *.pc file through
     CMake thanks to pkg_check_modules macro.
     It's working because PKG_CONFIG_PATH env variable is being loaded automatically
-    by the VirtualBuildEnv generator.
+    by the CMakeToolchain generator.
     """
     client = TestClient()
     dep = textwrap.dedent("""

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1257,7 +1257,7 @@ def test_cmaketoolchain_and_pkg_config_path():
         name = "pkg"
         version = "1.0"
         settings = "os", "compiler", "build_type", "arch"
-        generators = "PkgConfigDeps", "CMakeToolchain", "VirtualBuildEnv"
+        generators = "PkgConfigDeps", "CMakeToolchain"
         exports_sources = "CMakeLists.txt"
 
         def requirements(self):

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -778,6 +778,6 @@ def test_pkg_config_block():
     client.run("install . -pr:b profile -pr:h profile")
     toolchain = client.load("conan_toolchain.cmake")
     assert 'set(PKG_CONFIG_EXECUTABLE /usr/local/bin/pkg-config CACHE FILEPATH ' in toolchain
-    generators_folder = 'set(ENV{PKG_CONFIG_PATH} "%s$ENV{PKG_CONFIG_PATH}")' % \
-                        (client.current_folder + os.pathsep)
-    assert generators_folder in toolchain
+    pkg_config_path_set = 'set(ENV{PKG_CONFIG_PATH} "%s$ENV{PKG_CONFIG_PATH}")' % \
+                          (client.current_folder + os.pathsep)
+    assert pkg_config_path_set in toolchain

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -779,5 +779,5 @@ def test_pkg_config_block():
     toolchain = client.load("conan_toolchain.cmake")
     assert 'set(PKG_CONFIG_EXECUTABLE /usr/local/bin/pkg-config CACHE FILEPATH ' in toolchain
     pkg_config_path_set = 'set(ENV{PKG_CONFIG_PATH} "%s$ENV{PKG_CONFIG_PATH}")' % \
-                          (client.current_folder + os.pathsep)
+                          (client.current_folder.replace("\\", "/") + os.pathsep)
     assert pkg_config_path_set in toolchain

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -761,14 +761,16 @@ def test_presets_ninja_msvc(arch, arch_toolset):
 
 
 def test_pkg_config_block():
+    os_ = platform.system()
+    os_ = "Macos" if os_ == "Darwin" else os_
     profile = textwrap.dedent("""
         [settings]
-        os=Linux
-        arch=armv8
+        os=%s
+        arch=x86_64
 
         [conf]
         tools.gnu:pkg_config=/usr/local/bin/pkg-config
-        """)
+        """ % os_)
 
     client = TestClient(path_with_spaces=False)
     conanfile = GenConanfile().with_settings("os", "arch")\
@@ -778,6 +780,7 @@ def test_pkg_config_block():
     client.run("install . -pr:b profile -pr:h profile")
     toolchain = client.load("conan_toolchain.cmake")
     assert 'set(PKG_CONFIG_EXECUTABLE /usr/local/bin/pkg-config CACHE FILEPATH ' in toolchain
+    pathsep = ":" if os_ != "Windows" else ";"
     pkg_config_path_set = 'set(ENV{PKG_CONFIG_PATH} "%s$ENV{PKG_CONFIG_PATH}")' % \
-                          (client.current_folder.replace("\\", "/") + os.pathsep)
+                          (client.current_folder.replace("\\", "/") + pathsep)
     assert pkg_config_path_set in toolchain

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -758,3 +758,23 @@ def test_presets_ninja_msvc(arch, arch_toolset):
     presets = json.loads(client.load("build/14/generators/CMakePresets.json"))
     assert "architecture" in presets["configurePresets"][0]
     assert "toolset" not in presets["configurePresets"][0]
+
+
+def test_pkg_config_executable_variable():
+    profile = textwrap.dedent("""
+        [settings]
+        os=Linux
+        arch=armv8
+
+        [conf]
+        tools.gnu:pkg_config=/usr/local/bin/pkg-config
+        """)
+
+    client = TestClient(path_with_spaces=False)
+    conanfile = GenConanfile().with_settings("os", "arch")\
+        .with_generator("CMakeToolchain")
+    client.save({"conanfile.py": conanfile,
+                "profile": profile})
+    client.run("install . -pr:b profile -pr:h profile")
+    toolchain = client.load("conan_toolchain.cmake")
+    assert 'set(PKG_CONFIG_EXECUTABLE /usr/local/bin/pkg-config CACHE FILEPATH ' in toolchain

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -760,7 +760,7 @@ def test_presets_ninja_msvc(arch, arch_toolset):
     assert "toolset" not in presets["configurePresets"][0]
 
 
-def test_pkg_config_executable_variable():
+def test_pkg_config_block():
     profile = textwrap.dedent("""
         [settings]
         os=Linux
@@ -778,3 +778,6 @@ def test_pkg_config_executable_variable():
     client.run("install . -pr:b profile -pr:h profile")
     toolchain = client.load("conan_toolchain.cmake")
     assert 'set(PKG_CONFIG_EXECUTABLE /usr/local/bin/pkg-config CACHE FILEPATH ' in toolchain
+    generators_folder = 'set(ENV{PKG_CONFIG_PATH} "%s$ENV{PKG_CONFIG_PATH}")' % \
+                        (client.current_folder + os.pathsep)
+    assert generators_folder in toolchain


### PR DESCRIPTION
Changelog: Feature: Added generators folder to `PKG_CONFIG_PATH` environment variable in `CMakeToolchain`.
Changelog: Feature: Ensure that `CMakeToolchain` will enforce usage of `pkg-config` executable set in `tools.gnu:pkg_config` config.
Closes: https://github.com/conan-io/conan/issues/11962
Partial implementation of https://github.com/conan-io/conan/issues/12354
Docs: https://github.com/conan-io/docs/pull/2832

**Note**: Originally started by https://github.com/conan-io/conan/pull/12355
