### PR TITLE
Do not fallback to a compatible binary if a package is requested to be built

### DIFF
--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -92,6 +92,7 @@ class Node(object):
         self.id_indirect_prefs = None
 
         self.cant_build = False  # It will set to a str with a reason if the validate_build() fails
+        self.should_build = False  # If the --build or policy wants to build this binary
 
     @property
     def id(self):

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -47,6 +47,7 @@ class GraphBinariesAnalyzer(object):
                     with_deps_to_build = True
                     break
         if build_mode.forced(conanfile, ref, with_deps_to_build):
+            node.should_build = True
             conanfile.output.info('Forced build from source')
             if node.cant_build:
                 node.binary = BINARY_INVALID
@@ -181,6 +182,7 @@ class GraphBinariesAnalyzer(object):
             pref = PackageReference(locked.ref, locked.package_id, locked.prev)  # Keep locked PREV
             self._process_node(node, pref, build_mode, update, remotes)
             if node.binary == BINARY_MISSING and build_mode.allowed(node.conanfile):
+                node.should_build = True
                 if node.cant_build:
                     node.binary = BINARY_INVALID
                 else:
@@ -206,7 +208,7 @@ class GraphBinariesAnalyzer(object):
             assert node.binary is None, "Node.binary should be None if not locked"
             pref = PackageReference(node.ref, node.package_id)
             self._process_node(node, pref, build_mode, update, remotes)
-            if node.binary in (BINARY_MISSING, BINARY_INVALID):
+            if node.binary in (BINARY_MISSING, BINARY_INVALID) and not node.should_build:
                 conanfile = node.conanfile
                 self._compatibility.compatibles(conanfile)
                 if node.conanfile.compatible_packages:
@@ -237,6 +239,7 @@ class GraphBinariesAnalyzer(object):
                     if node.binary == BINARY_MISSING and node.package_id == PACKAGE_ID_INVALID:
                         node.binary = BINARY_INVALID
                 if node.binary == BINARY_MISSING and build_mode.allowed(node.conanfile):
+                    node.should_build = True
                     if node.cant_build:
                         node.binary = BINARY_INVALID
                     else:
@@ -258,7 +261,8 @@ class GraphBinariesAnalyzer(object):
 
         if pref.id == PACKAGE_ID_INVALID:
             # annotate pattern, so unused patterns in --build are not displayed as errors
-            build_mode.forced(node.conanfile, node.ref)
+            if build_mode.forced(node.conanfile, node.ref):
+                node.should_build = True
             node.binary = BINARY_INVALID
             return
 
@@ -304,6 +308,7 @@ class GraphBinariesAnalyzer(object):
                 local_recipe_hash = package_layout.recipe_manifest().summary_hash
                 if local_recipe_hash != recipe_hash:
                     conanfile.output.info("Outdated package!")
+                    node.should_build = True
                     if node.cant_build:
                         node.binary = BINARY_INVALID
                     else:
@@ -399,12 +404,6 @@ class GraphBinariesAnalyzer(object):
         if apple_clang_compatible:
             conanfile.compatible_packages.append(apple_clang_compatible)
 
-        # Once we are done, call package_id() to narrow and change possible values
-        with conanfile_exception_formatter(str(conanfile), "package_id"):
-            with conan_v2_property(conanfile, 'cpp_info',
-                                   "'self.cpp_info' access in package_id() method is deprecated"):
-                conanfile.package_id()
-
         if hasattr(conanfile, "validate") and callable(conanfile.validate):
             with conanfile_exception_formatter(str(conanfile), "validate"):
                 try:
@@ -421,6 +420,12 @@ class GraphBinariesAnalyzer(object):
                 except ConanInvalidConfiguration as e:
                     # This 'cant_build' will be ignored if we don't have to build the node.
                     node.cant_build = str(e)
+
+            # Once we are done, call package_id() to narrow and change possible values
+        with conanfile_exception_formatter(str(conanfile), "package_id"):
+            with conan_v2_property(conanfile, 'cpp_info',
+                                   "'self.cpp_info' access in package_id() method is deprecated"):
+                conanfile.package_id()
 
         info = conanfile.info
         node.package_id = info.package_id()

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -404,6 +404,12 @@ class GraphBinariesAnalyzer(object):
         if apple_clang_compatible:
             conanfile.compatible_packages.append(apple_clang_compatible)
 
+        # Once we are done, call package_id() to narrow and change possible values
+        with conanfile_exception_formatter(str(conanfile), "package_id"):
+            with conan_v2_property(conanfile, 'cpp_info',
+                                   "'self.cpp_info' access in package_id() method is deprecated"):
+                conanfile.package_id()
+
         if hasattr(conanfile, "validate") and callable(conanfile.validate):
             with conanfile_exception_formatter(str(conanfile), "validate"):
                 try:
@@ -420,12 +426,6 @@ class GraphBinariesAnalyzer(object):
                 except ConanInvalidConfiguration as e:
                     # This 'cant_build' will be ignored if we don't have to build the node.
                     node.cant_build = str(e)
-
-            # Once we are done, call package_id() to narrow and change possible values
-        with conanfile_exception_formatter(str(conanfile), "package_id"):
-            with conan_v2_property(conanfile, 'cpp_info',
-                                   "'self.cpp_info' access in package_id() method is deprecated"):
-                conanfile.package_id()
 
         info = conanfile.info
         node.package_id = info.package_id()

--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -433,7 +433,7 @@ class ConanInfo(object):
         """ Useful for build_id implementation
         """
         result = ConanInfo()
-        result.invalid = None  # self.invalid
+        result.invalid = self.invalid
         result.settings = self.settings.copy()
         result.options = self.options.copy()
         result.requires = self.requires.copy()

--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -433,7 +433,7 @@ class ConanInfo(object):
         """ Useful for build_id implementation
         """
         result = ConanInfo()
-        result.invalid = self.invalid
+        result.invalid = None  # self.invalid
         result.settings = self.settings.copy()
         result.options = self.options.copy()
         result.requires = self.requires.copy()

--- a/conans/test/integration/package_id/test_validate.py
+++ b/conans/test/integration/package_id/test_validate.py
@@ -133,6 +133,13 @@ class TestValidate(unittest.TestCase):
                       client.out)
         self.assertIn("pkg/0.1:cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31 - Cache", client.out)
 
+        # --build=missing means "use existing binary if possible", and compatibles are valid binaries
+        client.run("install pkg/0.1@ -s os=Windows --build=missing")
+        self.assertIn("pkg/0.1: Main binary package 'INVALID' missing. "
+                      "Using compatible package 'cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31'",
+                      client.out)
+        self.assertIn("pkg/0.1:cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31 - Cache", client.out)
+
         client.run("info pkg/0.1@ -s os=Windows")
         self.assertIn("pkg/0.1: Main binary package 'INVALID' missing. "
                       "Using compatible package 'cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31'",

--- a/conans/test/integration/package_id/test_validate.py
+++ b/conans/test/integration/package_id/test_validate.py
@@ -101,7 +101,62 @@ class TestValidate(unittest.TestCase):
             class Pkg(ConanFile):
                 settings = "os"
 
+                def validate_build(self):
+                    if self.settings.os == "Windows":
+                        raise ConanInvalidConfiguration("Windows not supported")
+
                 def validate(self):
+                    if self.info.settings.os == "Windows":
+                        raise ConanInvalidConfiguration("Invalid in Windows")
+
+                def package_id(self):
+                    if self.settings.os == "Windows":
+                        compatible_pkg = self.info.clone()
+                        compatible_pkg.settings.os = "Linux"
+                        self.compatible_packages.append(compatible_pkg)
+            """)
+
+        client.save({"conanfile.py": conanfile})
+
+        client.run("create . pkg/0.1@ -s os=Linux")
+        self.assertIn("pkg/0.1: Package 'cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31' created",
+                      client.out)
+
+        client.run("create . pkg/0.1@ -s os=Windows", assert_error=True)
+        # This is the main difference, the package_id is reported as INVALID
+        self.assertIn("pkg/0.1:INVALID - Invalid", client.out)
+        self.assertIn("pkg/0.1: Cannot build for this configuration: Windows not supported",
+                      client.out)
+
+        # We can install, package_id defines compatible
+        client.run("install pkg/0.1@ -s os=Windows")
+        self.assertIn("pkg/0.1:cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31 - Cache", client.out)
+        self.assertIn("pkg/0.1: Main binary package 'INVALID' "
+                      "missing. Using compatible package", client.out)
+
+        # Info simulates install, so results in same compatible one
+        client.run("info pkg/0.1@ -s os=Windows")
+        self.assertIn("ID: cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31", client.out)
+        self.assertIn("Binary: Cache", client.out)
+
+        # Info with --dry-build defines the --build, equal to create, so will return invalid
+        client.run("info pkg/0.1@ -s os=Windows --dry-build")
+        self.assertIn("ID: INVALID", client.out)
+        self.assertIn("Binary: Invalid", client.out)
+
+    def test_validate_build_compatible(self):
+        """
+        same as the above, but dropping ``validate()`` so it can define a real package_id, and not
+        only INVALID
+        """
+        client = TestClient()
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            from conan.errors import ConanInvalidConfiguration
+            class Pkg(ConanFile):
+                settings = "os"
+
+                def validate_build(self):
                     if self.settings.os == "Windows":
                         raise ConanInvalidConfiguration("Windows not supported")
 
@@ -118,16 +173,26 @@ class TestValidate(unittest.TestCase):
         self.assertIn("pkg/0.1: Package 'cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31' created",
                       client.out)
 
-        client.run("create . pkg/0.1@ -s os=Windows")
-        self.assertIn("pkg/0.1: Main binary package 'INVALID' missing. "
-                      "Using compatible package 'cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31'",
+        client.run("create . pkg/0.1@ -s os=Windows", assert_error=True)
+        self.assertIn("pkg/0.1:3475bd55b91ae904ac96fde0f106a136ab951a5e - Invalid", client.out)
+        self.assertIn("pkg/0.1: Cannot build for this configuration: Windows not supported",
                       client.out)
+
+        # We can install, package_id defines compatible
+        client.run("install pkg/0.1@ -s os=Windows")
         self.assertIn("pkg/0.1:cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31 - Cache", client.out)
+        self.assertIn("pkg/0.1: Main binary package '3475bd55b91ae904ac96fde0f106a136ab951a5e' "
+                      "missing. Using compatible package", client.out)
+
+        # Info simulates install, so results in same compatible one
         client.run("info pkg/0.1@ -s os=Windows")
-        self.assertIn("pkg/0.1: Main binary package 'INVALID' missing. "
-                      "Using compatible package 'cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31'",
-                      client.out)
         self.assertIn("ID: cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31", client.out)
+        self.assertIn("Binary: Cache", client.out)
+
+        # Info with --dry-build defines the --build, equal to create, so will return invalid
+        client.run("info pkg/0.1@ -s os=Windows --dry-build")
+        self.assertIn("ID: 3475bd55b91ae904ac96fde0f106a136ab951a5e", client.out)
+        self.assertIn("Binary: Invalid", client.out)
 
     def test_validate_compatible_also_invalid(self):
         client = TestClient()

--- a/conans/test/integration/package_id/test_validate.py
+++ b/conans/test/integration/package_id/test_validate.py
@@ -101,62 +101,7 @@ class TestValidate(unittest.TestCase):
             class Pkg(ConanFile):
                 settings = "os"
 
-                def validate_build(self):
-                    if self.settings.os == "Windows":
-                        raise ConanInvalidConfiguration("Windows not supported")
-
                 def validate(self):
-                    if self.info.settings.os == "Windows":
-                        raise ConanInvalidConfiguration("Invalid in Windows")
-
-                def package_id(self):
-                    if self.settings.os == "Windows":
-                        compatible_pkg = self.info.clone()
-                        compatible_pkg.settings.os = "Linux"
-                        self.compatible_packages.append(compatible_pkg)
-            """)
-
-        client.save({"conanfile.py": conanfile})
-
-        client.run("create . pkg/0.1@ -s os=Linux")
-        self.assertIn("pkg/0.1: Package 'cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31' created",
-                      client.out)
-
-        client.run("create . pkg/0.1@ -s os=Windows", assert_error=True)
-        # This is the main difference, the package_id is reported as INVALID
-        self.assertIn("pkg/0.1:INVALID - Invalid", client.out)
-        self.assertIn("pkg/0.1: Cannot build for this configuration: Windows not supported",
-                      client.out)
-
-        # We can install, package_id defines compatible
-        client.run("install pkg/0.1@ -s os=Windows")
-        self.assertIn("pkg/0.1:cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31 - Cache", client.out)
-        self.assertIn("pkg/0.1: Main binary package 'INVALID' "
-                      "missing. Using compatible package", client.out)
-
-        # Info simulates install, so results in same compatible one
-        client.run("info pkg/0.1@ -s os=Windows")
-        self.assertIn("ID: cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31", client.out)
-        self.assertIn("Binary: Cache", client.out)
-
-        # Info with --dry-build defines the --build, equal to create, so will return invalid
-        client.run("info pkg/0.1@ -s os=Windows --dry-build")
-        self.assertIn("ID: INVALID", client.out)
-        self.assertIn("Binary: Invalid", client.out)
-
-    def test_validate_build_compatible(self):
-        """
-        same as the above, but dropping ``validate()`` so it can define a real package_id, and not
-        only INVALID
-        """
-        client = TestClient()
-        conanfile = textwrap.dedent("""
-            from conan import ConanFile
-            from conan.errors import ConanInvalidConfiguration
-            class Pkg(ConanFile):
-                settings = "os"
-
-                def validate_build(self):
                     if self.settings.os == "Windows":
                         raise ConanInvalidConfiguration("Windows not supported")
 
@@ -173,25 +118,28 @@ class TestValidate(unittest.TestCase):
         self.assertIn("pkg/0.1: Package 'cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31' created",
                       client.out)
 
+        # This is the main difference, building from source for the specified conf, fails
         client.run("create . pkg/0.1@ -s os=Windows", assert_error=True)
-        self.assertIn("pkg/0.1:3475bd55b91ae904ac96fde0f106a136ab951a5e - Invalid", client.out)
-        self.assertIn("pkg/0.1: Cannot build for this configuration: Windows not supported",
-                      client.out)
+        self.assertIn("pkg/0.1:INVALID - Invalid", client.out)
+        self.assertIn("Windows not supported", client.out)
 
-        # We can install, package_id defines compatible
+        client.run("install pkg/0.1@ -s os=Windows --build=pkg", assert_error=True)
+        self.assertIn("pkg/0.1:INVALID - Invalid", client.out)
+        self.assertIn("Windows not supported", client.out)
+
         client.run("install pkg/0.1@ -s os=Windows")
+        self.assertIn("pkg/0.1: Main binary package 'INVALID' missing. "
+                      "Using compatible package 'cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31'",
+                      client.out)
         self.assertIn("pkg/0.1:cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31 - Cache", client.out)
-        self.assertIn("pkg/0.1: Main binary package '3475bd55b91ae904ac96fde0f106a136ab951a5e' "
-                      "missing. Using compatible package", client.out)
 
-        # Info simulates install, so results in same compatible one
         client.run("info pkg/0.1@ -s os=Windows")
+        self.assertIn("pkg/0.1: Main binary package 'INVALID' missing. "
+                      "Using compatible package 'cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31'",
+                      client.out)
         self.assertIn("ID: cb054d0b3e1ca595dc66bc2339d40f1f8f04ab31", client.out)
-        self.assertIn("Binary: Cache", client.out)
 
-        # Info with --dry-build defines the --build, equal to create, so will return invalid
-        client.run("info pkg/0.1@ -s os=Windows --dry-build")
-        self.assertIn("ID: 3475bd55b91ae904ac96fde0f106a136ab951a5e", client.out)
+        client.run("info pkg/0.1@ -s os=Windows --dry-build=pkg")
         self.assertIn("Binary: Invalid", client.out)
 
     def test_validate_compatible_also_invalid(self):


### PR DESCRIPTION
Changelog: Bugfix: Do not fallback to a compatible binary if a package is requested to be built from source for a given configuration.
Docs: Omit

Partially implement https://github.com/conan-io/conan/pull/12440 but without the riskier change of order of validate() and package_id()
