### PR TITLE
[develop2] New proposal for cppstd validate/validate_build

### DIFF
--- a/conans/client/graph/compatibility.py
+++ b/conans/client/graph/compatibility.py
@@ -84,14 +84,22 @@ class BinaryCompatibility:
 
         result = OrderedDict()
         original_info = conanfile.info
+        original_settings = conanfile.settings
+        original_options = conanfile.options
         for c in compat_infos:
+            # we replace the conanfile, so ``validate()`` and ``package_id()`` can
+            # use the compatible ones
             conanfile.info = c
+            conanfile.settings = c.settings
+            conanfile.options = c.options
             run_validate_package_id(conanfile)
             pid = c.package_id()
             if pid not in result and not c.invalid:
                 result[pid] = c
         # Restore the original state
         conanfile.info = original_info
+        conanfile.settings = original_settings
+        conanfile.options = original_options
         return result
 
     @staticmethod

--- a/conans/client/graph/compute_pid.py
+++ b/conans/client/graph/compute_pid.py
@@ -67,7 +67,7 @@ def run_validate_package_id(conanfile):
     # IMPORTANT: This validation code must run before calling info.package_id(), to mark "invalid"
     if hasattr(conanfile, "validate"):
         with conanfile_exception_formatter(conanfile, "validate"):
-            with conanfile_remove_attr(conanfile, ['cpp_info', 'settings', 'options'], "validate"):
+            with conanfile_remove_attr(conanfile, ['cpp_info'], "validate"):
                 try:
                     conanfile.validate()
                 except ConanInvalidConfiguration as e:

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -137,7 +137,7 @@ class GraphBinariesAnalyzer(object):
         assert node.prev is None, "Node.prev should be None"
 
         self._process_node(node, build_mode)
-        if node.binary in (BINARY_MISSING, BINARY_INVALID) \
+        if node.binary in (BINARY_MISSING,) \
                 and not build_mode.should_build_missing(node.conanfile) and not node.should_build:
             self._process_compatible_packages(node)
 

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -142,6 +142,7 @@ class GraphBinariesAnalyzer(object):
             self._process_compatible_packages(node)
 
         if node.binary == BINARY_MISSING and build_mode.allowed(node.conanfile):
+            node.should_build = True
             node.binary = BINARY_BUILD if not node.cant_build else BINARY_INVALID
 
         if (node.binary in (BINARY_BUILD, BINARY_MISSING) and node.conanfile.info.invalid and

--- a/conans/client/graph/install_graph.py
+++ b/conans/client/graph/install_graph.py
@@ -250,7 +250,7 @@ class InstallGraph:
             msg = ["There are invalid packages (packages that cannot exist for this configuration):"]
             for package in invalid:
                 node = package.nodes[0]
-                if node.cant_build:
+                if node.cant_build and node.should_build:
                     binary, reason = "Cannot build for this configuration", node.cant_build
                 else:
                     binary, reason = node.conanfile.info.invalid

--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -294,9 +294,12 @@ class Settings(object):
         for (name, value) in vals:
             list_settings = name.split(".")
             attr = self
-            for setting in list_settings[:-1]:
-                attr = getattr(attr, setting)
-            setattr(attr, list_settings[-1], str(value))
+            try:
+                for setting in list_settings[:-1]:
+                    attr = getattr(attr, setting)
+                setattr(attr, list_settings[-1], str(value))
+            except:  # fails if receiving settings doesn't have it defined
+                pass
 
     def constrained(self, constraint_def):
         """ allows to restrict a given Settings object with the input of another Settings object

--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -297,9 +297,11 @@ class Settings(object):
             try:
                 for setting in list_settings[:-1]:
                     attr = getattr(attr, setting)
-                setattr(attr, list_settings[-1], str(value))
-            except:  # fails if receiving settings doesn't have it defined
+            except ConanException:  # fails if receiving settings doesn't have it defined
                 pass
+            else:
+                setattr(attr, list_settings[-1], str(value))
+
 
     def constrained(self, constraint_def):
         """ allows to restrict a given Settings object with the input of another Settings object

--- a/conans/test/integration/conanfile/test_attributes_scope.py
+++ b/conans/test/integration/conanfile/test_attributes_scope.py
@@ -96,35 +96,3 @@ class TestAttributesScope:
         t.save({'conanfile.py': conanfile})
         t.run('create . --name=name --version=version -o shared=False', assert_error=True)
         assert "'self.options' access in 'source()' method is forbidden" in t.out
-
-    def test_validate_no_settings(self):
-        # self.setting is not available in 'validate'
-        t = TestClient()
-        conanfile = textwrap.dedent("""
-            from conan import ConanFile
-
-            class Recipe(ConanFile):
-                settings = "os",
-
-                def validate(self):
-                    self.settings.os
-           """)
-        t.save({'conanfile.py': conanfile})
-        t.run('create . --name=name --version=version -s os=Linux', assert_error=True)
-        assert "'self.settings' access in 'validate()' method is forbidden" in t.out
-
-    def test_validate_no_options(self):
-        # self.setting is not available in 'validate'
-        t = TestClient()
-        conanfile = textwrap.dedent("""
-            from conan import ConanFile
-
-            class Recipe(ConanFile):
-                options = {"shared": [True, False]}
-
-                def validate(self):
-                    self.options.shared
-           """)
-        t.save({'conanfile.py': conanfile})
-        t.run('create . --name=name --version=version', assert_error=True)
-        assert "'self.options' access in 'validate()' method is forbidden" in t.out

--- a/conans/test/integration/graph/core/test_build_require_invalid.py
+++ b/conans/test/integration/graph/core/test_build_require_invalid.py
@@ -123,13 +123,13 @@ class TestInvalidBuildPackageID:
        class Conan(ConanFile):
            settings = "os"
 
-           def validate(self):
-               if self.info.settings.os == "Windows":
+           def validate_build(self):
+               if self.settings.os == "Windows":
                    raise ConanInvalidConfiguration("Package does not work in Windows!")
 
            def package_id(self):
                del self.info.settings.os
-       """)
+        """)
     linux_package_id = NO_SETTINGS_PACKAGE_ID
     windows_package_id = NO_SETTINGS_PACKAGE_ID
 
@@ -157,7 +157,7 @@ class TestInvalidBuildPackageID:
         client.run("install consumer -s os=Windows --build='*'", assert_error=True)
         # Only when trying to build, it will try to build the Windows one
         client.assert_listed_binary({"pkg/0.1": (self.windows_package_id, "Invalid")})
-        assert "pkg/0.1: Invalid: Package does not work in Windows!" in client.out
+        assert "Package does not work in Windows!" in client.out
 
     def test_valid_build_require_two_profiles(self, client):
         conanfile_consumer = GenConanfile().with_tool_requires("pkg/0.1").with_settings("os")
@@ -182,8 +182,8 @@ class TestInvalidBuildCompatible(TestInvalidBuildPackageID):
        class Conan(ConanFile):
            settings = "os"
 
-           def validate(self):
-               if self.info.settings.os == "Windows":
+           def validate_build(self):
+               if self.settings.os == "Windows":
                    raise ConanInvalidConfiguration("Package does not work in Windows!")
 
            def compatibility(self):

--- a/conans/test/integration/package_id/test_cache_compatibles.py
+++ b/conans/test/integration/package_id/test_cache_compatibles.py
@@ -121,13 +121,10 @@ def test_cppstd_validated():
 
     base_settings = "-s compiler=gcc -s compiler.version=8 -s compiler.libcxx=libstdc++11"
     client.run(f"create dep {base_settings} -s compiler.cppstd=20")
-    package_id = client.created_package_id("dep/0.1")
 
-    client.run(f"install consumer {base_settings} -s compiler.cppstd=17")
-    # This message here proves it, only 1 configuraton passed the check
-    assert "dep/0.1: Checking 1 compatible configurations" in client.out
-    assert "dep/0.1: Main binary package '6179018ccb6b15e6443829bf3640e25f2718b931' missing. "\
-           f"Using compatible package '{package_id}'" in client.out
+    client.run(f"install consumer {base_settings} -s compiler.cppstd=17", assert_error=True)
+    assert "dep/0.1: Invalid: Current cppstd (17) is lower than the required C++ standard (20)." \
+           in client.out
 
 
 class TestDefaultCompat:
@@ -253,9 +250,9 @@ class TestDefaultCompat:
         c.run(f"create .  {settings} -s compiler.cppstd=17")
         assert "pkg/0.1: valid standard!!" in c.out
         assert "pkg/0.1: CPPSTD: 17" in c.out
-        c.run(f"install {settings} --requires=pkg/0.1 -s compiler.cppstd=14")
-        assert "valid standard!!" in c.out
-        assert "pkg/0.1: CPPSTD: 17" in c.out
+        c.run(f"install {settings} --requires=pkg/0.1 -s compiler.cppstd=14", assert_error=True)
+        assert "pkg/0.1: Invalid: Current cppstd (14) is lower than the required C++ standard (17)."\
+               in c.out
         c.run(f"install {settings} --requires=pkg/0.1 -s compiler.cppstd=20")
         assert "valid standard!!" in c.out
         assert "pkg/0.1: CPPSTD: 17" in c.out

--- a/conans/test/integration/package_id/test_validate.py
+++ b/conans/test/integration/package_id/test_validate.py
@@ -158,62 +158,6 @@ class TestValidate(unittest.TestCase):
         client.run("graph info --requires=pkg/0.1@ -s os=Windows --build=pkg*")
         self.assertIn("binary: Invalid", client.out)
 
-    def test_validate_compatible_cppstd(self):
-        client = TestClient()
-        # simplify it a bit
-        compat = textwrap.dedent("""\
-            def compatibility(conanfile):
-                return [{"settings": [("compiler.cppstd", v)]} for v in ("11", "14", "17", "20")]
-            """)
-        save(os.path.join(client.cache.plugins_path, "compatibility/compatibility.py"), compat)
-        conanfile = textwrap.dedent("""
-            from conan import ConanFile
-            from conan.errors import ConanInvalidConfiguration
-            class Pkg(ConanFile):
-                name = "pkg"
-                version = "0.1"
-                settings = "compiler"
-
-                def validate_build(self):
-                    # Explicit logic instead of using check_min_cppstd that hides details
-                    if int(str(self.settings.compiler.cppstd)) < 17:
-                        raise ConanInvalidConfiguration("I need at least cppstd=17 to build")
-
-                def validate(self):
-                    # Explicit use of info, for compatibles
-                    if int(str(self.settings.compiler.cppstd)) < 14:
-                        raise ConanInvalidConfiguration("I need at least cppstd=14 to be used")
-            """)
-
-        client.save({"conanfile.py": conanfile})
-
-        settings = "-s compiler=gcc -s compiler.version=9 -s compiler.libcxx=libstdc++"
-        client.run(f"create . {settings} -s compiler.cppstd=17")
-        client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
-                                                 "Build")})
-        # create with cppstd=14 fails, not enough
-        client.run(f"create . {settings} -s compiler.cppstd=14", assert_error=True)
-        client.assert_listed_binary({"pkg/0.1": ("36d978cbb4dc35906d0fd438732d5e17cd1e388d",
-                                                 "Invalid")})
-        assert "pkg/0.1: Cannot build for this configuration: I need at least cppstd=17 to build" \
-               in client.out
-
-        # Install with cppstd=14 can fallback to the previous one
-        client.run(f"install --requires=pkg/0.1 {settings} -s compiler.cppstd=14")
-        # 2 valid binaries, 17 and 20
-        assert "pkg/0.1: Checking 2 compatible configurations" in client.out
-        client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
-                                                 "Cache")})
-
-        # install with not enough cppstd should fail
-        client.run(f"install --requires=pkg/0.1@ {settings} -s compiler.cppstd=11",
-                   assert_error=True)
-        # not even trying to fallback to compatibles
-        assert "pkg/0.1: Checking" not in client.out
-        client.assert_listed_binary({"pkg/0.1": ("8415595b7485d90fc413c2f47298aa5fb05a5468",
-                                                 "Invalid")})
-        assert "I need at least cppstd=14 to be used" in client.out
-
     def test_validate_remove_package_id_create(self):
         client = TestClient()
         conanfile = textwrap.dedent("""
@@ -447,3 +391,204 @@ class TestValidate(unittest.TestCase):
         c.save({"conanfile.py": conanfile})
         c.run("install .", assert_error=True)
         assert "ERROR: conanfile.py: Invalid ID: Invalid: never ever" in c.out
+
+
+class TestValidateCppstd:
+    """ aims to be a very close to real use case of cppstd management and validation in recipes
+    """
+    def test_build_17_consume_14(self):
+        client = TestClient()
+        # simplify it a bit
+        compat = textwrap.dedent("""\
+            def compatibility(conanfile):
+                return [{"settings": [("compiler.cppstd", v)]} for v in ("11", "14", "17", "20")]
+            """)
+        save(os.path.join(client.cache.plugins_path, "compatibility/compatibility.py"), compat)
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            from conan.errors import ConanInvalidConfiguration
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "0.1"
+                settings = "compiler"
+
+                def validate_build(self):
+                    # Explicit logic instead of using check_min_cppstd that hides details
+                    if int(str(self.settings.compiler.cppstd)) < 17:
+                        raise ConanInvalidConfiguration("I need at least cppstd=17 to build")
+
+                def validate(self):
+                    if int(str(self.settings.compiler.cppstd)) < 14:
+                        raise ConanInvalidConfiguration("I need at least cppstd=14 to be used")
+            """)
+
+        client.save({"conanfile.py": conanfile})
+
+        settings = "-s compiler=gcc -s compiler.version=9 -s compiler.libcxx=libstdc++"
+        client.run(f"create . {settings} -s compiler.cppstd=17")
+        client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
+                                                 "Build")})
+        # create with cppstd=14 fails, not enough
+        client.run(f"create . {settings} -s compiler.cppstd=14", assert_error=True)
+        client.assert_listed_binary({"pkg/0.1": ("36d978cbb4dc35906d0fd438732d5e17cd1e388d",
+                                                 "Invalid")})
+        assert "pkg/0.1: Cannot build for this configuration: I need at least cppstd=17 to build" \
+               in client.out
+
+        # Install with cppstd=14 can fallback to the previous one
+        client.run(f"install --requires=pkg/0.1 {settings} -s compiler.cppstd=14")
+        # 2 valid binaries, 17 and 20
+        assert "pkg/0.1: Checking 2 compatible configurations" in client.out
+        client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
+                                                 "Cache")})
+
+        # install with not enough cppstd should fail
+        client.run(f"install --requires=pkg/0.1@ {settings} -s compiler.cppstd=11",
+                   assert_error=True)
+        # not even trying to fallback to compatibles
+        assert "pkg/0.1: Checking" not in client.out
+        client.assert_listed_binary({"pkg/0.1": ("8415595b7485d90fc413c2f47298aa5fb05a5468",
+                                                 "Invalid")})
+        assert "I need at least cppstd=14 to be used" in client.out
+
+    def test_build_17_consume_14_transitive(self):
+        """ what happens if we have:
+        app->engine(shared-lib)->pkg(static-lib)
+        if pkg is only buildable with cppstd>=17 and needs cppstd>=14 to be consumed, but
+        as it is static it becomes an implementation detail of engine, that doesn't have any
+        constraint or validate() at all
+        """
+        client = TestClient()
+        # simplify it a bit
+        compat = textwrap.dedent("""\
+            def compatibility(conanfile):
+                return [{"settings": [("compiler.cppstd", v)]} for v in ("11", "14", "17", "20")]
+            """)
+        save(os.path.join(client.cache.plugins_path, "compatibility/compatibility.py"), compat)
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            from conan.errors import ConanInvalidConfiguration
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "0.1"
+                settings = "compiler"
+                package_type = "static-library"
+
+                def validate_build(self):
+                    # Explicit logic instead of using check_min_cppstd that hides details
+                    if int(str(self.settings.compiler.cppstd)) < 17:
+                        raise ConanInvalidConfiguration("I need at least cppstd=17 to build")
+
+                def validate(self):
+                    if int(str(self.settings.compiler.cppstd)) < 14:
+                        raise ConanInvalidConfiguration("I need at least cppstd=14 to be used")
+            """)
+        engine = GenConanfile("engine", "0.1").with_package_type("shared-library") \
+                                              .with_requires("pkg/0.1")
+        app = GenConanfile("app", "0.1").with_package_type("application") \
+                                        .with_requires("engine/0.1")
+        client.save({"pkg/conanfile.py": conanfile,
+                     "engine/conanfile.py": engine,
+                     "app/conanfile.py": app})
+
+        settings = "-s compiler=gcc -s compiler.version=9 -s compiler.libcxx=libstdc++"
+        client.run(f"create pkg {settings} -s compiler.cppstd=17")
+        client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
+                                                 "Build")})
+        client.run(f"create engine {settings} -s compiler.cppstd=17")
+        client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
+                                                 "Cache")})
+        client.run(f"install app {settings} -s compiler.cppstd=17")
+        client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
+                                                 "Skip")})
+        client.run(f"install app {settings} -s compiler.cppstd=14")
+        client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
+                                                 "Skip")})
+        # No binary for engine exist for cppstd=11
+        client.run(f"install app {settings} -s compiler.cppstd=11", assert_error=True)
+        client.assert_listed_binary({"engine/0.1": ("dc24e2caf6e1fa3e8bb047ca0f5fa053c71df6db",
+                                                    "Missing")})
+        client.run(f"install app {settings} -s compiler.cppstd=11 --build=missing",
+                   assert_error=True)
+        assert 'pkg/0.1: Invalid: I need at least cppstd=14 to be used' in client.out
+
+    def test_build_17_consume_14_transitive_erasure(self):
+        """ The same as the above test:
+        app->engine(shared-lib)->pkg(static-lib)
+        but in this test, the engine shared-lib does "package_id()" erasure of "pkg" dependency,
+        being able to reuse it then even when cppstd==11
+        """
+        client = TestClient()
+        # simplify it a bit
+        compat = textwrap.dedent("""\
+            def compatibility(conanfile):
+                return [{"settings": [("compiler.cppstd", v)]} for v in ("11", "14", "17", "20")]
+            """)
+        save(os.path.join(client.cache.plugins_path, "compatibility/compatibility.py"), compat)
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            from conan.errors import ConanInvalidConfiguration
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "0.1"
+                settings = "compiler"
+                package_type = "static-library"
+
+                def validate_build(self):
+                    # Explicit logic instead of using check_min_cppstd that hides details
+                    if int(str(self.settings.compiler.cppstd)) < 17:
+                        raise ConanInvalidConfiguration("I need at least cppstd=17 to build")
+
+                def validate(self):
+                    if int(str(self.settings.compiler.cppstd)) < 14:
+                        raise ConanInvalidConfiguration("I need at least cppstd=14 to be used")
+            """)
+        engine = textwrap.dedent("""
+            from conan import ConanFile
+            from conan.errors import ConanInvalidConfiguration
+            class Pkg(ConanFile):
+                name = "engine"
+                version = "0.1"
+                settings = "compiler"
+                package_type = "shared-library"
+                requires = "pkg/0.1"
+
+                def package_id(self):
+                    del self.info.settings.compiler.cppstd
+                    self.info.requires["pkg"].full_version_mode()
+
+            """)
+        app = GenConanfile("app", "0.1").with_package_type("application") \
+                                        .with_requires("engine/0.1")
+        client.save({"pkg/conanfile.py": conanfile,
+                     "engine/conanfile.py": engine,
+                     "app/conanfile.py": app})
+
+        settings = "-s compiler=gcc -s compiler.version=9 -s compiler.libcxx=libstdc++"
+        client.run(f"create pkg {settings} -s compiler.cppstd=17")
+        client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
+                                                 "Build")})
+        client.run(f"create engine {settings} -s compiler.cppstd=17")
+        client.assert_listed_binary({"engine/0.1": ("493976208e9989b554704f94f9e7b8e5ba39e5ab",
+                                                    "Build")})
+        client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
+                                                 "Cache")})
+        client.run(f"install app {settings} -s compiler.cppstd=17")
+        client.assert_listed_binary({"engine/0.1": ("493976208e9989b554704f94f9e7b8e5ba39e5ab",
+                                                    "Cache")})
+        client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
+                                                 "Skip")})
+        client.run(f"install app {settings} -s compiler.cppstd=14")
+        client.assert_listed_binary({"engine/0.1": ("493976208e9989b554704f94f9e7b8e5ba39e5ab",
+                                                    "Cache")})
+        client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
+                                                 "Skip")})
+        # No binary for engine exist for cppstd=11
+        client.run(f"install app {settings} -s compiler.cppstd=11")
+        client.assert_listed_binary({"pkg/0.1": ("8415595b7485d90fc413c2f47298aa5fb05a5468",
+                                                 "Skip")})
+        client.assert_listed_binary({"engine/0.1": ("493976208e9989b554704f94f9e7b8e5ba39e5ab",
+                                                    "Cache")})
+        client.run(f"install app {settings} -s compiler.cppstd=11 --build=engine*",
+                   assert_error=True)
+        assert 'pkg/0.1: Invalid: I need at least cppstd=14 to be used' in client.out

--- a/conans/test/integration/package_id/test_validate.py
+++ b/conans/test/integration/package_id/test_validate.py
@@ -200,12 +200,16 @@ class TestValidate(unittest.TestCase):
 
         # Install with cppstd=14 can fallback to the previous one
         client.run(f"install --requires=pkg/0.1 {settings} -s compiler.cppstd=14")
+        # 2 valid binaries, 17 and 20
+        assert "pkg/0.1: Checking 2 compatible configurations" in client.out
         client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
                                                  "Cache")})
 
         # install with not enough cppstd should fail
         client.run(f"install --requires=pkg/0.1@ {settings} -s compiler.cppstd=11",
                    assert_error=True)
+        # not even trying to fallback to compatibles
+        assert "pkg/0.1: Checking" not in client.out
         client.assert_listed_binary({"pkg/0.1": ("8415595b7485d90fc413c2f47298aa5fb05a5468",
                                                  "Invalid")})
         assert "I need at least cppstd=14 to be used" in client.out


### PR DESCRIPTION
- trying again to replace ``conanfile.settings`` and ``conanfile.options`` for the compatibles ones, so it is possible to use the same ``validate()`` implementation for consumption validation and for compatible validation
- Only falling back to compatible if MISSING; but if the initial call of ``validate()`` returns INVALID, it shouldn't try to fall back for compatibles, because that means that the package cannot be consumed with that setting
- Enabled the usage of ``conanfile.settings`` in validate (compatible with 1.X)
- The main new test ``test_validate_compatible_cppstd`` implements the typical ``cppstd`` use case.