### PR TITLE
[BazelDeps][bugfix] Reading `dependencies.direct_host`

### DIFF
--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -146,7 +146,7 @@ class BazelDeps(object):
         lib_dir = 'lib'
 
         dependencies = []
-        for req, dep in dependency.dependencies.items():
+        for dep in dependency.dependencies.direct_host.values():
             dependencies.append(dep.ref.name)
 
         shared_library = dependency.options.get_safe("shared") if dependency.options else False

--- a/conans/test/integration/toolchains/google/test_bazel.py
+++ b/conans/test/integration/toolchains/google/test_bazel.py
@@ -76,3 +76,48 @@ def test_bazel_exclude_folders():
     c.run("install dep/0.1@ -g BazelDeps")
     build_file = c.load("dep/BUILD")
     assert 'static_library = "lib/libmymath.a"' in build_file
+
+
+def test_bazeldeps_and_build_requires():
+    """
+    Testing that direct build requires are not included in dependencies BUILD files
+
+    Issues related:
+        * https://github.com/conan-io/conan/issues/12444
+        * https://github.com/conan-io/conan/issues/12236
+    """
+    c = TestClient()
+    tool = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+
+        class ToolConanfile(ConanFile):
+            name = "tool"
+            version = "0.1"
+
+            def package_info(self):
+                self.cpp_info.libs = ["mymath"]
+        """)
+    c.save({"tool/conanfile.py": tool})
+    c.run("create tool")
+    dep = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+        from conan.tools.files import save
+        class ExampleConanIntegration(ConanFile):
+            name = "dep"
+            version = "0.1"
+
+            def build_requirements(self):
+                self.build_requires("tool/0.1")
+            def package(self):
+                save(self, os.path.join(self.package_folder, "lib", "mymath", "otherfile.a"), "")
+                save(self, os.path.join(self.package_folder, "lib", "libmymath.a"), "")
+            def package_info(self):
+                self.cpp_info.libs = ["mymath"]
+        """)
+    c.save({"dep/conanfile.py": dep})
+    c.run("create dep")
+    c.run("install dep/0.1@ -g BazelDeps")
+    build_file = c.load("dep/BUILD")
+    assert '@tool' not in build_file

--- a/conans/test/integration/toolchains/google/test_bazel.py
+++ b/conans/test/integration/toolchains/google/test_bazel.py
@@ -117,7 +117,7 @@ def test_bazeldeps_and_build_requires():
                 self.cpp_info.libs = ["mymath"]
         """)
     c.save({"dep/conanfile.py": dep})
-    c.run("create dep")
-    c.run("install dep/0.1@ -g BazelDeps")
+    c.run("export dep")
+    c.run("install dep/0.1@ -g BazelDeps --build=missing")
     build_file = c.load("dep/BUILD")
     assert '@tool' not in build_file


### PR DESCRIPTION
Changelog: Bugfix: Do not include build-context dependencies in Bazel BUILD file.
Docs: omit

Closes: https://github.com/conan-io/conan/issues/12444
Closes: https://github.com/conan-io/conan/issues/12236


Note: this PR should supersede https://github.com/conan-io/conan/pull/12445