### PR TITLE
test to capture behavior of validate()/validate_build() for 2.0

### DIFF
--- a/conans/test/integration/package_id/test_validate.py
+++ b/conans/test/integration/package_id/test_validate.py
@@ -399,6 +399,8 @@ class TestValidateCppstd:
         assert "pkg/0.1:7558a15eea8c5762fa0602874a38dde9d36229c1 - Cache" in client.out
 
         # FIXME 2.0: install with not enough cppstd should fail, but it doesnt
+        # It is important to know that this only happens with "compatible_packages", otherwise
+        # it will also fail (ConanCenter)
         client.run(f"install pkg/0.1@ {settings} -s compiler.cppstd=11")
         # not even trying to fallback to compatibles
         assert "Using compatible package '7558a15eea8c5762fa0602874a38dde9d36229c1'" in client.out


### PR DESCRIPTION
Changelog: Omit
Docs: Omit


Translate the 2.0 test in https://github.com/conan-io/conan/pull/12539, to see the effect and behavior in 1.X.
It works practically the same, except one scenario:

``client.run(f"install pkg/0.1@ {settings} -s compiler.cppstd=11")`` should fail if ``pkg`` contains:

```python
 def validate(self):
      if int(str(self.settings.compiler.cppstd)) < 14:
          raise ConanInvalidConfiguration("I need at least cppstd=14 to be used")
```

But it doesn't fail. It correctly fails in 2.0 https://github.com/conan-io/conan/pull/12539


