### PR TITLE
[develop2] Help testing, removed COMMAND_GROUPS dict

### DIFF
--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -110,8 +110,8 @@ class Cli:
         max_len = max((len(c) for c in self._commands)) + 1
         line_format = '{{: <{}}}'.format(max_len)
 
-        for group_name, comm_names in self._groups.items():
-            cli_out_write(group_name, Color.BRIGHT_MAGENTA)
+        for group_name, comm_names in sorted(self._groups.items()):
+            cli_out_write(group_name + " commands", Color.BRIGHT_MAGENTA)
             for name in comm_names:
                 # future-proof way to ensure tabular formatting
                 cli_out_write(line_format.format(name), Color.GREEN, endline="")

--- a/conan/cli/command.py
+++ b/conan/cli/command.py
@@ -5,12 +5,6 @@ import textwrap
 from conan.cli.commands import add_log_level_args, process_log_level_args
 from conans.errors import ConanException
 
-COMMAND_GROUPS = {
-    'consumer': 'Consumer commands',
-    'misc': 'Miscellaneous commands',
-    'creator': 'Creator commands'
-}
-
 
 class Extender(argparse.Action):
     """Allows using the same flag several times in command and creates a list with the values.
@@ -166,7 +160,7 @@ class ConanCommand(BaseConanCommand):
         super().__init__(method, formatters=formatters)
         self._subcommands = {}
         self._subcommand_parser = None
-        self._group = group or COMMAND_GROUPS['misc']
+        self._group = group or "Other"
         self._name = method.__name__.replace("_", "-")
         self._parser = ConanArgumentParser(description=self._doc,
                                            prog="conan {}".format(self._name),
@@ -213,25 +207,18 @@ class ConanSubCommand(BaseConanCommand):
 
     def set_parser(self, parent_parser, subcommand_parser):
         self._parser = subcommand_parser.add_parser(self._name, help=self._doc)
+        self._parser.description = self._doc
         self._parent_parser = parent_parser
         self._init_formatters()
         self._init_log_levels()
 
 
 def conan_command(group=None, formatters=None):
-    def decorator(f):
-        cmd = ConanCommand(f, group, formatters=formatters)
-        return cmd
-
-    return decorator
+    return lambda f: ConanCommand(f, group, formatters=formatters)
 
 
 def conan_subcommand(formatters=None):
-    def decorator(f):
-        cmd = ConanSubCommand(f, formatters=formatters)
-        return cmd
-
-    return decorator
+    return lambda f: ConanSubCommand(f, formatters=formatters)
 
 
 class CommandResult:

--- a/conan/cli/commands/build.py
+++ b/conan/cli/commands/build.py
@@ -1,7 +1,7 @@
 import os
 
 from conan.api.output import ConanOutput
-from conan.cli.command import conan_command, COMMAND_GROUPS
+from conan.cli.command import conan_command
 from conan.cli.commands import make_abs_path
 from conan.cli.commands.install import graph_compute, _get_conanfile_path
 from conan.cli.args import add_lockfile_args, _add_common_install_arguments, add_reference_args, \
@@ -10,7 +10,7 @@ from conan.api.conan_app import ConanApp
 from conans.client.conanfile.build import run_build_method
 
 
-@conan_command(group=COMMAND_GROUPS['creator'])
+@conan_command(group='Creator')
 def build(conan_api, parser, *args):
     """
     Install + calls the build() method

--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -1,12 +1,12 @@
 from conan.api.conan_api import ConanAPIV2
-from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand
+from conan.cli.command import conan_command, conan_subcommand
 from conan.cli.commands import default_text_formatter
 from conans.errors import ConanException
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
 
 
-@conan_command(group=COMMAND_GROUPS['consumer'])
+@conan_command(group="Consumer")
 def cache(conan_api: ConanAPIV2, parser, *args):
     """Performs file operations in the local cache (of recipes and packages)"""
     pass

--- a/conan/cli/commands/config.py
+++ b/conan/cli/commands/config.py
@@ -1,13 +1,13 @@
 import sys
 
 from conan.api.output import cli_out_write
-from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand
+from conan.cli.command import conan_command, conan_subcommand
 from conan.cli.commands import default_json_formatter, default_text_formatter
 from conans.model.conf import BUILT_IN_CONFS
 from conans.util.config_parser import get_bool_from_text
 
 
-@conan_command(group=COMMAND_GROUPS['consumer'])
+@conan_command(group='Consumer')
 def config(conan_api, parser, *args):
     """
     Manages the Conan configuration in the current Conan home.

--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -3,7 +3,7 @@ import os
 import shutil
 
 from conan.api.output import ConanOutput, cli_out_write
-from conan.cli.command import conan_command, COMMAND_GROUPS, OnceArgument
+from conan.cli.command import conan_command, OnceArgument
 from conan.cli.commands.export import common_args_export
 from conan.cli.commands.install import _get_conanfile_path
 from conan.cli.common import scope_options
@@ -21,7 +21,7 @@ def json_create(deps_graph):
     cli_out_write(json.dumps({"graph": deps_graph.serialize()}, indent=4))
 
 
-@conan_command(group=COMMAND_GROUPS['creator'], formatters={"json": json_create})
+@conan_command(group="Creator", formatters={"json": json_create})
 def create(conan_api, parser, *args):
     """
     Create a package

--- a/conan/cli/commands/download.py
+++ b/conan/cli/commands/download.py
@@ -2,11 +2,11 @@ from multiprocessing.pool import ThreadPool
 
 from conan.api.conan_api import ConanAPIV2
 from conan.api.output import ConanOutput
-from conan.cli.command import conan_command, COMMAND_GROUPS, OnceArgument
+from conan.cli.command import conan_command, OnceArgument
 from conans.errors import ConanException
 
 
-@conan_command(group=COMMAND_GROUPS['creator'])
+@conan_command(group="Creator")
 def download(conan_api: ConanAPIV2, parser, *args):
     """
     Download a conan package from a remote server, by its reference. It downloads just the package,

--- a/conan/cli/commands/editable.py
+++ b/conan/cli/commands/editable.py
@@ -1,14 +1,14 @@
 import os
 
 from conan.api.output import ConanOutput
-from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand
+from conan.cli.command import conan_command, conan_subcommand
 from conan.cli.commands import make_abs_path
 from conan.cli.commands.install import _get_conanfile_path
 from conan.api.conan_app import ConanApp
 from conans.model.recipe_ref import RecipeReference
 
 
-@conan_command(group=COMMAND_GROUPS['creator'])
+@conan_command(group="Creator")
 def editable(conan_api, parser, *args):
     """
     Allows working with a package in user folder

--- a/conan/cli/commands/export.py
+++ b/conan/cli/commands/export.py
@@ -2,7 +2,7 @@ import json
 import os
 
 from conan.api.output import ConanOutput, cli_out_write
-from conan.cli.command import conan_command, COMMAND_GROUPS, OnceArgument
+from conan.cli.command import conan_command, OnceArgument
 from conan.cli.commands.install import _get_conanfile_path
 from conan.cli.args import add_reference_args
 
@@ -16,7 +16,7 @@ def json_export(ref):
     cli_out_write(json.dumps({"reference": ref.repr_notime()}))
 
 
-@conan_command(group=COMMAND_GROUPS['creator'], formatters={"json": json_export})
+@conan_command(group="Creator", formatters={"json": json_export})
 def export(conan_api, parser, *args):
     """
     Export recipe to the Conan package cache

--- a/conan/cli/commands/export_pkg.py
+++ b/conan/cli/commands/export_pkg.py
@@ -2,7 +2,7 @@ import json
 import os
 
 from conan.api.output import cli_out_write
-from conan.cli.command import conan_command, COMMAND_GROUPS
+from conan.cli.command import conan_command
 from conan.cli.commands.install import _get_conanfile_path
 from conan.cli.common import scope_options
 from conan.cli.args import add_lockfile_args, add_profiles_args, add_reference_args
@@ -13,7 +13,7 @@ def json_export_pkg(info):
     cli_out_write(json.dumps({"graph": deps_graph.serialize()}, indent=4))
 
 
-@conan_command(group=COMMAND_GROUPS['creator'], formatters={"json": json_export_pkg})
+@conan_command(group="Creator", formatters={"json": json_export_pkg})
 def export_pkg(conan_api, parser, *args):
     """
     Export recipe to the Conan package cache, and create a package directly from pre-compiled binaries

--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -3,7 +3,7 @@ import os
 
 from conan.api.output import ConanOutput, cli_out_write
 from conan.api.subapi.install import do_deploys
-from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand, \
+from conan.cli.command import conan_command, conan_subcommand, \
     Extender, CommandResult
 from conan.cli.commands import make_abs_path
 from conan.cli.commands.install import graph_compute, common_graph_args
@@ -13,7 +13,7 @@ from conans.client.graph.install_graph import InstallGraph
 from conans.errors import ConanException
 
 
-@conan_command(group=COMMAND_GROUPS['consumer'])
+@conan_command(group="Consumer")
 def graph(conan_api, parser, *args):
     """
     Computes a dependency graph, without  installing or building the binaries

--- a/conan/cli/commands/inspect.py
+++ b/conan/cli/commands/inspect.py
@@ -2,7 +2,7 @@ import inspect as python_inspect
 import os
 
 from conan.api.output import cli_out_write
-from conan.cli.command import conan_command, COMMAND_GROUPS, conan_subcommand
+from conan.cli.command import conan_command
 from conan.cli.commands import default_json_formatter
 from conan.cli.commands.install import _get_conanfile_path
 
@@ -19,7 +19,7 @@ def inspect_text_formatter(data):
             cli_out_write("{}: {}".format(name, value))
 
 
-@conan_command(group=COMMAND_GROUPS['consumer'], formatters={"text": inspect_text_formatter, "json": default_json_formatter})
+@conan_command(group="Consumer", formatters={"text": inspect_text_formatter, "json": default_json_formatter})
 def inspect(conan_api, parser, *args):
     """
     Inspect a conanfile.py to return the public fields

--- a/conan/cli/commands/install.py
+++ b/conan/cli/commands/install.py
@@ -2,7 +2,7 @@ import json
 import os
 
 from conan.api.output import ConanOutput, cli_out_write
-from conan.cli.command import conan_command, Extender, COMMAND_GROUPS
+from conan.cli.command import conan_command, Extender
 from conan.cli.commands import make_abs_path
 from conan.cli.common import scope_options
 from conan.cli.args import add_lockfile_args, _add_common_install_arguments, add_reference_args, \
@@ -130,7 +130,7 @@ def common_graph_args(subparser):
     add_lockfile_args(subparser)
 
 
-@conan_command(group=COMMAND_GROUPS['consumer'], formatters={"json": json_install})
+@conan_command(group="Consumer", formatters={"json": json_install})
 def install(conan_api, parser, *args):
     """
     Installs the requirements specified in a recipe (conanfile.py or conanfile.txt).

--- a/conan/cli/commands/list.py
+++ b/conan/cli/commands/list.py
@@ -2,7 +2,7 @@ import json
 from collections import OrderedDict
 
 from conan.api.output import Color, cli_out_write
-from conan.cli.command import conan_command, conan_subcommand, Extender, COMMAND_GROUPS
+from conan.cli.command import conan_command, conan_subcommand, Extender
 from conan.cli.commands import default_json_formatter
 from conan.cli.formatters.list import list_packages_html
 from conans.errors import ConanException, InvalidNameException, NotFoundException
@@ -271,8 +271,8 @@ def list_packages(conan_api, parser, subparser, *args):
     return results
 
 
-@conan_command(group=COMMAND_GROUPS['consumer'])
+@conan_command(group="Consumer")
 def list(conan_api, parser, *args):
     """
-    Gets information about a recipe or package reference
+    List existing recipes, revisions or packages in the cache or in remotes
     """

--- a/conan/cli/commands/lock.py
+++ b/conan/cli/commands/lock.py
@@ -1,7 +1,7 @@
 import os
 
 from conan.api.output import ConanOutput
-from conan.cli.command import conan_command, COMMAND_GROUPS, OnceArgument, conan_subcommand
+from conan.cli.command import conan_command, OnceArgument, conan_subcommand
 from conan.cli.commands import make_abs_path
 from conan.cli.commands.install import common_graph_args, graph_compute
 from conans.errors import ConanException
@@ -9,7 +9,7 @@ from conans.model.graph_lock import Lockfile, LOCKFILE
 from conans.model.recipe_ref import RecipeReference
 
 
-@conan_command(group=COMMAND_GROUPS['consumer'])
+@conan_command(group="Consumer")
 def lock(conan_api, parser, *args):
     """
     Create or manages lockfiles

--- a/conan/cli/commands/new.py
+++ b/conan/cli/commands/new.py
@@ -4,12 +4,12 @@ import shutil
 from jinja2 import Environment, meta, exceptions
 
 from conan.api.output import ConanOutput
-from conan.cli.command import conan_command, COMMAND_GROUPS, Extender
+from conan.cli.command import conan_command, Extender
 from conans.errors import ConanException
 from conans.util.files import save
 
 
-@conan_command(group=COMMAND_GROUPS['creator'])
+@conan_command(group="Creator")
 def new(conan_api, parser, *args):
     """
     Create a new recipe (with conanfile.py and other files) from a predefined template

--- a/conan/cli/commands/profile.py
+++ b/conan/cli/commands/profile.py
@@ -1,7 +1,7 @@
 import os
 
 from conan.api.output import ConanOutput, cli_out_write
-from conan.cli.command import conan_command, conan_subcommand, COMMAND_GROUPS
+from conan.cli.command import conan_command, conan_subcommand
 from conan.cli.commands import default_text_formatter, default_json_formatter
 from conan.cli.args import add_profiles_args
 from conans.errors import ConanException
@@ -82,7 +82,7 @@ def profile_list(conan_api, parser, subparser, *args):
     return result
 
 
-@conan_command(group=COMMAND_GROUPS['consumer'])
+@conan_command(group="Consumer")
 def profile(conan_api, parser, *args):
     """
     Manages profiles

--- a/conan/cli/commands/remote.py
+++ b/conan/cli/commands/remote.py
@@ -261,7 +261,7 @@ def remote_logout(conan_api, parser, subparser, *args):
     return ret
 
 
-@conan_command()
+@conan_command(group="Consumer")
 def remote(conan_api, parser, *args):
     """
     Manages the remote list and the users authenticated on them.

--- a/conan/cli/commands/remove.py
+++ b/conan/cli/commands/remove.py
@@ -1,10 +1,10 @@
 from conan.api.conan_api import ConanAPIV2
-from conan.cli.command import conan_command, COMMAND_GROUPS, OnceArgument
+from conan.cli.command import conan_command, OnceArgument
 from conans.client.userio import UserInput
 from conans.errors import ConanException
 
 
-@conan_command(group=COMMAND_GROUPS['consumer'])
+@conan_command(group="Consumer")
 def remove(conan_api: ConanAPIV2, parser, *args):
     """
     Removes recipes or packages from local cache or a remote.

--- a/conan/cli/commands/search.py
+++ b/conan/cli/commands/search.py
@@ -1,12 +1,12 @@
 from collections import OrderedDict
 
 from conan.api.conan_api import ConanAPIV2
-from conan.cli.command import conan_command, Extender, COMMAND_GROUPS
+from conan.cli.command import conan_command, Extender
 from conan.cli.commands.list import print_list_recipes, default_json_formatter
 
 
 # FIXME: "conan search" == "conan list recipes -r="*" -c" --> implement @conan_alias_command??
-@conan_command(group=COMMAND_GROUPS['consumer'], formatters={"text": print_list_recipes, "json": default_json_formatter})
+@conan_command(group="Consumer", formatters={"text": print_list_recipes, "json": default_json_formatter})
 def search(conan_api: ConanAPIV2, parser, *args):
     """
     Searches for package recipes in a remote or remotes

--- a/conan/cli/commands/source.py
+++ b/conan/cli/commands/source.py
@@ -1,6 +1,6 @@
 import os
 
-from conan.cli.command import conan_command, COMMAND_GROUPS
+from conan.cli.command import conan_command
 from conan.cli.commands.install import _get_conanfile_path
 from conan.cli.args import add_reference_args
 from conan.api.conan_app import ConanApp
@@ -10,7 +10,7 @@ from conans.client.source import run_source_method
 from conans.errors import conanfile_exception_formatter
 
 
-@conan_command(group=COMMAND_GROUPS['creator'])
+@conan_command(group="Creator")
 def source(conan_api, parser, *args):
     """
     Calls the source() method

--- a/conan/cli/commands/test.py
+++ b/conan/cli/commands/test.py
@@ -1,7 +1,7 @@
 import os
 
 from conan.api.output import ConanOutput
-from conan.cli.command import conan_command, COMMAND_GROUPS, OnceArgument
+from conan.cli.command import conan_command, OnceArgument
 from conan.cli.commands.create import test_package, _check_tested_reference_matches
 from conan.cli.commands.install import _get_conanfile_path
 from conan.cli.args import add_lockfile_args, _add_common_install_arguments
@@ -9,7 +9,7 @@ from conan.cli.printers.graph import print_graph_basic, print_graph_packages
 from conans.model.recipe_ref import RecipeReference
 
 
-@conan_command(group=COMMAND_GROUPS['creator'])
+@conan_command(group="Creator")
 def test(conan_api, parser, *args):
     """
     Test a package from a test_package folder

--- a/conan/cli/commands/upload.py
+++ b/conan/cli/commands/upload.py
@@ -1,10 +1,10 @@
 from conan.api.conan_api import ConanAPIV2
-from conan.cli.command import conan_command, COMMAND_GROUPS, OnceArgument
+from conan.cli.command import conan_command, OnceArgument
 from conans.client.userio import UserInput
 from conans.errors import ConanException
 
 
-@conan_command(group=COMMAND_GROUPS['creator'])
+@conan_command(group="Creator")
 def upload(conan_api: ConanAPIV2, parser, *args):
     """
     Uploads a recipe and binary packages to a remote.

--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -324,12 +324,13 @@ class EnvVars:
         return self._values.keys()
 
     def get(self, name, default=None, variable_reference=None):
-        """
-        :param name: The name of the environment variable
-        :param default: The returned value if the variable doesn't exist, by default None
+        """ get the value of a env-var
+
+        :param name: The name of the environment variable.
+        :param default: The returned value if the variable doesn't exist, by default None.
         :param variable_reference: if specified, use a variable reference instead of the
-        pre-existing value of environment variable, where {name} can be used to refer to the
-        name of the variable.
+                                   pre-existing value of environment variable, where {name}
+                                   can be used to refer to the name of the variable.
         """
         v = self._values.get(name)
         if v is None:
@@ -341,9 +342,10 @@ class EnvVars:
 
     def items(self, variable_reference=None):
         """returns {str: str} (varname: value)
-         :param variable_reference: if specified, use a variable reference instead of the
-        pre-existing value of environment variable, where {name} can be used to refer to the
-        name of the variable.
+
+        :param variable_reference: if specified, use a variable reference instead of the
+                                   pre-existing value of environment variable, where {name}
+                                   can be used to refer to the name of the variable.
         """
         if variable_reference:
             return {k: v.get_str(variable_reference, self._subsystem, self._pathsep)

--- a/conans/test/integration/command/help_test.py
+++ b/conans/test/integration/command/help_test.py
@@ -1,88 +1,40 @@
-import unittest
-import textwrap
-
-import pytest
-
 from conans import __version__
 from conans.test.utils.tools import TestClient
 
 
-class BasicClientTest(unittest.TestCase):
+class TestHelp:
 
-    def test_help(self):
-        client = TestClient()
-        # FIXME: cli2.0 this will fail in testing because of ArgParse, maybe fix in the future
-        # client.run("")
-        # self.assertIn('Conan commands. Type "conan <command> -h" for help', client.out)
-
-        client.run("--version")
-        self.assertIn("Conan version %s" % __version__, client.out)
-
-        client.run("some_unknown_command123", assert_error=True)
-        self.assertIn("ERROR: Unknown command 'some_unknown_command123'", client.out)
+    def test_version(self):
+        c = TestClient()
+        c.run("--version")
+        assert "Conan version %s" % __version__ in c.out
 
     def test_unknown_command(self):
-        client = TestClient()
+        c = TestClient()
+        c.run("some_unknown_command123", assert_error=True)
+        assert "'some_unknown_command123' is not a Conan command" in c.out
 
-        client.run("some_unknown_command123", assert_error=True)
-        expected_output = textwrap.dedent(
-            """\
-                'some_unknown_command123' is not a Conan command. See 'conan --help'.
+    def test_similar(self):
+        c = TestClient()
+        c.run("instal", assert_error=True)
+        assert "The most similar command is" in c.out
+        assert "install" in c.out
 
-                ERROR: Unknown command 'some_unknown_command123'
-            """)
-        self.assertIn(
-            expected_output, client.out)
+    def test_help(self):
+        c = TestClient()
+        c.run("-h")
+        assert "Creator commands" in c.out
+        assert "Consumer commands" in c.out
 
+    def test_help_command(self):
+        c = TestClient()
+        c.run("new -h")
+        assert "Create a new recipe" in c.out
 
-        # FIXME: cli2.0 this will not work until we have all commands implemented
-        # Check for a single suggestion
-        #client.run("instal", assert_error=True)
-
-        # expected_output = textwrap.dedent(
-        #     """\
-        #         'instal' is not a Conan command. See 'conan --help'.
-        #
-        #         The most similar command is
-        #             install
-        #
-        #         ERROR: Unknown command 'instal'
-        #     """)
-        # self.assertIn(
-        #     expected_output, client.out)
-        #
-        # # Check for multiple suggestions
-        # client.run("remoe", assert_error=True)
-        # self.assertIn(
-        #     "", client.out)
-        #
-        # expected_output = textwrap.dedent(
-        #     """\
-        #         'remoe' is not a Conan command. See 'conan --help'.
-        #
-        #         The most similar commands are
-        #             remove
-        #             remote
-        #
-        #         ERROR: Unknown command 'remoe'
-        #     """)
-        # self.assertIn(
-        #     expected_output, client.out)
-
-    @pytest.mark.xfail(reason="the new help command cannot show the help of commands from the legacy system")
-    def test_help_cmd(self):
-        client = TestClient()
-        client.run("help new")
-        self.assertIn("Creates a new package recipe template with a 'conanfile.py'", client.out)
-
-        client.run("help build")
-        self.assertIn("Calls your local conanfile.py 'build()' method", client.out)
-
-        client.run("help")
-        self.assertIn("Creator commands", client.out)
-
-    @pytest.mark.xfail(reason="the new help command cannot show the help of commands from the legacy system")
-    def test_help_cmd_error(self):
-        client = TestClient()
-        client.run("help not-exists", assert_error=True)
-        self.assertIn("ERROR: Unknown command 'not-exists'", client.out)
+    def test_help_subcommand(self):
+        c = TestClient()
+        c.run("list -h")
+        # When listing subcommands, but line truncated
+        assert "Search available recipes in the local cache" in c.out
+        c.run("list recipes -h")
+        assert "Search available recipes in the local cache or in the remotes" in c.out


### PR DESCRIPTION
- Removed COMMAND_GROUPS, it was not adding much
- Recovered ``-h`` tests
- Changed order of consumer-creator in ``conan -h``
- Fixed a bug in ``conan command subcommand -h``, it was not displaying the docstring
- Fixed some broken docstrings


This was done to prepare docs for the reference - commands