### PR TITLE
remove hardcoded definitions of CMAKE_CXX_COMPILER in CMakeToolchain

### DIFF
--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain_win_clang.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain_win_clang.py
@@ -20,6 +20,8 @@ def client():
     t = tempfile.mkdtemp(suffix='conans')
     c = TestClient(cache_folder=t)
     save(c.cache.new_config_path, "tools.env.virtualenv:auto_use=True")
+    # TODO: Adding CXX, CC env-vars is good, but that forces users to activate environment
+    #  it would be better an abstraction that sends it directly to the toolchain
     clang_profile = textwrap.dedent("""
         [settings]
         os=Windows
@@ -27,6 +29,10 @@ def client():
         build_type=Release
         compiler=clang
         compiler.version=12
+        [buildenv]
+        CXX=clang++
+        CC=clang
+        RC=clang
         """)
     conanfile = textwrap.dedent("""
         import os

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -29,6 +29,7 @@ def conanfile():
     c.settings.compiler.libcxx = "libstdc++"
     c.settings.os = "Windows"
     c.conf = Conf()
+    c.conf.define("tools.cmake.cmaketoolchain:system_name", "potato")
     c.folders.set_base_generators(".")
     c._conan_node = Mock()
     c._conan_node.dependencies = []
@@ -38,29 +39,29 @@ def conanfile():
 def test_cmake_toolchain(conanfile):
     toolchain = CMakeToolchain(conanfile)
     content = toolchain.content
-    assert 'set(CMAKE_C_COMPILER clang)' in content
+    assert 'set(CMAKE_SYSTEM_NAME potato)' in content
 
 
 def test_remove(conanfile):
     toolchain = CMakeToolchain(conanfile)
     toolchain.blocks.remove("generic_system")
     content = toolchain.content
-    assert 'CMAKE_C_COMPILER' not in content
+    assert 'CMAKE_SYSTEM_NAME' not in content
 
 
 def test_template_remove(conanfile):
     toolchain = CMakeToolchain(conanfile)
     toolchain.blocks["generic_system"].template = ""
     content = toolchain.content
-    assert 'CMAKE_C_COMPILER' not in content
+    assert 'CMAKE_SYSTEM_NAME' not in content
 
 
 def test_template_change(conanfile):
     toolchain = CMakeToolchain(conanfile)
     tmp = toolchain.blocks["generic_system"].template
-    toolchain.blocks["generic_system"].template = tmp.replace("CMAKE_C_COMPILER", "OTHER_THING")
+    toolchain.blocks["generic_system"].template = tmp.replace("CMAKE_SYSTEM_NAME", "OTHER_THING")
     content = toolchain.content
-    assert 'set(OTHER_THING clang)' in content
+    assert 'set(OTHER_THING potato)' in content
 
 
 def test_context_change(conanfile):
@@ -69,25 +70,25 @@ def test_context_change(conanfile):
 
     def context(self):
         assert self
-        return {"compiler": None}
+        return {"cmake_system_name": None}
     tmp.context = types.MethodType(context, tmp)
     content = toolchain.content
-    assert 'CMAKE_C_COMPILER' not in content
+    assert 'CMAKE_SYSTEM_NAME' not in content
 
 
 def test_context_update(conanfile):
     toolchain = CMakeToolchain(conanfile)
-    compiler = toolchain.blocks["generic_system"].values["compiler"]
-    toolchain.blocks["generic_system"].values["compiler"] = "Super" + compiler
+    cmake_system_name = toolchain.blocks["generic_system"].values["cmake_system_name"]
+    toolchain.blocks["generic_system"].values["cmake_system_name"] = "Super" + cmake_system_name
     content = toolchain.content
-    assert 'set(CMAKE_C_COMPILER Superclang)' in content
+    assert 'set(CMAKE_SYSTEM_NAME Superpotato)' in content
 
 
 def test_context_replace(conanfile):
     toolchain = CMakeToolchain(conanfile)
-    toolchain.blocks["generic_system"].values = {"compiler": "SuperClang"}
+    toolchain.blocks["generic_system"].values = {"cmake_system_name": "SuperPotato"}
     content = toolchain.content
-    assert 'set(CMAKE_C_COMPILER SuperClang)' in content
+    assert 'set(CMAKE_SYSTEM_NAME SuperPotato)' in content
 
 
 def test_replace_block(conanfile):
@@ -117,7 +118,7 @@ def test_add_new_block(conanfile):
     toolchain.blocks["mynewblock"] = MyBlock
     content = toolchain.content
     assert 'Hello World!!!' in content
-    assert 'CMAKE_C_COMPILER' in content
+    assert 'set(CMAKE_SYSTEM_NAME potato)' in content
 
 
 def test_user_toolchain(conanfile):


### PR DESCRIPTION
Changelog: Fix: remove hardcoded definitions of CMAKE_CXX_COMPILER in CMakeToolchain
Docs: TODO

To prepare for https://github.com/conan-io/conan/pull/12556:

The hardcoded definition of CMAKE_XXX_COMPILER in CMakeToolchain can be removed:
- In Ninja it is good if VCVars activate the environment and put cl.exe there
- For Windows-Clang, it is necessary to add CC/CXX in ``[buildenv]`` in the profile. This is not great, because it forces users to have to activate the environment too. It would be better if there is a built-in mechanism like in  https://github.com/conan-io/conan/pull/12556 that puts it directly in ``conan_toolchain.cmake``