### PR TITLE
[develop2] fixing mocking of legacy attrs

### DIFF
--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -89,8 +89,6 @@ class _Component(object):
         # LEGACY 1.X fields, can be removed in 2.X
         self.names = MockInfoProperty("cpp_info.names")
         self.filenames = MockInfoProperty("cpp_info.filenames")
-        self.user_info = MockInfoProperty("cpp_info.user_info")
-        self.env_info = MockInfoProperty("cpp_info.env_info")
 
         if set_defaults:
             self.includedirs = ["include"]

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -246,8 +246,8 @@ class ConanFile:
         self.options = Options(self.options or {}, self.default_options)
 
         # user declared variables
-        self.user_info = MockInfoProperty("cpp_info.user_info")
-        self.env_info = MockInfoProperty("cpp_info.env_info")
+        self.user_info = MockInfoProperty("user_info")
+        self.env_info = MockInfoProperty("env_info")
         self._conan_dependencies = None
 
         if not hasattr(self, "virtualbuildenv"):  # Allow the user to override it with True or False

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from conan.api.output import ConanOutput
 from conans.client.subsystems import command_env_wrapper
 from conans.errors import ConanException
+from conans.model.build_info import MockInfoProperty
 from conans.model.conf import Conf
 from conans.model.dependencies import ConanFileDependencies
 from conans.model.layout import Folders, Infos
@@ -245,7 +246,8 @@ class ConanFile:
         self.options = Options(self.options or {}, self.default_options)
 
         # user declared variables
-        self.user_info = None
+        self.user_info = MockInfoProperty("cpp_info.user_info")
+        self.env_info = MockInfoProperty("cpp_info.env_info")
         self._conan_dependencies = None
 
         if not hasattr(self, "virtualbuildenv"):  # Allow the user to override it with True or False

--- a/conans/test/integration/conan_v2/test_legacy_cpp_info.py
+++ b/conans/test/integration/conan_v2/test_legacy_cpp_info.py
@@ -19,8 +19,8 @@ def test_legacy_names_filenames():
                 self.cpp_info.filenames["cmake_find_package"] = "tensorflowlite"
                 self.cpp_info.filenames["cmake_find_package_multi"] = "tensorflowlite"
 
-                self.cpp_info.env_info.whatever = "whatever-env_info"
-                self.cpp_info.user_info.whatever = "whatever-user_info"
+                self.env_info.whatever = "whatever-env_info"
+                self.user_info.whatever = "whatever-user_info"
         """)
     c.save({"conanfile.py": conanfile})
     c.run("create .")

--- a/conans/test/integration/conan_v2/test_legacy_cpp_info.py
+++ b/conans/test/integration/conan_v2/test_legacy_cpp_info.py
@@ -28,5 +28,5 @@ def test_legacy_names_filenames():
               "Conan 2.X. Please, update your recipes unless you are maintaining compatibility " \
               "with Conan 1.X"
 
-    for name in ["cpp_info.names", "cpp_info.filenames", "cpp_info.env_info", "cpp_info.user_info"]:
+    for name in ["cpp_info.names", "cpp_info.filenames", "env_info", "user_info"]:
         assert message.format(name) in c.out


### PR DESCRIPTION
Close https://github.com/conan-io/conan/issues/12584

Minor bug in the mocking of legacy attrs, it was adding the mock inside ``cpp_info``, but it should be a sibling
