### PR TITLE
[develop2] remove args.Extender, replace with action=append

### DIFF
--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -1,4 +1,4 @@
-from conan.cli.command import OnceArgument, ExtenderValueRequired, Extender
+from conan.cli.command import OnceArgument
 
 
 _help_build_policies = '''Optional, specify which packages to build from source. Combining multiple
@@ -36,9 +36,9 @@ def add_lockfile_args(parser):
 
 def _add_common_install_arguments(parser, build_help, update_help=None):
     if build_help:
-        parser.add_argument("-b", "--build", action=ExtenderValueRequired, nargs="?", help=build_help)
+        parser.add_argument("-b", "--build", action="append", help=build_help)
 
-    parser.add_argument("-r", "--remote", action=Extender, default=None,
+    parser.add_argument("-r", "--remote", action="append", default=None,
                         help='Look in the specified remote or remotes server')
 
     if not update_help:
@@ -57,14 +57,14 @@ def add_profiles_args(parser):
     def profile_args(machine, short_suffix="", long_suffix=""):
         parser.add_argument("-pr{}".format(short_suffix),
                             "--profile{}".format(long_suffix),
-                            default=None, action=Extender,
+                            default=None, action="append",
                             dest='profile_{}'.format(machine),
                             help='Apply the specified profile to the {} machine'.format(machine))
 
     def settings_args(machine, short_suffix="", long_suffix=""):
         parser.add_argument("-s{}".format(short_suffix),
                             "--settings{}".format(long_suffix),
-                            nargs=1, action=Extender,
+                            action="append",
                             dest='settings_{}'.format(machine),
                             help='Settings to build the package, overwriting the defaults'
                                  ' ({} machine). e.g.: -s{} compiler=gcc'.format(machine,
@@ -73,7 +73,7 @@ def add_profiles_args(parser):
     def options_args(machine, short_suffix="", long_suffix=""):
         parser.add_argument("-o{}".format(short_suffix),
                             "--options{}".format(long_suffix),
-                            nargs=1, action=Extender,
+                            action="append",
                             dest="options_{}".format(machine),
                             help='Define options values ({} machine), e.g.:'
                                  ' -o{} Pkg:with_qt=true'.format(machine, short_suffix))
@@ -81,7 +81,7 @@ def add_profiles_args(parser):
     def conf_args(machine, short_suffix="", long_suffix=""):
         parser.add_argument("-c{}".format(short_suffix),
                             "--conf{}".format(long_suffix),
-                            nargs=1, action=Extender,
+                            action="append",
                             dest='conf_{}'.format(machine),
                             help='Configuration to build the package, overwriting the defaults'
                                  ' ({} machine). e.g.: -c{} '

--- a/conan/cli/command.py
+++ b/conan/cli/command.py
@@ -6,45 +6,6 @@ from conan.cli.commands import add_log_level_args, process_log_level_args
 from conans.errors import ConanException
 
 
-class Extender(argparse.Action):
-    """Allows using the same flag several times in command and creates a list with the values.
-    For example:
-        conan install MyPackage/1.2@user/channel -o qt/*:value -o mode/*:2 -s cucumber/*:true
-      It creates:
-          options = ['qt:value', 'mode:2']
-          settings = ['cucumber:true']
-    """
-    raise_if_none = False
-
-    def __call__(self, parser, namespace, values, option_strings=None):  # @UnusedVariable
-        # Need None here incase `argparse.SUPPRESS` was supplied for `dest`
-        dest = getattr(namespace, self.dest, None)
-        if not hasattr(dest, 'extend') or dest == self.default:
-            dest = []
-            setattr(namespace, self.dest, dest)
-            # if default isn't set to None, this method might be called
-            # with the default as `values` for other arguments which
-            # share this destination.
-            parser.set_defaults(**{self.dest: None})
-
-        if isinstance(values, str):
-            dest.append(values)
-        elif values:
-            try:
-                dest.extend(values)
-            except ValueError:
-                dest.append(values)
-        else:  # When "--argument" with no value is specified
-            if self.raise_if_none:
-                raise argparse.ArgumentError(None, 'Specify --build="*" instead of --build')
-
-
-class ExtenderValueRequired(Extender):
-
-    # If --build is specified, it will raise
-    raise_if_none = True
-
-
 class OnceArgument(argparse.Action):
     """Allows declaring a parameter that can have only one value, by default argparse takes the
     latest declared and it's very confusing.

--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -3,8 +3,7 @@ import os
 
 from conan.api.output import ConanOutput, cli_out_write
 from conan.api.subapi.install import do_deploys
-from conan.cli.command import conan_command, conan_subcommand, \
-    Extender, CommandResult
+from conan.cli.command import conan_command, conan_subcommand, CommandResult
 from conan.cli.commands import make_abs_path
 from conan.cli.commands.install import graph_compute, common_graph_args
 from conan.cli.formatters.graph import format_graph_html, format_graph_json, format_graph_dot
@@ -66,7 +65,7 @@ def graph_build_order_merge(conan_api, parser, subparser, *args):
     """
     Merges more than 1 build-order file
     """
-    subparser.add_argument("--file", nargs="?", action=Extender, help="Files to be merged")
+    subparser.add_argument("--file", nargs="?", action="append", help="Files to be merged")
     args = parser.parse_args(*args)
 
     result = InstallGraph()
@@ -89,11 +88,11 @@ def graph_info(conan_api, parser, subparser, *args):
     """
     common_graph_args(subparser)
     subparser.add_argument("--check-updates", default=False, action="store_true")
-    subparser.add_argument("--filter", nargs=1, action=Extender,
+    subparser.add_argument("--filter", action="append",
                            help="Show only the specified fields")
-    subparser.add_argument("--package-filter", nargs=1, action=Extender,
+    subparser.add_argument("--package-filter", action="append",
                            help='Print information only for packages that match the patterns')
-    subparser.add_argument("--deploy", action=Extender,
+    subparser.add_argument("--deploy", action="append",
                            help='Deploy using the provided deployer to the output folder')
     args = parser.parse_args(*args)
 

--- a/conan/cli/commands/install.py
+++ b/conan/cli/commands/install.py
@@ -2,7 +2,7 @@ import json
 import os
 
 from conan.api.output import ConanOutput, cli_out_write
-from conan.cli.command import conan_command, Extender
+from conan.cli.command import conan_command
 from conan.cli.commands import make_abs_path
 from conan.cli.common import scope_options
 from conan.cli.args import add_lockfile_args, _add_common_install_arguments, add_reference_args, \
@@ -146,11 +146,11 @@ def install(conan_api, parser, *args):
     generators.
     """
     common_graph_args(parser)
-    parser.add_argument("-g", "--generator", nargs=1, action=Extender,
+    parser.add_argument("-g", "--generator", action="append",
                         help='Generators to use')
     parser.add_argument("-of", "--output-folder",
                         help='The root output folder for generated and build files')
-    parser.add_argument("--deploy", action=Extender,
+    parser.add_argument("--deploy", action="append",
                         help='Deploy using the provided deployer to the output folder')
     args = parser.parse_args(*args)
 

--- a/conan/cli/commands/list.py
+++ b/conan/cli/commands/list.py
@@ -2,7 +2,7 @@ import json
 from collections import OrderedDict
 
 from conan.api.output import Color, cli_out_write
-from conan.cli.command import conan_command, conan_subcommand, Extender
+from conan.cli.command import conan_command, conan_subcommand
 from conan.cli.commands import default_json_formatter
 from conan.cli.formatters.list import list_packages_html
 from conans.errors import ConanException, InvalidNameException, NotFoundException
@@ -96,7 +96,7 @@ def print_list_package_ids(results):
 
 
 def _add_remotes_and_cache_options(subparser):
-    subparser.add_argument("-r", "--remote", default=None, action=Extender,
+    subparser.add_argument("-r", "--remote", default=None, action="append",
                            help="Remote names. Accepts wildcards")
     subparser.add_argument("-c", "--cache", action='store_true', help="Search in the local cache")
 

--- a/conan/cli/commands/new.py
+++ b/conan/cli/commands/new.py
@@ -4,7 +4,7 @@ import shutil
 from jinja2 import Environment, meta, exceptions
 
 from conan.api.output import ConanOutput
-from conan.cli.command import conan_command, Extender
+from conan.cli.command import conan_command
 from conans.errors import ConanException
 from conans.util.files import save
 
@@ -21,7 +21,7 @@ def new(conan_api, parser, *args):
                         "E.g. 'conan new cmake_lib -d name=hello -d version=0.1'. "
                         "You can define your own templates too."
                         )
-    parser.add_argument("-d", "--define", action=Extender,
+    parser.add_argument("-d", "--define", action="append",
                         help="Define a template argument as key=value")
     parser.add_argument("-f", "--force", action='store_true', help="Overwrite file if exists")
 

--- a/conan/cli/commands/search.py
+++ b/conan/cli/commands/search.py
@@ -1,11 +1,14 @@
 from collections import OrderedDict
 
 from conan.api.conan_api import ConanAPIV2
-from conan.cli.command import conan_command, Extender
+from conan.cli.command import conan_command
 from conan.cli.commands.list import print_list_recipes, default_json_formatter
 
 
 # FIXME: "conan search" == "conan list recipes -r="*" -c" --> implement @conan_alias_command??
+from conans.errors import ConanException
+
+
 @conan_command(group="Consumer", formatters={"text": print_list_recipes, "json": default_json_formatter})
 def search(conan_api: ConanAPIV2, parser, *args):
     """
@@ -13,12 +16,14 @@ def search(conan_api: ConanAPIV2, parser, *args):
     """
     parser.add_argument("query",
                         help="Search query to find package recipe reference, e.g., 'boost', 'lib*'")
-    parser.add_argument("-r", "--remote", default="*", action=Extender,
+    parser.add_argument("-r", "--remote", action="append",
                         help="Remote names. Accepts wildcards. If not specified it searches "
                              "in all remotes")
     args = parser.parse_args(*args)
 
     remotes = conan_api.remotes.list(args.remote)
+    if not remotes:
+        raise ConanException("There are no remotes to search from")
 
     results = OrderedDict()
     for remote in remotes:

--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -338,6 +338,8 @@ def _profile_parse_args(settings, options, envs, conf):
             return []
         # Validate the pairs
         for item in items:
+            if not isinstance(item, str):
+                raise Exception("POTATO!!!!")
             chunks = item.split("=", 1)
             if len(chunks) != 2:
                 raise ConanException("Invalid input '%s', use 'name=value'" % item)

--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -338,8 +338,6 @@ def _profile_parse_args(settings, options, envs, conf):
             return []
         # Validate the pairs
         for item in items:
-            if not isinstance(item, str):
-                raise Exception("POTATO!!!!")
             chunks = item.split("=", 1)
             if len(chunks) != 2:
                 raise ConanException("Invalid input '%s', use 'name=value'" % item)

--- a/conans/test/integration/command_v2/search_test.py
+++ b/conans/test/integration/command_v2/search_test.py
@@ -40,7 +40,7 @@ class TestSearch:
         self.client = TestClient(servers=self.servers)
 
         self.client.run("search whatever", assert_error=True)
-        assert "ERROR: Remotes for pattern '*' can't be found or are disabled" in self.client.out
+        assert "There are no remotes to search from" in self.client.out
 
     def test_search_disabled_remote(self, remotes):
         self.client.run("remote disable remote1")
@@ -94,7 +94,7 @@ class TestRemotes:
 
     def test_no_remotes(self):
         self.client.run("search something", assert_error=True)
-        expected_output = "Remotes for pattern '*' can't be found or are disabled"
+        expected_output = "There are no remotes to search from"
         assert expected_output in self.client.out
 
     def test_search_by_name(self):


### PR DESCRIPTION
Not sure why it was needed, but apparently it is easy to replace with a ``action="append"`` builtin