### PR TITLE
editables env-vars and confs

### DIFF
--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -154,6 +154,12 @@ class _EnvValue:
         previous_value = os.getenv(self._name)
         return self.get_str(previous_value, subsystem, pathsep)
 
+    def set_relative_base_folder(self, folder):
+        if not self._path:
+            return
+        self._values = [os.path.join(folder, v) if v != _EnvVarPlaceHolder else v
+                        for v in self._values]
+
 
 class Environment:
     def __init__(self):
@@ -232,6 +238,10 @@ class Environment:
 
     def vars(self, conanfile, scope="build"):
         return EnvVars(conanfile, self._values, scope)
+
+    def set_relative_base_folder(self, folder):
+        for v in self._values.values():
+            v.set_relative_base_folder(folder)
 
 
 class EnvVars:

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -711,6 +711,12 @@ class BinaryInstaller(object):
                         # Paste the editable cpp_info but prioritizing it, only if a
                         # variable is not declared at build/source, the package will keep the value
                         fill_old_cppinfo(full_editable_cppinfo, conanfile.cpp_info)
+                        conanfile.buildenv_info.compose_env(conanfile.cpp.source.buildenv_info)
+                        conanfile.buildenv_info.compose_env(conanfile.cpp.build.buildenv_info)
+                        conanfile.runenv_info.compose_env(conanfile.cpp.source.runenv_info)
+                        conanfile.runenv_info.compose_env(conanfile.cpp.build.runenv_info)
+                        conanfile.conf_info.compose_conf(conanfile.cpp.source.conf_info)
+                        conanfile.conf_info.compose_conf(conanfile.cpp.build.conf_info)
 
                     if conanfile._conan_dep_cpp_info is None:
                         try:

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -174,6 +174,8 @@ class _ConfValue(object):
         if isinstance(self._value, list):
             self._value = [os.path.join(folder, v) if v != _ConfVarPlaceHolder else v
                            for v in self._value]
+        if isinstance(self._value, dict):
+            self._value = {k: os.path.join(folder, v) for k, v in self._value.items()}
         elif isinstance(self._value, str):
             self._value = os.path.join(folder, self._value)
 
@@ -299,9 +301,13 @@ class Conf:
         """
         return "\n".join([v.dumps() for v in reversed(self._values.values())])
 
-    def define(self, name, value, path=False):
+    def define(self, name, value):
         self._validate_lower_case(name)
-        self._values[name] = _ConfValue(name, value, path)
+        self._values[name] = _ConfValue(name, value)
+
+    def define_path(self, name, value):
+        self._validate_lower_case(name)
+        self._values[name] = _ConfValue(name, value, path=True)
 
     def unset(self, name):
         """
@@ -314,14 +320,29 @@ class Conf:
         conf_value = _ConfValue(name, {})
         self._values.setdefault(name, conf_value).update(value)
 
-    def append(self, name, value, path=False):
+    def update_path(self, name, value):
         self._validate_lower_case(name)
-        conf_value = _ConfValue(name, [_ConfVarPlaceHolder], path)
+        conf_value = _ConfValue(name, {}, path=True)
+        self._values.setdefault(name, conf_value).update(value)
+
+    def append(self, name, value):
+        self._validate_lower_case(name)
+        conf_value = _ConfValue(name, [_ConfVarPlaceHolder])
+        self._values.setdefault(name, conf_value).append(value)
+
+    def append_path(self, name, value):
+        self._validate_lower_case(name)
+        conf_value = _ConfValue(name, [_ConfVarPlaceHolder], path=True)
         self._values.setdefault(name, conf_value).append(value)
 
     def prepend(self, name, value):
         self._validate_lower_case(name)
         conf_value = _ConfValue(name, [_ConfVarPlaceHolder])
+        self._values.setdefault(name, conf_value).prepend(value)
+
+    def prepend_path(self, name, value):
+        self._validate_lower_case(name)
+        conf_value = _ConfValue(name, [_ConfVarPlaceHolder], path=True)
         self._values.setdefault(name, conf_value).prepend(value)
 
     def remove(self, name, value):

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -1,4 +1,5 @@
 import fnmatch
+import os
 from collections import OrderedDict
 
 import six
@@ -80,10 +81,11 @@ class _ConfVarPlaceHolder:
 
 class _ConfValue(object):
 
-    def __init__(self, name, value):
+    def __init__(self, name, value, path=False):
         self._name = name
         self._value = value
         self._value_type = type(value)
+        self._path = path
 
     def __repr__(self):
         return repr(self._value)
@@ -97,7 +99,7 @@ class _ConfValue(object):
         return self._value
 
     def copy(self):
-        return _ConfValue(self._name, self._value)
+        return _ConfValue(self._name, self._value, self._path)
 
     def dumps(self):
         if self._value is None:
@@ -163,6 +165,15 @@ class _ConfValue(object):
             raise ConanException("It's not possible to compose {} values "
                                  "and {} ones.".format(v_type.__name__, o_type.__name__))
         # TODO: In case of any other object types?
+
+    def set_relative_base_folder(self, folder):
+        if not self._path:
+            return
+        if isinstance(self._value, list):
+            self._value = [os.path.join(folder, v) if v != _ConfVarPlaceHolder else v
+                           for v in self._value]
+        elif isinstance(self._value, str):
+            self._value = os.path.join(folder, self._value)
 
 
 class Conf:
@@ -286,9 +297,9 @@ class Conf:
         """
         return "\n".join([v.dumps() for v in reversed(self._values.values())])
 
-    def define(self, name, value):
+    def define(self, name, value, path=False):
         self._validate_lower_case(name)
-        self._values[name] = _ConfValue(name, value)
+        self._values[name] = _ConfValue(name, value, path)
 
     def unset(self, name):
         """
@@ -301,9 +312,9 @@ class Conf:
         conf_value = _ConfValue(name, {})
         self._values.setdefault(name, conf_value).update(value)
 
-    def append(self, name, value):
+    def append(self, name, value, path=False):
         self._validate_lower_case(name)
-        conf_value = _ConfValue(name, [_ConfVarPlaceHolder])
+        conf_value = _ConfValue(name, [_ConfVarPlaceHolder], path)
         self._values.setdefault(name, conf_value).append(value)
 
     def prepend(self, name, value):
@@ -337,6 +348,10 @@ class Conf:
             if _is_profile_module(k):
                 result._values[k] = v
         return result
+
+    def set_relative_base_folder(self, folder):
+        for v in self._values.values():
+            v.set_relative_base_folder(folder)
 
 
 class ConfDefinition:

--- a/conans/model/layout.py
+++ b/conans/model/layout.py
@@ -1,14 +1,30 @@
 import os
 
+from conans.model.conf import Conf
 from conans.model.new_build_info import NewCppInfo
+
+
+class _SubInfo(NewCppInfo):
+    def __init__(self, with_defaults=False):
+        super().__init__(with_defaults)
+        from conan.tools.env import Environment
+        self.buildenv_info = Environment()
+        self.runenv_info = Environment()
+        self.conf_info = Conf()
+
+    def set_relative_base_folder(self, folder):
+        super().set_relative_base_folder(folder)
+        self.buildenv_info.set_relative_base_folder(folder)
+        self.runenv_info.set_relative_base_folder(folder)
+        self.conf_info.set_relative_base_folder(folder)
 
 
 class Infos(object):
 
     def __init__(self):
-        self.source = NewCppInfo()
-        self.build = NewCppInfo()
-        self.package = NewCppInfo(with_defaults=True)
+        self.source = _SubInfo()
+        self.build = _SubInfo()
+        self.package = _SubInfo(with_defaults=True)
 
 
 class Folders(object):

--- a/conans/test/integration/editable/test_editable_envvars.py
+++ b/conans/test/integration/editable/test_editable_envvars.py
@@ -1,0 +1,64 @@
+import os
+import textwrap
+
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.tools import TestClient
+
+
+def test_editable_envvars():
+    c = TestClient()
+    dep = textwrap.dedent("""
+        from conan import ConanFile
+        class Dep(ConanFile):
+            def layout(self):
+                self.folders.source = "mysource"
+                self.folders.build = "mybuild"
+                self.cpp.source.runenv_info.append_path("MYRUNPATH", "mylocalsrc")
+                self.cpp.build.buildenv_info.define_path("MYBUILDPATH", "mylocalbuild")
+        """)
+
+    c.save({"dep/conanfile.py": dep,
+            "pkg/conanfile.py": GenConanfile().with_settings("os")
+                                              .with_requires("dep/1.0")
+                                              .with_generator("VirtualBuildEnv")
+                                              .with_generator("VirtualRunEnv")})
+    c.run("editable add dep dep/1.0")
+    c.run("install pkg -s os=Linux -s:b os=Linux")
+    build_path = os.path.join(c.current_folder, "dep", "mybuild", "mylocalbuild")
+    buildenv = c.load("conanbuildenv.sh")
+    assert f'export MYBUILDPATH="{build_path}"' in buildenv
+    runenv = c.load("conanrunenv.sh")
+    run_path = os.path.join(c.current_folder, "dep", "mysource", "mylocalsrc")
+    assert f'export MYRUNPATH="$MYRUNPATH:{run_path}"' in runenv
+
+
+def test_editable_conf():
+    c = TestClient()
+    # TODO: Define if we want conf.xxxx_path(), instead of (..., path=True) methods
+    dep = textwrap.dedent("""
+        from conan import ConanFile
+        class Dep(ConanFile):
+            def layout(self):
+                self.folders.source = "mysource"
+                self.folders.build = "mybuild"
+                self.cpp.source.conf_info.append("myconf", "mylocalsrc", path=True)
+                self.cpp.build.conf_info.append("myconf", "mylocalbuild", path=True)
+        """)
+
+    pkg = textwrap.dedent("""
+        from conan import ConanFile
+        class Pkg(ConanFile):
+            requires = "dep/1.0"
+            def generate(self):
+                conf = self.dependencies["dep"].conf_info.get("myconf")
+                self.output.info(f"CONF: {conf}")
+        """)
+    c.save({"dep/conanfile.py": dep,
+            "pkg/conanfile.py": pkg})
+    c.run("editable add dep dep/1.0")
+    c.run("install pkg -s os=Linux -s:b os=Linux")
+    out = str(c.out).replace("\\\\", "\\")
+    build_path = os.path.join(c.current_folder, "dep", "mybuild", "mylocalbuild")
+    run_path = os.path.join(c.current_folder, "dep", "mysource", "mylocalsrc")
+    assert build_path in out
+    assert run_path in out


### PR DESCRIPTION
Changelog: Feature: Implement ``editable`` env-vars via ``layouts.xxx.buildenv_info`` and ``layouts.xxx.runenv_info`` and conf via ``layouts.xxx.conf_info``.
Docs: https://github.com/conan-io/docs/pull/2834

Close https://github.com/conan-io/conan/issues/12499