### PR TITLE
change CMakeDeps xxx_LIBRARIES to be a list of libraries not targets

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -214,7 +214,7 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
 
 
         ########## For the modules (FindXXX)
-        set({{ pkg_name }}_LIBRARIES{{ config_suffix }} {{root_target_name}})
+        set({{ pkg_name }}_LIBRARIES{{ config_suffix }} {{ '${' }}{{ pkg_name }}_LIBS{{ config_suffix }}})
 
         """)
 

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_components.py
@@ -398,7 +398,7 @@ def test_cmake_add_subdirectory():
     # only doing the configure failed before #11743 fix
     t.run("build .")
     # The boost::boost target has linked the two components
-    assert "AGGREGATED LIBS: boost::boost" in t.out
+    assert "AGGREGATED LIBS: " in t.out  # Not real libraries, so it is empty
     assert "AGGREGATED LINKED: boost::B;boost::A" in t.out
     assert "BOOST_B LINKED: $<$<CONFIG:Release>:>;$<$<CONFIG:Release>:>;boost_boost_B_DEPS_TARGET" in t.out
     assert "BOOST_A LINKED: $<$<CONFIG:Release>:>;$<$<CONFIG:Release>:>;boost_boost_A_DEPS_TARGET" in t.out

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_find_module_and_config.py
@@ -190,9 +190,10 @@ def test_transitive_modules_found(find_mode_PKGA, find_mode_PKGB, find_mode_cons
     assert "MYPKGB_VERSION_STRING: 1.0" in client.out
     assert "MYPKGB_INCLUDE_DIRS:" in client.out
     assert "MYPKGB_INCLUDE_DIR:" in client.out
-    # The MYPKG_LIBRARIES contains the target for the current package, but the target is linked
-    # with the dependencies also:
-    assert "MYPKGB_LIBRARIES: pkgb::pkgb" in client.out
+    # The MYPKG_LIBRARIES has been changed to be just the list of libraries, not targets:
+    # https://github.com/conan-io/conan/issues/12012
+    # https://github.com/conan-io/conan/issues/12180
+    assert "MYPKGB_LIBRARIES: " in client.out  # No libraries really declared
     assert "MYPKGB_LINKED_LIBRARIES: '$<$<CONFIG:Release>:>;$<$<CONFIG:Release>:>;pkgb_DEPS_TARGET'" in client.out
     assert "MYPKGB_DEPS_LIBRARIES: '$<$<CONFIG:Release>:>;$<$<CONFIG:Release>:>;" \
            "$<$<CONFIG:Release>:pkga::pkga>'" in client.out


### PR DESCRIPTION
Changelog: Fix: change CMakeDeps xxx_LIBRARIES to be a list of libraries not targets
Docs: https://github.com/conan-io/docs/pull/XXXX

Attempt at:
https://github.com/conan-io/conan/issues/12012
https://github.com/conan-io/conan/issues/12180

Just a draft attempt to see if something breaks...