### PR TITLE
Set some CMakeDeps properties from consumer

### DIFF
--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -119,7 +119,7 @@ class CMakeDeps(object):
 
     def get_property(self, prop, dep):
         try:
-            return self._properties[dep].get(prop)
+            return self._properties[dep].get(prop) or dep.get_property(prop)
         except KeyError:
             return dep.get_property(prop)
 

--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -115,12 +115,12 @@ class CMakeDeps(object):
             ret[config.filename] = config.render()
 
     def set_property(self, dep, prop, value, build_context=False):
-        build_suffix = "_build" if build_context else ""
+        build_suffix = "&build" if build_context else ""
         self._properties.setdefault(f"{dep}{build_suffix}", {}).update({prop: value})
 
     def get_property(self, prop, dep, comp_name=None):
         dep_name = dep.ref.name
-        build_suffix = "_build" if str(
+        build_suffix = "&build" if str(
             dep_name) in self.build_context_activated and dep.context == "build" else ""
         dep_comp = f"{str(dep_name)}::{comp_name}" if comp_name else f"{str(dep_name)}"
         try:

--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -118,31 +118,31 @@ class CMakeDeps(object):
     def set_property(self, dependency, prop, value):
         self._properties[dependency].update({prop: value})
 
-    def get_property(self, prop, dependency, component=None):
-        dep_property = dependency.cpp_info.get_property(prop) if not component else \
-        dependency.cpp_info.components[component].get_property(prop)
-        dep_and_comp = dependency.ref.name if not component else f"{dependency.ref.name}::{component}"
+    def get_property(self, prop, dep, component=None):
+        dep_property = dep.cpp_info.get_property(prop) if not component else \
+        dep.cpp_info.components[component].get_property(prop)
+        dep_and_comp = dep.ref.name if not component else f"{dep.ref.name}::{component}"
         return self._properties[dep_and_comp].get(prop) or dep_property
 
-    def get_cmake_package_name(self, req, module_mode=None):
+    def get_cmake_package_name(self, dep, module_mode=None):
         """Get the name of the file for the find_package(XXX)"""
         # This is used by CMakeDeps to determine:
         # - The filename to generate (XXX-config.cmake or FindXXX.cmake)
         # - The name of the defined XXX_DIR variables
         # - The name of transitive dependencies for calls to find_dependency
-        if module_mode and self.get_find_mode(req) in [FIND_MODE_MODULE, FIND_MODE_BOTH]:
-            ret = self.get_property("cmake_module_file_name", req)
+        if module_mode and self.get_find_mode(dep) in [FIND_MODE_MODULE, FIND_MODE_BOTH]:
+            ret = self.get_property("cmake_module_file_name", dep)
             if ret:
                 return ret
-        ret = self.get_property("cmake_file_name", req)
-        return ret or req.ref.name
+        ret = self.get_property("cmake_file_name", dep)
+        return ret or dep.ref.name
 
-    def get_find_mode(self, req):
+    def get_find_mode(self, dep):
         """
-        :param req: requirement
+        :param dep: requirement
         :return: "none" or "config" or "module" or "both" or "config" when not set
         """
-        tmp = self.get_property("cmake_find_mode", req)
+        tmp = self.get_property("cmake_find_mode", dep)
         if tmp is None:
             return "config"
         return tmp.lower()

--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -122,7 +122,10 @@ class CMakeDeps(object):
         dep_property = dep.cpp_info.get_property(prop) if not component else \
         dep.cpp_info.components[component].get_property(prop)
         dep_and_comp = dep.ref.name if not component else f"{dep.ref.name}::{component}"
-        return self._properties[dep_and_comp].get(prop) or dep_property
+        try:
+            return self._properties[dep_and_comp].get(prop) or dep_property
+        except KeyError:
+            return dep_property
 
     def get_cmake_package_name(self, dep, module_mode=None):
         """Get the name of the file for the find_package(XXX)"""

--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -119,7 +119,7 @@ class CMakeDeps(object):
 
     def get_property(self, prop, dep):
         try:
-            return self._properties[dep].get(prop) or dep.get_property(prop)
+            return self._properties[dep].get(prop)
         except KeyError:
             return dep.get_property(prop)
 

--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -115,7 +115,7 @@ class CMakeDeps(object):
         if not os.path.exists(config.filename):
             ret[config.filename] = config.render()
 
-    def set_property(self, prop, dependency, value):
+    def set_property(self, dependency, prop, value):
         self._properties[dependency].update({prop: value})
 
     def get_property(self, prop, dependency, component=None):

--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -33,7 +33,7 @@ class CMakeDeps(object):
 
         # Enable/Disable checking if a component target exists or not
         self.check_components_exist = False
-        self._properties = defaultdict(dict)
+        self._properties = {}
 
     def generate(self):
         # FIXME: Remove this in 2.0
@@ -116,7 +116,7 @@ class CMakeDeps(object):
             ret[config.filename] = config.render()
 
     def set_property(self, dep, prop, value):
-        self._properties[dep].update({prop: value})
+        self._properties.setdefault(dep, {}).update({prop: value})
 
     def get_property(self, prop, dep, component=None):
         dep_property = dep.cpp_info.get_property(prop) if not component else \

--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -115,8 +115,8 @@ class CMakeDeps(object):
         if not os.path.exists(config.filename):
             ret[config.filename] = config.render()
 
-    def set_property(self, dependency, prop, value):
-        self._properties[dependency].update({prop: value})
+    def set_property(self, dep, prop, value):
+        self._properties[dep].update({prop: value})
 
     def get_property(self, prop, dep, component=None):
         dep_property = dep.cpp_info.get_property(prop) if not component else \

--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -119,7 +119,7 @@ class CMakeDeps(object):
 
     def get_property(self, prop, dep):
         try:
-            return self._properties[dep].get(prop) or dep.get_property(prop)
+            return self._properties[dep][prop]
         except KeyError:
             return dep.get_property(prop)
 

--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -1,7 +1,6 @@
 import jinja2
 from jinja2 import Template
 
-from conan.tools.cmake.utils import get_cmake_package_name
 from conans.errors import ConanException
 
 
@@ -23,7 +22,7 @@ class CMakeDepsFileTemplate(object):
 
     @property
     def file_name(self):
-        return get_cmake_package_name(self.conanfile, module_mode=self.generating_module) + self.suffix
+        return self.cmakedeps.get_cmake_package_name(self.conanfile, module_mode=self.generating_module) + self.suffix
 
     @property
     def suffix(self):
@@ -85,10 +84,10 @@ class CMakeDepsFileTemplate(object):
 
     def get_root_target_name(self, req, suffix=""):
         if self.generating_module:
-            ret = req.cpp_info.get_property("cmake_module_target_name")
+            ret = self.cmakedeps.get_property("cmake_module_target_name", req)
             if ret:
                 return ret
-        ret = req.cpp_info.get_property("cmake_target_name")
+        ret = self.cmakedeps.get_property("cmake_target_name", req)
         return ret or self._get_target_default_name(req, suffix=suffix)
 
     def get_component_alias(self, req, comp_name):
@@ -99,10 +98,11 @@ class CMakeDepsFileTemplate(object):
             raise ConanException("Component '{name}::{cname}' not found in '{name}' "
                                  "package requirement".format(name=req.ref.name, cname=comp_name))
         if self.generating_module:
-            ret = req.cpp_info.components[comp_name].get_property("cmake_module_target_name")
+            ret = self.cmakedeps.get_property("cmake_module_target_name", req, comp_name)
             if ret:
                 return ret
-        ret = req.cpp_info.components[comp_name].get_property("cmake_target_name")
+        ret = self.cmakedeps.get_property("cmake_target_name", req, comp_name)
+
         # If we don't specify the `cmake_target_name` property for the component it will
         # fallback to the pkg_name::comp_name, it wont use the root cpp_info cmake_target_name
         # property because that is also an absolute name (Greetings::Greetings), it is not a namespace

--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -84,10 +84,10 @@ class CMakeDepsFileTemplate(object):
 
     def get_root_target_name(self, req, suffix=""):
         if self.generating_module:
-            ret = self.cmakedeps.get_property("cmake_module_target_name", req.cpp_info)
+            ret = self.cmakedeps.get_property("cmake_module_target_name", req)
             if ret:
                 return ret
-        ret = self.cmakedeps.get_property("cmake_target_name", req.cpp_info)
+        ret = self.cmakedeps.get_property("cmake_target_name", req)
         return ret or self._get_target_default_name(req, suffix=suffix)
 
     def get_component_alias(self, req, comp_name):
@@ -98,10 +98,10 @@ class CMakeDepsFileTemplate(object):
             raise ConanException("Component '{name}::{cname}' not found in '{name}' "
                                  "package requirement".format(name=req.ref.name, cname=comp_name))
         if self.generating_module:
-            ret = self.cmakedeps.get_property("cmake_module_target_name", req.cpp_info.components[comp_name])
+            ret = self.cmakedeps.get_property("cmake_module_target_name", req, comp_name=comp_name)
             if ret:
                 return ret
-        ret = self.cmakedeps.get_property("cmake_target_name", req.cpp_info.components[comp_name])
+        ret = self.cmakedeps.get_property("cmake_target_name", req, comp_name=comp_name)
 
         # If we don't specify the `cmake_target_name` property for the component it will
         # fallback to the pkg_name::comp_name, it wont use the root cpp_info cmake_target_name

--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -84,10 +84,10 @@ class CMakeDepsFileTemplate(object):
 
     def get_root_target_name(self, req, suffix=""):
         if self.generating_module:
-            ret = self.cmakedeps.get_property("cmake_module_target_name", req)
+            ret = self.cmakedeps.get_property("cmake_module_target_name", req.cpp_info)
             if ret:
                 return ret
-        ret = self.cmakedeps.get_property("cmake_target_name", req)
+        ret = self.cmakedeps.get_property("cmake_target_name", req.cpp_info)
         return ret or self._get_target_default_name(req, suffix=suffix)
 
     def get_component_alias(self, req, comp_name):
@@ -98,10 +98,10 @@ class CMakeDepsFileTemplate(object):
             raise ConanException("Component '{name}::{cname}' not found in '{name}' "
                                  "package requirement".format(name=req.ref.name, cname=comp_name))
         if self.generating_module:
-            ret = self.cmakedeps.get_property("cmake_module_target_name", req, comp_name)
+            ret = self.cmakedeps.get_property("cmake_module_target_name", req.cpp_info.components[comp_name])
             if ret:
                 return ret
-        ret = self.cmakedeps.get_property("cmake_target_name", req, comp_name)
+        ret = self.cmakedeps.get_property("cmake_target_name", req.cpp_info.components[comp_name])
 
         # If we don't specify the `cmake_target_name` property for the component it will
         # fallback to the pkg_name::comp_name, it wont use the root cpp_info cmake_target_name

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -4,7 +4,7 @@ import textwrap
 from conan.tools.cmake.cmakedeps import FIND_MODE_NONE, FIND_MODE_CONFIG, FIND_MODE_MODULE, \
     FIND_MODE_BOTH
 from conan.tools.cmake.cmakedeps.templates import CMakeDepsFileTemplate
-from conan.tools.cmake.utils import get_cmake_package_name, get_find_mode
+
 """
 
 foo-release-x86_64-data.cmake
@@ -177,9 +177,9 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
             for dep_name, _ in self.conanfile.cpp_info.required_components:
                 if dep_name and dep_name not in ret:  # External dep
                     req = direct_host[dep_name]
-                    ret.append(get_cmake_package_name(req))
+                    ret.append(self.cmakedeps.get_cmake_package_name(req))
         elif direct_host:
-            ret = [get_cmake_package_name(r, self.generating_module) for r in direct_host.values()]
+            ret = [self.cmakedeps.get_cmake_package_name(r, self.generating_module) for r in direct_host.values()]
 
         return ret
 
@@ -189,8 +189,8 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
             return ret
         deps = self.conanfile.dependencies.filter({"build": False, "visible": True, "direct": True})
         for dep in deps.values():
-            dep_file_name = get_cmake_package_name(dep, self.generating_module)
-            find_mode = get_find_mode(dep)
+            dep_file_name = self.cmakedeps.get_cmake_package_name(dep, self.generating_module)
+            find_mode = self.cmakedeps.get_find_mode(dep)
             default_value = "NO_MODULE" if not self.generating_module else "MODULE"
             values = {
                 FIND_MODE_NONE: "",

--- a/conan/tools/cmake/utils.py
+++ b/conan/tools/cmake/utils.py
@@ -6,27 +6,3 @@ def is_multi_configuration(generator):
         return False
     return "Visual" in generator or "Xcode" in generator or "Multi-Config" in generator
 
-
-def get_cmake_package_name(conanfile, module_mode=None):
-    """Get the name of the file for the find_package(XXX)"""
-    # This is used by CMakeToolchain/CMakeDeps to determine:
-    # - The filename to generate (XXX-config.cmake or FindXXX.cmake)
-    # - The name of the defined XXX_DIR variables
-    # - The name of transitive dependencies for calls to find_dependency
-    if module_mode and get_find_mode(conanfile) in [FIND_MODE_MODULE, FIND_MODE_BOTH]:
-        ret = conanfile.cpp_info.get_property("cmake_module_file_name")
-        if ret:
-            return ret
-    ret = conanfile.cpp_info.get_property("cmake_file_name")
-    return ret or conanfile.ref.name
-
-
-def get_find_mode(conanfile):
-    """
-    :param conanfile: conanfile of the requirement
-    :return: "none" or "config" or "module" or "both" or "config" when not set
-    """
-    tmp = conanfile.cpp_info.get_property("cmake_find_mode")
-    if tmp is None:
-        return "config"
-    return tmp.lower()

--- a/conans/client/generators/markdown.py
+++ b/conans/client/generators/markdown.py
@@ -6,9 +6,7 @@ from jinja2 import DictLoader
 from jinja2 import Environment
 
 from conan.tools.cmake.cmakedeps.cmakedeps import CMakeDeps
-from conan.tools.cmake.cmakedeps.templates import (
-    CMakeDepsFileTemplate,
-    get_cmake_package_name as cmake_get_file_name)
+from conan.tools.cmake.cmakedeps.templates import CMakeDepsFileTemplate
 from conan.tools.gnu.pkgconfigdeps import (
     _get_component_name as pkgconfig_get_component_name,
     _get_name_with_namespace as pkgconfig_get_name_with_namespace,
@@ -444,7 +442,7 @@ class MarkdownGenerator(Generator):
             cmake_variables = {
                 'global_target_name': requirement.cpp_info.get_property('cmake_target_name') or "{0}::{0}".format(requirement.ref.name),
                 'component_alias': cmake_component_alias,
-                'file_name': cmake_get_file_name(requirement)
+                'file_name': cmake_deps.cmake_get_file_name(requirement)
             }
 
             pkgconfig_component_alias = {

--- a/conans/client/generators/markdown.py
+++ b/conans/client/generators/markdown.py
@@ -442,7 +442,7 @@ class MarkdownGenerator(Generator):
             cmake_variables = {
                 'global_target_name': requirement.cpp_info.get_property('cmake_target_name') or "{0}::{0}".format(requirement.ref.name),
                 'component_alias': cmake_component_alias,
-                'file_name': cmake_deps.cmake_get_file_name(requirement)
+                'file_name': cmake_deps.get_cmake_package_name(requirement)
             }
 
             pkgconfig_component_alias = {

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -210,12 +210,12 @@ def test_cmakedeps_set_dependency_props_from_consumer():
                 cmake_layout(self)
             def generate(self):
                 deps = CMakeDeps(self)
-                deps.set_property("cmake_find_mode", "bar", "{find_mode}")
-                deps.set_property("cmake_file_name", "bar", "custom_bar_file_name")
-                deps.set_property("cmake_module_file_name", "bar", "custom_bar_module_file_name")
-                deps.set_property("cmake_target_name", "bar", "custom_bar_target_name")
-                deps.set_property("cmake_module_target_name", "bar", "custom_bar_module_target_name")
-                deps.set_property("cmake_target_name", "bar::component1", "custom_bar_component_target_name")
+                deps.set_property("bar", "cmake_find_mode", "{find_mode}")
+                deps.set_property("bar", "cmake_file_name", "custom_bar_file_name")
+                deps.set_property("bar", "cmake_module_file_name", "custom_bar_module_file_name")
+                deps.set_property("bar", "cmake_target_name", "custom_bar_target_name")
+                deps.set_property("bar", "cmake_module_target_name", "custom_bar_module_target_name")
+                deps.set_property("bar::component1", "cmake_target_name", "custom_bar_component_target_name")
                 deps.generate()
         ''')
 

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -189,7 +189,7 @@ def test_cmakedeps_cppinfo_complex_strings():
     assert r"answer=42" in deps
 
 
-def test_cmakedeps_set_dependency_props_from_consumer():
+def test_dependency_props_from_consumer():
     client = TestClient(path_with_spaces=False)
     bar = textwrap.dedent(r'''
         from conan import ConanFile
@@ -210,12 +210,12 @@ def test_cmakedeps_set_dependency_props_from_consumer():
                 cmake_layout(self)
             def generate(self):
                 deps = CMakeDeps(self)
-                deps.set_property("bar", "cmake_find_mode", "{find_mode}")
-                deps.set_property("bar", "cmake_file_name", "custom_bar_file_name")
-                deps.set_property("bar", "cmake_module_file_name", "custom_bar_module_file_name")
-                deps.set_property("bar", "cmake_target_name", "custom_bar_target_name")
-                deps.set_property("bar", "cmake_module_target_name", "custom_bar_module_target_name")
-                deps.set_property("bar::component1", "cmake_target_name", "custom_bar_component_target_name")
+                deps.set_property(self.dependencies["bar"].cpp_info, "cmake_find_mode", "{find_mode}")
+                deps.set_property(self.dependencies["bar"].cpp_info, "cmake_file_name", "custom_bar_file_name")
+                deps.set_property(self.dependencies["bar"].cpp_info, "cmake_module_file_name", "custom_bar_module_file_name")
+                deps.set_property(self.dependencies["bar"].cpp_info, "cmake_target_name", "custom_bar_target_name")
+                deps.set_property(self.dependencies["bar"].cpp_info, "cmake_module_target_name", "custom_bar_module_target_name")
+                deps.set_property(self.dependencies["bar"].cpp_info.components["component1"], "cmake_target_name", "custom_bar_component_target_name")
                 deps.generate()
         ''')
 
@@ -254,3 +254,105 @@ def test_cmakedeps_set_dependency_props_from_consumer():
     client.run("install foo.py foo/1.0@")
     assert not os.path.exists(module_file)
     assert os.path.exists(config_file)
+
+
+def test_props_from_consumer_build_context_activated():
+    client = TestClient(path_with_spaces=False)
+    bar = textwrap.dedent(r'''
+        from conan import ConanFile
+        class FooConan(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+            def package_info(self):
+                self.cpp_info.set_property("cmake_find_mode", "both")
+                self.cpp_info.components["component1"].requires = []
+        ''')
+
+    foo = textwrap.dedent(r'''
+        from conan import ConanFile
+        from conan.tools.cmake import CMakeDeps, cmake_layout
+        class FooConan(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+            requires = "bar/1.0"
+            tool_requires = "bar/1.0"
+            def layout(self):
+                cmake_layout(self)
+            def generate(self):
+                deps = CMakeDeps(self)
+                deps.build_context_activated = ["bar"]
+                deps.build_context_suffix = {{"bar": "_BUILD"}}
+                deps.set_property(self.dependencies["bar"].cpp_info, "cmake_find_mode", "{find_mode}")
+                deps.set_property(self.dependencies.build["bar"].cpp_info, "cmake_find_mode", "{find_mode}")
+
+                deps.set_property(self.dependencies["bar"].cpp_info, "cmake_file_name", "custom_bar_file_name")
+                deps.set_property(self.dependencies["bar"].cpp_info, "cmake_module_file_name", "custom_bar_module_file_name")
+                deps.set_property(self.dependencies["bar"].cpp_info, "cmake_target_name", "custom_bar_target_name")
+                deps.set_property(self.dependencies["bar"].cpp_info, "cmake_module_target_name", "custom_bar_module_target_name")
+                deps.set_property(self.dependencies["bar"].cpp_info.components["component1"], "cmake_target_name", "custom_bar_component_target_name")
+
+                deps.set_property(self.dependencies.build["bar"].cpp_info, "cmake_file_name", "custom_bar_build_file_name")
+                deps.set_property(self.dependencies.build["bar"].cpp_info, "cmake_module_file_name", "custom_bar_build_module_file_name")
+                deps.set_property(self.dependencies.build["bar"].cpp_info, "cmake_target_name", "custom_bar_build_target_name")
+                deps.set_property(self.dependencies.build["bar"].cpp_info, "cmake_module_target_name", "custom_bar_build_module_target_name")
+                deps.set_property(self.dependencies.build["bar"].cpp_info.components["component1"], "cmake_target_name", "custom_bar_build_component_target_name")
+
+                deps.generate()
+        ''')
+
+    client.save({"foo.py": foo.format(find_mode=""), "bar.py": bar}, clean_first=True)
+
+    module_file = os.path.join(client.current_folder, "build", "generators", "module-custom_bar_module_file_nameTargets.cmake")
+    components_module = os.path.join(client.current_folder, "build", "generators", "custom_bar_file_name-Target-release.cmake")
+    config_file = os.path.join(client.current_folder, "build", "generators", "custom_bar_file_nameTargets.cmake")
+
+    module_file_build = os.path.join(client.current_folder, "build", "generators", "module-custom_bar_build_module_file_name_BUILDTargets.cmake")
+    components_module_build = os.path.join(client.current_folder, "build", "generators", "custom_bar_build_file_name_BUILD-Target-release.cmake")
+    config_file_build = os.path.join(client.current_folder, "build", "generators", "custom_bar_build_file_name_BUILDTargets.cmake")
+
+    # uses cmake_find_mode set in bar: both
+    client.run("create bar.py bar/1.0@ -pr:h=default -pr:b=default")
+    client.run("install foo.py foo/1.0@ -pr:h=default -pr:b=default")
+    assert os.path.exists(module_file)
+    assert os.path.exists(config_file)
+    assert os.path.exists(module_file_build)
+    assert os.path.exists(config_file_build)
+
+    module_content = client.load(module_file)
+    assert "add_library(custom_bar_module_target_name INTERFACE IMPORTED)" in module_content
+    config_content = client.load(config_file)
+    assert "add_library(custom_bar_target_name INTERFACE IMPORTED)" in config_content
+
+    module_content_build = client.load(module_file_build)
+    assert "add_library(custom_bar_build_module_target_name INTERFACE IMPORTED)" in module_content_build
+    config_content_build = client.load(config_file_build)
+    assert "add_library(custom_bar_build_target_name INTERFACE IMPORTED)" in config_content_build
+
+    components_module_content = client.load(components_module)
+    assert "add_library(bar_custom_bar_component_target_name_DEPS_TARGET INTERFACE IMPORTED)" in components_module_content
+
+    components_module_content_build = client.load(components_module_build)
+    assert "add_library(bar_BUILD_custom_bar_build_component_target_name_DEPS_TARGET INTERFACE IMPORTED)" in components_module_content_build
+
+    client.save({"foo.py": foo.format(find_mode="none"), "bar.py": bar}, clean_first=True)
+    client.run("create bar.py bar/1.0@ -pr:h=default -pr:b=default")
+    client.run("install foo.py foo/1.0@ -pr:h=default -pr:b=default")
+    assert not os.path.exists(module_file)
+    assert not os.path.exists(config_file)
+    assert not os.path.exists(module_file_build)
+    assert not os.path.exists(config_file_build)
+
+    client.save({"foo.py": foo.format(find_mode="module"), "bar.py": bar}, clean_first=True)
+    client.run("create bar.py bar/1.0@ -pr:h=default -pr:b=default")
+    client.run("install foo.py foo/1.0@ -pr:h=default -pr:b=default")
+    assert os.path.exists(module_file)
+    assert not os.path.exists(config_file)
+    assert os.path.exists(module_file_build)
+    assert not os.path.exists(config_file_build)
+
+    client.save({"foo.py": foo.format(find_mode="config"), "bar.py": bar}, clean_first=True)
+    client.run("create bar.py bar/1.0@ -pr:h=default -pr:b=default")
+    client.run("install foo.py foo/1.0@ -pr:h=default -pr:b=default")
+    assert not os.path.exists(module_file)
+    assert os.path.exists(config_file)
+    assert not os.path.exists(module_file_build)
+    assert os.path.exists(config_file_build)
+

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -211,16 +211,16 @@ def test_dependency_props_from_consumer():
             def generate(self):
                 deps = CMakeDeps(self)
                 {set_find_mode}
-                deps.set_property(self.dependencies["bar"].cpp_info, "cmake_file_name", "custom_bar_file_name")
-                deps.set_property(self.dependencies["bar"].cpp_info, "cmake_module_file_name", "custom_bar_module_file_name")
-                deps.set_property(self.dependencies["bar"].cpp_info, "cmake_target_name", "custom_bar_target_name")
-                deps.set_property(self.dependencies["bar"].cpp_info, "cmake_module_target_name", "custom_bar_module_target_name")
-                deps.set_property(self.dependencies["bar"].cpp_info.components["component1"], "cmake_target_name", "custom_bar_component_target_name")
+                deps.set_property("bar", "cmake_file_name", "custom_bar_file_name")
+                deps.set_property("bar", "cmake_module_file_name", "custom_bar_module_file_name")
+                deps.set_property("bar", "cmake_target_name", "custom_bar_target_name")
+                deps.set_property("bar", "cmake_module_target_name", "custom_bar_module_target_name")
+                deps.set_property("bar::component1", "cmake_target_name", "custom_bar_component_target_name")
                 deps.generate()
         ''')
 
     set_find_mode = """
-        deps.set_property(self.dependencies["bar"].cpp_info, "cmake_find_mode", {find_mode})
+        deps.set_property("bar", "cmake_find_mode", {find_mode})
     """
 
     client.save({"foo.py": foo.format(set_find_mode=""), "bar.py": bar}, clean_first=True)
@@ -289,24 +289,24 @@ def test_props_from_consumer_build_context_activated():
                 deps.build_context_suffix = {{"bar": "_BUILD"}}
                 {set_find_mode}
 
-                deps.set_property(self.dependencies["bar"].cpp_info, "cmake_file_name", "custom_bar_file_name")
-                deps.set_property(self.dependencies["bar"].cpp_info, "cmake_module_file_name", "custom_bar_module_file_name")
-                deps.set_property(self.dependencies["bar"].cpp_info, "cmake_target_name", "custom_bar_target_name")
-                deps.set_property(self.dependencies["bar"].cpp_info, "cmake_module_target_name", "custom_bar_module_target_name")
-                deps.set_property(self.dependencies["bar"].cpp_info.components["component1"], "cmake_target_name", "custom_bar_component_target_name")
+                deps.set_property("bar", "cmake_file_name", "custom_bar_file_name")
+                deps.set_property("bar", "cmake_module_file_name", "custom_bar_module_file_name")
+                deps.set_property("bar", "cmake_target_name", "custom_bar_target_name")
+                deps.set_property("bar", "cmake_module_target_name", "custom_bar_module_target_name")
+                deps.set_property("bar::component1", "cmake_target_name", "custom_bar_component_target_name")
 
-                deps.set_property(self.dependencies.build["bar"].cpp_info, "cmake_file_name", "custom_bar_build_file_name")
-                deps.set_property(self.dependencies.build["bar"].cpp_info, "cmake_module_file_name", "custom_bar_build_module_file_name")
-                deps.set_property(self.dependencies.build["bar"].cpp_info, "cmake_target_name", "custom_bar_build_target_name")
-                deps.set_property(self.dependencies.build["bar"].cpp_info, "cmake_module_target_name", "custom_bar_build_module_target_name")
-                deps.set_property(self.dependencies.build["bar"].cpp_info.components["component1"], "cmake_target_name", "custom_bar_build_component_target_name")
+                deps.set_property("bar", "cmake_file_name", "custom_bar_build_file_name", build_context=True)
+                deps.set_property("bar", "cmake_module_file_name", "custom_bar_build_module_file_name", build_context=True)
+                deps.set_property("bar", "cmake_target_name", "custom_bar_build_target_name", build_context=True)
+                deps.set_property("bar", "cmake_module_target_name", "custom_bar_build_module_target_name", build_context=True)
+                deps.set_property("bar::component1", "cmake_target_name", "custom_bar_build_component_target_name", build_context=True)
 
                 deps.generate()
         ''')
 
     set_find_mode = """
-        deps.set_property(self.dependencies["bar"].cpp_info, "cmake_find_mode", {find_mode})
-        deps.set_property(self.dependencies.build["bar"].cpp_info, "cmake_find_mode", {find_mode})
+        deps.set_property("bar", "cmake_find_mode", {find_mode})
+        deps.set_property("bar", "cmake_find_mode", {find_mode}, build_context=True)
     """
 
     client.save({"foo.py": foo.format(set_find_mode=""), "bar.py": bar}, clean_first=True)


### PR DESCRIPTION
Changelog: Feature: Provide the ability to set CMakeDeps properties from consumer side.
Docs: https://github.com/conan-io/docs/pull/2827

Gives you the possibility to overwrite some properties set in dependencies in CMakeDeps: `cmake_file_name`, `cmake_target_name`, `cmake_find_mode`, `cmake_module_file_name` and `cmake_module_target_name`

The interface is:

```
def generate(self):
    deps = CMakeDeps(self)
    deps.set_property("<dep>", "cmake_find_mode", "module")
    deps.set_property("<dep>::<component>",  "cmake_target_name", "mycompname")
    deps.generate()
```
for the cases with `build_context_activated`:

```
def generate(self):
    ...
    deps = CMakeDeps(self)
    deps.set_property("<dep>", "cmake_find_mode", "module", build_context=True)
    deps.set_property("<dep>::<component>",  "cmake_target_name", "mycompname", build_context=True)
    deps.generate()
    ...
```

You can also invalidate from consumer the properties set upstream assigning a `None`:

```
def generate(self):
    ...
    deps.set_property("<dep>", "cmake_module_target_name",  None)
```

Closes: https://github.com/conan-io/conan/issues/12534
Close https://github.com/conan-io/conan/issues/7118

