### PR TITLE
[develop2] refactor around cli and api

### DIFF
--- a/conan/api/conan_api.py
+++ b/conan/api/conan_api.py
@@ -1,6 +1,7 @@
 import sys
 
 from conan.api.subapi.cache import CacheAPI
+from conan.api.subapi.local import LocalAPI
 from conan.api.subapi.lockfile import LockfileAPI
 from conans import __version__ as client_version
 from conan.api.subapi.config import ConfigAPI
@@ -23,7 +24,7 @@ from conans.model.version import Version
 from conans.paths import get_conan_user_home
 
 
-class ConanAPIV2(object):
+class ConanAPI(object):
     def __init__(self, cache_folder=None):
 
         version = sys.version_info
@@ -56,9 +57,7 @@ class ConanAPIV2(object):
         self.download = DownloadAPI(self)
         self.cache = CacheAPI(self)
         self.lockfile = LockfileAPI(self)
-
-
-ConanAPI = ConanAPIV2
+        self.local = LocalAPI(self)
 
 
 def set_conan_output_level(level, activate_logger=False):

--- a/conan/api/subapi/install.py
+++ b/conan/api/subapi/install.py
@@ -1,13 +1,10 @@
-import os
-
 from conan.api.subapi import api_method
 from conan.api.conan_app import ConanApp
-from conans.client.cache.cache import ClientCache
+from conan.internal.deploy import do_deploys
 from conans.client.generators import write_generators
 from conans.client.installer import BinaryInstaller, call_system_requirements
-from conans.client.loader import load_python_file
-from conans.errors import ConanException, ConanInvalidConfiguration
-from conans.util.files import rmdir, mkdir
+from conans.errors import ConanInvalidConfiguration
+from conans.util.files import mkdir
 
 
 class InstallAPI:
@@ -59,90 +56,3 @@ class InstallAPI:
         app = ConanApp(self.conan_api.cache_folder)
         write_generators(conanfile, app.hook_manager)
         call_system_requirements(conanfile)
-
-
-# TODO: Look for a better location for the deployers code
-def _find_deployer(d, cache_deploy_folder):
-    """ Implements the logic of finding a deployer, with priority:
-    - 1) absolute paths
-    - 2) relative to cwd
-    - 3) in the cache/extensions/deploy folder
-    - 4) built-in
-    """
-    def _load(path):
-        mod, _ = load_python_file(path)
-        return mod.deploy
-
-    if not d.endswith(".py"):
-        d += ".py"  # Deployers must be python files
-    if os.path.isabs(d):
-        return _load(d)
-    cwd = os.getcwd()
-    local_path = os.path.normpath(os.path.join(cwd, d))
-    if os.path.isfile(local_path):
-        return _load(local_path)
-    cache_path = os.path.join(cache_deploy_folder, d)
-    if os.path.isfile(cache_path):
-        return _load(cache_path)
-    builtin_deploy = {"full_deploy.py": full_deploy,
-                      "direct_deploy.py": direct_deploy}.get(d)
-    if builtin_deploy is not None:
-        return builtin_deploy
-    raise ConanException(f"Cannot find deployer '{d}'")
-
-
-def do_deploys(conan_api, graph, deploy, deploy_folder):
-    # Handle the deploys
-    cache = ClientCache(conan_api.cache_folder)
-    for d in deploy or []:
-        deployer = _find_deployer(d, cache.deployers_path)
-        # IMPORTANT: Use always kwargs to not break if it changes in the future
-        deployer(graph=graph, output_folder=deploy_folder)
-
-
-def full_deploy(graph, output_folder):
-    """
-    Deploys to output_folder + host/dep/0.1/Release/x86_64 subfolder
-    """
-    # TODO: This deployer needs to be put somewhere else
-    # TODO: Document that this will NOT work with editables
-    import os
-    import shutil
-
-    conanfile = graph.root.conanfile
-    conanfile.output.info(f"Conan built-in full deployer to {output_folder}")
-    for dep in conanfile.dependencies.values():
-        if dep.package_folder is None:
-            continue
-        folder_name = os.path.join(dep.context, dep.ref.name, str(dep.ref.version))
-        build_type = dep.info.settings.get_safe("build_type")
-        arch = dep.info.settings.get_safe("arch")
-        if build_type:
-            folder_name = os.path.join(folder_name, build_type)
-        if arch:
-            folder_name = os.path.join(folder_name, arch)
-        new_folder = os.path.join(output_folder, folder_name)
-        rmdir(new_folder)
-        shutil.copytree(dep.package_folder, new_folder)
-        dep.set_deploy_folder(new_folder)
-
-
-def direct_deploy(graph, output_folder):
-    """
-    Deploys to output_folder a single package,
-    """
-    # TODO: This deployer needs to be put somewhere else
-    # TODO: Document that this will NOT work with editables
-    import os
-    import shutil
-
-    conanfile = graph.root.conanfile
-    conanfile.output.info(f"Conan built-in pkg deployer to {output_folder}")
-    # If the argument is --requires, the current conanfile is a virtual one with 1 single
-    # dependency, the "reference" package. If the argument is a local path, then all direct
-    # dependencies
-    for dep in conanfile.dependencies.filter({"direct": True}).values():
-        new_folder = os.path.join(output_folder, dep.ref.name)
-        rmdir(new_folder)
-        shutil.copytree(dep.package_folder, new_folder)
-        dep.set_deploy_folder(new_folder)

--- a/conan/api/subapi/local.py
+++ b/conan/api/subapi/local.py
@@ -1,0 +1,35 @@
+import os
+
+from conan.cli.commands import make_abs_path
+from conans.errors import ConanException
+
+
+class LocalAPI:
+
+    def __init__(self, conan_api):
+        self.conan_api = conan_api
+
+    @staticmethod
+    def get_conanfile_path(path, cwd, py):
+        """
+        param py= True: Must be .py, None: Try .py, then .txt
+        """
+        path = make_abs_path(path, cwd)
+
+        if os.path.isdir(path):  # Can be a folder
+            path_py = os.path.join(path, "conanfile.py")
+            if py:
+                path = path_py
+            else:
+                path_txt = os.path.join(path, "conanfile.txt")
+                if os.path.isfile(path_py) and os.path.isfile(path_txt):
+                    raise ConanException("Ambiguous command, both conanfile.py and conanfile.txt exist")
+                path = path_py if os.path.isfile(path_py) else path_txt
+
+        if not os.path.isfile(path):  # Must exist
+            raise ConanException("Conanfile not found at %s" % path)
+
+        if py and not path.endswith(".py"):
+            raise ConanException("A conanfile.py is needed, " + path + " is not acceptable")
+
+        return path

--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -104,3 +104,17 @@ def add_reference_args(parser):
                         help='Provide a user if not specified in conanfile')
     parser.add_argument("--channel", action=OnceArgument,
                         help='Provide a channel if not specified in conanfil')
+
+
+def common_graph_args(subparser):
+    subparser.add_argument("path", nargs="?",
+                           help="Path to a folder containing a recipe (conanfile.py "
+                                "or conanfile.txt) or to a recipe file. e.g., "
+                                "./my_project/conanfile.txt.")
+    add_reference_args(subparser)
+    subparser.add_argument("--requires", action="append",
+                           help='Directly provide requires instead of a conanfile')
+    subparser.add_argument("--tool-requires", action='append',
+                           help='Directly provide tool-requires instead of a conanfile')
+    _add_common_install_arguments(subparser, build_help=_help_build_policies.format("never"))
+    add_lockfile_args(subparser)

--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from difflib import get_close_matches
 from inspect import getmembers
 
-from conan.api.conan_api import ConanAPIV2
+from conan.api.conan_api import ConanAPI
 from conan.api.output import ConanOutput, Color, cli_out_write
 from conan.cli.command import ConanSubCommand
 from conan.cli.exit_codes import SUCCESS, ERROR_MIGRATION, ERROR_GENERAL, USER_CTRL_C, \
@@ -27,7 +27,7 @@ class Cli:
     """
 
     def __init__(self, conan_api):
-        assert isinstance(conan_api, ConanAPIV2), \
+        assert isinstance(conan_api, ConanAPI), \
             "Expected 'Conan' type, got '{}'".format(type(conan_api))
         self._conan_api = conan_api
         self._groups = defaultdict(list)
@@ -208,7 +208,7 @@ def main(args):
     """
 
     try:
-        conan_api = ConanAPIV2()
+        conan_api = ConanAPI()
     except ConanMigrationError:  # Error migrating
         sys.exit(ERROR_MIGRATION)
     except ConanException as e:

--- a/conan/cli/commands/build.py
+++ b/conan/cli/commands/build.py
@@ -3,7 +3,7 @@ import os
 from conan.api.output import ConanOutput
 from conan.cli.command import conan_command
 from conan.cli.commands import make_abs_path
-from conan.cli.commands.install import graph_compute, _get_conanfile_path
+from conan.cli.commands.install import graph_compute
 from conan.cli.args import add_lockfile_args, _add_common_install_arguments, add_reference_args, \
     _help_build_policies
 from conan.api.conan_app import ConanApp
@@ -27,7 +27,7 @@ def build(conan_api, parser, *args):
     args = parser.parse_args(*args)
 
     cwd = os.getcwd()
-    path = _get_conanfile_path(args.path, cwd, py=True)
+    path = conan_api.local.get_conanfile_path(args.path, cwd, py=True)
     folder = os.path.dirname(path)
     remotes = conan_api.remotes.list(args.remote)
 

--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -1,4 +1,4 @@
-from conan.api.conan_api import ConanAPIV2
+from conan.api.conan_api import ConanAPI
 from conan.cli.command import conan_command, conan_subcommand
 from conan.cli.commands import default_text_formatter
 from conans.errors import ConanException
@@ -7,14 +7,14 @@ from conans.model.recipe_ref import RecipeReference
 
 
 @conan_command(group="Consumer")
-def cache(conan_api: ConanAPIV2, parser, *args):
+def cache(conan_api: ConanAPI, parser, *args):
     """Performs file operations in the local cache (of recipes and packages)
     """
     pass
 
 
 @conan_subcommand(formatters={"text": default_text_formatter})
-def cache_path(conan_api: ConanAPIV2, parser, subparser, *args):
+def cache_path(conan_api: ConanAPI, parser, subparser, *args):
     """
         Shows the path in the Conan cache af a given reference
     """

--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -5,7 +5,6 @@ import shutil
 from conan.api.output import ConanOutput, cli_out_write
 from conan.cli.command import conan_command, OnceArgument
 from conan.cli.commands.export import common_args_export
-from conan.cli.commands.install import _get_conanfile_path
 from conan.cli.common import scope_options
 from conan.cli.args import add_lockfile_args, _add_common_install_arguments, _help_build_policies
 from conan.api.conan_app import ConanApp
@@ -37,7 +36,7 @@ def create(conan_api, parser, *args):
     args = parser.parse_args(*args)
 
     cwd = os.getcwd()
-    path = _get_conanfile_path(args.path, cwd, py=True)
+    path = conan_api.local.get_conanfile_path(args.path, cwd, py=True)
     # Now if parameter --test-folder=None (string None) we have to skip tests
     test_folder = False if args.test_folder == "None" else args.test_folder
     test_conanfile_path = _get_test_conanfile_path(test_folder, path)

--- a/conan/cli/commands/download.py
+++ b/conan/cli/commands/download.py
@@ -1,13 +1,13 @@
 from multiprocessing.pool import ThreadPool
 
-from conan.api.conan_api import ConanAPIV2
+from conan.api.conan_api import ConanAPI
 from conan.api.output import ConanOutput
 from conan.cli.command import conan_command, OnceArgument
 from conan.internal.api.select_pattern import SelectPattern
 
 
 @conan_command(group="Creator")
-def download(conan_api: ConanAPIV2, parser, *args):
+def download(conan_api: ConanAPI, parser, *args):
     """
     Download a conan package from a remote server, by its reference. It downloads just the package,
     but not its transitive dependencies, and it will not call any generate, generators or deployers.

--- a/conan/cli/commands/editable.py
+++ b/conan/cli/commands/editable.py
@@ -3,7 +3,6 @@ import os
 from conan.api.output import ConanOutput
 from conan.cli.command import conan_command, conan_subcommand
 from conan.cli.commands import make_abs_path
-from conan.cli.commands.install import _get_conanfile_path
 from conan.api.conan_app import ConanApp
 from conans.model.recipe_ref import RecipeReference
 
@@ -34,7 +33,7 @@ def editable_add(conan_api, parser, subparser, *args):
     # TODO: Decide in which API we put this
     app = ConanApp(conan_api.cache_folder)
     # Retrieve conanfile.py from target_path
-    target_path = _get_conanfile_path(path=path, cwd=cwd, py=True)
+    target_path = conan_api.local.get_conanfile_path(path=path, cwd=cwd, py=True)
     output_folder = make_abs_path(args.output_folder) if args.output_folder else None
     # Check the conanfile is there, and name/version matches
     ref = RecipeReference.loads(reference)

--- a/conan/cli/commands/export.py
+++ b/conan/cli/commands/export.py
@@ -3,7 +3,6 @@ import os
 
 from conan.api.output import ConanOutput, cli_out_write
 from conan.cli.command import conan_command, OnceArgument
-from conan.cli.commands.install import _get_conanfile_path
 from conan.cli.args import add_reference_args
 
 
@@ -33,7 +32,7 @@ def export(conan_api, parser, *args):
     args = parser.parse_args(*args)
 
     cwd = os.getcwd()
-    path = _get_conanfile_path(args.path, cwd, py=True)
+    path = conan_api.local.get_conanfile_path(args.path, cwd, py=True)
     lockfile = conan_api.lockfile.get_lockfile(lockfile=args.lockfile,
                                                conanfile_path=path,
                                                cwd=cwd,

--- a/conan/cli/commands/export_pkg.py
+++ b/conan/cli/commands/export_pkg.py
@@ -3,7 +3,6 @@ import os
 
 from conan.api.output import cli_out_write
 from conan.cli.command import conan_command
-from conan.cli.commands.install import _get_conanfile_path
 from conan.cli.common import scope_options
 from conan.cli.args import add_lockfile_args, add_profiles_args, add_reference_args
 
@@ -25,7 +24,7 @@ def export_pkg(conan_api, parser, *args):
     args = parser.parse_args(*args)
 
     cwd = os.getcwd()
-    path = _get_conanfile_path(args.path, cwd, py=True)
+    path = conan_api.local.get_conanfile_path(args.path, cwd, py=True)
     lockfile = conan_api.lockfile.get_lockfile(lockfile=args.lockfile,
                                                conanfile_path=path,
                                                cwd=cwd,

--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -2,10 +2,11 @@ import json
 import os
 
 from conan.api.output import ConanOutput, cli_out_write
-from conan.api.subapi.install import do_deploys
+from conan.internal.deploy import do_deploys
 from conan.cli.command import conan_command, conan_subcommand, CommandResult
 from conan.cli.commands import make_abs_path
-from conan.cli.commands.install import graph_compute, common_graph_args
+from conan.cli.commands.install import graph_compute
+from conan.cli.args import common_graph_args
 from conan.cli.formatters.graph import format_graph_html, format_graph_json, format_graph_dot
 from conan.cli.formatters.graph.graph_info_text import format_graph_info
 from conans.client.graph.install_graph import InstallGraph

--- a/conan/cli/commands/inspect.py
+++ b/conan/cli/commands/inspect.py
@@ -4,7 +4,6 @@ import os
 from conan.api.output import cli_out_write
 from conan.cli.command import conan_command
 from conan.cli.commands import default_json_formatter
-from conan.cli.commands.install import _get_conanfile_path
 
 
 def inspect_text_formatter(data):
@@ -28,7 +27,7 @@ def inspect(conan_api, parser, *args):
 
     args = parser.parse_args(*args)
 
-    path = _get_conanfile_path(args.path, os.getcwd(), py=True)
+    path = conan_api.local.get_conanfile_path(args.path, os.getcwd(), py=True)
 
     conanfile = conan_api.graph.load_conanfile_class(path)
     ret = {}

--- a/conan/cli/commands/lock.py
+++ b/conan/cli/commands/lock.py
@@ -3,7 +3,8 @@ import os
 from conan.api.output import ConanOutput
 from conan.cli.command import conan_command, OnceArgument, conan_subcommand
 from conan.cli.commands import make_abs_path
-from conan.cli.commands.install import common_graph_args, graph_compute
+from conan.cli.commands.install import graph_compute
+from conan.cli.args import common_graph_args
 from conans.errors import ConanException
 from conans.model.graph_lock import Lockfile, LOCKFILE
 from conans.model.recipe_ref import RecipeReference

--- a/conan/cli/commands/remote.py
+++ b/conan/cli/commands/remote.py
@@ -2,7 +2,7 @@ import json
 from collections import OrderedDict
 
 from conan.api.output import cli_out_write
-from conan.api.conan_api import ConanAPIV2
+from conan.api.conan_api import ConanAPI
 from conan.api.model import Remote
 from conan.cli.command import conan_command, conan_subcommand, OnceArgument
 from conan.cli.commands.list import remote_color, error_color, recipe_color, \
@@ -52,7 +52,7 @@ def output_remotes_json(results):
 
 
 @conan_subcommand(formatters={"text": print_remote_list, "json": formatter_remote_list_json})
-def remote_list(conan_api: ConanAPIV2, parser, subparser, *args):
+def remote_list(conan_api: ConanAPI, parser, subparser, *args):
     """
     List current remotes
     """

--- a/conan/cli/commands/remove.py
+++ b/conan/cli/commands/remove.py
@@ -1,11 +1,11 @@
-from conan.api.conan_api import ConanAPIV2
+from conan.api.conan_api import ConanAPI
 from conan.cli.command import conan_command, OnceArgument
 from conan.internal.api.select_pattern import SelectPattern
 from conans.client.userio import UserInput
 
 
 @conan_command(group="Consumer")
-def remove(conan_api: ConanAPIV2, parser, *args):
+def remove(conan_api: ConanAPI, parser, *args):
     """
     Removes recipes or packages from local cache or a remote.
     - If no remote is specified (-r), the removal will be done in the local conan cache.

--- a/conan/cli/commands/search.py
+++ b/conan/cli/commands/search.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 
-from conan.api.conan_api import ConanAPIV2
+from conan.api.conan_api import ConanAPI
 from conan.cli.command import conan_command
 from conan.cli.commands.list import print_list_recipes, default_json_formatter
 
@@ -10,7 +10,7 @@ from conans.errors import ConanException
 
 
 @conan_command(group="Consumer", formatters={"text": print_list_recipes, "json": default_json_formatter})
-def search(conan_api: ConanAPIV2, parser, *args):
+def search(conan_api: ConanAPI, parser, *args):
     """
     Searches for package recipes in a remote or remotes
     """

--- a/conan/cli/commands/source.py
+++ b/conan/cli/commands/source.py
@@ -1,7 +1,6 @@
 import os
 
 from conan.cli.command import conan_command
-from conan.cli.commands.install import _get_conanfile_path
 from conan.cli.args import add_reference_args
 from conan.api.conan_app import ConanApp
 from conans.client.graph.graph import CONTEXT_HOST
@@ -23,7 +22,7 @@ def source(conan_api, parser, *args):
     args = parser.parse_args(*args)
 
     cwd = os.getcwd()
-    path = _get_conanfile_path(args.path, cwd, py=True)
+    path = conan_api.local.get_conanfile_path(args.path, cwd, py=True)
     folder = os.path.dirname(path)
 
     # TODO: Decide API to put this

--- a/conan/cli/commands/test.py
+++ b/conan/cli/commands/test.py
@@ -3,7 +3,6 @@ import os
 from conan.api.output import ConanOutput
 from conan.cli.command import conan_command, OnceArgument
 from conan.cli.commands.create import test_package, _check_tested_reference_matches
-from conan.cli.commands.install import _get_conanfile_path
 from conan.cli.args import add_lockfile_args, _add_common_install_arguments
 from conan.cli.printers.graph import print_graph_basic, print_graph_packages
 from conans.model.recipe_ref import RecipeReference
@@ -24,7 +23,7 @@ def test(conan_api, parser, *args):
 
     cwd = os.getcwd()
     ref = RecipeReference.loads(args.reference)
-    path = _get_conanfile_path(args.path, cwd, py=True)
+    path = conan_api.local.get_conanfile_path(args.path, cwd, py=True)
     lockfile = conan_api.lockfile.get_lockfile(lockfile=args.lockfile,
                                                conanfile_path=path,
                                                cwd=cwd,

--- a/conan/cli/commands/upload.py
+++ b/conan/cli/commands/upload.py
@@ -1,11 +1,11 @@
-from conan.api.conan_api import ConanAPIV2
+from conan.api.conan_api import ConanAPI
 from conan.cli.command import conan_command, OnceArgument
 from conans.client.userio import UserInput
 from conans.errors import ConanException
 
 
 @conan_command(group="Creator")
-def upload(conan_api: ConanAPIV2, parser, *args):
+def upload(conan_api: ConanAPI, parser, *args):
     """
     Uploads a recipe and binary packages to a remote.
     By default, all the matching references are uploaded (all revisions).

--- a/conan/internal/deploy.py
+++ b/conan/internal/deploy.py
@@ -1,0 +1,92 @@
+import os
+
+from conans.client.cache.cache import ClientCache
+from conans.client.loader import load_python_file
+from conans.errors import ConanException
+from conans.util.files import rmdir
+
+
+def _find_deployer(d, cache_deploy_folder):
+    """ Implements the logic of finding a deployer, with priority:
+    - 1) absolute paths
+    - 2) relative to cwd
+    - 3) in the cache/extensions/deploy folder
+    - 4) built-in
+    """
+    def _load(path):
+        mod, _ = load_python_file(path)
+        return mod.deploy
+
+    if not d.endswith(".py"):
+        d += ".py"  # Deployers must be python files
+    if os.path.isabs(d):
+        return _load(d)
+    cwd = os.getcwd()
+    local_path = os.path.normpath(os.path.join(cwd, d))
+    if os.path.isfile(local_path):
+        return _load(local_path)
+    cache_path = os.path.join(cache_deploy_folder, d)
+    if os.path.isfile(cache_path):
+        return _load(cache_path)
+    builtin_deploy = {"full_deploy.py": full_deploy,
+                      "direct_deploy.py": direct_deploy}.get(d)
+    if builtin_deploy is not None:
+        return builtin_deploy
+    raise ConanException(f"Cannot find deployer '{d}'")
+
+
+def do_deploys(conan_api, graph, deploy, deploy_folder):
+    # Handle the deploys
+    cache = ClientCache(conan_api.cache_folder)
+    for d in deploy or []:
+        deployer = _find_deployer(d, cache.deployers_path)
+        # IMPORTANT: Use always kwargs to not break if it changes in the future
+        deployer(graph=graph, output_folder=deploy_folder)
+
+
+def full_deploy(graph, output_folder):
+    """
+    Deploys to output_folder + host/dep/0.1/Release/x86_64 subfolder
+    """
+    # TODO: This deployer needs to be put somewhere else
+    # TODO: Document that this will NOT work with editables
+    import os
+    import shutil
+
+    conanfile = graph.root.conanfile
+    conanfile.output.info(f"Conan built-in full deployer to {output_folder}")
+    for dep in conanfile.dependencies.values():
+        if dep.package_folder is None:
+            continue
+        folder_name = os.path.join(dep.context, dep.ref.name, str(dep.ref.version))
+        build_type = dep.info.settings.get_safe("build_type")
+        arch = dep.info.settings.get_safe("arch")
+        if build_type:
+            folder_name = os.path.join(folder_name, build_type)
+        if arch:
+            folder_name = os.path.join(folder_name, arch)
+        new_folder = os.path.join(output_folder, folder_name)
+        rmdir(new_folder)
+        shutil.copytree(dep.package_folder, new_folder)
+        dep.set_deploy_folder(new_folder)
+
+
+def direct_deploy(graph, output_folder):
+    """
+    Deploys to output_folder a single package,
+    """
+    # TODO: This deployer needs to be put somewhere else
+    # TODO: Document that this will NOT work with editables
+    import os
+    import shutil
+
+    conanfile = graph.root.conanfile
+    conanfile.output.info(f"Conan built-in pkg deployer to {output_folder}")
+    # If the argument is --requires, the current conanfile is a virtual one with 1 single
+    # dependency, the "reference" package. If the argument is a local path, then all direct
+    # dependencies
+    for dep in conanfile.dependencies.filter({"direct": True}).values():
+        new_folder = os.path.join(output_folder, dep.ref.name)
+        rmdir(new_folder)
+        shutil.copytree(dep.package_folder, new_folder)
+        dep.set_deploy_folder(new_folder)

--- a/conans/test/integration/command/remove_test.py
+++ b/conans/test/integration/command/remove_test.py
@@ -3,7 +3,7 @@ import unittest
 
 import pytest
 
-from conan.api.conan_api import ConanAPIV2
+from conan.api.conan_api import ConanAPI
 from conans.errors import NotFoundException
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
@@ -353,7 +353,7 @@ def test_new_remove_package_revisions_expressions(populated_client, with_remote,
 
 
 def _get_all_recipes(client, with_remote):
-    api = ConanAPIV2(client.cache_folder)
+    api = ConanAPI(client.cache_folder)
     remote = api.remotes.get("default") if with_remote else None
     with client.mocked_servers():
         return set([r.repr_notime() for r in api.search.recipes("*", remote=remote)])
@@ -361,7 +361,7 @@ def _get_all_recipes(client, with_remote):
 
 def _get_all_packages(client, ref, with_remote):
     ref = RecipeReference.loads(ref)
-    api = ConanAPIV2(client.cache_folder)
+    api = ConanAPI(client.cache_folder)
     remote = api.remotes.get("default") if with_remote else None
     with client.mocked_servers():
         try:
@@ -372,7 +372,7 @@ def _get_all_packages(client, ref, with_remote):
 
 def _get_revisions_recipes(client, ref, with_remote):
     ref = RecipeReference.loads(ref)
-    api = ConanAPIV2(client.cache_folder)
+    api = ConanAPI(client.cache_folder)
     remote = api.remotes.get("default") if with_remote else None
     with client.mocked_servers():
         try:
@@ -383,7 +383,7 @@ def _get_revisions_recipes(client, ref, with_remote):
 
 def _get_revisions_packages(client, pref, with_remote):
     pref = PkgReference.loads(pref)
-    api = ConanAPIV2(client.cache_folder)
+    api = ConanAPI(client.cache_folder)
     remote = api.remotes.get("default") if with_remote else None
     with client.mocked_servers():
         try:

--- a/conans/test/integration/conan_api/list_test.py
+++ b/conans/test/integration/conan_api/list_test.py
@@ -1,7 +1,7 @@
 import copy
 
 
-from conan.api.conan_api import ConanAPIV2
+from conan.api.conan_api import ConanAPI
 from conans.model.recipe_ref import RecipeReference
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TurboTestClient, TestClient
@@ -30,7 +30,7 @@ def test_get_recipe_revisions():
     client.upload_all(pref2.ref, "default")
     client.upload_all(pref3.ref, "default")
 
-    api = ConanAPIV2(client.cache_folder)
+    api = ConanAPI(client.cache_folder)
 
     # Check the revisions locally
     sot = api.list.recipe_revisions(ref)
@@ -60,7 +60,7 @@ def test_get_package_revisions():
     _pref = copy.copy(pref1)
     _pref.revision = None
 
-    api = ConanAPIV2(client.cache_folder)
+    api = ConanAPI(client.cache_folder)
 
     # Check the revisions locally
     sot = api.list.package_revisions(_pref)

--- a/conans/test/integration/conan_api/search_test.py
+++ b/conans/test/integration/conan_api/search_test.py
@@ -1,4 +1,4 @@
-from conan.api.conan_api import ConanAPIV2
+from conan.api.conan_api import ConanAPI
 from conans.model.recipe_ref import RecipeReference
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TurboTestClient
@@ -20,7 +20,7 @@ def test_search_recipes():
     client.upload_all(pref3.ref, "default")
 
     # Search all the recipes locally and in the remote
-    api = ConanAPIV2(client.cache_folder)
+    api = ConanAPI(client.cache_folder)
     for remote in [None, api.remotes.get("default")]:
         with client.mocked_servers():
             sot = api.search.recipes(query="f*", remote=remote)

--- a/conans/test/integration/graph/core/graph_manager_base.py
+++ b/conans/test/integration/graph/core/graph_manager_base.py
@@ -2,7 +2,7 @@ import os
 import textwrap
 import unittest
 
-from conan.api.conan_api import ConanAPIV2
+from conan.api.conan_api import ConanAPI
 from conans.client.cache.cache import ClientCache
 from conans.model.manifest import FileTreeManifest
 from conans.model.options import Options
@@ -117,7 +117,7 @@ class GraphManagerTest(unittest.TestCase):
         profile_build.process_settings(self.cache)
         build_mode = []  # Means build all
 
-        conan_api = ConanAPIV2(cache_folder=self.cache_folder)
+        conan_api = ConanAPI(cache_folder=self.cache_folder)
 
         root_node = conan_api.graph.load_root_consumer_conanfile(path, profile_host, profile_build)
         deps_graph = conan_api.graph.load_graph(root_node, profile_host, profile_build)

--- a/conans/test/unittests/cli/common_test.py
+++ b/conans/test/unittests/cli/common_test.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from conan.api.conan_api import ConanAPIV2
+from conan.api.conan_api import ConanAPI
 from conan.tools.files import save
 from conans.client.cache.cache import ClientCache
 from conans.errors import ConanException
@@ -14,7 +14,7 @@ def conan_api():
     tmp_folder = temp_folder()
     cache = ClientCache(tmp_folder)
     save(None, cache.default_profile_path, "")
-    return ConanAPIV2(tmp_folder)
+    return ConanAPI(tmp_folder)
 
 
 @pytest.fixture()

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -25,7 +25,7 @@ from webtest.app import TestApp
 
 from conan.internal.cache.cache import PackageLayout, RecipeLayout
 from conans import REVISIONS
-from conan.api.conan_api import ConanAPIV2
+from conan.api.conan_api import ConanAPI
 from conan.api.model import Remote
 from conan.cli.cli import Cli
 from conans.client.cache.cache import ClientCache
@@ -427,7 +427,7 @@ class TestClient(object):
         return self.cache.store
 
     def update_servers(self):
-        api = ConanAPIV2(cache_folder=self.cache_folder)
+        api = ConanAPI(cache_folder=self.cache_folder)
         for r in api.remotes.list():
             api.remotes.remove(r.name)
 
@@ -481,7 +481,7 @@ class TestClient(object):
 
         args = shlex.split(command_line)
 
-        self.api = ConanAPIV2(cache_folder=self.cache_folder)
+        self.api = ConanAPI(cache_folder=self.cache_folder)
         command = Cli(self.api)
 
         error = None
@@ -656,11 +656,11 @@ class TestClient(object):
         return ref_layout
 
     def get_default_host_profile(self):
-        api = ConanAPIV2(cache_folder=self.cache_folder)
+        api = ConanAPI(cache_folder=self.cache_folder)
         return api.profiles.get_profile([api.profiles.get_default_host()])
 
     def get_default_build_profile(self):
-        api = ConanAPIV2(cache_folder=self.cache_folder)
+        api = ConanAPI(cache_folder=self.cache_folder)
         return api.profiles.get_profile([api.profiles.get_default_build()])
 
     def recipe_exists(self, ref):


### PR DESCRIPTION
Pure refactors, no functional change:

- Renamed ConanAPIV2 -> ConanAPI (it is confusing for the users to mix 2.0 version with api version, this is the first public documented api)
- Moved ``_get_conanfile_path()`` helper, used in many places to its own ``LocalAPI`` api. It seems there are other bits of code that we will have to find a location for them, and ``LocalAPI`` could be good. We could discuss if ``editable`` api could be part of this, maybe yes
- Moved ``deployers`` code from ``api`` to its own internal ``deploy.py`` module
- Moved some helpers related to CLI arguments to ``args.py``

TODO: (in another PR). Find a place to the global ``graph_compute()`` function, used in multiple commands.