### PR TITLE
Add prefix argument to AutotoolsToolchain

### DIFF
--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -13,9 +13,10 @@ from conans.tools import args_to_string
 
 
 class AutotoolsToolchain:
-    def __init__(self, conanfile, namespace=None):
+    def __init__(self, conanfile, namespace=None, prefix="/"):
         self._conanfile = conanfile
         self._namespace = namespace
+        self._prefix = prefix
 
         self.configure_args = self._default_configure_shared_flags() + self._default_configure_install_flags()
         self.autoreconf_args = self._default_autoreconf_flags()
@@ -168,7 +169,7 @@ class AutotoolsToolchain:
             return "--{}=${{prefix}}/{}".format(argument_name, elements[0]) if elements else ""
 
         # If someone want arguments but not the defaults can pass them in args manually
-        configure_install_flags.extend(["--prefix=/",
+        configure_install_flags.extend([f"--prefix={self._prefix}",
                                        _get_argument("bindir", "bindirs"),
                                        _get_argument("sbindir", "bindirs"),
                                        _get_argument("libdir", "libdirs"),

--- a/conans/test/integration/toolchains/gnu/test_autotoolstoolchain.py
+++ b/conans/test/integration/toolchains/gnu/test_autotoolstoolchain.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import textwrap
 
@@ -67,3 +68,27 @@ def test_not_none_values():
     client.save({"conanfile.py": conanfile})
     client.run("install .")
 
+
+def test_set_prefix():
+
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.gnu import AutotoolsToolchain
+        from conan.tools.layout import basic_layout
+
+
+        class Foo(ConanFile):
+            name = "foo"
+            version = "1.0"
+            def layout(self):
+                basic_layout(self)
+            def generate(self):
+                at_toolchain = AutotoolsToolchain(self, prefix="/somefolder")
+                at_toolchain.generate()
+    """)
+
+    client = TestClient()
+    client.save({"conanfile.py": conanfile})
+    client.run("install .")
+    conanbuild = client.load(os.path.join(client.current_folder, "build", "conan", "conanbuild.conf"))
+    assert "configure_args = '--prefix=/somefolder'" in conanbuild

--- a/conans/test/integration/toolchains/gnu/test_autotoolstoolchain.py
+++ b/conans/test/integration/toolchains/gnu/test_autotoolstoolchain.py
@@ -91,4 +91,5 @@ def test_set_prefix():
     client.save({"conanfile.py": conanfile})
     client.run("install .")
     conanbuild = client.load(os.path.join(client.current_folder, "build", "conan", "conanbuild.conf"))
-    assert "configure_args = '--prefix=/somefolder'" in conanbuild
+    assert "--prefix=/somefolder" in conanbuild
+    assert conanbuild.count("--prefix") == 1


### PR DESCRIPTION
Changelog: Feature: Add `prefix` argument to `AutotoolsToolchain`.
Docs: https://github.com/conan-io/docs/pull/2824

```
def generate(self):
    at_toolchain = AutotoolsToolchain(self, prefix="/somefolder")
    at_toolchain.generate()
```

Closes: https://github.com/conan-io/conan/issues/12338