### PR TITLE
Use --confirm to not request confirmation when removing instead of --force

### DIFF
--- a/conan/cli/commands/remove.py
+++ b/conan/cli/commands/remove.py
@@ -16,7 +16,7 @@ def remove(conan_api: ConanAPI, parser, *args):
     """
     parser.add_argument('reference', help="Recipe reference or package reference, can contain * as"
                                           "wildcard at any reference field. e.g: lib/*")
-    parser.add_argument('-f', '--force', default=False, action='store_true',
+    parser.add_argument('-c', '--confirm', default=False, action='store_true',
                         help='Remove without requesting a confirmation')
     parser.add_argument('-p', '--package-query', action=OnceArgument,
                         help="Remove all packages (empty) or provide a query: "
@@ -29,7 +29,7 @@ def remove(conan_api: ConanAPI, parser, *args):
     remote = conan_api.remotes.get(args.remote) if args.remote else None
 
     def confirmation(message):
-        return args.force or ui.request_boolean(message)
+        return args.confirm or ui.request_boolean(message)
 
     only_recipe = ":" not in args.reference and not args.package_query
     ref_pattern = SelectPattern(args.reference, rrev="*", prev="*")

--- a/conans/test/functional/command/test_install_deploy.py
+++ b/conans/test/functional/command/test_install_deploy.py
@@ -34,7 +34,7 @@ def test_install_deploy():
             "main.cpp": gen_function_cpp(name="main", includes=["hello"], calls=["hello"])},
            clean_first=True)
     c.run("install . --deploy=deploy.py -of=mydeploy -g CMakeToolchain -g CMakeDeps")
-    c.run("remove * -f")  # Make sure the cache is clean, no deps there
+    c.run("remove * -c")  # Make sure the cache is clean, no deps there
     cwd = c.current_folder.replace("\\", "/")
     arch = c.get_default_host_profile().settings['arch']
     deps = c.load(f"mydeploy/hello-release-{arch}-data.cmake")

--- a/conans/test/functional/configuration/profile_test.py
+++ b/conans/test/functional/configuration/profile_test.py
@@ -381,7 +381,7 @@ class DefaultNameConan(ConanFile):
 
     def test_info_with_profiles(self):
 
-        self.client.run("remove '*' -f")
+        self.client.run("remove '*' -c")
         # Create a simple recipe to require
         winreq_conanfile = '''
 from conans.model.conan_file import ConanFile

--- a/conans/test/functional/graph_lock/lock_install_test.py
+++ b/conans/test/functional/graph_lock/lock_install_test.py
@@ -46,7 +46,7 @@ def test_install_recipes():
     assert "pkgb/0.1@user/channel:cfd10f60aeaa00f5ca1f90b5fe97c3fe19e7ec23 - Cache" in client.out
 
     client.run("upload * -c -r default")
-    client.run("remove * -f")
+    client.run("remove * -c")
     client.run("lock install lock1.lock --recipes")
 
     assert "pkga/0.1@user/channel:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 - Download" in client.out

--- a/conans/test/functional/revisions_test.py
+++ b/conans/test/functional/revisions_test.py
@@ -36,7 +36,7 @@ class InstallingPackagesWithRevisionsTest(unittest.TestCase):
         the_time = time.time()
         with patch.object(RevisionList, '_now', return_value=the_time):
             self.c_v2.upload_all(self.ref, remote="default")
-        self.c_v2.run("remove {}#*:{} -f -r default".format(self.ref, pref.package_id))
+        self.c_v2.run("remove {}#*:{} -c -r default".format(self.ref, pref.package_id))
         # Same RREV, different PREV
         with environment_update({"MY_VAR": "2"}):
             pref2 = self.c_v2.create(self.ref, conanfile=conanfile)
@@ -271,7 +271,7 @@ class RemoveWithRevisionsTest(unittest.TestCase):
         # If I remove the ref, the revision is gone, of course
         ref1 = client.export(self.ref)
         ref1.revision = None
-        client.run("remove {} -f".format(repr(ref1)))
+        client.run("remove {} -c".format(repr(ref1)))
         self.assertFalse(client.recipe_exists(self.ref))
 
         # If I remove a ref with a wrong revision, the revision is not removed
@@ -279,7 +279,7 @@ class RemoveWithRevisionsTest(unittest.TestCase):
         fakeref = copy.copy(ref1)
         fakeref.revision = "fakerev"
         full_ref = repr(fakeref)
-        client.run("remove {} -f".format(repr(fakeref)), assert_error=True)
+        client.run("remove {} -c".format(repr(fakeref)), assert_error=True)
         self.assertIn(f"ERROR: Recipe revision '{full_ref}' not found", client.out)
         self.assertTrue(client.recipe_exists(self.ref))
 
@@ -295,7 +295,7 @@ class RemoveWithRevisionsTest(unittest.TestCase):
         pref1 = client.create(self.ref)
         tmp = copy.copy(pref1.ref)
         tmp.revision = None
-        client.run("remove {} -f".format(repr(tmp)))
+        client.run("remove {} -c".format(repr(tmp)))
         self.assertFalse(client.package_exists(pref1))
 
         # If I remove the ref with fake RREV, the packages are not removed
@@ -303,33 +303,33 @@ class RemoveWithRevisionsTest(unittest.TestCase):
         fakeref = copy.copy(pref1.ref)
         fakeref.revision = "fakerev"
         str_ref = repr(fakeref)
-        client.run("remove {} -f".format(repr(fakeref)), assert_error=True)
+        client.run("remove {} -c".format(repr(fakeref)), assert_error=True)
         self.assertTrue(client.package_exists(pref1))
         self.assertIn("Recipe revision '{}' not found".format(str_ref), client.out)
 
         # If I remove the ref with valid RREV, the packages are removed
         pref1 = client.create(self.ref)
-        client.run("remove {} -f".format(repr(pref1.ref)))
+        client.run("remove {} -c".format(repr(pref1.ref)))
         self.assertFalse(client.package_exists(pref1))
 
         # If I remove the ref without RREV but specifying PREV it raises
         pref1 = client.create(self.ref)
         tmp = copy.copy(pref1.ref)
         tmp.revision = None
-        command = "remove {}:{}#{} -f".format(repr(tmp), pref1.package_id, pref1.revision)
+        command = "remove {}:{}#{} -c".format(repr(tmp), pref1.package_id, pref1.revision)
         client.run(command)
         self.assertFalse(client.package_exists(pref1))
 
         # A wrong PREV doesn't remove the PREV
         pref1 = client.create(self.ref)
-        command = "remove {}:{}#fakeprev -f".format(repr(pref1.ref), pref1.package_id)
+        command = "remove {}:{}#fakeprev -c".format(repr(pref1.ref), pref1.package_id)
         client.run(command, assert_error=True)
         self.assertTrue(client.package_exists(pref1))
         self.assertIn("ERROR: Package revision", client.out)
 
         # Everything correct, removes the unique local package revision
         pref1 = client.create(self.ref)
-        command = "remove {}:{}#{} -f".format(repr(pref1.ref), pref1.package_id, pref1.revision)
+        command = "remove {}:{}#{} -c".format(repr(pref1.ref), pref1.package_id, pref1.revision)
         client.run(command)
         self.assertFalse(client.package_exists(pref1))
 
@@ -348,7 +348,7 @@ class RemoveWithRevisionsTest(unittest.TestCase):
         remover_client = self.c_v2
 
         # Remove ref without revision in a remote
-        remover_client.run("remove {} -f -r default".format(self.ref))
+        remover_client.run("remove {} -c -r default".format(self.ref))
         self.assertFalse(self.server.recipe_exists(self.ref))
         self.assertFalse(self.server.recipe_exists(pref1.ref))
         self.assertFalse(self.server.recipe_exists(pref2.ref))
@@ -370,7 +370,7 @@ class RemoveWithRevisionsTest(unittest.TestCase):
         remover_client = self.c_v2
 
         # Remove ref without revision in a remote
-        command = "remove {} -f -r default".format(repr(pref1.ref))
+        command = "remove {} -c -r default".format(repr(pref1.ref))
         remover_client.run(command)
         self.assertFalse(self.server.recipe_exists(pref1.ref))
         self.assertTrue(self.server.recipe_exists(pref2.ref))
@@ -393,7 +393,7 @@ class RemoveWithRevisionsTest(unittest.TestCase):
         remover_client = self.c_v2
 
         # Remove pref without RREV in a remote
-        remover_client.run("remove {}#*:{} -f -r default".format(self.ref, pref2.package_id))
+        remover_client.run("remove {}#*:{} -c -r default".format(self.ref, pref2.package_id))
         self.assertTrue(self.server.recipe_exists(pref1.ref))
         self.assertTrue(self.server.recipe_exists(pref2.ref))
         self.assertFalse(self.server.package_exists(pref1))
@@ -431,7 +431,7 @@ class RemoveWithRevisionsTest(unittest.TestCase):
         remover_client = self.c_v2
 
         # Remove PREV without RREV in a remote, the client has to fail
-        command = "remove {}:{}#{} -f -r default".format(self.ref, pref2.package_id, pref2.revision)
+        command = "remove {}:{}#{} -c -r default".format(self.ref, pref2.package_id, pref2.revision)
         remover_client.run(command)
 
         self.assertTrue(self.server.recipe_exists(pref1.ref))
@@ -442,7 +442,7 @@ class RemoveWithRevisionsTest(unittest.TestCase):
         self.assertFalse(self.server.package_exists(pref2))
 
         # Try to remove a missing revision
-        command = "remove {}:{}#fakerev -f -r default".format(repr(pref2.ref), pref2.package_id)
+        command = "remove {}:{}#fakerev -c -r default".format(repr(pref2.ref), pref2.package_id)
         remover_client.run(command, assert_error=True)
         fakeref = copy.copy(pref2)
         fakeref.revision = "fakerev"
@@ -867,7 +867,7 @@ class ServerRevisionsIndexes(unittest.TestCase):
                          ref3.revision)
 
         # Delete the latest from the server
-        self.c_v2.run("remove {} -r default -f".format(repr(ref3)))
+        self.c_v2.run("remove {} -r default -c".format(repr(ref3)))
         revs = [r.revision for r in self.server.server_store.get_recipe_revisions_references(self.ref)]
         self.assertEqual(revs, [ref2.revision, ref1.revision])
         self.assertEqual(self.server.server_store.get_last_revision(self.ref).revision,
@@ -910,7 +910,7 @@ class ServerRevisionsIndexes(unittest.TestCase):
                          pref3.revision)
 
         # Delete the latest from the server
-        self.c_v2.run("remove {}:{}#{} -r default -f".format(repr(pref3.ref),pref3.package_id,
+        self.c_v2.run("remove {}:{}#{} -r default -c".format(repr(pref3.ref),pref3.package_id,
                                                              pref3.revision))
         revs = [r.revision
                 for r in self.server.server_store.get_package_revisions_references(pref)]
@@ -930,9 +930,9 @@ class ServerRevisionsIndexes(unittest.TestCase):
         ref3 = self.c_v2.export(self.ref, conanfile=GenConanfile().with_build_msg("I'm rev3"))
         self.c_v2.upload_all(ref3)
 
-        self.c_v2.run("remove {} -r default -f".format(repr(ref1)))
-        self.c_v2.run("remove {} -r default -f".format(repr(ref2)))
-        self.c_v2.run("remove {} -r default -f".format(repr(ref3)))
+        self.c_v2.run("remove {} -r default -c".format(repr(ref1)))
+        self.c_v2.run("remove {} -r default -c".format(repr(ref2)))
+        self.c_v2.run("remove {} -r default -c".format(repr(ref3)))
 
         self.assertRaises(RecipeNotFoundException,
                           self.server.server_store.get_recipe_revisions_references, self.ref)
@@ -960,7 +960,7 @@ class ServerRevisionsIndexes(unittest.TestCase):
         self.c_v2.upload_all(self.ref)
 
         # Delete the package revisions (all of them have the same ref#rev and id)
-        command = "remove {}:{}#{{}} -r default -f".format(pref3.ref.repr_notime(), pref3.package_id)
+        command = "remove {}:{}#{{}} -r default -c".format(pref3.ref.repr_notime(), pref3.package_id)
         self.c_v2.run(command.format(pref3.revision))
         self.c_v2.run(command.format(pref2.revision))
         self.c_v2.run(command.format(pref1.revision))
@@ -984,7 +984,7 @@ def test_touching_other_server():
     c.save({"conanfile.py": GenConanfile().with_settings("os")})
     c.run("create . --name=pkg --version=0.1 --user=conan --channel=channel -s os=Windows")
     c.run("upload * -c -r=remote1")
-    c.run("remove * -f")
+    c.run("remove * -c")
 
     # This is OK, binary found
     c.run("install --requires=pkg/0.1@conan/channel -r=remote1 -s os=Windows")

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_transitivity.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_transitivity.py
@@ -89,7 +89,7 @@ def test_shared_requires_static(transitive_libraries):
 def test_transitive_binary_skipped(transitive_libraries):
     c = transitive_libraries
     # IMPORTANT: liba binary can be removed, no longer necessary
-    c.run("remove liba*:* -f")
+    c.run("remove liba*:* -c")
 
     conanfile = textwrap.dedent("""\
        from conan import ConanFile

--- a/conans/test/functional/toolchains/cmake/test_shared_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_shared_cmake.py
@@ -21,7 +21,7 @@ def test_shared_cmake_toolchain():
     client.save(pkg_cmake_app("app", "0.1", requires=["chat/0.1"]), clean_first=True)
     client.run("create . -o chat/*:shared=True -o hello/*:shared=True")
     client.run("upload * -c -r default")
-    client.run("remove * -f")
+    client.run("remove * -c")
 
     client = TestClient(servers=client.servers)
     client.run("install --requires=app/0.1@ -o chat*:shared=True -o hello/*:shared=True -g VirtualRunEnv")
@@ -96,7 +96,7 @@ def test_client_shared():
 
     # We try to remove the hello package and run again the executable from the test package,
     # this time it should fail, it doesn't find the shared library
-    client.run("remove '*' -f")
+    client.run("remove '*' -c")
     client.run_command(os.path.join(exe_folder, "example"), assert_error=True)
     return client
 
@@ -181,7 +181,7 @@ def test_shared_same_dir_using_cmake(test_client_shared):
                 """)
     test_client_shared.save({"test_package/CMakeLists.txt": cmake, "test_package/conanfile.py": cf})
     test_client_shared.run("create . -o hello*:shared=True")
-    test_client_shared.run("remove '*' -f")
+    test_client_shared.run("remove '*' -c")
     exe_folder = os.path.join("test_package", "test_output", "bin")
     test_client_shared.run_command(os.path.join(exe_folder, "test"))
 
@@ -199,7 +199,7 @@ def test_shared_same_dir_using_env_var_current_dir(test_client_shared):
     exe_folder = os.path.join("test_package", "test_output", "build", "release")
     rmdir(os.path.join(test_client_shared.current_folder, exe_folder))
     test_client_shared.run("create . -o hello*:shared=True")
-    test_client_shared.run("remove '*' -f")
+    test_client_shared.run("remove '*' -c")
     test_client_shared.current_folder = os.path.join(test_client_shared.current_folder, exe_folder)
     test_client_shared.run_command("DYLD_LIBRARY_PATH=$(pwd) ./example")
     test_client_shared.run_command("DYLD_LIBRARY_PATH=. ./example")

--- a/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
+++ b/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
@@ -133,7 +133,7 @@ def test_autotools_relocatable_libs_darwin_downloaded():
     client.run("new autotools_lib -d name=hello -d version=0.1")
     client.run("create . -o hello/*:shared=True -tf=None")
     client.run("upload hello/0.1 -c -r default")
-    client.run("remove * -f")
+    client.run("remove * -c")
 
     conanfile = textwrap.dedent("""
         from conan import ConanFile

--- a/conans/test/integration/build_requires/profile_build_requires_test.py
+++ b/conans/test/integration/build_requires/profile_build_requires_test.py
@@ -98,7 +98,7 @@ class BuildRequiresTest(unittest.TestCase):
         self.assertIn("tool/0.1@lasote/stable: Generated conaninfo.txt", client.out)
 
         # now remove packages, ensure --build=missing also creates them
-        client.run('remove "*:*" -f')
+        client.run('remove "*:*" -c')
         client.run("install . --profile ./profile.txt --build=missing")
         self.assertIn("tool/0.1@lasote/stable: Generated conaninfo.txt", client.out)
 

--- a/conans/test/integration/build_requires/test_toolchain_packages.py
+++ b/conans/test/integration/build_requires/test_toolchain_packages.py
@@ -103,7 +103,7 @@ def test_android_ndk():
     # IMPORTANT: The consumption via test_package allows specifying the type of requires
     # in this case: None, as this is intended to be injected via profile [tool_requires]
     # can be tested like that
-    c.run("remove * -f")
+    c.run("remove * -c")
     c.save({"test_package/conanfile.py": test})
 
     # Creating the NDK packages for Windows, Linux

--- a/conans/test/integration/cache/cache2_update_test.py
+++ b/conans/test/integration/cache/cache2_update_test.py
@@ -82,7 +82,7 @@ class TestUpdateFlows:
         self.client2.assert_listed_require({"liba/1.0.0": "Cache"})
         assert "liba/1.0.0: Already installed!" in self.client2.out
 
-        self.client.run("remove * -f")
+        self.client.run("remove * -c")
 
         # | CLIENT      | CLIENT2    | SERVER0    | SERVER1   | SERVER2    |
         # |-------------|------------|------------|-----------|------------|
@@ -122,7 +122,7 @@ class TestUpdateFlows:
         # to the date in server0 and associate that remote but not install anything
 
         # we create a newer revision in client2
-        self.client2.run("remove * -f")
+        self.client2.run("remove * -c")
         self.client2.save({"conanfile.py": GenConanfile("liba", "1.0.0").with_build_msg("REV2")})
         self.client2.run("create .")
 
@@ -144,10 +144,10 @@ class TestUpdateFlows:
         assert self.client.cache.get_recipe_timestamp(latest_rrev) == self.server_times["server2"]
 
         # we create a newer revision in client
-        self.client.run("remove * -f")
+        self.client.run("remove * -c")
         self.client.save({"conanfile.py": GenConanfile("liba", "1.0.0").with_build_msg("REV2")})
         self.client.run("create .")
-        self.client.run(f"remove {latest_rrev.repr_notime()} -f -r server2")
+        self.client.run(f"remove {latest_rrev.repr_notime()} -c -r server2")
 
         # | CLIENT      | CLIENT2    | SERVER0    | SERVER1   | SERVER2    |
         # |-------------|------------|------------|-----------|------------|
@@ -213,11 +213,11 @@ class TestUpdateFlows:
         self.client.assert_listed_require({"liba/1.0.0": "Cache"})
         assert "liba/1.0.0: Already installed!" in self.client.out
 
-        self.client.run("remove * -f")
+        self.client.run("remove * -c")
 
-        self.client.run("remove '*' -f -r server0")
-        self.client.run("remove '*' -f -r server1")
-        self.client.run("remove '*' -f -r server2")
+        self.client.run("remove '*' -c -r server0")
+        self.client.run("remove '*' -c -r server1")
+        self.client.run("remove '*' -c -r server2")
 
         # create new older revisions in servers
         self.client.save({"conanfile.py": GenConanfile("liba", "1.0.0").with_build_msg("REV4")})
@@ -227,7 +227,7 @@ class TestUpdateFlows:
 
         self._upload_ref_to_all_servers("liba/1.0.0", self.client)
 
-        self.client.run("remove * -f")
+        self.client.run("remove * -c")
 
         # | CLIENT      | CLIENT2    | SERVER0    | SERVER1   | SERVER2    |
         # |-------------|------------|------------|-----------|------------|
@@ -280,10 +280,10 @@ class TestUpdateFlows:
         assert self.the_time == self.client.cache.get_recipe_timestamp(server_rrev)
         self.client.assert_listed_require({"liba/1.0.0": "Cache (Updated date) (server2)"})
 
-        self.client.run("remove * -f")
-        self.client.run("remove '*' -f -r server0")
-        self.client.run("remove '*' -f -r server1")
-        self.client.run("remove '*' -f -r server2")
+        self.client.run("remove * -c")
+        self.client.run("remove '*' -c -r server0")
+        self.client.run("remove '*' -c -r server1")
+        self.client.run("remove '*' -c -r server2")
 
         self.client.save({"conanfile.py": GenConanfile("liba", "1.0.0").with_build_msg("REV6")})
         self.client.run("create .")
@@ -318,7 +318,7 @@ class TestUpdateFlows:
         # |             | REV0 (1000)|            |           |            |
         # |             |            |            |           |            |
 
-        self.client.run("remove * -f")
+        self.client.run("remove * -c")
 
         # | CLIENT      | CLIENT2    | SERVER0    | SERVER1   | SERVER2    |
         # |-------------|------------|------------|-----------|------------|
@@ -365,7 +365,7 @@ class TestUpdateFlows:
         assert "liba/[>0.9.0]: liba/1.0.0" in self.client.out
         assert "liba/1.0.0: Already installed!" in self.client.out
 
-        self.client.run("remove * -f")
+        self.client.run("remove * -c")
 
         # | CLIENT         | CLIENT2        | SERVER0        | SERVER1        | SERVER2        |
         # |----------------|----------------|----------------|----------------|----------------|
@@ -417,8 +417,8 @@ class TestUpdateFlows:
         # |                |                |                |                |                |
         # |                |                |                |                |                |
 
-        self.client.run("remove * -f")
-        self.client2.run("remove * -f")
+        self.client.run("remove * -c")
+        self.client2.run("remove * -c")
 
         # now we are uploading different revisions with different dates, but the same version
         for minor in range(3):

--- a/conans/test/integration/cache/download_cache_test.py
+++ b/conans/test/integration/cache/download_cache_test.py
@@ -18,7 +18,7 @@ class TestDownloadCache:
         client.save({"conanfile.py": GenConanfile().with_package_file("file.txt", "content")})
         client.run("create . --name=mypkg --version=0.1 --user=user --channel=testing")
         client.run("upload * --confirm -r default")
-        client.run("remove * -f")
+        client.run("remove * -c")
 
         # enable cache
         tmp_folder = temp_folder()
@@ -27,20 +27,20 @@ class TestDownloadCache:
         client.run("install --requires=mypkg/0.1@user/testing")
         assert "Downloading" in client.out
 
-        client.run("remove * -f")
+        client.run("remove * -c")
         client.run("install --requires=mypkg/0.1@user/testing")
         assert "Downloading" not in client.out
 
         # removing the config downloads things
         client.save({"global.conf": ""}, path=client.cache.cache_folder)
-        client.run("remove * -f")
+        client.run("remove * -c")
         client.run("install --requires=mypkg/0.1@user/testing")
         assert "Downloading" in client.out
 
         client.save({"global.conf": f"core.download:download_cache={tmp_folder}"},
                     path=client.cache.cache_folder)
 
-        client.run("remove * -f")
+        client.run("remove * -c")
         client.run("install --requires=mypkg/0.1@user/testing")
         assert "Downloading" not in client.out
 
@@ -54,7 +54,7 @@ class TestDownloadCache:
         client.save({"conanfile.py": GenConanfile().with_package_file("file.txt", "content")})
         client.run("create . --name=pkg --version=0.1")
         client.run("upload * -c -r default")
-        client.run("remove * -f")
+        client.run("remove * -c")
         client.run("install --requires=pkg/0.1@")
 
         # Make the cache dirty
@@ -65,11 +65,11 @@ class TestDownloadCache:
                 save(path, "broken!")
                 set_dirty(path)
 
-        client.run("remove * -f")
+        client.run("remove * -c")
         client.run("install --requires=pkg/0.1@")
         assert "Downloading" in client.out
 
-        client.run("remove * -f")
+        client.run("remove * -c")
         client.run("install --requires=pkg/0.1@")
         assert "Downloading" not in client.out
 
@@ -157,7 +157,7 @@ class TestDownloadCache:
         c.save({"conanfile.py": GenConanfile().with_package_file("file.txt", "content")})
         c.run("create . --name=mypkg --version=0.1 --user=user --channel=testing")
         c.run("upload * --confirm -r default")
-        c.run("remove * -f")
+        c.run("remove * -c")
 
         # enable cache
         c.save({"global.conf": f"core.download:download_cache=mytmp_folder"},

--- a/conans/test/integration/cache/read_only_test.py
+++ b/conans/test/integration/cache/read_only_test.py
@@ -46,12 +46,12 @@ class MyPkg(ConanFile):
     def test_remove(self):
         self.client.run("search")
         self.assertIn("pkg/0.1@lasote/channel", self.client.out)
-        self.client.run("remove pkg* -f")
+        self.client.run("remove pkg* -c")
         self.assertNotIn("pkg/0.1@lasote/channel", self.client.out)
 
     def test_upload(self):
         self.client.run("upload * --confirm -r default")
-        self.client.run("remove pkg* -f")
+        self.client.run("remove pkg* -c")
         self.client.run("install --requires=pkg/0.1@lasote/channel")
         self.test_basic()
 

--- a/conans/test/integration/command/alias_test.py
+++ b/conans/test/integration/command/alias_test.py
@@ -46,7 +46,7 @@ class ConanAliasTest(unittest.TestCase):
         self.assertNotIn("hello/0.x", conaninfo)
 
         client.run('upload "*" --confirm -r default')
-        client.run('remove "*" -f')
+        client.run('remove "*" -c')
 
         client.run("install .")
         client.assert_listed_require({"hello/0.1@lasote/channel": "Downloaded (default)"})

--- a/conans/test/integration/command/download/download_parallel_test.py
+++ b/conans/test/integration/command/download/download_parallel_test.py
@@ -15,7 +15,7 @@ def test_basic_parallel_download():
         package_id = client.created_package_id("pkg/0.1@user/testing")
         package_ids.append(package_id)
     client.run("upload * --confirm -r default")
-    client.run("remove * -f")
+    client.run("remove * -c")
 
     # Lets download the packages
     client.run("download pkg/0.1@user/testing#*:* -r default")

--- a/conans/test/integration/command/download/download_revisions_test.py
+++ b/conans/test/integration/command/download/download_revisions_test.py
@@ -17,7 +17,7 @@ class DownloadRevisionsTest(unittest.TestCase):
         # create new revision from recipe
         client.create(ref, conanfile=GenConanfile().with_build_msg("new revision"))
         client.run("upload pkg/1.0@user/channel --confirm -r default")
-        client.run("remove * -f")
+        client.run("remove * -c")
         client.run("download pkg/1.0@user/channel#{}".format(pref.ref.revision))
         self.assertIn("pkg/1.0@user/channel: Package installed {}".format(pref.package_id),
                       client.out)
@@ -35,7 +35,7 @@ class DownloadRevisionsTest(unittest.TestCase):
         # create new revision from recipe
         client.create(ref, conanfile=GenConanfile().with_build_msg("new revision"))
         client.run("upload pkg/1.0@ --confirm -r default")
-        client.run("remove * -f")
+        client.run("remove * -c")
         client.run("download pkg/1.0@#{}".format(pref.ref.revision))
         self.assertIn("pkg/1.0: Package installed {}".format(pref.package_id), client.out)
         search_result = client.search("pkg/1.0@ --revisions")[0]
@@ -50,7 +50,7 @@ class DownloadRevisionsTest(unittest.TestCase):
         client.run("upload pkg/1.0@user/channel --confirm -r default")
         client.create(ref, conanfile=GenConanfile().with_build_msg("new revision"))
         client.run("upload pkg/1.0@user/channel --confirm -r default")
-        client.run("remove * -f")
+        client.run("remove * -c")
         client.run("download pkg/1.0@user/channel#{}:{}#{}".format(pref.ref.revision,
                                                                    pref.package_id,
                                                                    pref.revision))

--- a/conans/test/integration/command/download/download_test.py
+++ b/conans/test/integration/command/download/download_test.py
@@ -24,7 +24,7 @@ class Pkg(ConanFile):
 
         ref = RecipeReference.loads("pkg/0.1@lasote/stable")
         client.run("upload pkg/0.1@lasote/stable -r default")
-        client.run("remove pkg/0.1@lasote/stable -f")
+        client.run("remove pkg/0.1@lasote/stable -c")
 
         client.run("download pkg/0.1@lasote/stable -r default")
         self.assertIn("Downloading conan_sources.tgz", client.out)
@@ -38,14 +38,14 @@ class Pkg(ConanFile):
         client.save({"conanfile.py": GenConanfile()})
         client.run("create . --name=pkg --version=1.0")
         client.run("upload * --confirm -r default")
-        client.run("remove * -f")
+        client.run("remove * -c")
 
         client.run("download pkg/1.0:{} -r default".format(NO_SETTINGS_PACKAGE_ID))
         self.assertIn("Downloading package 'pkg/1.0#4d670581ccb765839f2239cc8dff8fbd:%s" %
                       NO_SETTINGS_PACKAGE_ID, client.out)
 
         # All
-        client.run("remove * -f")
+        client.run("remove * -c")
         client.run("download pkg/1.0#*:* -r default")
         self.assertIn("Downloading package 'pkg/1.0#4d670581ccb765839f2239cc8dff8fbd:%s" %
                       NO_SETTINGS_PACKAGE_ID, client.out)
@@ -65,11 +65,11 @@ class Pkg(ConanFile):
         c.run("create pkg")
         c.run("upload tool* -r tools -c")
         c.run("upload pkg* -r pkgs -c")
-        c.run("remove * -f")
+        c.run("remove * -c")
 
         c.run("install --requires=pkg/0.1 -r pkgs -r tools")
         self.assertIn("Downloading", c.out)
-        c.run("remove * -f")
+        c.run("remove * -c")
 
         # This fails, as it won't allow 2 remotes
         c.run("download pkg/0.1 -r pkgs -r tools", assert_error=True)

--- a/conans/test/integration/command/export/exports_method_test.py
+++ b/conans/test/integration/command/export/exports_method_test.py
@@ -246,7 +246,7 @@ class ExportsSourcesMethodTest(unittest.TestCase):
         self.assertIn("Copied 1 '.txt' file: myfile.txt",
                       client.out)
         client.run("upload pkg/0.1 -r default")
-        client.run("remove * -f")
+        client.run("remove * -c")
         client.run("install --requires=pkg/0.1@ --build='*'")
         self.assertIn("Downloading conan_sources.tgz", client.out)
         self.assertIn("pkg/0.1: CONTENT: mycontent", client.out)

--- a/conans/test/integration/command/export_pkg_test.py
+++ b/conans/test/integration/command/export_pkg_test.py
@@ -414,8 +414,8 @@ class MyConan(ConanFile):
         _check_json_output()
 
         # Error on missing dependency
-        self.client.run("remove pkg1/1.0@danimtb/testing --force")
-        self.client.run("remove pkg2/1.0@danimtb/testing --force")
+        self.client.run("remove pkg1/1.0@danimtb/testing --confirm")
+        self.client.run("remove pkg2/1.0@danimtb/testing --confirm")
         self.client.run("export-pkg conanfile.py --name=pkg2 --version=1.0 --user=danimtb --channel=testing --json output.json",
                         assert_error=True)
         _check_json_output(with_error=True)

--- a/conans/test/integration/command/install/install_parallel_test.py
+++ b/conans/test/integration/command/install/install_parallel_test.py
@@ -18,7 +18,7 @@ class InstallParallelTest(unittest.TestCase):
         for i in range(counter):
             client.run("create . --name=pkg%s --version=0.1 --user=user --channel=testing" % i)
         client.run("upload * --confirm -r default")
-        client.run("remove * -f")
+        client.run("remove * -c")
 
         # Lets consume the packages
         conanfile_txt = ["[requires]"]

--- a/conans/test/integration/command/install/install_test.py
+++ b/conans/test/integration/command/install/install_test.py
@@ -52,7 +52,7 @@ def test_install_system_requirements(client):
     client.run(" install --requires=pkg/0.1@lasote/testing --build='*'")
     assert "Running system requirements!!" in client.out
     client.run("upload * --confirm -r default")
-    client.run('remove "*" -f')
+    client.run('remove "*" -c')
     client.run(" install --requires=pkg/0.1@lasote/testing")
     assert "Running system requirements!!" in client.out
 
@@ -263,7 +263,7 @@ def test_install_without_ref(client):
     client.run('upload lib/1.0 -c -r default')
     assert "Uploading recipe 'lib/1.0" in client.out
 
-    client.run('remove "*" -f')
+    client.run('remove "*" -c')
 
     # This fails, Conan thinks this is a path
     client.run('install lib/1.0', assert_error=True)
@@ -298,7 +298,7 @@ def test_install_skip_disabled_remote():
     client.run("create . --name=pkg --version=0.1 --user=lasote --channel=testing")
     client.run("upload * --confirm -r default")
     client.run("upload * --confirm -r server3")
-    client.run("remove * -f")
+    client.run("remove * -c")
     client.run("remote disable default")
     client.run("install --requires=pkg/0.1@lasote/testing", assert_error=False)
     assert "Trying with 'default'..." not in client.out

--- a/conans/test/integration/command/remove_empty_dirs_test.py
+++ b/conans/test/integration/command/remove_empty_dirs_test.py
@@ -15,7 +15,7 @@ class RemoveEmptyDirsTest(unittest.TestCase):
         rrev = client.cache.get_latest_recipe_reference(RecipeReference.loads("hello/0.1@lasote/stable"))
         ref_layout = client.cache.ref_layout(rrev)
         self.assertTrue(os.path.exists(ref_layout.base_folder))
-        client.run("remove hello* -f")
+        client.run("remove hello* -c")
         self.assertFalse(os.path.exists(ref_layout.base_folder))
 
     def test_shared_folder(self):
@@ -29,6 +29,6 @@ class RemoveEmptyDirsTest(unittest.TestCase):
         rrev2 = client.cache.get_latest_recipe_reference(RecipeReference.loads("hello/0.1@lasote2/stable"))
         ref_layout2 = client.cache.ref_layout(rrev2)
         self.assertTrue(os.path.exists(ref_layout2.base_folder))
-        client.run("remove hello/0.1@lasote/stable -f")
+        client.run("remove hello/0.1@lasote/stable -c")
         self.assertFalse(os.path.exists(ref_layout.base_folder))
         self.assertTrue(os.path.exists(ref_layout2.base_folder))

--- a/conans/test/integration/command/source_test.py
+++ b/conans/test/integration/command/source_test.py
@@ -156,7 +156,7 @@ class ConanLib(ConanFile):
         client.run("create . --name=hello --version=0.1")
         rrev = client.exported_recipe_revision()
         client.run("upload hello/0.1 -r server0")
-        client.run("remove * -f")
+        client.run("remove * -c")
 
         # install from server0 that has the sources, upload to server1 (does not have the package)
         # download the sources from server0
@@ -167,7 +167,7 @@ class ConanLib(ConanFile):
 
         # install from server1 that has the sources, upload to server1
         # Will not download sources, revision already in server
-        client.run("remove * -f")
+        client.run("remove * -c")
         client.run("install --requires=hello/0.1@ -r server1")
         client.run("upload hello/0.1 -r server1")
         assert f"'hello/0.1#{rrev}' already in server, skipping upload" in client.out
@@ -176,7 +176,7 @@ class ConanLib(ConanFile):
 
         # install from server0 and build
         # download sources from server0
-        client.run("remove * -f")
+        client.run("remove * -c")
         client.run("install --requires=hello/0.1@ -r server0 --build='*'")
         self.assertIn("Downloading conan_sources.tgz", client.out)
         self.assertIn("Sources downloaded from 'server0'", client.out)

--- a/conans/test/integration/command/upload/upload_test.py
+++ b/conans/test/integration/command/upload/upload_test.py
@@ -54,7 +54,7 @@ class UploadTest(unittest.TestCase):
                       % NO_SETTINGS_PACKAGE_ID, client.out)
 
         # TODO: cache2.0 check if this makes sense for 2.0, xfail test for the moment
-        client.run("remove hello/0.1@lasote/testing -p=%s -f" % NO_SETTINGS_PACKAGE_ID)
+        client.run("remove hello/0.1@lasote/testing -p=%s -c" % NO_SETTINGS_PACKAGE_ID)
         client.run("upload * --confirm")
 
     @pytest.mark.artifactory_ready
@@ -71,7 +71,7 @@ class UploadTest(unittest.TestCase):
         package_file_path = os.path.join(package_folder, "myfile.sh")
 
         if platform.system() == "Linux":
-            client.run("remove '*' -f")
+            client.run("remove '*' -c")
             client.create(ref, conanfile=GenConanfile().with_package_file("myfile.sh", "foo"))
             os.system('chmod +x "{}"'.format(package_file_path))
             self.assertTrue(os.stat(package_file_path).st_mode & stat.S_IXUSR)
@@ -87,7 +87,7 @@ class UploadTest(unittest.TestCase):
         self.assertIn("-> conan_package.tgz", client.out)
 
         if platform.system() == "Linux":
-            client.run("remove '*' -f")
+            client.run("remove '*' -c")
             client.run("install --requires={}".format(ref))
             # Owner with execute permissions
             self.assertTrue(os.stat(package_file_path).st_mode & stat.S_IXUSR)
@@ -461,7 +461,7 @@ class UploadTest(unittest.TestCase):
         client.run("remote login server1 lasote -p mypass")
         client.run("remote login server2 lasote -p mypass")
         client.run("upload hello0/1.2.1@user/testing -r server1")
-        client.run("remove * --force")
+        client.run("remove * --confirm")
         client.run("install --requires=hello0/1.2.1@user/testing -r server1")
         client.run("remote remove server1")
         client.run("upload hello0/1.2.1@user/testing -r server2")

--- a/conans/test/integration/corrupted_packages_test.py
+++ b/conans/test/integration/corrupted_packages_test.py
@@ -51,7 +51,7 @@ class CorruptedPackagesTest(unittest.TestCase):
         self.assertIn("There are no packages for reference 'pkg/0.1@user/testing', "
                       "but package recipe found", self.client.out)
         # Try fresh install
-        self.client.run("remove * -f")
+        self.client.run("remove * -c")
         self.client.run("install --requires=pkg/0.1@user/testing", assert_error=True)
         self.assertIn(f"pkg/0.1@user/testing:{NO_SETTINGS_PACKAGE_ID} - Missing",
                       self.client.out)
@@ -68,7 +68,7 @@ class CorruptedPackagesTest(unittest.TestCase):
         self.client.run("search pkg/0.1@user/testing -r default")
         self.assertIn(f"Package_ID: {NO_SETTINGS_PACKAGE_ID}", self.client.out)
         # Try fresh install
-        self.client.run("remove * -f")
+        self.client.run("remove * -c")
         self.client.run("install --requires=pkg/0.1@user/testing", assert_error=True)
         self.assertIn("ERROR: Binary package not found", self.client.out)
         self.assertIn(NO_SETTINGS_PACKAGE_ID, self.client.out)
@@ -87,7 +87,7 @@ class CorruptedPackagesTest(unittest.TestCase):
         self.assertIn("There are no packages for reference 'pkg/0.1@user/testing', "
                       "but package recipe found", self.client.out)
         # Try fresh install
-        self.client.run("remove * -f")
+        self.client.run("remove * -c")
         self.client.run("install --requires=pkg/0.1@user/testing", assert_error=True)
         self.assertIn(f"pkg/0.1@user/testing:{NO_SETTINGS_PACKAGE_ID} - Missing", self.client.out)
         # Try upload of fresh package
@@ -104,7 +104,7 @@ class CorruptedPackagesTest(unittest.TestCase):
         # Try search
         self.client.run("search pkg/0.1@user/testing -r default")
         # Try fresh install
-        self.client.run("remove * -f")
+        self.client.run("remove * -c")
         self.client.run("install --requires=pkg/0.1@user/testing", assert_error=True)
         self.assertIn("ERROR: Binary package not found", self.client.out)
         # Try upload of fresh package
@@ -123,7 +123,7 @@ class CorruptedPackagesTest(unittest.TestCase):
         self.client.run("search pkg/0.1@user/testing -r default")
         self.assertIn(f"Package_ID: {NO_SETTINGS_PACKAGE_ID}", self.client.out)
         # Try fresh install
-        self.client.run("remove * -f")
+        self.client.run("remove * -c")
         self.client.run("install --requires=pkg/0.1@user/testing", assert_error=True)
         self.assertIn("ERROR: Binary package not found", self.client.out)
         # Try upload of fresh package
@@ -141,7 +141,7 @@ class CorruptedPackagesTest(unittest.TestCase):
         self.assertIn("There are no packages for reference 'pkg/0.1@user/testing', "
                       "but package recipe found", self.client.out)
         # Try fresh install
-        self.client.run("remove * -f")
+        self.client.run("remove * -c")
         self.client.run("install --requires=pkg/0.1@user/testing", assert_error=True)
         self.assertIn(f"pkg/0.1@user/testing:{NO_SETTINGS_PACKAGE_ID} - Missing", self.client.out)
         # Try upload of fresh package

--- a/conans/test/integration/editable/forbidden_commands_test.py
+++ b/conans/test/integration/editable/forbidden_commands_test.py
@@ -37,7 +37,7 @@ class TestOtherCommands:
         t.run('upload lib/0.1 -r default')
         assert "Uploading recipe 'lib/0.1" in t.out
 
-        t.run("remove * -f")
+        t.run("remove * -c")
         # Nothing in the cache
         t.run("list recipes *")
         assert "There are no matching recipe references" in t.out

--- a/conans/test/integration/editable/test_editable_import.py
+++ b/conans/test/integration/editable/test_editable_import.py
@@ -51,7 +51,7 @@ class TestEditableImport:
         t.run("install consumer")
         assert t.load("consumer/imports/myfile.txt") == "mydata"
 
-        t.run("remove * -f")
+        t.run("remove * -c")
         t.run('editable add dep dep/0.1@')
         shutil.rmtree(os.path.join(t.current_folder, "consumer", "imports"))
         t.run("install consumer")

--- a/conans/test/integration/graph/alias_test.py
+++ b/conans/test/integration/graph/alias_test.py
@@ -375,7 +375,7 @@ class Pkg(ConanFile):
         self.assertNotIn("hello/0.X@lasote/channel", conaninfo)
 
         client.run('upload "*" --confirm -r default')
-        client.run('remove "*" -c")
+        client.run('remove "*" -c"')
 
         client.run("install .")
         self.assertIn("hello/0.1@lasote/channel from 'default'", client.out)

--- a/conans/test/integration/graph/alias_test.py
+++ b/conans/test/integration/graph/alias_test.py
@@ -375,7 +375,7 @@ class Pkg(ConanFile):
         self.assertNotIn("hello/0.X@lasote/channel", conaninfo)
 
         client.run('upload "*" --confirm -r default')
-        client.run('remove "*" -f')
+        client.run('remove "*" -c")
 
         client.run("install .")
         self.assertIn("hello/0.1@lasote/channel from 'default'", client.out)

--- a/conans/test/integration/graph/core/test_version_ranges.py
+++ b/conans/test/integration/graph/core/test_version_ranges.py
@@ -358,7 +358,7 @@ def test_mixed_user_channel():
     t.run("create . --name=pkg --version=1.1 --user=user --channel=testing")
     t.run("create . --name=pkg --version=2.0 --user=user --channel=testing")
     t.run("upload * --confirm -r default")
-    t.run("remove * -f")
+    t.run("remove * -c")
 
     t.run('install --requires="pkg/[>0 <2]@"')
     t.assert_listed_require({"pkg/1.1": "Downloaded (default)"})
@@ -383,7 +383,7 @@ def test_remote_version_ranges():
                            ("~2", "2.2.1"),
                            ("~2.1", "2.1"),
                            ]:
-        t.run("remove * -f")
+        t.run("remove * -c")
         t.save({"conanfile.py": GenConanfile().with_requires(f"dep/[{expr}]")})
         t.run("install .")
         assert str(t.out).count("Not found in local cache, looking in remotes") == 1

--- a/conans/test/integration/graph/test_remote_resolution.py
+++ b/conans/test/integration/graph/test_remote_resolution.py
@@ -16,7 +16,7 @@ def test_build_requires_ranges():
     client.run("create . --name=cmake --version=0.5")
     client.run("create . --name=cmake --version=1.0")
     client.run("upload cmake/1.0* -c -r default")
-    client.run("remove cmake/1.0* -f")
+    client.run("remove cmake/1.0* -c")
 
     conanfile = textwrap.dedent("""
         from conan import ConanFile

--- a/conans/test/integration/graph/test_skip_binaries.py
+++ b/conans/test/integration/graph/test_skip_binaries.py
@@ -11,7 +11,7 @@ def test_private_skip():
     client.run("create . --name=dep --version=1.0")
     client.save({"conanfile.py": GenConanfile().with_requirement("dep/1.0", visible=False)})
     client.run("create . --name=pkg --version=1.0")
-    client.run("remove dep/1.0:* -f")  # Dep binary is removed not used at all
+    client.run("remove dep/1.0:* -c")  # Dep binary is removed not used at all
 
     client.save({"conanfile.py": GenConanfile().with_requires("pkg/1.0")})
     client.run("create . --name=app --version=1.0")
@@ -30,7 +30,7 @@ def test_private_no_skip():
     client.run("create . --name=app --version=1.0 --build=app/* --build=pkg/*")
     client.assert_listed_binary({"dep/1.0": (NO_SETTINGS_PACKAGE_ID, "Cache")})
 
-    client.run("remove dep/1.0:* -f")  # Dep binary is removed not used at all
+    client.run("remove dep/1.0:* -c")  # Dep binary is removed not used at all
     client.run("create . --name=app --version=1.0 --build=app/* --build=pkg/*", assert_error=True)
     client.assert_listed_binary({"dep/1.0": (NO_SETTINGS_PACKAGE_ID, "Missing")})
 
@@ -60,7 +60,7 @@ def test_shared_link_static_skip():
     client.save({"conanfile.py": GenConanfile().with_requirement("dep/1.0").
                 with_shared_option(True)})
     client.run("create . --name=pkg --version=1.0")
-    client.run("remove dep/1.0:* -f")  # Dep binary is removed not used at all
+    client.run("remove dep/1.0:* -c")  # Dep binary is removed not used at all
 
     client.save({"conanfile.py": GenConanfile().with_requires("pkg/1.0")})
     client.run("create . --name=app --version=1.0")
@@ -77,7 +77,7 @@ def test_test_requires():
     client.save({"conanfile.py": GenConanfile().with_test_requires("gtest/1.0").
                 with_shared_option(False)})
     client.run("create . --name=pkg --version=1.0")
-    client.run("remove gtest/1.0:* -f")  # Dep binary is removed not used at all
+    client.run("remove gtest/1.0:* -c")  # Dep binary is removed not used at all
 
     client.save({"conanfile.py": GenConanfile().with_requires("pkg/1.0")})
     client.run("create . --name=app --version=1.0")

--- a/conans/test/integration/graph/version_ranges/version_ranges_cached_test.py
+++ b/conans/test/integration/graph/version_ranges/version_ranges_cached_test.py
@@ -49,7 +49,7 @@ class TestVersionRangesCache:
             client.run("create .")
             client.run(f"upload liba/2.{minor}.0 -r server1 -c")
 
-        client.run("remove * -f")
+        client.run("remove * -c")
 
         client.save({"conanfile.py": GenConanfile("libb", "1.0").with_require("liba/[>=2.0]")})
         client.run("create .")

--- a/conans/test/integration/graph/version_ranges/version_ranges_diamond_test.py
+++ b/conans/test/integration/graph/version_ranges/version_ranges_diamond_test.py
@@ -27,7 +27,7 @@ class VersionRangesUpdatingTest(unittest.TestCase):
         client.run("create . --name=boost --version=1.69.0 --user=lasote --channel=stable")
         client.run("create . --name=boost --version=1.70.0 --user=lasote --channel=stable")
         client.run("upload * -r=default --confirm")
-        client.run("remove * -f")
+        client.run("remove * -c")
         conanfile = textwrap.dedent("""
             [requires]
             boost/[>=1.68.0]@lasote/stable
@@ -57,7 +57,7 @@ class VersionRangesUpdatingTest(unittest.TestCase):
         client.run("create pkg.py --name=pkg --veersion=1.1 --user=lasote --channel=testing")
         client.run("create pkg.py --name=pkg --veersion=1.2 --user=lasote --channel=testing")
         client.run("upload pkg* -r=default --confirm")
-        client.run("remove pkg/1.2@lasote/testing -f")
+        client.run("remove pkg/1.2@lasote/testing -c")
 
         client.save({"consumer.py": GenConanfile().with_requirement("pkg/[~1]@lasote/testing")})
         client.run("install consumer.py")
@@ -72,10 +72,10 @@ class VersionRangesUpdatingTest(unittest.TestCase):
         client.run("create pkg.py --name=pkg --veersion=1.3 --user=lasote --channel=testing")
         client.run("install consumer.py --update")
         self.assertIn("pkg/1.3@lasote/testing: Already installed!", client.out)
-        client.run("remove pkg/1.3@lasote/testing -f")
+        client.run("remove pkg/1.3@lasote/testing -c")
 
         # removes remote
-        client.run("remove Pkg* -r=default --f")
+        client.run("remove Pkg* -r=default --c")
         # Resolves to local package
         client.run("install consumer.py")
         self.assertIn("pkg/1.2@lasote/testing: Already installed!", client.out)
@@ -170,7 +170,7 @@ class HelloReuseConan(ConanFile):
                      upload=False)
 
         for remote, solution in [("default", "0.2"), ("other", "0.3")]:
-            self.client.run('remove "hello0/0.*" -f')
+            self.client.run('remove "hello0/0.*" -c')
             self.client.run("install . --build missing -r=%s" % remote)
             self.assertIn("Version range '>0.1,<0.4' required by "
                           "'conanfile.py (hello1/0.1)' "
@@ -213,7 +213,7 @@ class HelloReuseConan(ConanFile):
         self._export("hello1", "0.1", ["hello0/[>0.1,<0.3]@lasote/stable"], export=False,
                      upload=False)
 
-        self.client.run('remove "hello0/0.*" -f')
+        self.client.run('remove "hello0/0.*" -c')
         self.client.run("install . --build missing")
         self.assertIn("Version range '>0.1,<0.3' required by 'conanfile.py (hello1/0.1)' "
                       "resolved to 'hello0/0.2@lasote/stable'", self.client.out)
@@ -229,7 +229,7 @@ class HelloReuseConan(ConanFile):
                      export=False, upload=upload)
 
         if upload:
-            self.client.run('remove "*" -f')
+            self.client.run('remove "*" -c')
 
         self.client.run("install . --build missing")
 
@@ -246,7 +246,7 @@ class HelloReuseConan(ConanFile):
 
         if upload:
             self._export("hello0", "0.2.1", upload=upload)
-            self.client.run('remove hello0/0.2.1@lasote/stable -f')
+            self.client.run('remove hello0/0.2.1@lasote/stable -c')
             self._export("Hello3", "0.1", ["hello1/[>=0]@lasote/stable",
                                            "hello2/[~=0]@lasote/stable"],
                          export=False, upload=upload)
@@ -275,7 +275,7 @@ class HelloReuseConan(ConanFile):
                      ["RequirementTwo/[=4.5.6]@lasote/stable",
                       "RequirementOne/[=1.2.3]@lasote/stable"], upload=True)
 
-        self.client.run("remove '*' -f")
+        self.client.run("remove '*' -c")
         self.client.run("install --requires=Project/1.0.0@lasote/stable --build missing", assert_error=True)
         self.assertIn("Conflict in RequirementOne/1.2.3@lasote/stable:\n"
             "    'RequirementOne/1.2.3@lasote/stable' requires "
@@ -289,7 +289,7 @@ class HelloReuseConan(ConanFile):
                      ["RequirementOne/[=1.2.3]@lasote/stable",
                       "RequirementTwo/[=4.5.6]@lasote/stable",
                       ], upload=True)
-        self.client.run("remove '*' -f")
+        self.client.run("remove '*' -c")
         self.client.run("install --requires=Project/1.0.0@lasote/stable --build missing", assert_error=True)
         self.assertIn("Conflict in RequirementTwo/4.5.6@lasote/stable:\n"
               "    'RequirementTwo/4.5.6@lasote/stable' requires "

--- a/conans/test/integration/package_id/build_id_test.py
+++ b/conans/test/integration/package_id/build_id_test.py
@@ -168,7 +168,7 @@ class BuildIdTest(unittest.TestCase):
 
         # TODO: cache2.0 check if we will maintain the remove -p
         # Check that repackaging works, not necessary to re-build
-        # client.run("remove pkg/0.1@user/channel -p -f")
+        # client.run("remove pkg/0.1@user/channel -p -c")
         # # Windows Debug
         # client.run('install . -s os=Windows -s build_type=Debug')
         # self.assertNotIn("Building my code!", client.out)
@@ -197,7 +197,7 @@ class BuildIdTest(unittest.TestCase):
         # self._check_conaninfo(client)
 
         # But if the build folder is removed, the packages are there, do nothing
-        client.run("remove pkg/0.1@user/channel -b -f")
+        client.run("remove pkg/0.1@user/channel -b -c")
         client.run('install . -s os=Windows -s build_type=Debug')
         self.assertNotIn("Building my code!", client.out)
         self.assertNotIn("Packaging Debug!", client.out)
@@ -245,9 +245,9 @@ class BuildIdTest(unittest.TestCase):
         build, packages = _check_builds()
         # TODO: cache2.0 remove -p and -b is not yet fully implemented
         # we are commenting the first part of this until it is
-        #client.run("remove pkg/0.1@user/channel -b %s -f" % packages[0])
+        #client.run("remove pkg/0.1@user/channel -b %s -c" % packages[0])
         #_check_builds()
-        #client.run("remove pkg/0.1@user/channel -b %s -f" % build)
+        #client.run("remove pkg/0.1@user/channel -b %s -c" % build)
         #cache_builds = client.cache.package_layout(ref).conan_builds()
         #self.assertEqual(0, len(cache_builds))
         #package_ids = client.cache.package_layout(ref).package_ids()

--- a/conans/test/integration/package_id/compatible_test.py
+++ b/conans/test/integration/package_id/compatible_test.py
@@ -101,7 +101,7 @@ class CompatibleIDsTest(unittest.TestCase):
         # Create the recipe and upload it into the remote
         client.run("create . -s build_type=Release")
         client.run("upload pkg* -r=default --confirm")
-        client.run("remove * -f")
+        client.run("remove * -c")
 
         # Install locally the uploaded package
         client.run("install --requires=pkga/0.1")

--- a/conans/test/integration/package_id/package_id_test.py
+++ b/conans/test/integration/package_id/package_id_test.py
@@ -77,7 +77,7 @@ def test_value_parse():
     client.run("search test/0.1@danimtb/testing")
     assert "arch: kk=kk" in client.out
     client.run("upload test/0.1@danimtb/testing -r default")
-    client.run("remove test/0.1@danimtb/testing --force")
+    client.run("remove test/0.1@danimtb/testing --confirm")
     client.run("install --requires=test/0.1@danimtb/testing")
     client.run("search test/0.1@danimtb/testing")
     assert "arch: kk=kk" in client.out

--- a/conans/test/integration/py_requires/python_requires_test.py
+++ b/conans/test/integration/py_requires/python_requires_test.py
@@ -48,10 +48,10 @@ class PyRequiresExtendTest(unittest.TestCase):
         self.assertIn("pkg/0.1@user/testing: My cool package_info!", client.out)
 
         client.run("upload * --confirm -r default")
-        client.run("remove * -f")
+        client.run("remove * -c")
         client.run("install --requires=pkg/0.1@user/testing")
         self.assertIn("pkg/0.1@user/testing: My cool package_info!", client.out)
-        client.run("remove * -f")
+        client.run("remove * -c")
         client.run("download pkg/0.1@user/testing#latest:* -r default")
         self.assertIn(f"pkg/0.1@user/testing: Package installed {package_id}", client.out)
 
@@ -275,10 +275,10 @@ class PyRequiresExtendTest(unittest.TestCase):
         self.assertIn("pkg/0.1@user/testing: My cool package_info!", client.out)
 
         client.run("upload * --confirm -r default")
-        client.run("remove * -f")
+        client.run("remove * -c")
         client.run("install --requires=pkg/0.1@user/testing")
         self.assertIn("pkg/0.1@user/testing: My cool package_info!", client.out)
-        client.run("remove * -f")
+        client.run("remove * -c")
         client.run("download pkg/0.1@user/testing#*:* -r default")
         self.assertIn(f"pkg/0.1@user/testing: Package installed {package_id}", client.out)
 

--- a/conans/test/integration/remote/auth_test.py
+++ b/conans/test/integration/remote/auth_test.py
@@ -207,7 +207,7 @@ def test_token_expired():
     c.users = {}
     conan_conf = "core:non_interactive=True"
     c.save({"global.conf": conan_conf}, path=c.cache.cache_folder)
-    c.run("remove * -f")
+    c.run("remove * -c")
     c.run("install --requires=pkg/0.1@user/stable")
     user, token, _ = c.cache.localdb.get_login(server.fake_url)
     assert user == "admin"

--- a/conans/test/integration/remote/broken_download_test.py
+++ b/conans/test/integration/remote/broken_download_test.py
@@ -21,7 +21,7 @@ class BrokenDownloadTest(unittest.TestCase):
         self.assertTrue(os.path.exists(client.get_latest_ref_layout(ref).export()))
         client.run("upload hello/0.1@lasote/stable -r default --only-recipe")
         export_folder = client.get_latest_ref_layout(ref).export()
-        client.run("remove hello/0.1@lasote/stable -f")
+        client.run("remove hello/0.1@lasote/stable -c")
         self.assertFalse(os.path.exists(export_folder))
 
         rev = server.server_store.get_last_revision(ref).revision

--- a/conans/test/integration/remote/multi_remote_checks_test.py
+++ b/conans/test/integration/remote/multi_remote_checks_test.py
@@ -20,7 +20,7 @@ class Pkg(ConanFile):
         client.run("upload pkg* -r=server2 --confirm")
 
         # It takes the default remote
-        client.run("remove * -f")
+        client.run("remove * -c")
 
         # Exported recipe gets binary from default remote
         client.run("export . --name=pkg --version=0.1 --user=lasote --channel=testing")
@@ -31,7 +31,7 @@ class Pkg(ConanFile):
                       "%s from remote 'server1'" % NO_SETTINGS_PACKAGE_ID, client.out)
 
         # Explicit remote also defines the remote
-        client.run("remove * -f")
+        client.run("remove * -c")
         client.run("export . --name=pkg --version=0.1 --user=lasote --channel=testing")
         client.run("install --requires=pkg/0.1@lasote/testing -r=server2")
         client.assert_listed_binary(
@@ -40,8 +40,8 @@ class Pkg(ConanFile):
                       "%s from remote 'server2'" % NO_SETTINGS_PACKAGE_ID, client.out)
 
         # Ordered search of binary works
-        client.run("remove * -f")
-        client.run("remove * -f -r=server1")
+        client.run("remove * -c")
+        client.run("remove * -c -r=server1")
         client.run("export . --name=pkg --version=0.1 --user=lasote --channel=testing")
         client.run("install --requires=pkg/0.1@lasote/testing")
         client.assert_listed_binary(
@@ -50,8 +50,8 @@ class Pkg(ConanFile):
                       "%s from remote 'server2'" % NO_SETTINGS_PACKAGE_ID, client.out)
 
         # Download recipe and binary from the remote2 by iterating
-        client.run("remove * -f")
-        client.run("remove * -f -r=server1")
+        client.run("remove * -c")
+        client.run("remove * -c -r=server1")
         client.run("install --requires=pkg/0.1@lasote/testing")
         client.assert_listed_binary(
             {"pkg/0.1@lasote/testing": (NO_SETTINGS_PACKAGE_ID, "Download (server2)")})
@@ -70,11 +70,11 @@ class Pkg(ConanFile):
         client.save({"conanfile.py": conanfile})
         client.run("create . --name=pkg --version=0.1 --user=lasote --channel=testing -o pkg/*:opt=1")
         client.run("upload pkg* -r=server1 --confirm")
-        client.run("remove *:* -f")
+        client.run("remove *:* -c")
         client.run("create . --name=pkg --version=0.1 --user=lasote --channel=testing -o pkg/*:opt=2")
         package_id2 = client.created_package_id("pkg/0.1@lasote/testing")
         client.run("upload pkg* -r=server2 --confirm")
-        client.run("remove *:* -f")
+        client.run("remove *:* -c")
 
         # recipe is cached, takes binary from server2
         client.run("install --requires=pkg/0.1@lasote/testing -o pkg/*:opt=2 -r=server2")

--- a/conans/test/integration/remote/multi_remote_test.py
+++ b/conans/test/integration/remote/multi_remote_test.py
@@ -32,7 +32,7 @@ class ExportsSourcesMissingTest(unittest.TestCase):
         # Failure because remote removed the package
         client2 = TestClient(servers=servers, inputs=2*["admin", "password"])
         client2.run("install --requires=pkg/0.1@user/testing")
-        client2.run("remove * -r=default -f")
+        client2.run("remove * -r=default -c")
         client2.run("upload pkg/0.1@user/testing -r=new_server", assert_error=True)
         self.assertIn("pkg/0.1@user/testing Error while compressing: The 'pkg/0.1@user/testing' ",
                       client2.out)
@@ -126,7 +126,7 @@ class MultiRemotesTest(unittest.TestCase):
         self._create(client, "hello0", "0.0", modifier=" ")
         client.run("install --requires=hello0/0.0@lasote/stable --build missing")
         client.run("upload hello0/0.0@lasote/stable#latest -r local")
-        client.run("remove '*' -f")
+        client.run("remove '*' -c")
 
         client.run("install --requires=hello0/0.0@lasote/stable")
         # If we don't set a remote we find between all remotes and get the first match

--- a/conans/test/integration/remote/selected_remotes_test.py
+++ b/conans/test/integration/remote/selected_remotes_test.py
@@ -19,27 +19,27 @@ class TestSelectedRemotesInstall:
         self.client.save({"conanfile.py": GenConanfile("liba", "1.0").with_build_msg("OLDREV")})
         self.client.run("create .")
         self.client.run("upload liba/1.0 -r server0 -c")
-        self.client.run("remove * -f")
+        self.client.run("remove * -c")
         self.client.save({"conanfile.py": GenConanfile("liba", "1.0").with_build_msg("NEWER_REV")})
         self.client.run("create .")
         self.client.run("upload liba/1.0 -r server1 -c")
-        self.client.run("remove * -f")
+        self.client.run("remove * -c")
 
         self.client.run("install --requires=liba/1.0 -r server0 -r server1 --build='*'")
         # we install the revision from the server with more preference
         assert "OLDREV" in self.client.out
-        self.client.run("remove * -f")
+        self.client.run("remove * -c")
         self.client.run("install --requires=liba/1.0 -r server1 -r server0 --build='*'")
         # changing the order of the remotes in the arguments does change the result
         # we install the revision from the server with more preference
         assert "NEWER_REV" in self.client.out
         # select two remotes, just one has liba, will install the rev from that one
-        self.client.run("remove * -f")
+        self.client.run("remove * -c")
         self.client.run("install --requires=liba/1.0 -r server2 -r server1 --build='*'")
         assert "NEWER_REV" in self.client.out
 
         self.client.save({"consumer.py": GenConanfile().with_require("liba/1.0")})
-        self.client.run("remove * -f")
+        self.client.run("remove * -c")
         self.client.run("create . --build='*' -r server0 -r server1 -r server2")
         assert "NEWER_REV" in self.client.out
 
@@ -48,5 +48,5 @@ class TestSelectedRemotesInstall:
         assert "conan upload: error: -r can only be specified once" in self.client.out
 
     def test_remove_raise_multiple_remotes(self):
-        self.client.run("remove liba -r server0 -r server1 -f", assert_error=True)
+        self.client.run("remove liba -r server0 -r server1 -c", assert_error=True)
         assert "conan remove: error: -r can only be specified once" in self.client.out

--- a/conans/test/integration/settings/settings_override_test.py
+++ b/conans/test/integration/settings/settings_override_test.py
@@ -100,7 +100,7 @@ def test_exclude_patterns_settings():
     client.run("install --requires consumer/1.0 -s consumer/*:build_type=Debug")
 
     # Priority between package scoped settings
-    client.run('remove consumer/*#* -p="build_type=Debug" -f')
+    client.run('remove consumer/*#* -p="build_type=Debug" -c')
     client.run("install --reference consumer/1.0 -s build_type=Debug", assert_error=True)
     # Pre-check, there is no Debug package for any of them
     assert "ERROR: Missing prebuilt package for 'consumer/1.0', 'openssl/1.0', 'zlib/1.0'"

--- a/conans/test/integration/symlinks/symlinks_test.py
+++ b/conans/test/integration/symlinks/symlinks_test.py
@@ -162,7 +162,7 @@ class TestConan(ConanFile):
         pref = PkgReference.loads("hello/0.1@lasote/stable:%s" % NO_SETTINGS_PACKAGE_ID)
 
         client.run("upload hello/0.1@lasote/stable -r default")
-        client.run('remove "*" -f')
+        client.run('remove "*" -c')
         client.save({"conanfile.txt": test_conanfile}, clean_first=True)
         client.run("install conanfile.txt")
         self._check(client, pref, build=False)

--- a/conans/test/integration/test_package_python_files.py
+++ b/conans/test/integration/test_package_python_files.py
@@ -44,7 +44,7 @@ def test_package_python_files():
     assert ".DS_Store" not in manifest
 
     client.run("upload * -r=default --confirm")
-    client.run("remove * -f")
+    client.run("remove * -c")
     client.run("download pkg/0.1#*:* -r default")
 
     assert os.path.isfile(os.path.join(export_sources, "myfile.pyc"))

--- a/conans/test/integration/test_pkg_signing.py
+++ b/conans/test/integration/test_pkg_signing.py
@@ -41,7 +41,7 @@ def test_pkg_sign():
     c.run("upload * -r=default -c")
     assert "Signing ref:  pkg/0.1" in c.out
     assert "Signing ref:  pkg/0.1:da39a3ee5e6b4b0d3255bfef95601890afd80709" in c.out
-    c.run("remove * -f")
+    c.run("remove * -c")
     c.run("install --requires=pkg/0.1")
     assert "Verifying ref:  pkg/0.1" in c.out
     assert "Verifying ref:  pkg/0.1:da39a3ee5e6b4b0d3255bfef95601890afd80709" in c.out

--- a/conans/test/integration/test_timestamp_error.py
+++ b/conans/test/integration/test_timestamp_error.py
@@ -36,7 +36,7 @@ def test_timestamp_error():
     c.run("create gtest")
     c.run("create engine")
     c.run("upload * -r=default -c")
-    c.run("remove * -f")
+    c.run("remove * -c")
     c.run("install app")
     # This used to fail, now it is not crashing anymore
     assert "Finalizing install" in c.out

--- a/conans/test/integration/ui/json_output_test.py
+++ b/conans/test/integration/ui/json_output_test.py
@@ -36,7 +36,7 @@ class JsonOutputTest(unittest.TestCase):
 
         # Result of an install retrieving only the recipe
         self.client.run("upload cc/1.0@private_user/channel -c -r default --only-recipe")
-        self.client.run("remove '*' -f")
+        self.client.run("remove '*' -c")
         self.client.run("install --requires=c/1.0@private_user/channel --json=myfile.json --build missing ")
         my_json = json.loads(self.client.load("myfile.json"))
 
@@ -52,7 +52,7 @@ class JsonOutputTest(unittest.TestCase):
 
         # Upload the binary too
         self.client.run("upload cc/1.0@private_user/channel -c -r default")
-        self.client.run("remove '*' -f")
+        self.client.run("remove '*' -c")
         self.client.run("install --requires=c/1.0@private_user/channel --json=myfile.json")
         my_json = json.loads(self.client.load("myfile.json"))
 
@@ -65,7 +65,7 @@ class JsonOutputTest(unittest.TestCase):
         self.assertTrue(my_json["installed"][0]["packages"][0]["cpp_info"])
 
         # Force build
-        self.client.run("remove '*' -f")
+        self.client.run("remove '*' -c")
         self.client.run("install --requires=cc/1.0@private_user/channel --json=myfile.json --build")
         my_json = json.loads(self.client.load("myfile.json"))
 
@@ -93,7 +93,7 @@ class JsonOutputTest(unittest.TestCase):
         self.client.save({"conanfile.py": GenConanfile("c", "1.0")}, clean_first=True)
         self.client.run("create . private_user/channel --json=myfile.json ")
         self.client.run("upload c/1.0@private_user/channel -c -r default --only-recipe")
-        self.client.run("remove '*' -f")
+        self.client.run("remove '*' -c")
         self.client.run("install --requires=c/1.0@private_user/channel --json=myfile.json", assert_error=True)
         my_json = json.loads(self.client.load("myfile.json"))
 

--- a/conans/test/unittests/client/tools/collect_libs_test.py
+++ b/conans/test/unittests/client/tools/collect_libs_test.py
@@ -38,7 +38,7 @@ class CollectLibsTest(unittest.TestCase):
         self.assertIn("set(mylib_LIBS_RELEASE mylibname)", conanbuildinfo)
 
         # rebuilding the binary in cache
-        client.run('remove "*" -p -f')
+        client.run('remove "*" -p -c')
         client.run('install . --build -g cmake')
         conanbuildinfo = client.load("mylib-release-data.cmake")
         self.assertIn("set(mylib_LIBS_RELEASE mylibname)", conanbuildinfo)

--- a/conans/test/unittests/model/other_settings_test.py
+++ b/conans/test/unittests/model/other_settings_test.py
@@ -148,7 +148,7 @@ class SayConan(ConanFile):
         conan_info = self._get_conaninfo("say/0.1@", client)
         self.assertEqual(conan_info["settings"]["os"], "Windows")
 
-        client.run("remove say/0.1 -f")
+        client.run("remove say/0.1 -c")
         client.run("create . -s os=Linux --build missing")
         # Now read the conaninfo and verify that settings applied is only os and value is windows
         conan_info = self._get_conaninfo("say/0.1@", client)
@@ -237,7 +237,7 @@ class SayConan(ConanFile):
     settings = None
 """
         client.save({CONANFILE: content})
-        client.run("remove say/0.1 -f")
+        client.run("remove say/0.1 -c")
         client.run("create . --build missing")
         self.assertIn('Generated conaninfo.txt', client.out)
         conan_info = self._get_conaninfo("say/0.1", client)
@@ -253,7 +253,7 @@ class SayConan(ConanFile):
     settings = {}
 """
         client.save({CONANFILE: content})
-        client.run("remove say/0.1 -f")
+        client.run("remove say/0.1 -c")
         client.run("create . --build missing")
         self.assertIn('Generated conaninfo.txt', client.out)
 

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -584,7 +584,7 @@ class TestClient(object):
 
     # Higher level operations
     def remove_all(self):
-        self.run("remove '*' -f")
+        self.run("remove '*' -c")
 
     def export(self, ref, conanfile=GenConanfile(), args=None):
         """ export a ConanFile with as "ref" and return the reference with recipe revision


### PR DESCRIPTION
Changelog: Feature: Use --confirm to not request confirmation when removing instead of --force to make cli more homogeneous.
Docs: TODO

Closes: https://github.com/conan-io/conan/issues/12523

