### PR TITLE
[bugfix] AutotoolsToolchain and configure_args overwriting

### DIFF
--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -185,9 +185,10 @@ class AutotoolsToolchain:
         configure_args = []
         configure_args.extend(self.configure_args)
         user_args_str = args_to_string(self.configure_args)
-        for flag, var in (("host", self._host), ("build", self._build), ("target", self._target)):
+        for flag, var in (("--host=", self._host), ("--build=", self._build),
+                          ("--target=", self._target)):
             if var and flag not in user_args_str:
-                configure_args.append('--{}={}'.format(flag, var))
+                configure_args.append('{}{}'.format(flag, var))
 
         args = {"configure_args": args_to_string(configure_args),
                 "make_args":  args_to_string(self.make_args),

--- a/conans/test/unittests/tools/gnu/autotoolschain_test.py
+++ b/conans/test/unittests/tools/gnu/autotoolschain_test.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from conan.tools.gnu import AutotoolsToolchain
@@ -108,3 +110,30 @@ def test_compilers_mapping():
     env = autotoolschain.environment().vars(conanfile)
     for compiler, env_var in autotools_mapping.items():
         assert env[env_var] == f"path_to_{compiler}"
+
+
+@patch("conan.tools.gnu.autotoolstoolchain.save_toolchain_args")
+def test_check_configure_args_overwriting(save_args):
+    # Issue: https://github.com/conan-io/conan/issues/12642
+    settings_build = MockSettings({"os": "Linux",
+                                   "arch": "x86_64",
+                                   "compiler": "gcc",
+                                   "compiler.version": "11",
+                                   "compiler.libcxx": "libstdc++",
+                                   "build_type": "Release"})
+    settings = MockSettings({"os": "Emscripten",
+                             "arch": "wasm"})
+    conanfile = ConanFileMock()
+    conanfile.settings = settings
+    conanfile.settings_build = settings_build
+    at = AutotoolsToolchain(conanfile)
+    at.configure_args.extend([
+        "--with-cross-build=my_path",
+        "--something-host=my_host"
+    ])
+    at.generate_args()
+    configure_args = save_args.call_args[0][0]['configure_args']
+    assert "--build=x86_64-linux-gnu" in configure_args
+    assert "--host=wasm32-local-emscripten" in configure_args
+    assert "--with-cross-build=my_path" in configure_args
+    assert "--something-host=my_host" in configure_args


### PR DESCRIPTION
Changelog: Bugfix: `AutotoolsToolchain.configure_args` was overwriting Conan's pre-calculated arguments.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/12642
