### PR TITLE
[AutotoolsToolchain] Added `self.xxxx_options`

### DIFF
--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -102,8 +102,8 @@ class AutotoolsToolchain:
                               self._get_triplets()
         self.autoreconf_args = self._default_autoreconf_flags()
         self.make_args = []
-        # FIXME: Remove this whenever self.xxx_args disappear
-        self.use_new_options = False  # Remove this whenever self.xxx_args are not used anymore
+        # FIXME: Remove this whenever self.xxx_args are not used anymore
+        self.use_new_options = False
         # New dict-like attributes since Conan 1.57
         self.configure_options = _args_to_dict(self.configure_args)
         self.autoreconf_options = _args_to_dict(self.autoreconf_args)

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -7,7 +7,7 @@ from conan.tools.build.cross_building import cross_building, get_cross_building_
 from conan.tools.env import Environment
 from conan.tools.files.files import save_toolchain_args
 from conan.tools.gnu.get_gnu_triplet import _get_gnu_triplet
-from conan.tools.microsoft import VCVars, is_msvc, msvc_runtime_flag
+from conan.tools.microsoft import VCVars, msvc_runtime_flag
 from conans.errors import ConanException
 from conans.tools import args_to_string
 
@@ -187,7 +187,8 @@ class AutotoolsToolchain:
                                        _get_argument("datarootdir", "resdirs")])
         return [el for el in configure_install_flags if el]
 
-    def _default_autoreconf_flags(self):
+    @staticmethod
+    def _default_autoreconf_flags():
         return ["--force", "--install"]
 
     def _get_triplets(self):
@@ -197,6 +198,48 @@ class AutotoolsToolchain:
             if value:
                 triplets.append(f'{flag}{value}')
         return triplets
+
+    def update_configure_args(self, **updated_flags):
+        """
+        Helper to update/prune flags from ``self.configure_args``.
+
+        :param updated_flags: ``dict`` with arguments as keys and their argument values.
+                              Notice that if argument value is ``None``, this one will be pruned.
+        """
+        self._update_flags("configure_args", **updated_flags)
+
+    def update_make_args(self, **updated_flags):
+        """
+        Helper to update/prune arguments from ``self.make_args``.
+
+        :param updated_flags: ``dict`` with arguments as keys and their argument values.
+                              Notice that if argument value is ``None``, this one will be pruned.
+        """
+        self._update_flags("make_args", **updated_flags)
+
+    def update_autoreconf_args(self, **updated_flags):
+        """
+        Helper to update/prune arguments from ``self.autoreconf_args``.
+
+        :param updated_flags: ``dict`` with arguments as keys and their argument values.
+                              Notice that if argument value is ``None``, this one will be pruned.
+        """
+        self._update_flags("autoreconf_args", **updated_flags)
+
+    def _update_flags(self, attr_name, **updated_flags):
+        _new_flags = []
+        self_args = getattr(self, attr_name)
+        for index, flag in enumerate(self_args):
+            flag_name = flag.split("=")[0].replace("--", "")
+            if flag_name in updated_flags:
+                new_flag_value = updated_flags[flag_name]
+                # if {"build": None} is passed, then "--build=xxxx" will be pruned
+                if new_flag_value is not None:
+                    _new_flags.append(f"--{flag_name}={new_flag_value}")
+            else:
+                _new_flags.append(flag)
+        # Update the current ones
+        setattr(self, attr_name, _new_flags)
 
     def generate_args(self):
         args = {"configure_args": args_to_string(self.configure_args),

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -18,10 +18,6 @@ class AutotoolsToolchain:
         self._namespace = namespace
         self._prefix = prefix
 
-        self.configure_args = self._default_configure_shared_flags() + self._default_configure_install_flags()
-        self.autoreconf_args = self._default_autoreconf_flags()
-        self.make_args = []
-
         # Flags
         self.extra_cxxflags = []
         self.extra_cflags = []
@@ -81,11 +77,11 @@ class AutotoolsToolchain:
         sysroot = sysroot.replace("\\", "/") if sysroot is not None else None
         self.sysroot_flag = "--sysroot {}".format(sysroot) if sysroot else None
 
-        # Initializing the triplets values
-        for flag, value in (("--host=", self._host), ("--build=", self._build),
-                            ("--target=", self._target)):
-            if value:
-                self.configure_args.append(f"{flag}{value}")
+        self.configure_args = self._default_configure_shared_flags() + \
+                              self._default_configure_install_flags() + \
+                              self._get_triplets()
+        self.autoreconf_args = self._default_autoreconf_flags()
+        self.make_args = []
 
         check_using_build_profile(self._conanfile)
 
@@ -193,6 +189,14 @@ class AutotoolsToolchain:
 
     def _default_autoreconf_flags(self):
         return ["--force", "--install"]
+
+    def _get_triplets(self):
+        triplets = []
+        for flag, value in (("--host=", self._host), ("--build=", self._build),
+                            ("--target=", self._target)):
+            if value:
+                triplets.append(f'{flag}{value}')
+        return triplets
 
     def generate_args(self):
         args = {"configure_args": args_to_string(self.configure_args),

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -185,9 +185,10 @@ class AutotoolsToolchain:
         configure_args = []
         configure_args.extend(self.configure_args)
         user_args_str = args_to_string(self.configure_args)
-        for flag, var in (("host", self._host), ("build", self._build), ("target", self._target)):
+        for flag, var in (("--host=", self._host), ("--build=", self._build),
+                          ("--target=", self._target)):
             if var and flag not in user_args_str:
-                configure_args.append('--{}={}'.format(flag, var))
+                configure_args.append('{}{}'.format(flag, var))
 
         args = {"configure_args": args_to_string(configure_args),
                 "make_args":  args_to_string(self.make_args),

--- a/conans/test/unittests/tools/gnu/autotoolschain_test.py
+++ b/conans/test/unittests/tools/gnu/autotoolschain_test.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from conan.tools.gnu import AutotoolsToolchain
@@ -125,3 +127,30 @@ def test_compilers_mapping():
     env = autotoolschain.environment().vars(conanfile)
     for compiler, env_var in autotools_mapping.items():
         assert env[env_var] == f"path_to_{compiler}"
+
+
+@patch("conan.tools.gnu.autotoolstoolchain.save_toolchain_args")
+def test_check_configure_args_overwriting(save_args):
+    # Issue: https://github.com/conan-io/conan/issues/12642
+    settings_build = MockSettings({"os": "Linux",
+                                   "arch": "x86_64",
+                                   "compiler": "gcc",
+                                   "compiler.version": "11",
+                                   "compiler.libcxx": "libstdc++",
+                                   "build_type": "Release"})
+    settings = MockSettings({"os": "Emscripten",
+                             "arch": "wasm"})
+    conanfile = ConanFileMock()
+    conanfile.settings = settings
+    conanfile.settings_build = settings_build
+    at = AutotoolsToolchain(conanfile)
+    at.configure_args.extend([
+        "--with-cross-build=my_path",
+        "--something-host=my_host"
+    ])
+    at.generate_args()
+    configure_args = save_args.call_args[0][0]['configure_args']
+    assert "--build=x86_64-linux-gnu" in configure_args
+    assert "--host=wasm32-local-emscripten" in configure_args
+    assert "--with-cross-build=my_path" in configure_args
+    assert "--something-host=my_host" in configure_args

--- a/conans/test/unittests/tools/gnu/autotoolschain_test.py
+++ b/conans/test/unittests/tools/gnu/autotoolschain_test.py
@@ -185,5 +185,6 @@ def test_update_or_prune_any_args(cross_building_conanfile):
     new_autoreconf_args = args_to_string(at.autoreconf_args)
     assert "--force" not in new_autoreconf_args
     at.make_args.append("--complex-flag=complex-value")
-    at.update_autoreconf_args(**{"complex-flag": "new-value"})
-    assert "--complex-flag=new-value" not in new_autoreconf_args
+    at.update_make_args(**{"complex-flag": "new-value"})
+    new_make_args = args_to_string(at.make_args)
+    assert "--complex-flag=new-value" in new_make_args


### PR DESCRIPTION
Changelog: Feature: Added new attributes (Python dict) to `AutotoolsToolchain`:  `self.configure_options`, `self.autoreconf_options`, and `self.make_options`.
Changelog: Feature: Added new attribute `AutotoolsToolchain.use_new_options` (boolean) to keep backward compatibility.
Changelog: Feature: `AutotoolsToolchain.xxxxx_args` are adequately initialized.
Changelog: Bugfix: `AutotoolsToolchain.configure_args` was overwriting Conan's pre-calculated arguments.
Docs: https://github.com/conan-io/docs/pull/XXXX
Closes: https://github.com/conan-io/conan/issues/12431
Closes: https://github.com/conan-io/conan/issues/12642
Closes: https://github.com/conan-io/conan/issues/12705
Closes: https://github.com/conan-io/conan/issues/12546

Summary:

* Deprecating `AutotoolsToolchain.xxxx_args` attributes (lists) in favor of `AutotoolsToolchain.xxxxx_options` ones (dicts).
* Keeping backward compatibility thanks to `AutotoolsToolchain.use_new_options` (bool) attr. Notice that it should disappear in the future when `xxxx_args` won't be used.