### PR TITLE
fix new Environment ps1 files when spaces in path

### DIFF
--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -58,7 +58,7 @@ def environment_wrap_command(env_filenames, env_folder, cmd, subsystem=None,
         return '{} && {}'.format(launchers, cmd)
     elif ps1s:
         # TODO: at the moment it only works with path without spaces
-        launchers = " ; ".join('{}'.format(f) for f in ps1s)
+        launchers = " ; ".join('"&\'{}\'"'.format(f) for f in ps1s)
         return 'powershell.exe {} ; cmd /c {}'.format(launchers, cmd)
     else:
         return cmd

--- a/conans/test/integration/toolchains/env/test_virtualenv_powershell.py
+++ b/conans/test/integration/toolchains/env/test_virtualenv_powershell.py
@@ -5,13 +5,17 @@ import textwrap
 import pytest
 
 from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient
 from conans.tools import save
 
 
 @pytest.fixture
 def client():
-    client = TestClient(path_with_spaces=False)
+    # We use special characters and spaces, to check everything works
+    # https://github.com/conan-io/conan/issues/12648
+    cache_folder = os.path.join(temp_folder(), "[sub] folder")
+    client = TestClient(cache_folder)
     conanfile = str(GenConanfile("pkg", "0.1"))
     conanfile += """
 


### PR DESCRIPTION
Changelog: Fix: Fix new Environment `.ps1` files when spaces in path
Docs: Omit

Close https://github.com/conan-io/conan/issues/12648
