### PR TITLE
[NMakeToolchain] Refactoring to expose similar interface than other toolchains & honor build config

### DIFF
--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -1,5 +1,6 @@
 from conan.tools._compilers import cppstd_flag, build_type_flags, build_type_link_flags
 from conan.tools.env import Environment
+from conan.tools.microsoft.visual import msvc_runtime_flag, VCVars
 
 
 class NMakeToolchain(object):
@@ -35,7 +36,6 @@ class NMakeToolchain(object):
         self.msvc_runtime_flag = self._get_msvc_runtime_flag()
 
     def _get_msvc_runtime_flag(self):
-        from conan.tools.microsoft import msvc_runtime_flag
         flag = msvc_runtime_flag(self._conanfile)
         if flag:
             flag = f"/{flag}"
@@ -109,5 +109,4 @@ class NMakeToolchain(object):
         env = env or self.environment()
         env = env.vars(self._conanfile, scope=scope)
         env.save_script("conannmaketoolchain")
-        from conan.tools.microsoft import VCVars
         VCVars(self._conanfile).generate(scope=scope)

--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -81,14 +81,19 @@ class NMakeToolchain(object):
         defines = [f"/D{d.replace('=', '#')}" for d in self.defines]
         return nologo + self.cxxflags + self._curate_options(conf_cflags) + defines
 
+    @property
+    def _link(self):
+        nologo = ["/NOLOGO"]
+        return nologo + self.ldflags
+
     def environment(self):
         env = Environment()
         # Injection of compile flags in CL env-var:
         # https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables
         env.append("CL", self._cl)
-        # Injection of link flags in LINK env-var:
+        # Injection of link flags in _LINK_ env-var:
         # https://learn.microsoft.com/en-us/cpp/build/reference/linking
-        env.append("LINK", self.ldflags)
+        env.append("_LINK_", self._link)
         # Also define some special env-vars which can override special NMake macros:
         # https://learn.microsoft.com/en-us/cpp/build/reference/special-nmake-macros
         conf_compilers = self._conanfile.conf.get("tools.build:compiler_executables", default={}, check_type=dict)

--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -35,7 +35,16 @@ class NMakeToolchain(object):
         flag = msvc_runtime_flag(self._conanfile)
         if flag:
             cppflags.append("-{}".format(flag))
+        cppflags.extend(self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list))
+        cppflags.extend(self._conanfile.conf.get("tools.build:cxxflags", default=[], check_type=list))
         return " ".join(cppflags).replace("-", "/")
+
+    @property
+    def link_flags(self):
+        linkflags = []
+        linkflags.extend(self._conanfile.conf.get("tools.build:sharedlinkflags", default=[], check_type=list))
+        linkflags.extend(self._conanfile.conf.get("tools.build:exelinkflags", default=[], check_type=list))
+        return " ".join(linkflags).replace("-", "/")
 
     @property
     def environment(self):
@@ -44,6 +53,7 @@ class NMakeToolchain(object):
             env = Environment()
             # The whole injection of toolchain happens in CL env-var, the others LIBS, _LINK_
             env.append("CL", self.cl_flags)
+            env.append("_LINK_", self.link_flags)
             self._environment = env
         return self._environment
 

--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -99,7 +99,7 @@ class NMakeToolchain(object):
     @property
     def _link(self):
         nologo = ["/nologo"]
-        return nologo + self.ldflags
+        return nologo + self._ldflags
 
     def environment(self):
         env = Environment()

--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -113,6 +113,5 @@ class NMakeToolchain(object):
 
     def generate(self, env=None, scope="build"):
         env = env or self.environment()
-        env = env.vars(self._conanfile, scope=scope)
-        env.save_script("conannmaketoolchain")
+        env.vars(self._conanfile, scope=scope).save_script("conannmaketoolchain")
         VCVars(self._conanfile).generate(scope=scope)

--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -51,7 +51,9 @@ class NMakeToolchain(object):
                 # CL env-var can't accept '=' sign in /D option, it can be replaced by '#' sign:
                 # https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables
                 macro, value = define.split("=", 1)
-                if value.isnumeric():
+                if not value:
+                    curated_defines.append(f"/D{macro}")
+                elif value.isnumeric():
                     curated_defines.append(f"/D{macro}#{value}")
                 else:
                     # if value of macro is a string, it must be protected by protected quotes

--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -93,7 +93,13 @@ class NMakeToolchain(object):
         # https://learn.microsoft.com/en-us/cpp/build/reference/special-nmake-macros
         conf_compilers = self._conanfile.conf.get("tools.build:compiler_executables", default={}, check_type=dict)
         if conf_compilers:
-            compilers_mapping = {"AS": "asm", "CC": "c", "CPP": "cpp", "CXX": "cpp", "RC": "rc"}
+            compilers_mapping = {
+                "AS": "asm",
+                "CC": "c",
+                "CPP": "cpp",
+                "CXX": "cpp",
+                "RC": "rc",
+            }
             for env_var, comp in compilers_mapping.items():
                 if comp in conf_compilers:
                     env.define(env_var, conf_compilers[comp])

--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -1,5 +1,6 @@
-from conan.tools._compilers import cppstd_flag, build_type_flags
+from conan.tools._compilers import cppstd_flag, build_type_flags, build_type_link_flags
 from conan.tools.env import Environment
+from conan.tools.microsoft import msvc_runtime_flag, VCVars
 
 
 class NMakeToolchain(object):
@@ -15,52 +16,96 @@ class NMakeToolchain(object):
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         """
         self._conanfile = conanfile
-        self._environment = None
 
-    @property
-    def cl_flags(self):
-        cppflags = []
+        # Flags
+        self.extra_cflags = []
+        self.extra_cxxflags = []
+        self.extra_ldflags = []
+        self.extra_defines = []
+
+        # Defines
+        self.ndebug = None
         build_type = self._conanfile.settings.get_safe("build_type")
-        if build_type in ['Release', 'RelWithDebInfo', 'MinSizeRel']:
-            cppflags.append("/DNDEBUG")
+        if build_type in ["Release", "RelWithDebInfo", "MinSizeRel"]:
+            self.ndebug = "NDEBUG"
 
-        bt = build_type_flags(self._conanfile.settings)
-        if bt:
-            cppflags.extend(bt)
+        self.build_type_flags = build_type_flags(self._conanfile.settings)
+        self.build_type_link_flags = build_type_link_flags(self._conanfile.settings)
 
-        cppstd = cppstd_flag(self._conanfile.settings)
-        if cppstd:
-            cppflags.append(cppstd)
-        from conan.tools.microsoft import msvc_runtime_flag
+        self.cppstd = cppstd_flag(self._conanfile.settings)
+        self.msvc_runtime_flag = self._get_msvc_runtime_flag()
+
+    def _get_msvc_runtime_flag(self):
         flag = msvc_runtime_flag(self._conanfile)
         if flag:
-            cppflags.append("-{}".format(flag))
-        cppflags.extend(self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list))
-        cppflags.extend(self._conanfile.conf.get("tools.build:cxxflags", default=[], check_type=list))
-        return " ".join(cppflags).replace("-", "/")
+            flag = f"/{flag}"
+        return flag
+
+    def _curate_options(self, options):
+        return [f"{opt[0].replace('-', '/')}{opt[1:]}" for opt in options if len(opt) > 1]
 
     @property
-    def link_flags(self):
-        linkflags = []
-        linkflags.extend(self._conanfile.conf.get("tools.build:sharedlinkflags", default=[], check_type=list))
-        linkflags.extend(self._conanfile.conf.get("tools.build:exelinkflags", default=[], check_type=list))
-        return " ".join(linkflags).replace("-", "/")
+    def cflags(self):
+        bt_flags = self.build_type_flags if self.build_type_flags else []
+        rt_flags = [self.msvc_runtime_flag] if self.msvc_runtime_flag else []
+        conf_cflags = self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
+        return self._curate_options(bt_flags + rt_flags + conf_cflags + self.extra_cflags)
 
     @property
+    def cxxflags(self):
+        bt_flags = self.build_type_flags if self.build_type_flags else []
+        rt_flags = [self.msvc_runtime_flag] if self.msvc_runtime_flag else []
+        cppstd_flags = [self.cppstd] if self.cppstd else []
+        conf_cxxflags = self._conanfile.conf.get("tools.build:cxxflags", default=[], check_type=list)
+        return self._curate_options(bt_flags + rt_flags + cppstd_flags + conf_cxxflags + self.extra_cxxflags)
+
+    @property
+    def ldflags(self):
+        conf_shared_ldflags = self._conanfile.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)
+        conf_exe_ldflags = self._conanfile.conf.get("tools.build:exelinkflags", default=[], check_type=list)
+        return self._curate_options(conf_shared_ldflags + conf_exe_ldflags + self.extra_ldflags)
+
+    @property
+    def defines(self):
+        ndebug_defines = [self.ndebug] if self.ndebug else []
+        conf_defines = self._conanfile.conf.get("tools.build:defines", default=[], check_type=list)
+        return ndebug_defines + conf_defines + self.extra_defines
+
+    @property
+    def _cl(self):
+        nologo = ["/NOLOGO"]
+        conf_cflags = self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
+        # CL env-var can't accept '=' sign in /D option, it can be replaced by '#' sign:
+        # https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables
+        defines = [f"/D{d.replace('=', '#')}" for d in self.defines]
+        return nologo + self.cxxflags + self._curate_options(conf_cflags) + defines
+
     def environment(self):
-        # TODO: Seems we want to make this uniform, equal to other generators
-        if self._environment is None:
-            env = Environment()
-            # The whole injection of toolchain happens in CL env-var, the others LIBS, _LINK_
-            env.append("CL", self.cl_flags)
-            env.append("_LINK_", self.link_flags)
-            self._environment = env
-        return self._environment
+        env = Environment()
+        # Injection of compile flags CL env-var:
+        # https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables
+        env.append("CL", self._cl)
+        # Injection of link flags in LINK env-var:
+        # https://learn.microsoft.com/en-us/cpp/build/reference/linking
+        env.append("LINK", self.ldflags)
+        # Also define some special env-vars which can override special NMake macros:
+        # https://learn.microsoft.com/en-us/cpp/build/reference/special-nmake-macros
+        conf_compilers = self._conanfile.conf.get("tools.build:compiler_executables", default={}, check_type=dict)
+        if conf_compilers:
+            compilers_mapping = {"AS": "asm", "CC": "c", "CPP": "cpp", "CXX": "cpp", "RC": "rc"}
+            for env_var, comp in compilers_mapping.items():
+                if comp in conf_compilers:
+                    env.define(env_var, conf_compilers[comp])
+        env.append("CFLAGS", self.cflags)
+        env.append("CPPFLAGS", self.cxxflags)
+        env.append("CXXFLAGS", self.cxxflags)
+        return env
 
-    def vars(self, scope="build"):
-        return self.environment.vars(self._conanfile, scope=scope)
+    def vars(self):
+        return self.environment().vars(self._conanfile, scope="build")
 
-    def generate(self, scope="build"):
-        self.vars(scope).save_script("conannmaketoolchain")
-        from conan.tools.microsoft import VCVars
-        VCVars(self._conanfile).generate()
+    def generate(self, env=None, scope="build"):
+        env = env or self.environment()
+        env = env.vars(self._conanfile, scope=scope)
+        env.save_script("conannmaketoolchain")
+        VCVars(self._conanfile).generate(scope=scope)

--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -48,10 +48,13 @@ class NMakeToolchain(object):
         curated_defines = []
         for define in defines:
             if "=" in define:
+                # CL env-var can't accept '=' sign in /D option, it can be replaced by '#' sign:
+                # https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables
                 macro, value = define.split("=", 1)
                 if value.isnumeric():
                     curated_defines.append(f"/D{macro}#{value}")
                 else:
+                    # if value of macro is a string, it must be protected by protected quotes
                     curated_defines.append(f"/D{macro}#\\\"{value}\\\"")
             else:
                 curated_defines.append(f"/D{define}")
@@ -89,8 +92,6 @@ class NMakeToolchain(object):
     def _cl(self):
         nologo = ["/nologo"]
         conf_cflags = self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
-        # CL env-var can't accept '=' sign in /D option, it can be replaced by '#' sign:
-        # https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables
         return nologo + self.cxxflags + self._curate_options(conf_cflags) + self._defines_for_cl(self.defines)
 
     @property

--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -74,7 +74,7 @@ class NMakeToolchain(object):
 
     @property
     def _cl(self):
-        nologo = ["/NOLOGO"]
+        nologo = ["/nologo"]
         conf_cflags = self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
         # CL env-var can't accept '=' sign in /D option, it can be replaced by '#' sign:
         # https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables
@@ -83,7 +83,7 @@ class NMakeToolchain(object):
 
     @property
     def _link(self):
-        nologo = ["/NOLOGO"]
+        nologo = ["/nologo"]
         return nologo + self.ldflags
 
     def environment(self):

--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -61,9 +61,10 @@ class NMakeToolchain(object):
 
     @property
     def ldflags(self):
+        bt_ldflags = self.build_type_link_flags if self.build_type_link_flags else []
         conf_shared_ldflags = self._conanfile.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)
         conf_exe_ldflags = self._conanfile.conf.get("tools.build:exelinkflags", default=[], check_type=list)
-        return self._curate_options(conf_shared_ldflags + conf_exe_ldflags + self.extra_ldflags)
+        return self._curate_options(bt_ldflags + conf_shared_ldflags + conf_exe_ldflags + self.extra_ldflags)
 
     @property
     def defines(self):

--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -23,29 +23,11 @@ class NMakeToolchain(object):
         self.extra_ldflags = []
         self.extra_defines = []
 
-        # Defines
-        self._ndebug = None
-        build_type = self._conanfile.settings.get_safe("build_type")
-        if build_type in ["Release", "RelWithDebInfo", "MinSizeRel"]:
-            self._ndebug = "NDEBUG"
-
-        self._build_type_flags = build_type_flags(self._conanfile.settings)
-        self._build_type_link_flags = build_type_link_flags(self._conanfile.settings)
-
-        self._cppstd = cppstd_flag(self._conanfile.settings)
-        self._msvc_runtime_flag = self._get_msvc_runtime_flag()
-
-    def _get_msvc_runtime_flag(self):
-        flag = msvc_runtime_flag(self._conanfile)
-        if flag:
-            flag = f"/{flag}"
-        return flag
-
-    def _sanitized_options(self, options):
+    def _format_options(self, options):
         return [f"{opt[0].replace('-', '/')}{opt[1:]}" for opt in options if len(opt) > 1]
 
-    def _sanitized_defines(self, defines):
-        sanitized_defines = []
+    def _format_defines(self, defines):
+        formated_defines = []
         for define in defines:
             if "=" in define:
                 # CL env-var can't accept '=' sign in /D option, it can be replaced by '#' sign:
@@ -54,47 +36,51 @@ class NMakeToolchain(object):
                 if value and not value.isnumeric():
                     value = f'\\"{value}\\"'
                 define = f"{macro}#{value}"
-            sanitized_defines.append(f"/D{define}")
-        return sanitized_defines
-
-    @property
-    def _cflags(self):
-        bt_flags = self._build_type_flags if self._build_type_flags else []
-        rt_flags = [self._msvc_runtime_flag] if self._msvc_runtime_flag else []
-        conf_cflags = self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
-        return self._sanitized_options(bt_flags + rt_flags + conf_cflags + self.extra_cflags)
-
-    @property
-    def _cxxflags(self):
-        bt_flags = self._build_type_flags if self._build_type_flags else []
-        rt_flags = [self._msvc_runtime_flag] if self._msvc_runtime_flag else []
-        cppstd_flags = [self._cppstd] if self._cppstd else []
-        conf_cxxflags = self._conanfile.conf.get("tools.build:cxxflags", default=[], check_type=list)
-        return self._sanitized_options(bt_flags + rt_flags + cppstd_flags + conf_cxxflags + self.extra_cxxflags)
-
-    @property
-    def _ldflags(self):
-        bt_ldflags = self._build_type_link_flags if self._build_type_link_flags else []
-        conf_shared_ldflags = self._conanfile.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)
-        conf_exe_ldflags = self._conanfile.conf.get("tools.build:exelinkflags", default=[], check_type=list)
-        return self._sanitized_options(bt_ldflags + conf_shared_ldflags + conf_exe_ldflags + self.extra_ldflags)
-
-    @property
-    def _defines(self):
-        ndebug_defines = [self._ndebug] if self._ndebug else []
-        conf_defines = self._conanfile.conf.get("tools.build:defines", default=[], check_type=list)
-        return self._sanitized_defines(ndebug_defines + conf_defines + self.extra_defines)
+            formated_defines.append(f"/D{define}")
+        return formated_defines
 
     @property
     def _cl(self):
-        nologo = ["/nologo"]
-        conf_cflags = self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
-        return nologo + self._cxxflags + self._sanitized_options(conf_cflags) + self._defines
+        bt_flags = build_type_flags(self._conanfile.settings)
+        bt_flags = bt_flags if bt_flags else []
+
+        rt_flags = msvc_runtime_flag(self._conanfile)
+        rt_flags = [f"/{rt_flags}"] if rt_flags else []
+
+        cflags = []
+        cflags.extend(self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list))
+        cflags.extend(self.extra_cflags)
+
+        cxxflags = []
+        cppstd = cppstd_flag(self._conanfile.settings)
+        if cppstd:
+            cxxflags.append(cppstd)
+        cxxflags.extend(self._conanfile.conf.get("tools.build:cxxflags", default=[], check_type=list))
+        cxxflags.extend(self.extra_cxxflags)
+
+        defines = []
+        build_type = self._conanfile.settings.get_safe("build_type")
+        if build_type in ["Release", "RelWithDebInfo", "MinSizeRel"]:
+            defines.append("NDEBUG")
+        defines.extend(self._conanfile.conf.get("tools.build:defines", default=[], check_type=list))
+        defines.extend(self.extra_defines)
+
+        return ["/nologo"] + \
+               self._format_options(bt_flags + rt_flags + cflags + cxxflags) + \
+               self._format_defines(defines)
 
     @property
     def _link(self):
-        nologo = ["/nologo"]
-        return nologo + self._ldflags
+        bt_ldflags = build_type_link_flags(self._conanfile.settings)
+        bt_ldflags = bt_ldflags if bt_ldflags else []
+
+        ldflags = []
+        ldflags.extend(bt_ldflags)
+        ldflags.extend(self._conanfile.conf.get("tools.build:sharedlinkflags", default=[], check_type=list))
+        ldflags.extend(self._conanfile.conf.get("tools.build:exelinkflags", default=[], check_type=list))
+        ldflags.extend(self.extra_ldflags)
+
+        return ["/nologo"] + self._format_options(ldflags)
 
     def environment(self):
         env = Environment()
@@ -118,9 +104,6 @@ class NMakeToolchain(object):
             for env_var, comp in compilers_mapping.items():
                 if comp in conf_compilers:
                     env.define(env_var, conf_compilers[comp])
-        env.append("CFLAGS", self._cflags)
-        env.append("CPPFLAGS", self._cxxflags)
-        env.append("CXXFLAGS", self._cxxflags)
         return env
 
     def vars(self):

--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -83,7 +83,7 @@ class NMakeToolchain(object):
 
     def environment(self):
         env = Environment()
-        # Injection of compile flags CL env-var:
+        # Injection of compile flags in CL env-var:
         # https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables
         env.append("CL", self._cl)
         # Injection of link flags in LINK env-var:

--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -1,6 +1,5 @@
 from conan.tools._compilers import cppstd_flag, build_type_flags, build_type_link_flags
 from conan.tools.env import Environment
-from conan.tools.microsoft import msvc_runtime_flag, VCVars
 
 
 class NMakeToolchain(object):
@@ -36,6 +35,7 @@ class NMakeToolchain(object):
         self.msvc_runtime_flag = self._get_msvc_runtime_flag()
 
     def _get_msvc_runtime_flag(self):
+        from conan.tools.microsoft import msvc_runtime_flag
         flag = msvc_runtime_flag(self._conanfile)
         if flag:
             flag = f"/{flag}"
@@ -109,4 +109,5 @@ class NMakeToolchain(object):
         env = env or self.environment()
         env = env.vars(self._conanfile, scope=scope)
         env.save_script("conannmaketoolchain")
+        from conan.tools.microsoft import VCVars
         VCVars(self._conanfile).generate(scope=scope)

--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -51,15 +51,10 @@ class NMakeToolchain(object):
                 # CL env-var can't accept '=' sign in /D option, it can be replaced by '#' sign:
                 # https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables
                 macro, value = define.split("=", 1)
-                if not value:
-                    sanitized_defines.append(f"/D{macro}")
-                elif value.isnumeric():
-                    sanitized_defines.append(f"/D{macro}#{value}")
-                else:
-                    # if value of macro is a string, it must be protected by protected quotes
-                    sanitized_defines.append(f"/D{macro}#\\\"{value}\\\"")
-            else:
-                sanitized_defines.append(f"/D{define}")
+                if value and not value.isnumeric():
+                    value = f'\\"{value}\\"'
+                define = f"{macro}#{value}"
+            sanitized_defines.append(f"/D{define}")
         return sanitized_defines
 
     @property

--- a/conans/test/functional/toolchains/test_nmake_toolchain.py
+++ b/conans/test/functional/toolchains/test_nmake_toolchain.py
@@ -8,11 +8,13 @@ from conans.test.functional.utils import check_exe_run
 from conans.test.utils.tools import TestClient
 
 
-@pytest.mark.parametrize("compiler, version, runtime, cppstd, build_type",
-                         [("msvc", "190", "dynamic", "14", "Release"),
-                          ("msvc", "191", "static", "17", "Debug")])
+@pytest.mark.parametrize("compiler, version, runtime, cppstd, build_type, cflags, cxxflags, sharedlinkflags, exelinkflags",
+                         [("msvc", "190", "dynamic", "14", "Release", [], [], [], []),
+                          ("msvc", "190", "dynamic", "14", "Release", ["/GL"], ["/GL"], ["/LTCG"], ["/LTCG"]),
+                          ("msvc", "191", "static", "17", "Debug", [], [], [], [])])
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
-def test_toolchain_nmake(compiler, version, runtime, cppstd, build_type):
+def test_toolchain_nmake(compiler, version, runtime, cppstd, build_type,
+                         cflags, cxxflags, sharedlinkflags, exelinkflags):
     client = TestClient(path_with_spaces=False)
     settings = {"compiler": compiler,
                 "compiler.version": version,
@@ -21,10 +23,18 @@ def test_toolchain_nmake(compiler, version, runtime, cppstd, build_type):
                 "build_type": build_type,
                 "arch": "x86_64"}
 
+    conf = {
+        "tools.build:cflags": "[{}]".format(",".join([f"'{flag}'" for flag in cflags])) if cflags else "",
+        "tools.build:cxxflags": "[{}]".format(",".join([f"'{flag}'" for flag in cxxflags])) if cxxflags else "",
+        "tools.build:sharedlinkflags": "[{}]".format(",".join([f"'{flag}'" for flag in sharedlinkflags])) if sharedlinkflags else "",
+        "tools.build:exelinkflags": "[{}]".format(",".join([f"'{flag}'" for flag in exelinkflags])) if exelinkflags else "",
+    }
+
     # Build the profile according to the settings provided
     settings = " ".join('-s %s="%s"' % (k, v) for k, v in settings.items() if v)
+    conf = " ".join(f'-c {k}="{v}"' for k, v in conf.items() if v)
     client.run("new dep/1.0 -m=cmake_lib")
-    client.run(f'create . -tf=None {settings} '
+    client.run(f'create . -tf=None {settings} {conf} '
                f'-c tools.cmake.cmaketoolchain:generator="Visual Studio 15"')
 
     conanfile = textwrap.dedent("""
@@ -50,7 +60,7 @@ def test_toolchain_nmake(compiler, version, runtime, cppstd, build_type):
                  "makefile": makefile,
                  "simple.cpp": gen_function_cpp(name="main", includes=["dep"], calls=["dep"])},
                 clean_first=True)
-    client.run("install . {}".format(settings))
+    client.run(f"install . {settings} {conf}")
     client.run("build .")
     client.run_command("simple.exe")
     assert "dep/1.0" in client.out

--- a/conans/test/functional/toolchains/test_nmake_toolchain.py
+++ b/conans/test/functional/toolchains/test_nmake_toolchain.py
@@ -8,13 +8,17 @@ from conans.test.functional.utils import check_exe_run
 from conans.test.utils.tools import TestClient
 
 
-@pytest.mark.parametrize("compiler, version, runtime, cppstd, build_type, cflags, cxxflags, sharedlinkflags, exelinkflags",
-                         [("msvc", "190", "dynamic", "14", "Release", [], [], [], []),
-                          ("msvc", "190", "dynamic", "14", "Release", ["/GL"], ["/GL"], ["/LTCG"], ["/LTCG"]),
-                          ("msvc", "191", "static", "17", "Debug", [], [], [], [])])
+@pytest.mark.parametrize(
+    "compiler, version, runtime, cppstd, build_type, defines, cflags, cxxflags, sharedlinkflags, exelinkflags",
+    [
+        ("msvc", "193", "dynamic", "14", "Release", [], [], [], [], []),
+        ("msvc", "193", "dynamic", "14", "Release", ["TEST_DEFINITION1", "TEST_DEFINITION2=0", "TEST_DEFINITION3=TestPpdValue3"], ["/GL"], ["/GL"], ["/LTCG"], ["/LTCG"]),
+        ("msvc", "193", "static", "17", "Debug", [], [], [], [], []),
+    ],
+)
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
 def test_toolchain_nmake(compiler, version, runtime, cppstd, build_type,
-                         cflags, cxxflags, sharedlinkflags, exelinkflags):
+                         defines, cflags, cxxflags, sharedlinkflags, exelinkflags):
     client = TestClient(path_with_spaces=False)
     settings = {"compiler": compiler,
                 "compiler.version": version,
@@ -23,19 +27,29 @@ def test_toolchain_nmake(compiler, version, runtime, cppstd, build_type,
                 "build_type": build_type,
                 "arch": "x86_64"}
 
+    serialize_array = lambda arr: "[{}]".format(",".join([f"'{v}'" for v in arr]))
     conf = {
-        "tools.build:cflags": "[{}]".format(",".join([f"'{flag}'" for flag in cflags])) if cflags else "",
-        "tools.build:cxxflags": "[{}]".format(",".join([f"'{flag}'" for flag in cxxflags])) if cxxflags else "",
-        "tools.build:sharedlinkflags": "[{}]".format(",".join([f"'{flag}'" for flag in sharedlinkflags])) if sharedlinkflags else "",
-        "tools.build:exelinkflags": "[{}]".format(",".join([f"'{flag}'" for flag in exelinkflags])) if exelinkflags else "",
+        "tools.build:defines": serialize_array(defines) if defines else "",
+        "tools.build:cflags": serialize_array(cflags) if cflags else "",
+        "tools.build:cxxflags": serialize_array(cxxflags) if cxxflags else "",
+        "tools.build:sharedlinkflags": serialize_array(sharedlinkflags) if sharedlinkflags else "",
+        "tools.build:exelinkflags": serialize_array(exelinkflags) if exelinkflags else "",
     }
 
     # Build the profile according to the settings provided
     settings = " ".join('-s %s="%s"' % (k, v) for k, v in settings.items() if v)
     conf = " ".join(f'-c {k}="{v}"' for k, v in conf.items() if v)
     client.run("new dep/1.0 -m=cmake_lib")
-    client.run(f'create . -tf=None {settings} {conf} '
-               f'-c tools.cmake.cmaketoolchain:generator="Visual Studio 15"')
+    client.run(f'create . -tf=None {settings} {conf}')
+
+    # Rearrange defines to macro / value dict
+    conf_preprocessors = {}
+    for define in defines:
+        if "=" in define:
+            key, value = define.split("=", 1)
+            conf_preprocessors[key] = value
+        else:
+            conf_preprocessors[define] = "1"
 
     conanfile = textwrap.dedent("""
         from conan import ConanFile
@@ -51,17 +65,20 @@ def test_toolchain_nmake(compiler, version, runtime, cppstd, build_type,
         all: simple.exe
 
         .cpp.obj:
-          cl $(cppflags) $*.cpp
+          $(CPP) $(CPPFLAGS) $*.cpp
 
         simple.exe: simple.obj
-          cl $(cppflags) simple.obj
+          $(CPP) $(CPPFLAGS) simple.obj
         """)
     client.save({"conanfile.py": conanfile,
                  "makefile": makefile,
-                 "simple.cpp": gen_function_cpp(name="main", includes=["dep"], calls=["dep"])},
+                 "simple.cpp": gen_function_cpp(name="main", includes=["dep"], calls=["dep"], preprocessor=conf_preprocessors.keys())},
                 clean_first=True)
     client.run(f"install . {settings} {conf}")
     client.run("build .")
     client.run_command("simple.exe")
     assert "dep/1.0" in client.out
+    assert f"main: {'Debug' if build_type == 'Debug' else 'Release'}!" in client.out
+    for preprocessor_name, preprocessor_value in conf_preprocessors.items():
+        assert f"{preprocessor_name}: {preprocessor_value}" in client.out
     check_exe_run(client.out, "main", "msvc", version, build_type, "x86_64", cppstd)

--- a/conans/test/functional/toolchains/test_nmake_toolchain.py
+++ b/conans/test/functional/toolchains/test_nmake_toolchain.py
@@ -11,11 +11,11 @@ from conans.test.utils.tools import TestClient
 @pytest.mark.parametrize(
     "compiler, version, runtime, cppstd, build_type, defines, cflags, cxxflags, sharedlinkflags, exelinkflags",
     [
-        ("msvc", "193", "dynamic", "14", "Release", [], [], [], [], []),
-        ("msvc", "193", "dynamic", "14", "Release",
+        ("msvc", "190", "dynamic", "14", "Release", [], [], [], [], []),
+        ("msvc", "190", "dynamic", "14", "Release",
          ["TEST_DEFINITION1", "TEST_DEFINITION2=0", "TEST_DEFINITION3=", "TEST_DEFINITION4=TestPpdValue4"],
          ["/GL"], ["/GL"], ["/LTCG"], ["/LTCG"]),
-        ("msvc", "193", "static", "17", "Debug", [], [], [], [], []),
+        ("msvc", "191", "static", "17", "Debug", [], [], [], [], []),
     ],
 )
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")

--- a/conans/test/functional/toolchains/test_nmake_toolchain.py
+++ b/conans/test/functional/toolchains/test_nmake_toolchain.py
@@ -69,10 +69,10 @@ def test_toolchain_nmake(compiler, version, runtime, cppstd, build_type,
         all: simple.exe
 
         .cpp.obj:
-          $(CPP) $(CPPFLAGS) $*.cpp
+          $(CPP) $*.cpp
 
         simple.exe: simple.obj
-          $(CPP) $(CPPFLAGS) simple.obj
+          $(CPP) simple.obj
         """)
     client.save({"conanfile.py": conanfile,
                  "makefile": makefile,

--- a/conans/test/functional/toolchains/test_nmake_toolchain.py
+++ b/conans/test/functional/toolchains/test_nmake_toolchain.py
@@ -49,9 +49,8 @@ def test_toolchain_nmake(compiler, version, runtime, cppstd, build_type,
     for define in defines:
         if "=" in define:
             key, value = define.split("=", 1)
-            if not value:
-                conf_preprocessors[key] = "1"
-            else:
+            # gen_function_cpp doesn't properly handle empty macros
+            if value:
                 conf_preprocessors[key] = value
         else:
             conf_preprocessors[define] = "1"

--- a/conans/test/functional/toolchains/test_nmake_toolchain.py
+++ b/conans/test/functional/toolchains/test_nmake_toolchain.py
@@ -11,11 +11,11 @@ from conans.test.utils.tools import TestClient
 @pytest.mark.parametrize(
     "compiler, version, runtime, cppstd, build_type, defines, cflags, cxxflags, sharedlinkflags, exelinkflags",
     [
-        ("msvc", "190", "dynamic", "14", "Release", [], [], [], [], []),
-        ("msvc", "190", "dynamic", "14", "Release",
+        ("msvc", "193", "dynamic", "14", "Release", [], [], [], [], []),
+        ("msvc", "193", "dynamic", "14", "Release",
          ["TEST_DEFINITION1", "TEST_DEFINITION2=0", "TEST_DEFINITION3=", "TEST_DEFINITION4=TestPpdValue4"],
          ["/GL"], ["/GL"], ["/LTCG"], ["/LTCG"]),
-        ("msvc", "191", "static", "17", "Debug", [], [], [], [], []),
+        ("msvc", "193", "static", "17", "Debug", [], [], [], [], []),
     ],
 )
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
@@ -82,7 +82,4 @@ def test_toolchain_nmake(compiler, version, runtime, cppstd, build_type,
     client.run("build .")
     client.run_command("simple.exe")
     assert "dep/1.0" in client.out
-    assert f"main: {'Debug' if build_type == 'Debug' else 'Release'}!" in client.out
-    for preprocessor_name, preprocessor_value in conf_preprocessors.items():
-        assert f"{preprocessor_name}: {preprocessor_value}" in client.out
-    check_exe_run(client.out, "main", "msvc", version, build_type, "x86_64", cppstd)
+    check_exe_run(client.out, "main", "msvc", version, build_type, "x86_64", cppstd, conf_preprocessors)

--- a/conans/test/functional/toolchains/test_nmake_toolchain.py
+++ b/conans/test/functional/toolchains/test_nmake_toolchain.py
@@ -12,7 +12,9 @@ from conans.test.utils.tools import TestClient
     "compiler, version, runtime, cppstd, build_type, defines, cflags, cxxflags, sharedlinkflags, exelinkflags",
     [
         ("msvc", "193", "dynamic", "14", "Release", [], [], [], [], []),
-        ("msvc", "193", "dynamic", "14", "Release", ["TEST_DEFINITION1", "TEST_DEFINITION2=0", "TEST_DEFINITION3=TestPpdValue3"], ["/GL"], ["/GL"], ["/LTCG"], ["/LTCG"]),
+        ("msvc", "193", "dynamic", "14", "Release",
+         ["TEST_DEFINITION1", "TEST_DEFINITION2=0", "TEST_DEFINITION3=", "TEST_DEFINITION4=TestPpdValue4"],
+         ["/GL"], ["/GL"], ["/LTCG"], ["/LTCG"]),
         ("msvc", "193", "static", "17", "Debug", [], [], [], [], []),
     ],
 )
@@ -47,7 +49,10 @@ def test_toolchain_nmake(compiler, version, runtime, cppstd, build_type,
     for define in defines:
         if "=" in define:
             key, value = define.split("=", 1)
-            conf_preprocessors[key] = value
+            if not value:
+                conf_preprocessors[key] = "1"
+            else:
+                conf_preprocessors[key] = value
         else:
             conf_preprocessors[define] = "1"
 


### PR DESCRIPTION
Changelog: Fix: Refactoring of `NMakeToolchain` to expose similar attributes than other toolchains, and honor build config like cflags, cxxflags, sharedlinkflags, exelinkflags, defines & compiler_executables.
Docs: https://github.com/conan-io/docs/pull/2848

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
