### PR TITLE
Fix MockInfoProperty to mimic list interface

### DIFF
--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -50,7 +50,7 @@ class MockInfoProperty(object):
     def __getattr__(self, attr):
         if attr != "_message":
             ConanOutput().warning(self._message)
-        return list()
+        return []
 
     def __setattr__(self, attr, value):
         if attr != "_message":

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -50,6 +50,7 @@ class MockInfoProperty(object):
     def __getattr__(self, attr):
         if attr != "_message":
             ConanOutput().warning(self._message)
+        return list()
 
     def __setattr__(self, attr, value):
         if attr != "_message":

--- a/conans/test/integration/conan_v2/test_legacy_cpp_info.py
+++ b/conans/test/integration/conan_v2/test_legacy_cpp_info.py
@@ -24,6 +24,7 @@ def test_legacy_names_filenames():
                 self.cpp_info.build_modules["cmake_find_package_multi"] = ["nice_rel_path"]
 
                 self.env_info.whatever = "whatever-env_info"
+                self.env_info.PATH.append("/path/to/folder")
                 self.user_info.whatever = "whatever-user_info"
         """)
     c.save({"conanfile.py": conanfile})


### PR DESCRIPTION
Usage of this in recipes:
```
self.env_info.PATH.append("/path/to/folder")
```

is failing in 2.0.0b6 with the following error:
```
'NoneType' object has no attribute 'append'
```

because the `env_info` accessor was not returning an object with a list-like interface. The 1.x implementation would have returned an empty list, so this does the same - still with no consequence as usage of `env_info` in 2.0 is a no-op.

