### PR TITLE
fix issue with CMakeDeps not creating xxx-config.cmake in build context

### DIFF
--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -74,7 +74,7 @@ class CMakeDeps(object):
             # Require is not used at the moment, but its information could be used,
             # and will be used in Conan 2.0
             # Filter the build_requires not activated with cmakedeps.build_context_activated
-            if dep.is_build_context and dep.ref.name not in self.build_context_activated:
+            if require.build and dep.ref.name not in self.build_context_activated:
                 continue
 
             cmake_find_mode = self.get_property("cmake_find_mode", dep)


### PR DESCRIPTION
Changelog: Bugfix: Fix issue with `CMakeDeps` not creating `xxx-config.cmake` files in build context.
Docs: Omit


Close: https://github.com/conan-io/conan/issues/12664