### PR TITLE
Add `conan.tools.gnu.is_mingw()` in conan API

### DIFF
--- a/conan/tools/gnu/__init__.py
+++ b/conan/tools/gnu/__init__.py
@@ -1,5 +1,6 @@
 from conan.tools.gnu.autotools import Autotools
 from conan.tools.gnu.autotoolstoolchain import AutotoolsToolchain
 from conan.tools.gnu.autotoolsdeps import AutotoolsDeps
+from conan.tools.gnu.mingw import is_mingw
 from conan.tools.gnu.pkgconfig import PkgConfig
 from conan.tools.gnu.pkgconfigdeps import PkgConfigDeps

--- a/conan/tools/gnu/mingw.py
+++ b/conan/tools/gnu/mingw.py
@@ -6,9 +6,10 @@ def is_mingw(conanfile):
     """
     host_os = conanfile.settings.get_safe("os")
     host_subsystem = conanfile.settings.get_safe("os.subsystem")
-    is_windows_native = host_os == "Windows" and host_subsystem not in ["cygwin", "wsl"]
+    is_wsl = host_os == "Windows" and host_subsystem == "wsl"
+    is_cygwin = host_os == "Windows" and host_subsystem == "cygwin"
     host_compiler = conanfile.settings.get_safe("compiler")
-    is_mingw_gcc = is_windows_native and host_compiler == "gcc"
-    is_mingw_clang = is_windows_native and host_compiler == "clang" and \
+    is_mingw_gcc = host_os == "Windows" and not (is_wsl or is_cygwin) and host_compiler == "gcc"
+    is_mingw_clang = host_os == "Windows" and not (is_wsl or is_cygwin) and host_compiler == "clang" and \
                      not conanfile.settings.get_safe("compiler.runtime")
     return is_mingw_gcc or is_mingw_clang

--- a/conan/tools/gnu/mingw.py
+++ b/conan/tools/gnu/mingw.py
@@ -5,8 +5,10 @@ def is_mingw(conanfile):
     :return: True, if the host compiler is related to MinGW, otherwise False.
     """
     host_os = conanfile.settings.get_safe("os")
+    host_subsystem = conanfile.settings.get_safe("os.subsystem")
+    is_windows_native = host_os == "Windows" and host_subsystem not in ["cygwin", "wsl"]
     host_compiler = conanfile.settings.get_safe("compiler")
-    is_mingw_gcc = host_os == "Windows" and host_compiler == "gcc"
-    is_mingw_clang = host_os == "Windows" and host_compiler == "clang" and \
+    is_mingw_gcc = is_windows_native and host_compiler == "gcc"
+    is_mingw_clang = is_windows_native and host_compiler == "clang" and \
                      not conanfile.settings.get_safe("compiler.runtime")
     return is_mingw_gcc or is_mingw_clang

--- a/conan/tools/gnu/mingw.py
+++ b/conan/tools/gnu/mingw.py
@@ -1,0 +1,12 @@
+def is_mingw(conanfile):
+    """
+    Validate if current compiler in host setttings is related to MinGW
+    :param conanfile: ConanFile instance
+    :return: True, if the host compiler is related to MinGW, otherwise False.
+    """
+    host_os = conanfile.settings.get_safe("os")
+    host_compiler = conanfile.settings.get_safe("compiler")
+    is_mingw_gcc = host_os == "Windows" and host_compiler == "gcc"
+    is_mingw_clang = host_os == "Windows" and host_compiler == "clang" and \
+                     not conanfile.settings.get_safe("compiler.runtime")
+    return is_mingw_gcc or is_mingw_clang

--- a/conan/tools/gnu/mingw.py
+++ b/conan/tools/gnu/mingw.py
@@ -6,10 +6,9 @@ def is_mingw(conanfile):
     """
     host_os = conanfile.settings.get_safe("os")
     host_subsystem = conanfile.settings.get_safe("os.subsystem")
-    is_wsl = host_os == "Windows" and host_subsystem == "wsl"
     is_cygwin = host_os == "Windows" and host_subsystem == "cygwin"
     host_compiler = conanfile.settings.get_safe("compiler")
-    is_mingw_gcc = host_os == "Windows" and not (is_wsl or is_cygwin) and host_compiler == "gcc"
-    is_mingw_clang = host_os == "Windows" and not (is_wsl or is_cygwin) and host_compiler == "clang" and \
+    is_mingw_gcc = host_os == "Windows" and not is_cygwin and host_compiler == "gcc"
+    is_mingw_clang = host_os == "Windows" and not is_cygwin and host_compiler == "clang" and \
                      not conanfile.settings.get_safe("compiler.runtime")
     return is_mingw_gcc or is_mingw_clang

--- a/conan/tools/gnu/mingw.py
+++ b/conan/tools/gnu/mingw.py
@@ -5,8 +5,7 @@ def is_mingw(conanfile):
     :return: True, if the host compiler is related to MinGW, otherwise False.
     """
     host_os = conanfile.settings.get_safe("os")
-    host_subsystem = conanfile.settings.get_safe("os.subsystem")
-    is_cygwin = host_os == "Windows" and host_subsystem == "cygwin"
+    is_cygwin = host_os == "Windows" and conanfile.settings.get_safe("os.subsystem") == "cygwin"
     host_compiler = conanfile.settings.get_safe("compiler")
     is_mingw_gcc = host_os == "Windows" and not is_cygwin and host_compiler == "gcc"
     is_mingw_clang = host_os == "Windows" and not is_cygwin and host_compiler == "clang" and \

--- a/conans/test/unittests/tools/gnu/mingw_test.py
+++ b/conans/test/unittests/tools/gnu/mingw_test.py
@@ -1,0 +1,49 @@
+import pytest
+from mock import Mock
+
+from conan.tools.gnu import is_mingw
+from conans import ConanFile, Settings
+from conans.model.env_info import EnvValues
+
+
+@pytest.mark.parametrize(
+    "os,compiler_name,compiler_version,compiler_libcxx,compiler_runtime,compiler_runtime_type,expected",
+    [
+        ("Windows", "gcc", "9", "libstdc++11", None, None, True),
+        ("Windows", "clang", "16", "libstdc++11", None, None, True),
+        ("Windows", "Visual Studio", "17", "MD", None, None, False),
+        ("Windows", "msvc", "193", None, "dynamic", "Release", False),
+        ("Windows", "clang", "16", None, "MD", None, False),
+        ("Windows", "clang", "16", None, "dynamic", "Release", False),
+        ("Linux", "gcc", "9", "libstdc++11", None, None, False),
+        ("Linux", "clang", "16", "libc++", None, None, False),
+        ("Macos", "apple-clang", "14", "libc++", None, None, False),
+    ],
+)
+def test_is_mingw(os, compiler_name, compiler_version, compiler_libcxx, compiler_runtime, compiler_runtime_type, expected):
+    compiler = {compiler_name: {"version": [compiler_version]}}
+    if compiler_libcxx:
+        compiler[compiler_name].update({"libcxx": [compiler_libcxx]})
+    if compiler_runtime:
+        compiler[compiler_name].update({"runtime": [compiler_runtime]})
+    if compiler_runtime_type:
+        compiler[compiler_name].update({"runtime_type": [compiler_runtime_type]})
+    settings = Settings({
+        "os": [os],
+        "arch": ["x86_64"],
+        "compiler": compiler,
+        "build_type": ["Release"],
+    })
+    conanfile = ConanFile(Mock(), None)
+    conanfile.settings = "os", "arch", "compiler", "build_type"
+    conanfile.initialize(settings, EnvValues())
+    conanfile.settings.os = os
+    conanfile.settings.compiler = compiler_name
+    conanfile.settings.compiler.version = compiler_version
+    if compiler_libcxx:
+        conanfile.settings.compiler.libcxx = compiler_libcxx
+    if compiler_runtime:
+        conanfile.settings.compiler.runtime = compiler_runtime
+    if compiler_runtime_type:
+        conanfile.settings.compiler.runtime_type = compiler_runtime_type
+    assert is_mingw(conanfile) == expected


### PR DESCRIPTION
Changelog: (Feature): Add conan.tools.gnu.is_mingw() function
Docs: https://github.com/conan-io/docs/pull/2849

Partially implement features requested in https://github.com/conan-io/conan/issues/12336#issuecomment-1342464853. Such function is useful in recipes to know whether a user is using a canonical conan profile describing a MinGW toolchain, since there might be specific branching in a recipe based on this toolchain (using Autotools instead of NMake or MSBuild, deduce information for package info depending on logic in underlying build files etc).

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
