### PR TITLE
Add better error UX when spaces are found in required_conan_version

### DIFF
--- a/conans/model/version_range.py
+++ b/conans/model/version_range.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 
+from conans.errors import ConanException
 from conans.model.recipe_ref import Version
 
 
@@ -35,6 +36,8 @@ class _ConditionSet:
                 operator += "="
                 index = 2
         version = expression[index:]
+        if version == "":
+            raise ConanException(f"Error parsing version range {expression}")
         if operator == "~":  # tilde minor
             v = Version(version)
             index = 1 if len(v.main) > 1 else 0

--- a/conans/test/integration/conanfile/required_conan_version_test.py
+++ b/conans/test/integration/conanfile/required_conan_version_test.py
@@ -84,7 +84,7 @@ class RequiredConanVersionTest(unittest.TestCase):
             # https://github.com/conan-io/conan/issues/12692
             client = TestClient()
             conanfile = textwrap.dedent("""
-            from conan import missing
+            from conan import ConanFile
             required_conan_version = ">= 1.0"
             class Lib(ConanFile):
                 pass""")

--- a/conans/test/integration/conanfile/required_conan_version_test.py
+++ b/conans/test/integration/conanfile/required_conan_version_test.py
@@ -85,7 +85,7 @@ class RequiredConanVersionTest(unittest.TestCase):
             client = TestClient()
             conanfile = textwrap.dedent("""
             from conan import missing
-            required_conan_version = "
+            required_conan_version = ">= 1.0"
             class Lib(ConanFile):
                 pass""")
             client.save({"conanfile.py": conanfile})

--- a/conans/test/integration/conanfile/required_conan_version_test.py
+++ b/conans/test/integration/conanfile/required_conan_version_test.py
@@ -77,3 +77,19 @@ class RequiredConanVersionTest(unittest.TestCase):
                             """)
         client.save({"conanfile.py": conanfile})
         client.run("export . --name=pkg --version=1.0")
+
+    def test_required_conan_version_invalid_syntax(self):
+            """ required_conan_version used to warn of mismatching versions if spaces were present,
+             but now we have a nicer error"""
+            # https://github.com/conan-io/conan/issues/12692
+            client = TestClient()
+            conanfile = textwrap.dedent("""
+            from conan import missing
+            required_conan_version = "
+            class Lib(ConanFile):
+                pass""")
+            client.save({"conanfile.py": conanfile})
+            client.run("export . --name=pkg --version=1.0", assert_error=True)
+            self.assertNotIn(f"Current Conan version ({__version__}) does not satisfy the defined one "
+                            "(>= 1.0)", client.out)
+            self.assertIn("Error parsing version range >=", client.out)

--- a/conans/test/unittests/model/version/test_version_range.py
+++ b/conans/test/unittests/model/version/test_version_range.py
@@ -1,5 +1,6 @@
 import pytest
 
+from conans.errors import ConanException
 from conans.model.recipe_ref import Version
 from conans.model.version_range import VersionRange
 
@@ -50,3 +51,8 @@ def test_range(version_range, conditions, versions_in, versions_out):
 
     for v in versions_out:
         assert Version(v) not in r
+
+def test_wrong_range_syntax():
+    # https://github.com/conan-io/conan/issues/12692
+    with pytest.raises(ConanException) as e:
+        VersionRange(">= 1.0")


### PR DESCRIPTION
Changelog: (Fix): Display a better error when `required_conan_version` has spaces between the operator and the version.

This used to never allow the version check, even if the error was in the syntax, so now we just give a better error message

Closes #12692 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
