### PR TITLE
[develop2] adding missing remotes to export for python_requires

### DIFF
--- a/conan/api/subapi/export.py
+++ b/conan/api/subapi/export.py
@@ -16,9 +16,10 @@ class ExportAPI:
         self.conan_api = conan_api
 
     @api_method
-    def export(self, path, name, version, user, channel, lockfile=None):
+    def export(self, path, name, version, user, channel, lockfile=None, remotes=None):
         app = ConanApp(self.conan_api.cache_folder)
-        return cmd_export(app, path, name, version, user, channel, graph_lock=lockfile)
+        return cmd_export(app, path, name, version, user, channel, graph_lock=lockfile,
+                          remotes=remotes)
 
     @api_method
     def export_pkg(self, deps_graph, path):

--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -52,7 +52,8 @@ def create(conan_api, parser, *args):
     ref, conanfile = conan_api.export.export(path=path,
                                              name=args.name, version=args.version,
                                              user=args.user, channel=args.channel,
-                                             lockfile=lockfile)
+                                             lockfile=lockfile,
+                                             remotes=remotes)
     # The package_type is not fully processed at export
     is_python_require = conanfile.package_type == "python-require"
     lockfile = conan_api.lockfile.update_lockfile_export(lockfile, conanfile, ref,

--- a/conan/cli/commands/export.py
+++ b/conan/cli/commands/export.py
@@ -21,6 +21,8 @@ def export(conan_api, parser, *args):
     Export recipe to the Conan package cache
     """
     common_args_export(parser)
+    parser.add_argument("-r", "--remote", action="append", default=None,
+                        help='Look in the specified remote or remotes server')
     parser.add_argument("-l", "--lockfile", action=OnceArgument,
                         help="Path to a lockfile.")
     parser.add_argument("--lockfile-out", action=OnceArgument,
@@ -33,6 +35,7 @@ def export(conan_api, parser, *args):
 
     cwd = os.getcwd()
     path = conan_api.local.get_conanfile_path(args.path, cwd, py=True)
+    remotes = conan_api.remotes.list(args.remote)
     lockfile = conan_api.lockfile.get_lockfile(lockfile=args.lockfile,
                                                conanfile_path=path,
                                                cwd=cwd,
@@ -40,7 +43,8 @@ def export(conan_api, parser, *args):
     ref, conanfile = conan_api.export.export(path=path,
                                              name=args.name, version=args.version,
                                              user=args.user, channel=args.channel,
-                                             lockfile=lockfile)
+                                             lockfile=lockfile,
+                                             remotes=remotes)
     lockfile = conan_api.lockfile.update_lockfile_export(lockfile, conanfile, ref,
                                                          args.build_require)
     conan_api.lockfile.save_lockfile(lockfile, args.lockfile_out, cwd)

--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -12,13 +12,14 @@ from conans.util.files import is_dirty, rmdir, set_dirty, mkdir, clean_dirty, ch
 from conans.util.runners import check_output_runner
 
 
-def cmd_export(app, conanfile_path, name, version, user, channel, graph_lock=None):
+def cmd_export(app, conanfile_path, name, version, user, channel, graph_lock=None, remotes=None):
     """ Export the recipe
     param conanfile_path: the original source directory of the user containing a
                        conanfile.py
     """
     loader, cache, hook_manager = app.loader, app.cache, app.hook_manager
-    conanfile = loader.load_export(conanfile_path, name, version, user, channel, graph_lock)
+    conanfile = loader.load_export(conanfile_path, name, version, user, channel, graph_lock,
+                                   remotes=remotes)
 
     ref = RecipeReference(conanfile.name, conanfile.version,  conanfile.user, conanfile.channel)
     ref.validate_ref()

--- a/conans/client/graph/python_requires.py
+++ b/conans/client/graph/python_requires.py
@@ -112,7 +112,10 @@ class PyRequireLoader(object):
         return ref
 
     def _load_pyreq_conanfile(self, loader, graph_lock, ref, remotes, update, check_update):
-        recipe = self._proxy.get_recipe(ref, remotes, update, check_update)
+        try:
+            recipe = self._proxy.get_recipe(ref, remotes, update, check_update)
+        except ConanException as e:
+            raise ConanException(f"Cannot resolve python_requires '{ref}': {str(e)}")
         path, recipe_status, remote, new_ref = recipe
         conanfile, module = loader.load_basic_module(path, graph_lock, update, check_update)
         conanfile.name = new_ref.name

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -137,10 +137,12 @@ class ConanFileLoader:
 
         return conanfile
 
-    def load_export(self, conanfile_path, name, version, user, channel, graph_lock=None):
+    def load_export(self, conanfile_path, name, version, user, channel, graph_lock=None,
+                    remotes=None):
         """ loads the conanfile and evaluates its name, version, and enforce its existence
         """
-        conanfile = self.load_named(conanfile_path, name, version, user, channel, graph_lock)
+        conanfile = self.load_named(conanfile_path, name, version, user, channel, graph_lock,
+                                    remotes=remotes)
         if not conanfile.name:
             raise ConanException("conanfile didn't specify name")
         if not conanfile.version:


### PR DESCRIPTION
``python_requires`` are failing to be resolved from remotes at ``conan export`` stage (can also happen at ``conan create``)