### PR TITLE
[bugfix][PkgConfigDeps] No `xxx.pc` in build context

### DIFF
--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -397,7 +397,7 @@ class PkgConfigDeps:
             # Require is not used at the moment, but its information could be used,
             # and will be used in Conan 2.0
             # Filter the build_requires not activated with PkgConfigDeps.build_context_activated
-            if dep.is_build_context and dep.ref.name not in self.build_context_activated:
+            if require.build and dep.ref.name not in self.build_context_activated:
                 continue
 
             pc_generator = _PCGenerator(self._conanfile, dep, build_context_suffix=self.build_context_suffix)


### PR DESCRIPTION
Changelog: Bugfix: Fix issue with `PkgConfigDeps` not creating `.pc` files in build context.
Docs: Omit
Closes: https://github.com/conan-io/conan/issues/12703
Closes: https://github.com/conan-io/conan/issues/12437

This stills @memsharded's work on https://github.com/conan-io/conan/pull/12675