### PR TITLE
Respect `force_host_context` when resolving dependencies

### DIFF
--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -437,6 +437,9 @@ class DepsGraphBuilder(object):
         if context_switch:
             profile = profile_build
             context = CONTEXT_BUILD
+        elif requirement.force_host_context:
+            profile = profile_host
+            context = CONTEXT_HOST
         else:
             profile = profile_host if current_node.context == CONTEXT_HOST else profile_build
             context = current_node.context


### PR DESCRIPTION
When a depedency is added with `test_requires` within `build_requirements` we set `force_host_context` on the requirement.

However, when we build the graph and resolve the recursive dependencies, we fail to respect that and set the profile/context to the target node context.

If the original target node has a `build` context, we start to resolve the nested node as `build` rather than as `host` context.

This patch adds a new branch to the context decision to respect the `force_host_context` on the requirement and set the context appropriately.

Closes #12710

Changelog: (Fix): Resolve `test_require` dependencies in the `host` context.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] ~~I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.~~

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
