### PR TITLE
Allow append in legacy cpp info mockup

### DIFF
--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -43,6 +43,7 @@ class MockInfoProperty(object):
 
     def __getitem__(self, key):
         ConanOutput().warning(self._message)
+        return []
 
     def __setitem__(self, key, value):
         ConanOutput().warning(self._message)

--- a/conans/test/integration/conan_v2/test_legacy_cpp_info.py
+++ b/conans/test/integration/conan_v2/test_legacy_cpp_info.py
@@ -14,6 +14,7 @@ def test_legacy_names_filenames():
                 self.cpp_info.components["comp"].names["cmake_find_package"] = "hello"
                 self.cpp_info.components["comp"].names["cmake_find_package_multi"] = "hello"
                 self.cpp_info.components["comp"].build_modules["cmake_find_package"] = ["nice_rel_path"]
+                self.cpp_info.components["comp"].build_modules["cmake_find_package"].append("some_file_name")
                 self.cpp_info.components["comp"].build_modules["cmake_find_package_multi"] = ["nice_rel_path"]
 
                 self.cpp_info.names["cmake_find_package"] = "absl"


### PR DESCRIPTION
Changelog: Bugfix: Fix issue to allow appending to objects returned by the legacy `build_modules` mock object.

(Similar to https://github.com/conan-io/conan/pull/12673)

Fixes issue with pybind11 recipe in Conan Center with Conan2:

```
      cmake_file = os.path.join(cmake_base_path, "pybind11Common.cmake")
        self.cpp_info.set_property("cmake_build_modules", [cmake_file])
        for generator in ["cmake_find_package", "cmake_find_package_multi"]:
            self.cpp_info.components["pybind11_"].build_modules[generator].append(cmake_file)
```
