### PR TITLE
Raise error when a generator is defined in generators and generate()

### DIFF
--- a/conan/internal/__init__.py
+++ b/conan/internal/__init__.py
@@ -1,0 +1,8 @@
+from conan.errors import ConanException
+
+
+def check_duplicated_generator(generator, conanfile):
+    if generator.__class__.__name__ in conanfile.generators:
+        raise ConanException(f"{generator.__class__.__name__} is declared in the generators "
+                             "attribute, but was instantiated in the generate() method too. "
+                             "It should only be present in one of them.")

--- a/conan/tools/__init__.py
+++ b/conan/tools/__init__.py
@@ -7,5 +7,5 @@ CONAN_TOOLCHAIN_ARGS_SECTION = "toolchain"
 def _check_duplicated_generator(generator, conanfile):
     if generator.__class__.__name__ in conanfile.generators:
         raise ConanException(f"{generator.__class__.__name__} is declared in the generators "
-                             "attribute, but was instantiated in the generate() method toos. "
+                             "attribute, but was instantiated in the generate() method too. "
                              "It should only be present in one of them.")

--- a/conan/tools/__init__.py
+++ b/conan/tools/__init__.py
@@ -7,5 +7,5 @@ CONAN_TOOLCHAIN_ARGS_SECTION = "toolchain"
 def _check_duplicated_generator(generator, conanfile):
     if generator.__class__.__name__ in conanfile.generators:
         raise ConanException(f"{generator.__class__.__name__} is declared in the generators "
-                             "attribute, but was also instantiated in the generate() method. "
+                             "attribute, but was instantiated in the generate() method toos. "
                              "It should only be present in one of them.")

--- a/conan/tools/__init__.py
+++ b/conan/tools/__init__.py
@@ -1,11 +1,4 @@
-from conan.errors import ConanException
-
 CONAN_TOOLCHAIN_ARGS_FILE = "conanbuild.conf"
 CONAN_TOOLCHAIN_ARGS_SECTION = "toolchain"
 
 
-def _check_duplicated_generator(generator, conanfile):
-    if generator.__class__.__name__ in conanfile.generators:
-        raise ConanException(f"{generator.__class__.__name__} is declared in the generators "
-                             "attribute, but was instantiated in the generate() method too. "
-                             "It should only be present in one of them.")

--- a/conan/tools/__init__.py
+++ b/conan/tools/__init__.py
@@ -1,2 +1,11 @@
+from conans.errors import ConanException
+
 CONAN_TOOLCHAIN_ARGS_FILE = "conanbuild.conf"
 CONAN_TOOLCHAIN_ARGS_SECTION = "toolchain"
+
+
+def _check_duplicated_generator(generator, conanfile):
+    if generator.__class__.__name__ in conanfile.generators:
+        raise ConanException(f"{generator.__class__.__name__} is declared in the generators "
+                             "attribute, but was also instantiated in the generate() method. "
+                             "It should only be present in one of them.")

--- a/conan/tools/__init__.py
+++ b/conan/tools/__init__.py
@@ -1,4 +1,4 @@
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 CONAN_TOOLCHAIN_ARGS_FILE = "conanbuild.conf"
 CONAN_TOOLCHAIN_ARGS_SECTION = "toolchain"

--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -1,6 +1,5 @@
 import os
 
-from conans.errors import ConanException
 from conans.util.runners import check_output_runner
 from conan.tools.build import cmd_args_to_string
 from conans.errors import ConanException

--- a/conan/tools/apple/xcodebuild.py
+++ b/conan/tools/apple/xcodebuild.py
@@ -1,5 +1,3 @@
-import os
-
 from conan.tools.apple import to_apple_arch
 from conans.errors import ConanException
 

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -106,7 +106,7 @@ class XcodeDeps(object):
 
     def __init__(self, conanfile):
         if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
                                  "attribute, but was also instantiated in the generate() method."
                                  "It should only be present in one of them.")
         self._conanfile = conanfile

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 
 from jinja2 import Template
 
-from conan.tools import _check_duplicated_generator
+from conan.internal import check_duplicated_generator
 from conans.errors import ConanException
 from conans.model.dependencies import get_transitive_requires
 from conans.util.files import load, save
@@ -116,7 +116,7 @@ class XcodeDeps(object):
         self.sdk_version = conanfile.settings.get_safe("os.sdk_version")
 
     def generate(self):
-        _check_duplicated_generator(self, self._conanfile)
+        check_duplicated_generator(self, self._conanfile)
         if self.configuration is None:
             raise ConanException("XcodeDeps.configuration is None, it should have a value")
         if self.architecture is None:

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -107,7 +107,7 @@ class XcodeDeps(object):
     def __init__(self, conanfile):
         if self.__class__.__name__ in conanfile.generators:
             raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method."
+                                 "attribute, but was also instantiated in the generate() method. "
                                  "It should only be present in one of them.")
         self._conanfile = conanfile
         self.configuration = conanfile.settings.get_safe("build_type")

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 
 from jinja2 import Template
 
+from conan.tools import _check_duplicated_generator
 from conans.errors import ConanException
 from conans.model.dependencies import get_transitive_requires
 from conans.util.files import load, save
@@ -105,10 +106,7 @@ class XcodeDeps(object):
         """)
 
     def __init__(self, conanfile):
-        if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method. "
-                                 "It should only be present in one of them.")
+        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self.configuration = conanfile.settings.get_safe("build_type")
         arch = conanfile.settings.get_safe("arch")

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -105,6 +105,10 @@ class XcodeDeps(object):
         """)
 
     def __init__(self, conanfile):
+        if self.__class__.__name__ in conanfile.generators:
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+                                 "attribute, but was also instantiated in the generate() method."
+                                 "It should only be present in one of them.")
         self._conanfile = conanfile
         self.configuration = conanfile.settings.get_safe("build_type")
         arch = conanfile.settings.get_safe("arch")

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -106,7 +106,6 @@ class XcodeDeps(object):
         """)
 
     def __init__(self, conanfile):
-        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self.configuration = conanfile.settings.get_safe("build_type")
         arch = conanfile.settings.get_safe("arch")
@@ -117,6 +116,7 @@ class XcodeDeps(object):
         self.sdk_version = conanfile.settings.get_safe("os.sdk_version")
 
     def generate(self):
+        _check_duplicated_generator(self, self._conanfile)
         if self.configuration is None:
             raise ConanException("XcodeDeps.configuration is None, it should have a value")
         if self.architecture is None:

--- a/conan/tools/apple/xcodetoolchain.py
+++ b/conan/tools/apple/xcodetoolchain.py
@@ -34,7 +34,7 @@ class XcodeToolchain(object):
 
     def __init__(self, conanfile):
         if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
                                  "attribute, but was also instantiated in the generate() method."
                                  "It should only be present in one of them.")
         self._conanfile = conanfile

--- a/conan/tools/apple/xcodetoolchain.py
+++ b/conan/tools/apple/xcodetoolchain.py
@@ -33,7 +33,6 @@ class XcodeToolchain(object):
         """)
 
     def __init__(self, conanfile):
-        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         arch = conanfile.settings.get_safe("arch")
         self.architecture = to_apple_arch(self._conanfile, default=arch)
@@ -48,6 +47,7 @@ class XcodeToolchain(object):
         self._global_ldflags = sharedlinkflags + exelinkflags
 
     def generate(self):
+        _check_duplicated_generator(self, self._conanfile)
         save(self._agreggated_xconfig_filename, self._agreggated_xconfig_content)
         save(self._vars_xconfig_filename, self._vars_xconfig_content)
         if self._check_if_extra_flags:

--- a/conan/tools/apple/xcodetoolchain.py
+++ b/conan/tools/apple/xcodetoolchain.py
@@ -1,6 +1,6 @@
 import textwrap
 
-from conan.tools import _check_duplicated_generator
+from conan.internal import check_duplicated_generator
 from conan.tools.apple.apple import to_apple_arch
 from conan.tools.apple.xcodedeps import GLOBAL_XCCONFIG_FILENAME, GLOBAL_XCCONFIG_TEMPLATE, \
     _add_includes_to_file_or_create, _xcconfig_settings_filename, _xcconfig_conditional
@@ -47,7 +47,7 @@ class XcodeToolchain(object):
         self._global_ldflags = sharedlinkflags + exelinkflags
 
     def generate(self):
-        _check_duplicated_generator(self, self._conanfile)
+        check_duplicated_generator(self, self._conanfile)
         save(self._agreggated_xconfig_filename, self._agreggated_xconfig_content)
         save(self._vars_xconfig_filename, self._vars_xconfig_content)
         if self._check_if_extra_flags:

--- a/conan/tools/apple/xcodetoolchain.py
+++ b/conan/tools/apple/xcodetoolchain.py
@@ -1,9 +1,9 @@
 import textwrap
 
+from conan.tools import _check_duplicated_generator
 from conan.tools.apple.apple import to_apple_arch
 from conan.tools.apple.xcodedeps import GLOBAL_XCCONFIG_FILENAME, GLOBAL_XCCONFIG_TEMPLATE, \
     _add_includes_to_file_or_create, _xcconfig_settings_filename, _xcconfig_conditional
-from conans.errors import ConanException
 from conans.util.files import save
 
 
@@ -33,10 +33,7 @@ class XcodeToolchain(object):
         """)
 
     def __init__(self, conanfile):
-        if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method. "
-                                 "It should only be present in one of them.")
+        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         arch = conanfile.settings.get_safe("arch")
         self.architecture = to_apple_arch(self._conanfile, default=arch)

--- a/conan/tools/apple/xcodetoolchain.py
+++ b/conan/tools/apple/xcodetoolchain.py
@@ -35,7 +35,7 @@ class XcodeToolchain(object):
     def __init__(self, conanfile):
         if self.__class__.__name__ in conanfile.generators:
             raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method."
+                                 "attribute, but was also instantiated in the generate() method. "
                                  "It should only be present in one of them.")
         self._conanfile = conanfile
         arch = conanfile.settings.get_safe("arch")

--- a/conan/tools/apple/xcodetoolchain.py
+++ b/conan/tools/apple/xcodetoolchain.py
@@ -3,6 +3,7 @@ import textwrap
 from conan.tools.apple.apple import to_apple_arch
 from conan.tools.apple.xcodedeps import GLOBAL_XCCONFIG_FILENAME, GLOBAL_XCCONFIG_TEMPLATE, \
     _add_includes_to_file_or_create, _xcconfig_settings_filename, _xcconfig_conditional
+from conans.errors import ConanException
 from conans.util.files import save
 
 
@@ -32,6 +33,10 @@ class XcodeToolchain(object):
         """)
 
     def __init__(self, conanfile):
+        if self.__class__.__name__ in conanfile.generators:
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+                                 "attribute, but was also instantiated in the generate() method."
+                                 "It should only be present in one of them.")
         self._conanfile = conanfile
         arch = conanfile.settings.get_safe("arch")
         self.architecture = to_apple_arch(self._conanfile, default=arch)

--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -15,6 +15,10 @@ from conans.util.files import save
 class CMakeDeps(object):
 
     def __init__(self, conanfile):
+        if self.__class__.__name__ in conanfile.generators:
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+                                 "attribute, but was also instantiated in the generate() method."
+                                 "It should only be present in one of them.")
         self._conanfile = conanfile
         self.arch = self._conanfile.settings.get_safe("arch")
         self.configuration = str(self._conanfile.settings.build_type)

--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -1,5 +1,6 @@
 import os
 
+from conan.tools import _check_duplicated_generator
 from conan.tools.cmake.cmakedeps import FIND_MODE_CONFIG, FIND_MODE_NONE, FIND_MODE_BOTH, \
     FIND_MODE_MODULE
 from conan.tools.cmake.cmakedeps.templates.config import ConfigTemplate
@@ -15,10 +16,7 @@ from conans.util.files import save
 class CMakeDeps(object):
 
     def __init__(self, conanfile):
-        if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method. "
-                                 "It should only be present in one of them.")
+        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self.arch = self._conanfile.settings.get_safe("arch")
         self.configuration = str(self._conanfile.settings.build_type)

--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -17,7 +17,7 @@ class CMakeDeps(object):
     def __init__(self, conanfile):
         if self.__class__.__name__ in conanfile.generators:
             raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method."
+                                 "attribute, but was also instantiated in the generate() method. "
                                  "It should only be present in one of them.")
         self._conanfile = conanfile
         self.arch = self._conanfile.settings.get_safe("arch")

--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -1,6 +1,6 @@
 import os
 
-from conan.tools import _check_duplicated_generator
+from conan.internal import check_duplicated_generator
 from conan.tools.cmake.cmakedeps import FIND_MODE_CONFIG, FIND_MODE_NONE, FIND_MODE_BOTH, \
     FIND_MODE_MODULE
 from conan.tools.cmake.cmakedeps.templates.config import ConfigTemplate
@@ -36,7 +36,7 @@ class CMakeDeps(object):
         """
         This method will save the generated files to the conanfile.generators_folder
         """
-        _check_duplicated_generator(self, self._conanfile)
+        check_duplicated_generator(self, self._conanfile)
         # FIXME: Remove this in 2.0
         if not hasattr(self._conanfile, "settings_build") and \
                       (self.build_context_activated or self.build_context_build_modules or

--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -16,7 +16,7 @@ class CMakeDeps(object):
 
     def __init__(self, conanfile):
         if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
                                  "attribute, but was also instantiated in the generate() method."
                                  "It should only be present in one of them.")
         self._conanfile = conanfile

--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -16,7 +16,6 @@ from conans.util.files import save
 class CMakeDeps(object):
 
     def __init__(self, conanfile):
-        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self.arch = self._conanfile.settings.get_safe("arch")
         self.configuration = str(self._conanfile.settings.build_type)
@@ -37,6 +36,7 @@ class CMakeDeps(object):
         """
         This method will save the generated files to the conanfile.generators_folder
         """
+        _check_duplicated_generator(self, self._conanfile)
         # FIXME: Remove this in 2.0
         if not hasattr(self._conanfile, "settings_build") and \
                       (self.build_context_activated or self.build_context_build_modules or

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -115,6 +115,10 @@ class CMakeToolchain(object):
         """)
 
     def __init__(self, conanfile, generator=None):
+        if self.__class__.__name__ in conanfile.generators:
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+                                 "attribute, but was also instantiated in the generate() method."
+                                 "It should only be present in one of them.")
         self._conanfile = conanfile
         self.generator = self._get_generator(generator)
         self.variables = Variables()

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -116,7 +116,6 @@ class CMakeToolchain(object):
         """)
 
     def __init__(self, conanfile, generator=None):
-        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self.generator = self._get_generator(generator)
         self.variables = Variables()
@@ -152,6 +151,7 @@ class CMakeToolchain(object):
     def _context(self):
         """ Returns dict, the context for the template
         """
+        _check_duplicated_generator(self, self._conanfile)
         self.preprocessor_definitions.quote_preprocessor_strings()
 
         blocks = self.blocks.process_blocks()

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -151,7 +151,6 @@ class CMakeToolchain(object):
     def _context(self):
         """ Returns dict, the context for the template
         """
-        _check_duplicated_generator(self, self._conanfile)
         self.preprocessor_definitions.quote_preprocessor_strings()
 
         blocks = self.blocks.process_blocks()
@@ -175,6 +174,7 @@ class CMakeToolchain(object):
         """
           This method will save the generated files to the conanfile.generators_folder
         """
+        _check_duplicated_generator(self, self._conanfile)
         toolchain_file = self._conanfile.conf.get("tools.cmake.cmaketoolchain:toolchain_file")
         if toolchain_file is None:  # The main toolchain file generated only if user dont define
             save(os.path.join(self._conanfile.generators_folder, self.filename), self.content)

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -117,7 +117,7 @@ class CMakeToolchain(object):
     def __init__(self, conanfile, generator=None):
         if self.__class__.__name__ in conanfile.generators:
             raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method."
+                                 "attribute, but was also instantiated in the generate() method. "
                                  "It should only be present in one of them.")
         self._conanfile = conanfile
         self.generator = self._get_generator(generator)

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 
 from jinja2 import Template
 
+from conan.tools import _check_duplicated_generator
 from conan.tools.build import use_win_mingw
 from conan.tools.cmake.presets import write_cmake_presets
 from conan.tools.cmake.toolchain import CONAN_TOOLCHAIN_FILENAME
@@ -115,10 +116,7 @@ class CMakeToolchain(object):
         """)
 
     def __init__(self, conanfile, generator=None):
-        if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method. "
-                                 "It should only be present in one of them.")
+        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self.generator = self._get_generator(generator)
         self.variables = Variables()

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -116,7 +116,7 @@ class CMakeToolchain(object):
 
     def __init__(self, conanfile, generator=None):
         if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
                                  "attribute, but was also instantiated in the generate() method."
                                  "It should only be present in one of them.")
         self._conanfile = conanfile

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 
 from jinja2 import Template
 
-from conan.tools import _check_duplicated_generator
+from conan.internal import check_duplicated_generator
 from conan.tools.build import use_win_mingw
 from conan.tools.cmake.presets import write_cmake_presets
 from conan.tools.cmake.toolchain import CONAN_TOOLCHAIN_FILENAME
@@ -174,7 +174,7 @@ class CMakeToolchain(object):
         """
           This method will save the generated files to the conanfile.generators_folder
         """
-        _check_duplicated_generator(self, self._conanfile)
+        check_duplicated_generator(self, self._conanfile)
         toolchain_file = self._conanfile.conf.get("tools.cmake.cmaketoolchain:toolchain_file")
         if toolchain_file is None:  # The main toolchain file generated only if user dont define
             save(os.path.join(self._conanfile.generators_folder, self.filename), self.content)

--- a/conan/tools/env/virtualbuildenv.py
+++ b/conan/tools/env/virtualbuildenv.py
@@ -1,4 +1,4 @@
-from conan.tools import _check_duplicated_generator
+from conan.internal import check_duplicated_generator
 from conan.tools.env import Environment
 from conan.tools.env.virtualrunenv import runenv_from_cpp_info
 
@@ -79,6 +79,6 @@ class VirtualBuildEnv:
 
         :param scope: Scope to be used.
         """
-        _check_duplicated_generator(self, self._conanfile)
+        check_duplicated_generator(self, self._conanfile)
         build_env = self.environment()
         build_env.vars(self._conanfile, scope=scope).save_script(self._filename)

--- a/conan/tools/env/virtualbuildenv.py
+++ b/conan/tools/env/virtualbuildenv.py
@@ -1,5 +1,6 @@
 from conan.tools.env import Environment
 from conan.tools.env.virtualrunenv import runenv_from_cpp_info
+from conans.errors import ConanException
 
 
 class VirtualBuildEnv:
@@ -8,6 +9,10 @@ class VirtualBuildEnv:
     """
 
     def __init__(self, conanfile):
+        if self.__class__.__name__ in conanfile.generators:
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+                                 "attribute, but was also instantiated in the generate() method."
+                                 "It should only be present in one of them.")
         self._conanfile = conanfile
         self._conanfile.virtualbuildenv = False
         self.basename = "conanbuildenv"

--- a/conan/tools/env/virtualbuildenv.py
+++ b/conan/tools/env/virtualbuildenv.py
@@ -10,8 +10,8 @@ class VirtualBuildEnv:
 
     def __init__(self, conanfile):
         if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
-                                 "attribute, but was also instantiated in the generate() method."
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
+                                 "attribute, but was also instantiated in the generate() method. "
                                  "It should only be present in one of them.")
         self._conanfile = conanfile
         self._conanfile.virtualbuildenv = False

--- a/conan/tools/env/virtualbuildenv.py
+++ b/conan/tools/env/virtualbuildenv.py
@@ -1,6 +1,6 @@
+from conan.tools import _check_duplicated_generator
 from conan.tools.env import Environment
 from conan.tools.env.virtualrunenv import runenv_from_cpp_info
-from conans.errors import ConanException
 
 
 class VirtualBuildEnv:
@@ -9,10 +9,7 @@ class VirtualBuildEnv:
     """
 
     def __init__(self, conanfile):
-        if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method. "
-                                 "It should only be present in one of them.")
+        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self._conanfile.virtualbuildenv = False
         self.basename = "conanbuildenv"

--- a/conan/tools/env/virtualbuildenv.py
+++ b/conan/tools/env/virtualbuildenv.py
@@ -9,7 +9,6 @@ class VirtualBuildEnv:
     """
 
     def __init__(self, conanfile):
-        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self._conanfile.virtualbuildenv = False
         self.basename = "conanbuildenv"
@@ -80,6 +79,6 @@ class VirtualBuildEnv:
 
         :param scope: Scope to be used.
         """
-
+        _check_duplicated_generator(self, self._conanfile)
         build_env = self.environment()
         build_env.vars(self._conanfile, scope=scope).save_script(self._filename)

--- a/conan/tools/env/virtualrunenv.py
+++ b/conan/tools/env/virtualrunenv.py
@@ -1,7 +1,7 @@
 import os
 
+from conan.tools import _check_duplicated_generator
 from conan.tools.env import Environment
-from conans.errors import ConanException
 
 
 def runenv_from_cpp_info(dep, os_name):
@@ -34,10 +34,7 @@ class VirtualRunEnv:
 
         :param conanfile:  The current recipe object. Always use ``self``.
         """
-        if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method. "
-                                 "It should only be present in one of them.")
+        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self._conanfile.virtualrunenv = False
         self.basename = "conanrunenv"

--- a/conan/tools/env/virtualrunenv.py
+++ b/conan/tools/env/virtualrunenv.py
@@ -1,6 +1,7 @@
 import os
 
 from conan.tools.env import Environment
+from conans.errors import ConanException
 
 
 def runenv_from_cpp_info(dep, os_name):
@@ -33,6 +34,10 @@ class VirtualRunEnv:
 
         :param conanfile:  The current recipe object. Always use ``self``.
         """
+        if self.__class__.__name__ in conanfile.generators:
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+                                 "attribute, but was also instantiated in the generate() method."
+                                 "It should only be present in one of them.")
         self._conanfile = conanfile
         self._conanfile.virtualrunenv = False
         self.basename = "conanrunenv"

--- a/conan/tools/env/virtualrunenv.py
+++ b/conan/tools/env/virtualrunenv.py
@@ -36,7 +36,7 @@ class VirtualRunEnv:
         """
         if self.__class__.__name__ in conanfile.generators:
             raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method."
+                                 "attribute, but was also instantiated in the generate() method. "
                                  "It should only be present in one of them.")
         self._conanfile = conanfile
         self._conanfile.virtualrunenv = False

--- a/conan/tools/env/virtualrunenv.py
+++ b/conan/tools/env/virtualrunenv.py
@@ -34,7 +34,6 @@ class VirtualRunEnv:
 
         :param conanfile:  The current recipe object. Always use ``self``.
         """
-        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self._conanfile.virtualrunenv = False
         self.basename = "conanrunenv"
@@ -91,5 +90,6 @@ class VirtualRunEnv:
 
         :param scope: Scope to be used.
         """
+        _check_duplicated_generator(self, self._conanfile)
         run_env = self.environment()
         run_env.vars(self._conanfile, scope=scope).save_script(self._filename)

--- a/conan/tools/env/virtualrunenv.py
+++ b/conan/tools/env/virtualrunenv.py
@@ -35,7 +35,7 @@ class VirtualRunEnv:
         :param conanfile:  The current recipe object. Always use ``self``.
         """
         if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
                                  "attribute, but was also instantiated in the generate() method."
                                  "It should only be present in one of them.")
         self._conanfile = conanfile

--- a/conan/tools/env/virtualrunenv.py
+++ b/conan/tools/env/virtualrunenv.py
@@ -1,6 +1,6 @@
 import os
 
-from conan.tools import _check_duplicated_generator
+from conan.internal import check_duplicated_generator
 from conan.tools.env import Environment
 
 
@@ -90,6 +90,6 @@ class VirtualRunEnv:
 
         :param scope: Scope to be used.
         """
-        _check_duplicated_generator(self, self._conanfile)
+        check_duplicated_generator(self, self._conanfile)
         run_env = self.environment()
         run_env.vars(self._conanfile, scope=scope).save_script(self._filename)

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -1,7 +1,6 @@
 import configparser
 import errno
 import gzip
-import hashlib
 import os
 import platform
 import shutil

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -7,7 +7,7 @@ from conans.model.build_info import CppInfo
 class AutotoolsDeps:
     def __init__(self, conanfile):
         if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
                                  "attribute, but was also instantiated in the generate() method."
                                  "It should only be present in one of them.")
         self._conanfile = conanfile

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -1,4 +1,4 @@
-from conan.tools import _check_duplicated_generator
+from conan.internal import check_duplicated_generator
 from conan.tools.env import Environment
 from conan.tools.gnu.gnudeps_flags import GnuDepsFlags
 from conans.model.build_info import CppInfo
@@ -80,5 +80,5 @@ class AutotoolsDeps:
         return self.environment.vars(self._conanfile, scope=scope)
 
     def generate(self,  scope="build"):
-        _check_duplicated_generator(self, self._conanfile)
+        check_duplicated_generator(self, self._conanfile)
         self.vars(scope).save_script("conanautotoolsdeps")

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -1,10 +1,15 @@
 from conan.tools.env import Environment
 from conan.tools.gnu.gnudeps_flags import GnuDepsFlags
+from conans.errors import ConanException
 from conans.model.build_info import CppInfo
 
 
 class AutotoolsDeps:
     def __init__(self, conanfile):
+        if self.__class__.__name__ in conanfile.generators:
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+                                 "attribute, but was also instantiated in the generate() method."
+                                 "It should only be present in one of them.")
         self._conanfile = conanfile
         self._environment = None
         self._ordered_deps = []

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -6,7 +6,6 @@ from conans.model.build_info import CppInfo
 
 class AutotoolsDeps:
     def __init__(self, conanfile):
-        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self._environment = None
         self._ordered_deps = []
@@ -81,4 +80,5 @@ class AutotoolsDeps:
         return self.environment.vars(self._conanfile, scope=scope)
 
     def generate(self,  scope="build"):
+        _check_duplicated_generator(self, self._conanfile)
         self.vars(scope).save_script("conanautotoolsdeps")

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -1,15 +1,12 @@
+from conan.tools import _check_duplicated_generator
 from conan.tools.env import Environment
 from conan.tools.gnu.gnudeps_flags import GnuDepsFlags
-from conans.errors import ConanException
 from conans.model.build_info import CppInfo
 
 
 class AutotoolsDeps:
     def __init__(self, conanfile):
-        if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method. "
-                                 "It should only be present in one of them.")
+        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self._environment = None
         self._ordered_deps = []

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -8,7 +8,7 @@ class AutotoolsDeps:
     def __init__(self, conanfile):
         if self.__class__.__name__ in conanfile.generators:
             raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method."
+                                 "attribute, but was also instantiated in the generate() method. "
                                  "It should only be present in one of them.")
         self._conanfile = conanfile
         self._environment = None

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -25,7 +25,7 @@ class AutotoolsToolchain:
         """
         if self.__class__.__name__ in conanfile.generators:
             raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method."
+                                 "attribute, but was also instantiated in the generate() method. "
                                  "It should only be present in one of them.")
         self._conanfile = conanfile
         self._namespace = namespace

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -24,7 +24,6 @@ class AutotoolsToolchain:
                helper so that it reads the information from the proper file.
         :param prefix: Folder to use for ``--prefix`` argument ("/" by default).
         """
-        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self._namespace = namespace
         self._prefix = prefix
@@ -160,6 +159,7 @@ class AutotoolsToolchain:
         return self.environment().vars(self._conanfile, scope="build")
 
     def generate(self, env=None, scope="build"):
+        _check_duplicated_generator(self, self._conanfile)
         env = env or self.environment()
         env = env.vars(self._conanfile, scope=scope)
         env.save_script("conanautotoolstoolchain")

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -24,7 +24,7 @@ class AutotoolsToolchain:
         :param prefix: Folder to use for ``--prefix`` argument ("/" by default).
         """
         if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
                                  "attribute, but was also instantiated in the generate() method."
                                  "It should only be present in one of them.")
         self._conanfile = conanfile

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -23,6 +23,10 @@ class AutotoolsToolchain:
                helper so that it reads the information from the proper file.
         :param prefix: Folder to use for ``--prefix`` argument ("/" by default).
         """
+        if self.__class__.__name__ in conanfile.generators:
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+                                 "attribute, but was also instantiated in the generate() method."
+                                 "It should only be present in one of them.")
         self._conanfile = conanfile
         self._namespace = namespace
         self._prefix = prefix

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -1,3 +1,4 @@
+from conan.tools import _check_duplicated_generator
 from conan.tools.apple.apple import apple_min_version_flag, to_apple_arch
 from conan.tools.apple.apple import get_apple_sdk_fullname
 from conan.tools.build import cmd_args_to_string
@@ -6,7 +7,7 @@ from conan.tools.build.flags import architecture_flag, build_type_flags, cppstd_
 from conan.tools.env import Environment
 from conan.tools.files.files import save_toolchain_args
 from conan.tools.gnu.get_gnu_triplet import _get_gnu_triplet
-from conan.tools.microsoft import VCVars, is_msvc, msvc_runtime_flag
+from conan.tools.microsoft import VCVars, msvc_runtime_flag
 from conans.errors import ConanException
 
 
@@ -23,10 +24,7 @@ class AutotoolsToolchain:
                helper so that it reads the information from the proper file.
         :param prefix: Folder to use for ``--prefix`` argument ("/" by default).
         """
-        if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method. "
-                                 "It should only be present in one of them.")
+        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self._namespace = namespace
         self._prefix = prefix

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -1,4 +1,4 @@
-from conan.tools import _check_duplicated_generator
+from conan.internal import check_duplicated_generator
 from conan.tools.apple.apple import apple_min_version_flag, to_apple_arch
 from conan.tools.apple.apple import get_apple_sdk_fullname
 from conan.tools.build import cmd_args_to_string
@@ -159,7 +159,7 @@ class AutotoolsToolchain:
         return self.environment().vars(self._conanfile, scope="build")
 
     def generate(self, env=None, scope="build"):
-        _check_duplicated_generator(self, self._conanfile)
+        check_duplicated_generator(self, self._conanfile)
         env = env or self.environment()
         env = env.vars(self._conanfile, scope=scope)
         env.save_script("conanautotoolstoolchain")

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -362,7 +362,7 @@ class PkgConfigDeps:
     def __init__(self, conanfile):
         if self.__class__.__name__ in conanfile.generators:
             raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method."
+                                 "attribute, but was also instantiated in the generate() method. "
                                  "It should only be present in one of them.")
         self._conanfile = conanfile
         # Activate the build *.pc files for the specified libraries

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -361,7 +361,7 @@ class PkgConfigDeps:
 
     def __init__(self, conanfile):
         if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
                                  "attribute, but was also instantiated in the generate() method."
                                  "It should only be present in one of them.")
         self._conanfile = conanfile

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -360,6 +360,10 @@ class _PCGenerator:
 class PkgConfigDeps:
 
     def __init__(self, conanfile):
+        if self.__class__.__name__ in conanfile.generators:
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+                                 "attribute, but was also instantiated in the generate() method."
+                                 "It should only be present in one of them.")
         self._conanfile = conanfile
         # Activate the build *.pc files for the specified libraries
         self.build_context_activated = []

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 
 from jinja2 import Template, StrictUndefined
 
+from conan.tools import _check_duplicated_generator
 from conan.tools.gnu.gnudeps_flags import GnuDepsFlags
 from conans.errors import ConanException
 from conans.util.files import save
@@ -360,10 +361,7 @@ class _PCGenerator:
 class PkgConfigDeps:
 
     def __init__(self, conanfile):
-        if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method. "
-                                 "It should only be present in one of them.")
+        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         # Activate the build *.pc files for the specified libraries
         self.build_context_activated = []

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -361,7 +361,6 @@ class _PCGenerator:
 class PkgConfigDeps:
 
     def __init__(self, conanfile):
-        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         # Activate the build *.pc files for the specified libraries
         self.build_context_activated = []
@@ -416,6 +415,7 @@ class PkgConfigDeps:
         """
         Save all the `*.pc` files
         """
+        _check_duplicated_generator(self, self._conanfile)
         # Current directory is the generators_folder
         generator_files = self.content
         for generator_file, content in generator_files.items():

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 
 from jinja2 import Template, StrictUndefined
 
-from conan.tools import _check_duplicated_generator
+from conan.internal import check_duplicated_generator
 from conan.tools.gnu.gnudeps_flags import GnuDepsFlags
 from conans.errors import ConanException
 from conans.util.files import save
@@ -415,7 +415,7 @@ class PkgConfigDeps:
         """
         Save all the `*.pc` files
         """
-        _check_duplicated_generator(self, self._conanfile)
+        check_duplicated_generator(self, self._conanfile)
         # Current directory is the generators_folder
         generator_files = self.content
         for generator_file, content in generator_files.items():

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -11,10 +11,10 @@ from conans.util.files import save
 
 class BazelDeps(object):
     def __init__(self, conanfile):
-        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
 
     def generate(self):
+        _check_duplicated_generator(self, self._conanfile)
         local_repositories = []
         generators_folder = self._conanfile.generators_folder
 

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -4,7 +4,7 @@ import textwrap
 
 from jinja2 import Template
 
-from conan.tools import _check_duplicated_generator
+from conan.internal import check_duplicated_generator
 from conans.errors import ConanException
 from conans.util.files import save
 
@@ -14,7 +14,7 @@ class BazelDeps(object):
         self._conanfile = conanfile
 
     def generate(self):
-        _check_duplicated_generator(self, self._conanfile)
+        check_duplicated_generator(self, self._conanfile)
         local_repositories = []
         generators_folder = self._conanfile.generators_folder
 

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -11,7 +11,7 @@ from conans.util.files import save
 class BazelDeps(object):
     def __init__(self, conanfile):
         if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
                                  "attribute, but was also instantiated in the generate() method."
                                  "It should only be present in one of them.")
         self._conanfile = conanfile

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -4,16 +4,14 @@ import textwrap
 
 from jinja2 import Template
 
+from conan.tools import _check_duplicated_generator
 from conans.errors import ConanException
 from conans.util.files import save
 
 
 class BazelDeps(object):
     def __init__(self, conanfile):
-        if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method. "
-                                 "It should only be present in one of them.")
+        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
 
     def generate(self):

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -12,7 +12,7 @@ class BazelDeps(object):
     def __init__(self, conanfile):
         if self.__class__.__name__ in conanfile.generators:
             raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method."
+                                 "attribute, but was also instantiated in the generate() method. "
                                  "It should only be present in one of them.")
         self._conanfile = conanfile
 

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -10,6 +10,10 @@ from conans.util.files import save
 
 class BazelDeps(object):
     def __init__(self, conanfile):
+        if self.__class__.__name__ in conanfile.generators:
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+                                 "attribute, but was also instantiated in the generate() method."
+                                 "It should only be present in one of them.")
         self._conanfile = conanfile
 
     def generate(self):

--- a/conan/tools/google/toolchain.py
+++ b/conan/tools/google/toolchain.py
@@ -1,13 +1,11 @@
+from conan.tools import _check_duplicated_generator
 from conan.tools.files.files import save_toolchain_args
 
 
 class BazelToolchain(object):
 
     def __init__(self, conanfile, namespace=None):
-        if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method. "
-                                 "It should only be present in one of them.")
+        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self._namespace = namespace
 

--- a/conan/tools/google/toolchain.py
+++ b/conan/tools/google/toolchain.py
@@ -6,7 +6,7 @@ class BazelToolchain(object):
     def __init__(self, conanfile, namespace=None):
         if self.__class__.__name__ in conanfile.generators:
             raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method."
+                                 "attribute, but was also instantiated in the generate() method. "
                                  "It should only be present in one of them.")
         self._conanfile = conanfile
         self._namespace = namespace

--- a/conan/tools/google/toolchain.py
+++ b/conan/tools/google/toolchain.py
@@ -5,7 +5,7 @@ class BazelToolchain(object):
 
     def __init__(self, conanfile, namespace=None):
         if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
                                  "attribute, but was also instantiated in the generate() method."
                                  "It should only be present in one of them.")
         self._conanfile = conanfile

--- a/conan/tools/google/toolchain.py
+++ b/conan/tools/google/toolchain.py
@@ -1,4 +1,4 @@
-from conan.tools import _check_duplicated_generator
+from conan.internal import check_duplicated_generator
 from conan.tools.files.files import save_toolchain_args
 
 
@@ -9,7 +9,7 @@ class BazelToolchain(object):
         self._namespace = namespace
 
     def generate(self):
-        _check_duplicated_generator(self, self._conanfile)
+        check_duplicated_generator(self, self._conanfile)
         content = {}
         configs = ",".join(self._conanfile.conf.get("tools.google.bazel:configs",
                                                     default=[],

--- a/conan/tools/google/toolchain.py
+++ b/conan/tools/google/toolchain.py
@@ -5,11 +5,11 @@ from conan.tools.files.files import save_toolchain_args
 class BazelToolchain(object):
 
     def __init__(self, conanfile, namespace=None):
-        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self._namespace = namespace
 
     def generate(self):
+        _check_duplicated_generator(self, self._conanfile)
         content = {}
         configs = ",".join(self._conanfile.conf.get("tools.google.bazel:configs",
                                                     default=[],

--- a/conan/tools/google/toolchain.py
+++ b/conan/tools/google/toolchain.py
@@ -4,6 +4,10 @@ from conan.tools.files.files import save_toolchain_args
 class BazelToolchain(object):
 
     def __init__(self, conanfile, namespace=None):
+        if self.__class__.__name__ in conanfile.generators:
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+                                 "attribute, but was also instantiated in the generate() method."
+                                 "It should only be present in one of them.")
         self._conanfile = conanfile
         self._namespace = namespace
 

--- a/conan/tools/intel/intel_cc.py
+++ b/conan/tools/intel/intel_cc.py
@@ -41,7 +41,7 @@ class IntelCC:
         # Let's check the compatibility
         if self.__class__.__name__ in conanfile.generators:
             raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method."
+                                 "attribute, but was also instantiated in the generate() method. "
                                  "It should only be present in one of them.")
         compiler_version = conanfile.settings.get_safe("compiler.version")
         mode = conanfile.settings.get_safe("compiler.mode")

--- a/conan/tools/intel/intel_cc.py
+++ b/conan/tools/intel/intel_cc.py
@@ -39,6 +39,10 @@ class IntelCC:
 
     def __init__(self, conanfile):
         # Let's check the compatibility
+        if self.__class__.__name__ in conanfile.generators:
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+                                 "attribute, but was also instantiated in the generate() method."
+                                 "It should only be present in one of them.")
         compiler_version = conanfile.settings.get_safe("compiler.version")
         mode = conanfile.settings.get_safe("compiler.mode")
         if _is_using_intel_oneapi(compiler_version):

--- a/conan/tools/intel/intel_cc.py
+++ b/conan/tools/intel/intel_cc.py
@@ -21,6 +21,7 @@ import os
 import platform
 import textwrap
 
+from conan.tools import _check_duplicated_generator
 from conans.errors import ConanException
 
 
@@ -39,10 +40,7 @@ class IntelCC:
 
     def __init__(self, conanfile):
         # Let's check the compatibility
-        if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method. "
-                                 "It should only be present in one of them.")
+        _check_duplicated_generator(self, conanfile)
         compiler_version = conanfile.settings.get_safe("compiler.version")
         mode = conanfile.settings.get_safe("compiler.mode")
         if _is_using_intel_oneapi(compiler_version):

--- a/conan/tools/intel/intel_cc.py
+++ b/conan/tools/intel/intel_cc.py
@@ -40,7 +40,6 @@ class IntelCC:
 
     def __init__(self, conanfile):
         # Let's check the compatibility
-        _check_duplicated_generator(self, conanfile)
         compiler_version = conanfile.settings.get_safe("compiler.version")
         mode = conanfile.settings.get_safe("compiler.mode")
         if _is_using_intel_oneapi(compiler_version):
@@ -74,6 +73,7 @@ class IntelCC:
 
     def generate(self, scope="build"):
         """Generate the Conan Intel file to be loaded in build environment by default"""
+        _check_duplicated_generator(self, self._conanfile)
         if platform.system() == "Windows" and not self._conanfile.win_bash:
             content = textwrap.dedent("""\
                 @echo off

--- a/conan/tools/intel/intel_cc.py
+++ b/conan/tools/intel/intel_cc.py
@@ -21,7 +21,7 @@ import os
 import platform
 import textwrap
 
-from conan.tools import _check_duplicated_generator
+from conan.internal import check_duplicated_generator
 from conans.errors import ConanException
 
 
@@ -73,7 +73,7 @@ class IntelCC:
 
     def generate(self, scope="build"):
         """Generate the Conan Intel file to be loaded in build environment by default"""
-        _check_duplicated_generator(self, self._conanfile)
+        check_duplicated_generator(self, self._conanfile)
         if platform.system() == "Windows" and not self._conanfile.win_bash:
             content = textwrap.dedent("""\
                 @echo off

--- a/conan/tools/intel/intel_cc.py
+++ b/conan/tools/intel/intel_cc.py
@@ -40,7 +40,7 @@ class IntelCC:
     def __init__(self, conanfile):
         # Let's check the compatibility
         if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
                                  "attribute, but was also instantiated in the generate() method."
                                  "It should only be present in one of them.")
         compiler_version = conanfile.settings.get_safe("compiler.version")

--- a/conan/tools/meson/mesondeps.py
+++ b/conan/tools/meson/mesondeps.py
@@ -2,7 +2,7 @@ import textwrap
 
 from jinja2 import Template
 
-from conan.tools import _check_duplicated_generator
+from conan.internal import check_duplicated_generator
 from conan.tools.gnu.gnudeps_flags import GnuDepsFlags
 from conan.tools.meson.helpers import to_meson_value
 from conans.model.build_info import CppInfo
@@ -103,5 +103,5 @@ class MesonDeps:
         return content
 
     def generate(self):
-        _check_duplicated_generator(self, self._conanfile)
+        check_duplicated_generator(self, self._conanfile)
         save(self.filename, self._content())

--- a/conan/tools/meson/mesondeps.py
+++ b/conan/tools/meson/mesondeps.py
@@ -4,6 +4,7 @@ from jinja2 import Template
 
 from conan.tools.gnu.gnudeps_flags import GnuDepsFlags
 from conan.tools.meson.helpers import to_meson_value
+from conans.errors import ConanException
 from conans.model.build_info import CppInfo
 from conans.util.files import save
 
@@ -22,6 +23,10 @@ class MesonDeps:
     """)
 
     def __init__(self, conanfile):
+        if self.__class__.__name__ in conanfile.generators:
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+                                 "attribute, but was also instantiated in the generate() method."
+                                 "It should only be present in one of them.")
         self._conanfile = conanfile
         self._ordered_deps = []
         # constants

--- a/conan/tools/meson/mesondeps.py
+++ b/conan/tools/meson/mesondeps.py
@@ -23,7 +23,6 @@ class MesonDeps:
     """)
 
     def __init__(self, conanfile):
-        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self._ordered_deps = []
         # constants
@@ -104,4 +103,5 @@ class MesonDeps:
         return content
 
     def generate(self):
+        _check_duplicated_generator(self, self._conanfile)
         save(self.filename, self._content())

--- a/conan/tools/meson/mesondeps.py
+++ b/conan/tools/meson/mesondeps.py
@@ -25,7 +25,7 @@ class MesonDeps:
     def __init__(self, conanfile):
         if self.__class__.__name__ in conanfile.generators:
             raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method."
+                                 "attribute, but was also instantiated in the generate() method. "
                                  "It should only be present in one of them.")
         self._conanfile = conanfile
         self._ordered_deps = []

--- a/conan/tools/meson/mesondeps.py
+++ b/conan/tools/meson/mesondeps.py
@@ -24,7 +24,7 @@ class MesonDeps:
 
     def __init__(self, conanfile):
         if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
                                  "attribute, but was also instantiated in the generate() method."
                                  "It should only be present in one of them.")
         self._conanfile = conanfile

--- a/conan/tools/meson/mesondeps.py
+++ b/conan/tools/meson/mesondeps.py
@@ -2,9 +2,9 @@ import textwrap
 
 from jinja2 import Template
 
+from conan.tools import _check_duplicated_generator
 from conan.tools.gnu.gnudeps_flags import GnuDepsFlags
 from conan.tools.meson.helpers import to_meson_value
-from conans.errors import ConanException
 from conans.model.build_info import CppInfo
 from conans.util.files import save
 
@@ -23,10 +23,7 @@ class MesonDeps:
     """)
 
     def __init__(self, conanfile):
-        if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method. "
-                                 "It should only be present in one of them.")
+        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self._ordered_deps = []
         # constants

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -3,7 +3,7 @@ import textwrap
 
 from jinja2 import Template
 
-from conan.tools import _check_duplicated_generator
+from conan.internal import check_duplicated_generator
 from conan.tools.apple.apple import to_apple_arch, is_apple_os, apple_min_version_flag
 from conan.tools.build.cross_building import cross_building
 from conan.tools.build.flags import libcxx_flags
@@ -428,7 +428,7 @@ class MesonToolchain(object):
         ``conan_meson_cross.ini`` (if cross builds) with the proper content.
         If Windows OS, it will be created a ``conanvcvars.bat`` as well.
         """
-        _check_duplicated_generator(self, self._conanfile)
+        check_duplicated_generator(self, self._conanfile)
         filename = self.native_filename if not self.cross_build else self.cross_filename
         save(filename, self._content)
         # FIXME: Should we check the OS and compiler to call VCVars?

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -95,7 +95,7 @@ class MesonToolchain(object):
         """
         if self.__class__.__name__ in conanfile.generators:
             raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method."
+                                 "attribute, but was also instantiated in the generate() method. "
                                  "It should only be present in one of them.")
         self._conanfile = conanfile
         self._os = self._conanfile.settings.get_safe("os")

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -94,7 +94,7 @@ class MesonToolchain(object):
         :param backend: ``str`` ``backend`` Meson variable value. By default, ``ninja``.
         """
         if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
                                  "attribute, but was also instantiated in the generate() method."
                                  "It should only be present in one of them.")
         self._conanfile = conanfile

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -93,6 +93,10 @@ class MesonToolchain(object):
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         :param backend: ``str`` ``backend`` Meson variable value. By default, ``ninja``.
         """
+        if self.__class__.__name__ in conanfile.generators:
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+                                 "attribute, but was also instantiated in the generate() method."
+                                 "It should only be present in one of them.")
         self._conanfile = conanfile
         self._os = self._conanfile.settings.get_safe("os")
         self._is_apple_system = is_apple_os(self._conanfile)

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -3,6 +3,7 @@ import textwrap
 
 from jinja2 import Template
 
+from conan.tools import _check_duplicated_generator
 from conan.tools.apple.apple import to_apple_arch, is_apple_os, apple_min_version_flag
 from conan.tools.build.cross_building import cross_building
 from conan.tools.build.flags import libcxx_flags
@@ -93,10 +94,7 @@ class MesonToolchain(object):
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         :param backend: ``str`` ``backend`` Meson variable value. By default, ``ninja``.
         """
-        if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method. "
-                                 "It should only be present in one of them.")
+        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self._os = self._conanfile.settings.get_safe("os")
         self._is_apple_system = is_apple_os(self._conanfile)

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -94,7 +94,6 @@ class MesonToolchain(object):
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         :param backend: ``str`` ``backend`` Meson variable value. By default, ``ninja``.
         """
-        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self._os = self._conanfile.settings.get_safe("os")
         self._is_apple_system = is_apple_os(self._conanfile)
@@ -429,6 +428,7 @@ class MesonToolchain(object):
         ``conan_meson_cross.ini`` (if cross builds) with the proper content.
         If Windows OS, it will be created a ``conanvcvars.bat`` as well.
         """
+        _check_duplicated_generator(self, self._conanfile)
         filename = self.native_filename if not self.cross_build else self.cross_filename
         save(filename, self._content)
         # FIXME: Should we check the OS and compiler to call VCVars?

--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -92,6 +92,10 @@ class MSBuildDeps(object):
         """
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         """
+        if self.__class__.__name__ in conanfile.generators:
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+                                 "attribute, but was also instantiated in the generate() method."
+                                 "It should only be present in one of them.")
         self._conanfile = conanfile
         #: Defines the build type. By default, ``settings.build_type``.
         self.configuration = conanfile.settings.build_type

--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -6,7 +6,7 @@ from xml.dom import minidom
 
 from jinja2 import Template
 
-from conan.tools import _check_duplicated_generator
+from conan.internal import check_duplicated_generator
 from conans.errors import ConanException
 from conans.model.dependencies import get_transitive_requires
 from conans.util.files import load, save
@@ -114,7 +114,7 @@ class MSBuildDeps(object):
         Generates ``conan_<pkg>_<config>_vars.props``, ``conan_<pkg>_<config>.props``,
         and ``conan_<pkg>.props`` files into the ``conanfile.generators_folder``.
         """
-        _check_duplicated_generator(self, self._conanfile)
+        check_duplicated_generator(self, self._conanfile)
         if self.configuration is None:
             raise ConanException("MSBuildDeps.configuration is None, it should have a value")
         if self.platform is None:

--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -93,7 +93,7 @@ class MSBuildDeps(object):
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         """
         if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
                                  "attribute, but was also instantiated in the generate() method."
                                  "It should only be present in one of them.")
         self._conanfile = conanfile

--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -6,6 +6,7 @@ from xml.dom import minidom
 
 from jinja2 import Template
 
+from conan.tools import _check_duplicated_generator
 from conans.errors import ConanException
 from conans.model.dependencies import get_transitive_requires
 from conans.util.files import load, save
@@ -92,10 +93,7 @@ class MSBuildDeps(object):
         """
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         """
-        if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method. "
-                                 "It should only be present in one of them.")
+        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         #: Defines the build type. By default, ``settings.build_type``.
         self.configuration = conanfile.settings.build_type

--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -93,7 +93,6 @@ class MSBuildDeps(object):
         """
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         """
-        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         #: Defines the build type. By default, ``settings.build_type``.
         self.configuration = conanfile.settings.build_type
@@ -115,6 +114,7 @@ class MSBuildDeps(object):
         Generates ``conan_<pkg>_<config>_vars.props``, ``conan_<pkg>_<config>.props``,
         and ``conan_<pkg>.props`` files into the ``conanfile.generators_folder``.
         """
+        _check_duplicated_generator(self, self._conanfile)
         if self.configuration is None:
             raise ConanException("MSBuildDeps.configuration is None, it should have a value")
         if self.platform is None:

--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -94,7 +94,7 @@ class MSBuildDeps(object):
         """
         if self.__class__.__name__ in conanfile.generators:
             raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method."
+                                 "attribute, but was also instantiated in the generate() method. "
                                  "It should only be present in one of them.")
         self._conanfile = conanfile
         #: Defines the build type. By default, ``settings.build_type``.

--- a/conan/tools/microsoft/nmakedeps.py
+++ b/conan/tools/microsoft/nmakedeps.py
@@ -1,6 +1,6 @@
 import os
 
-from conan.tools import _check_duplicated_generator
+from conan.internal import check_duplicated_generator
 from conan.tools.env import Environment
 from conans.model.build_info import CppInfo
 
@@ -59,5 +59,5 @@ class NMakeDeps(object):
         return self.environment.vars(self._conanfile, scope=scope)
 
     def generate(self, scope="build"):
-        _check_duplicated_generator(self, self._conanfile)
+        check_duplicated_generator(self, self._conanfile)
         self.vars(scope).save_script("conannmakedeps")

--- a/conan/tools/microsoft/nmakedeps.py
+++ b/conan/tools/microsoft/nmakedeps.py
@@ -12,7 +12,7 @@ class NMakeDeps(object):
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         """
         if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
                                  "attribute, but was also instantiated in the generate() method."
                                  "It should only be present in one of them.")
         self._conanfile = conanfile

--- a/conan/tools/microsoft/nmakedeps.py
+++ b/conan/tools/microsoft/nmakedeps.py
@@ -11,7 +11,6 @@ class NMakeDeps(object):
         """
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         """
-        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self._environment = None
 
@@ -60,4 +59,5 @@ class NMakeDeps(object):
         return self.environment.vars(self._conanfile, scope=scope)
 
     def generate(self, scope="build"):
+        _check_duplicated_generator(self, self._conanfile)
         self.vars(scope).save_script("conannmakedeps")

--- a/conan/tools/microsoft/nmakedeps.py
+++ b/conan/tools/microsoft/nmakedeps.py
@@ -1,7 +1,7 @@
 import os
 
+from conan.tools import _check_duplicated_generator
 from conan.tools.env import Environment
-from conans.errors import ConanException
 from conans.model.build_info import CppInfo
 
 
@@ -11,10 +11,7 @@ class NMakeDeps(object):
         """
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         """
-        if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method. "
-                                 "It should only be present in one of them.")
+        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self._environment = None
 

--- a/conan/tools/microsoft/nmakedeps.py
+++ b/conan/tools/microsoft/nmakedeps.py
@@ -1,6 +1,7 @@
 import os
 
 from conan.tools.env import Environment
+from conans.errors import ConanException
 from conans.model.build_info import CppInfo
 
 
@@ -10,6 +11,10 @@ class NMakeDeps(object):
         """
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         """
+        if self.__class__.__name__ in conanfile.generators:
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+                                 "attribute, but was also instantiated in the generate() method."
+                                 "It should only be present in one of them.")
         self._conanfile = conanfile
         self._environment = None
 

--- a/conan/tools/microsoft/nmakedeps.py
+++ b/conan/tools/microsoft/nmakedeps.py
@@ -13,7 +13,7 @@ class NMakeDeps(object):
         """
         if self.__class__.__name__ in conanfile.generators:
             raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method."
+                                 "attribute, but was also instantiated in the generate() method. "
                                  "It should only be present in one of them.")
         self._conanfile = conanfile
         self._environment = None

--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -15,7 +15,6 @@ class NMakeToolchain(object):
         """
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         """
-        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self._environment = None
 
@@ -53,6 +52,7 @@ class NMakeToolchain(object):
         return self.environment.vars(self._conanfile, scope=scope)
 
     def generate(self, scope="build"):
+        _check_duplicated_generator(self, self._conanfile)
         self.vars(scope).save_script("conannmaketoolchain")
         from conan.tools.microsoft import VCVars
         VCVars(self._conanfile).generate()

--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -17,7 +17,7 @@ class NMakeToolchain(object):
         """
         if self.__class__.__name__ in conanfile.generators:
             raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method."
+                                 "attribute, but was also instantiated in the generate() method. "
                                  "It should only be present in one of them.")
         self._conanfile = conanfile
         self._environment = None

--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -1,6 +1,6 @@
+from conan.tools import _check_duplicated_generator
 from conan.tools.build.flags import build_type_flags, cppstd_flag
 from conan.tools.env import Environment
-from conans.errors import ConanException
 
 
 class NMakeToolchain(object):
@@ -15,10 +15,7 @@ class NMakeToolchain(object):
         """
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         """
-        if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method. "
-                                 "It should only be present in one of them.")
+        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         self._environment = None
 

--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -1,5 +1,6 @@
 from conan.tools.build.flags import build_type_flags, cppstd_flag
 from conan.tools.env import Environment
+from conans.errors import ConanException
 
 
 class NMakeToolchain(object):
@@ -14,6 +15,10 @@ class NMakeToolchain(object):
         """
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         """
+        if self.__class__.__name__ in conanfile.generators:
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+                                 "attribute, but was also instantiated in the generate() method."
+                                 "It should only be present in one of them.")
         self._conanfile = conanfile
         self._environment = None
 

--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -1,4 +1,4 @@
-from conan.tools import _check_duplicated_generator
+from conan.internal import check_duplicated_generator
 from conan.tools.build.flags import build_type_flags, cppstd_flag
 from conan.tools.env import Environment
 
@@ -52,7 +52,7 @@ class NMakeToolchain(object):
         return self.environment.vars(self._conanfile, scope=scope)
 
     def generate(self, scope="build"):
-        _check_duplicated_generator(self, self._conanfile)
+        check_duplicated_generator(self, self._conanfile)
         self.vars(scope).save_script("conannmaketoolchain")
         from conan.tools.microsoft import VCVars
         VCVars(self._conanfile).generate()

--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -16,7 +16,7 @@ class NMakeToolchain(object):
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         """
         if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
                                  "attribute, but was also instantiated in the generate() method."
                                  "It should only be present in one of them.")
         self._conanfile = conanfile

--- a/conan/tools/microsoft/toolchain.py
+++ b/conan/tools/microsoft/toolchain.py
@@ -51,7 +51,7 @@ class MSBuildToolchain(object):
         """
         if self.__class__.__name__ in conanfile.generators:
             raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method."
+                                 "attribute, but was also instantiated in the generate() method. "
                                  "It should only be present in one of them.")
         self._conanfile = conanfile
         #: Dict-like that defines the preprocessor definitions

--- a/conan/tools/microsoft/toolchain.py
+++ b/conan/tools/microsoft/toolchain.py
@@ -50,7 +50,6 @@ class MSBuildToolchain(object):
         """
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         """
-        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         #: Dict-like that defines the preprocessor definitions
         self.preprocessor_definitions = {}
@@ -93,6 +92,7 @@ class MSBuildToolchain(object):
         valid XML format with all the good settings like any other VS project ``*.props`` file. The
         last one emulates the ``vcvarsall.bat`` env script. See also :class:`VCVars`.
         """
+        _check_duplicated_generator(self, self._conanfile)
         name, condition = self._name_condition(self._conanfile.settings)
         config_filename = "conantoolchain{}.props".format(name)
         # Writing the props files

--- a/conan/tools/microsoft/toolchain.py
+++ b/conan/tools/microsoft/toolchain.py
@@ -4,6 +4,7 @@ from xml.dom import minidom
 
 from jinja2 import Template
 
+from conan.tools import _check_duplicated_generator
 from conan.tools.build import build_jobs
 from conan.tools.intel.intel_cc import IntelCC
 from conan.tools.microsoft.visual import VCVars, msvc_version_to_toolset_version
@@ -49,10 +50,7 @@ class MSBuildToolchain(object):
         """
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         """
-        if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method. "
-                                 "It should only be present in one of them.")
+        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
         #: Dict-like that defines the preprocessor definitions
         self.preprocessor_definitions = {}

--- a/conan/tools/microsoft/toolchain.py
+++ b/conan/tools/microsoft/toolchain.py
@@ -49,6 +49,10 @@ class MSBuildToolchain(object):
         """
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         """
+        if self.__class__.__name__ in conanfile.generators:
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+                                 "attribute, but was also instantiated in the generate() method."
+                                 "It should only be present in one of them.")
         self._conanfile = conanfile
         #: Dict-like that defines the preprocessor definitions
         self.preprocessor_definitions = {}

--- a/conan/tools/microsoft/toolchain.py
+++ b/conan/tools/microsoft/toolchain.py
@@ -50,7 +50,7 @@ class MSBuildToolchain(object):
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         """
         if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
                                  "attribute, but was also instantiated in the generate() method."
                                  "It should only be present in one of them.")
         self._conanfile = conanfile

--- a/conan/tools/microsoft/toolchain.py
+++ b/conan/tools/microsoft/toolchain.py
@@ -4,7 +4,7 @@ from xml.dom import minidom
 
 from jinja2 import Template
 
-from conan.tools import _check_duplicated_generator
+from conan.internal import check_duplicated_generator
 from conan.tools.build import build_jobs
 from conan.tools.intel.intel_cc import IntelCC
 from conan.tools.microsoft.visual import VCVars, msvc_version_to_toolset_version
@@ -92,7 +92,7 @@ class MSBuildToolchain(object):
         valid XML format with all the good settings like any other VS project ``*.props`` file. The
         last one emulates the ``vcvarsall.bat`` env script. See also :class:`VCVars`.
         """
-        _check_duplicated_generator(self, self._conanfile)
+        check_duplicated_generator(self, self._conanfile)
         name, condition = self._name_condition(self._conanfile.settings)
         config_filename = "conantoolchain{}.props".format(name)
         # Writing the props files

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -80,6 +80,10 @@ class VCVars:
         """
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         """
+        if self.__class__.__name__ in conanfile.generators:
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+                                 "attribute, but was also instantiated in the generate() method."
+                                 "It should only be present in one of them.")
         self._conanfile = conanfile
 
     def generate(self, scope="build"):

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -81,7 +81,7 @@ class VCVars:
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         """
         if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
                                  "attribute, but was also instantiated in the generate() method."
                                  "It should only be present in one of them.")
         self._conanfile = conanfile

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -81,7 +81,6 @@ class VCVars:
         """
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         """
-        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
 
     def generate(self, scope="build"):
@@ -92,6 +91,7 @@ class VCVars:
         :param scope: ``str`` Launcher to be used to run all the variables. For instance,
                       if ``build``, then it'll be used the ``conanbuild`` launcher.
         """
+        _check_duplicated_generator(self, self._conanfile)
         conanfile = self._conanfile
         os_ = conanfile.settings.get_safe("os")
         if os_ != "Windows":

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -1,7 +1,7 @@
 import os
 import textwrap
 
-from conan.tools import _check_duplicated_generator
+from conan.internal import check_duplicated_generator
 from conans.client.conf.detect_vs import vs_installation_path
 from conans.errors import ConanException, ConanInvalidConfiguration
 from conan.tools.scm import Version
@@ -91,7 +91,7 @@ class VCVars:
         :param scope: ``str`` Launcher to be used to run all the variables. For instance,
                       if ``build``, then it'll be used the ``conanbuild`` launcher.
         """
-        _check_duplicated_generator(self, self._conanfile)
+        check_duplicated_generator(self, self._conanfile)
         conanfile = self._conanfile
         os_ = conanfile.settings.get_safe("os")
         if os_ != "Windows":

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -82,7 +82,7 @@ class VCVars:
         """
         if self.__class__.__name__ in conanfile.generators:
             raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method."
+                                 "attribute, but was also instantiated in the generate() method. "
                                  "It should only be present in one of them.")
         self._conanfile = conanfile
 

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -1,6 +1,7 @@
 import os
 import textwrap
 
+from conan.tools import _check_duplicated_generator
 from conans.client.conf.detect_vs import vs_installation_path
 from conans.errors import ConanException, ConanInvalidConfiguration
 from conan.tools.scm import Version
@@ -80,10 +81,7 @@ class VCVars:
         """
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         """
-        if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method. "
-                                 "It should only be present in one of them.")
+        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
 
     def generate(self, scope="build"):

--- a/conan/tools/premake/premakedeps.py
+++ b/conan/tools/premake/premakedeps.py
@@ -41,7 +41,7 @@ class PremakeDeps(object):
     def __init__(self, conanfile):
         if self.__class__.__name__ in conanfile.generators:
             raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method."
+                                 "attribute, but was also instantiated in the generate() method. "
                                  "It should only be present in one of them.")
         self._conanfile = conanfile
 

--- a/conan/tools/premake/premakedeps.py
+++ b/conan/tools/premake/premakedeps.py
@@ -40,7 +40,7 @@ class PremakeDeps(object):
 
     def __init__(self, conanfile):
         if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
                                  "attribute, but was also instantiated in the generate() method."
                                  "It should only be present in one of them.")
         self._conanfile = conanfile

--- a/conan/tools/premake/premakedeps.py
+++ b/conan/tools/premake/premakedeps.py
@@ -1,4 +1,4 @@
-from conan.tools import _check_duplicated_generator
+from conan.internal import check_duplicated_generator
 from conans.model.build_info import CppInfo
 from conans.util.files import save
 
@@ -42,7 +42,7 @@ class PremakeDeps(object):
         self._conanfile = conanfile
 
     def generate(self):
-        _check_duplicated_generator(self, self._conanfile)
+        check_duplicated_generator(self, self._conanfile)
         # Current directory is the generators_folder
         generator_files = self.content
         for generator_file, content in generator_files.items():

--- a/conan/tools/premake/premakedeps.py
+++ b/conan/tools/premake/premakedeps.py
@@ -1,3 +1,4 @@
+from conans.errors import ConanException
 from conans.model.build_info import CppInfo
 from conans.util.files import save
 
@@ -38,6 +39,10 @@ class _PremakeTemplate(object):
 class PremakeDeps(object):
 
     def __init__(self, conanfile):
+        if self.__class__.__name__ in conanfile.generators:
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+                                 "attribute, but was also instantiated in the generate() method."
+                                 "It should only be present in one of them.")
         self._conanfile = conanfile
 
     def generate(self):

--- a/conan/tools/premake/premakedeps.py
+++ b/conan/tools/premake/premakedeps.py
@@ -1,4 +1,4 @@
-from conans.errors import ConanException
+from conan.tools import _check_duplicated_generator
 from conans.model.build_info import CppInfo
 from conans.util.files import save
 
@@ -39,10 +39,7 @@ class _PremakeTemplate(object):
 class PremakeDeps(object):
 
     def __init__(self, conanfile):
-        if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method. "
-                                 "It should only be present in one of them.")
+        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
 
     def generate(self):

--- a/conan/tools/premake/premakedeps.py
+++ b/conan/tools/premake/premakedeps.py
@@ -39,10 +39,10 @@ class _PremakeTemplate(object):
 class PremakeDeps(object):
 
     def __init__(self, conanfile):
-        _check_duplicated_generator(self, conanfile)
         self._conanfile = conanfile
 
     def generate(self):
+        _check_duplicated_generator(self, self._conanfile)
         # Current directory is the generators_folder
         generator_files = self.content
         for generator_file, content in generator_files.items():

--- a/conan/tools/qbs/qbsprofile.py
+++ b/conan/tools/qbs/qbsprofile.py
@@ -5,7 +5,7 @@ import textwrap
 from io import StringIO
 from jinja2 import Template
 
-from conan.tools import _check_duplicated_generator
+from conan.internal import check_duplicated_generator
 from conans.errors import ConanException
 from conans.util.files import save
 
@@ -286,7 +286,7 @@ class QbsProfile(object):
             conanfile.options.get_safe('fPIC'))
 
     def generate(self):
-        _check_duplicated_generator(self, self._conanfile)
+        check_duplicated_generator(self, self._conanfile)
         save(self.old_filename, self.content)
         save(self.filename, self.content)
 

--- a/conan/tools/qbs/qbsprofile.py
+++ b/conan/tools/qbs/qbsprofile.py
@@ -260,7 +260,7 @@ class QbsProfile(object):
 
     def __init__(self, conanfile):
         if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
                                  "attribute, but was also instantiated in the generate() method."
                                  "It should only be present in one of them.")
         _check_for_compiler(conanfile)

--- a/conan/tools/qbs/qbsprofile.py
+++ b/conan/tools/qbs/qbsprofile.py
@@ -259,6 +259,10 @@ class QbsProfile(object):
         ''')
 
     def __init__(self, conanfile):
+        if self.__class__.__name__ in conanfile.generators:
+            raise ConanException(f"{self.__class__.__name__} is declared in the generators"
+                                 "attribute, but was also instantiated in the generate() method."
+                                 "It should only be present in one of them.")
         _check_for_compiler(conanfile)
         self._conanfile = conanfile
         _setup_toolchains(conanfile)

--- a/conan/tools/qbs/qbsprofile.py
+++ b/conan/tools/qbs/qbsprofile.py
@@ -261,7 +261,7 @@ class QbsProfile(object):
     def __init__(self, conanfile):
         if self.__class__.__name__ in conanfile.generators:
             raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method."
+                                 "attribute, but was also instantiated in the generate() method. "
                                  "It should only be present in one of them.")
         _check_for_compiler(conanfile)
         self._conanfile = conanfile

--- a/conan/tools/qbs/qbsprofile.py
+++ b/conan/tools/qbs/qbsprofile.py
@@ -261,7 +261,6 @@ class QbsProfile(object):
         ''')
 
     def __init__(self, conanfile):
-        _check_duplicated_generator(self, conanfile)
         _check_for_compiler(conanfile)
         self._conanfile = conanfile
         _setup_toolchains(conanfile)
@@ -287,6 +286,7 @@ class QbsProfile(object):
             conanfile.options.get_safe('fPIC'))
 
     def generate(self):
+        _check_duplicated_generator(self, self._conanfile)
         save(self.old_filename, self.content)
         save(self.filename, self.content)
 

--- a/conan/tools/qbs/qbsprofile.py
+++ b/conan/tools/qbs/qbsprofile.py
@@ -4,6 +4,8 @@ import textwrap
 
 from io import StringIO
 from jinja2 import Template
+
+from conan.tools import _check_duplicated_generator
 from conans.errors import ConanException
 from conans.util.files import save
 
@@ -259,10 +261,7 @@ class QbsProfile(object):
         ''')
 
     def __init__(self, conanfile):
-        if self.__class__.__name__ in conanfile.generators:
-            raise ConanException(f"{self.__class__.__name__} is declared in the generators "
-                                 "attribute, but was also instantiated in the generate() method. "
-                                 "It should only be present in one of them.")
+        _check_duplicated_generator(self, conanfile)
         _check_for_compiler(conanfile)
         self._conanfile = conanfile
         _setup_toolchains(conanfile)

--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -93,7 +93,12 @@ def write_generators(conanfile, hook_manager):
 
     if conanfile.generators:
         conanfile.output.info(f"Writing generators to {new_gen_folder}")
-    for generator_name in set(conanfile.generators):
+    # generators check that they are not present in the generators field,
+    # to avoid duplicates between the generators attribute and the generate() method
+    # They would raise an exception here if we don't invalidate the field while we call them
+    old_generators = set(conanfile.generators)
+    conanfile.generators = []
+    for generator_name in old_generators:
         generator_class = _get_generator_class(generator_name)
         if generator_class:
             try:
@@ -107,7 +112,9 @@ def write_generators(conanfile, hook_manager):
                 # When a generator fails, it is very useful to have the whole stacktrace
                 conanfile.output.error(traceback.format_exc())
                 raise ConanException("Error in generator '{}': {}".format(generator_name, str(e)))
-
+    # restore the generators attribute, so it can be checked and raise
+    # if the user tries to instantiate a generator present in generators
+    conanfile.generators = old_generators
     if hasattr(conanfile, "generate"):
         conanfile.output.highlight("Calling generate()")
         mkdir(new_gen_folder)

--- a/conans/test/integration/conanfile/generators_list_test.py
+++ b/conans/test/integration/conanfile/generators_list_test.py
@@ -83,3 +83,4 @@ class ConanfileRepeatedGeneratorsTestCase(unittest.TestCase):
         t.save({'conanfile.py': conanfile})
         # This used to not throw any errors
         t.run("install .", assert_error=True)
+        assert "was instantiated in the generate() method too" in t.out


### PR DESCRIPTION
This used to be a mistake, but no error was ever given to the user

Changelog: (Feature): Raise an error when a generator is both defined in generators attribute and instantiated in generate() method
Docs: Omit

- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
