### PR TITLE
fix CMakeDeps build-requires

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -26,13 +26,13 @@ class CMakeDepsFileTemplate(object):
 
     @property
     def suffix(self):
-        if not self.conanfile.is_build_context:
+        if not self.require.build:
             return ""
         return self.cmakedeps.build_context_suffix.get(self.conanfile.ref.name, "")
 
     @property
     def build_modules_activated(self):
-        if self.conanfile.is_build_context:
+        if self.require.build:
             return self.conanfile.ref.name in self.cmakedeps.build_context_build_modules
         else:
             return self.conanfile.ref.name not in self.cmakedeps.build_context_build_modules
@@ -60,7 +60,7 @@ class CMakeDepsFileTemplate(object):
 
     @property
     def configuration(self):
-        if not self.conanfile.is_build_context:
+        if not self.require.build:
             return self.cmakedeps.configuration \
                 if self.cmakedeps.configuration else None
         else:
@@ -68,7 +68,7 @@ class CMakeDepsFileTemplate(object):
 
     @property
     def arch(self):
-        if not self.conanfile.is_build_context:
+        if not self.require.build:
             return self.cmakedeps.arch if self.cmakedeps.arch else None
         else:
             return self.conanfile.settings_build.get_safe("arch")

--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -20,7 +20,7 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
     @property
     def context(self):
         deps_targets_names = self.get_deps_targets_names() \
-            if not self.conanfile.is_build_context else []
+            if not self.require.build else []
 
         components_targets_names = self.get_declared_components_targets_names()
         components_names = [(components_target_name.replace("::", "_"), components_target_name)

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -180,7 +180,7 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
         return ret
 
     def _get_dependency_filenames(self):
-        if self.conanfile.is_build_context:
+        if self.require.build:
             return []
         ret = []
         direct_host = self.conanfile.dependencies.filter({"build": False, "visible": True,
@@ -197,7 +197,7 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
 
     def _get_dependencies_find_modes(self):
         ret = {}
-        if self.conanfile.is_build_context:
+        if self.require.build:
             return ret
         deps = self.conanfile.dependencies.filter({"build": False, "visible": True, "direct": True})
         for dep in deps.values():


### PR DESCRIPTION
Changelog: Bugfix: Fix ``CMakeDeps`` when a ``tool_requires`` needs to be built from source and it has transitive dependencies that are regular ``requires``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/12664