### PR TITLE
Check for comment only in line start for required_conan_version

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -364,9 +364,9 @@ def _get_required_conan_version_without_loading(conan_file_path):
     txt_version = None
 
     try:
-        found = re.search(r"(.*)required_conan_version\s*=\s*(.*)", contents)
+        found = re.search(r"(.*)required_conan_version\s*=\s*[\"'](.*)[\"']", contents)
         if found and "#" not in found.group(1):
-            txt_version = found.group(2).replace('"', "")
+            txt_version = found.group(2)
     except:
         pass
 

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -364,9 +364,9 @@ def _get_required_conan_version_without_loading(conan_file_path):
     txt_version = None
 
     try:
-        found = re.search(r".*required_conan_version\s*=\s*(.*)", contents)
-        if found and "#" not in found.group(0):
-            txt_version = found.group(1).replace('"', "")
+        found = re.search(r"(.*)required_conan_version\s*=\s*(.*)", contents)
+        if found and "#" not in found.group(1):
+            txt_version = found.group(2).replace('"', "")
     except:
         pass
 

--- a/conans/test/integration/conanfile/required_conan_version_test.py
+++ b/conans/test/integration/conanfile/required_conan_version_test.py
@@ -80,16 +80,18 @@ class RequiredConanVersionTest(unittest.TestCase):
 
     def test_comment_after_required_conan_version(self):
         """
-        An error used to pop out if you tried
+        An error used to pop out if you tried to add a comment in the same line than
+        required_conan_version, as it was trying to compare against >=10.0 # This should work
+        instead of just >= 10.0
         """
         client = TestClient()
         conanfile = textwrap.dedent("""
-                                    from conan import ConanFile
-                                    from LIB_THAT_DOES_NOT_EXIST import MADE_UP_NAME
-                                    required_conan_version = ">=10.0" # This should work
-                                    class Lib(ConanFile):
-                                        pass
-                                    """)
+                    from conan import ConanFile
+                    from LIB_THAT_DOES_NOT_EXIST import MADE_UP_NAME
+                    required_conan_version = ">=10.0" # This should work
+                    class Lib(ConanFile):
+                        pass
+                    """)
         client.save({"conanfile.py": conanfile})
         client.run("export . --name=pkg --version=1.0", assert_error=True)
         self.assertIn("Current Conan version (%s) does not satisfy the defined one (>=10.0)"
@@ -132,10 +134,10 @@ class RequiredConanVersionTest(unittest.TestCase):
             # https://github.com/conan-io/conan/issues/12692
             client = TestClient()
             conanfile = textwrap.dedent("""
-            from conan import ConanFile
-            required_conan_version = ">= 1.0"
-            class Lib(ConanFile):
-                pass""")
+                        from conan import ConanFile
+                        required_conan_version = ">= 1.0"
+                        class Lib(ConanFile):
+                            pass""")
             client.save({"conanfile.py": conanfile})
             client.run("export . --name=pkg --version=1.0", assert_error=True)
             self.assertNotIn(f"Current Conan version ({__version__}) does not satisfy the defined one "

--- a/conans/test/integration/conanfile/required_conan_version_test.py
+++ b/conans/test/integration/conanfile/required_conan_version_test.py
@@ -104,12 +104,12 @@ class RequiredConanVersionTest(unittest.TestCase):
         """
         client = TestClient()
         conanfile = textwrap.dedent("""
-                                    from conan import ConanFile
-                                    from LIB_THAT_DOES_NOT_EXIST import MADE_UP_NAME
-                                    required_conan_version = ">=1.0" # required_conan_version = ">=100.0"
-                                    class Lib(ConanFile):
-                                        pass
-                                    """)
+                    from conan import ConanFile
+                    from LIB_THAT_DOES_NOT_EXIST import MADE_UP_NAME
+                    required_conan_version = ">=1.0" # required_conan_version = ">=100.0"
+                    class Lib(ConanFile):
+                        pass
+                    """)
         client.save({"conanfile.py": conanfile})
         client.run("export . --name=pkg --version=10.0", assert_error=True)
         self.assertNotIn("Current Conan version (%s) does not satisfy the defined one (>=1.0)"
@@ -129,17 +129,17 @@ class RequiredConanVersionTest(unittest.TestCase):
                          % __version__, client.out)
 
     def test_required_conan_version_invalid_syntax(self):
-            """ required_conan_version used to warn of mismatching versions if spaces were present,
-             but now we have a nicer error"""
-            # https://github.com/conan-io/conan/issues/12692
-            client = TestClient()
-            conanfile = textwrap.dedent("""
-                        from conan import ConanFile
-                        required_conan_version = ">= 1.0"
-                        class Lib(ConanFile):
-                            pass""")
-            client.save({"conanfile.py": conanfile})
-            client.run("export . --name=pkg --version=1.0", assert_error=True)
-            self.assertNotIn(f"Current Conan version ({__version__}) does not satisfy the defined one "
-                            "(>= 1.0)", client.out)
-            self.assertIn("Error parsing version range >=", client.out)
+        """ required_conan_version used to warn of mismatching versions if spaces were present,
+         but now we have a nicer error"""
+        # https://github.com/conan-io/conan/issues/12692
+        client = TestClient()
+        conanfile = textwrap.dedent("""
+                    from conan import ConanFile
+                    required_conan_version = ">= 1.0"
+                    class Lib(ConanFile):
+                        pass""")
+        client.save({"conanfile.py": conanfile})
+        client.run("export . --name=pkg --version=1.0", assert_error=True)
+        self.assertNotIn(f"Current Conan version ({__version__}) does not satisfy the defined one "
+                        "(>= 1.0)", client.out)
+        self.assertIn("Error parsing version range >=", client.out)


### PR DESCRIPTION
Changelog: (Bugfix) Allow comments for `required_conan_version`
Docs: Omit

This ensures that both `# required_conan_version = ">=xxx"` and `required_conan_version = ">=xxx" # This is a comment` work when a bad import didn't allow us to load the file normally.

