### PR TITLE
[develop2] Temporarily opt-in to allow uppercase package names

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -22,7 +22,8 @@ def cmd_export(app, conanfile_path, name, version, user, channel, graph_lock=Non
                                    remotes=remotes)
 
     ref = RecipeReference(conanfile.name, conanfile.version,  conanfile.user, conanfile.channel)
-    ref.validate_ref()
+    ref.validate_ref(allow_uppercase=cache.new_config.get("core:allow_uppercase_pkg_names",
+                                                          check_type=bool))
 
     conanfile.display_name = str(ref)
     conanfile.output.scope = conanfile.display_name

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -12,6 +12,7 @@ BUILT_IN_CONFS = {
     "core:non_interactive": "Disable interactive user input, raises error if input necessary",
     "core:default_profile": "Defines the default host profile ('default' by default)",
     "core:default_build_profile": "Defines the default build profile (None by default)",
+    "core:allow_uppercase_pkg_names": "Temporarily (will be removed in 2.X) allow uppercase names",
     "core.upload:retry": "Number of retries in case of failure when uploading to Conan server",
     "core.upload:retry_wait": "Seconds to wait between upload attempts to Conan server",
     "core.download:parallel": "Number of concurrent threads to download packages",

--- a/conans/test/integration/command/export/export_test.py
+++ b/conans/test/integration/command/export/export_test.py
@@ -517,6 +517,17 @@ def test_export_invalid_refs():
     assert "ERROR: Invalid package channel 'channel%'" in c.out
 
 
+def test_allow_temp_uppercase():
+    c = TestClient()
+    c.save({"conanfile.py": GenConanfile()})
+    c.run("export . --name=Pkg --version=0.1", assert_error=True)
+    assert "ERROR: Conan packages names 'Pkg/0.1' must be all lowercase" in c.out
+    c.save({"global.conf": "core:allow_uppercase_pkg_names=True"}, path=c.cache.cache_folder)
+    c.run("export . --name=Pkg --version=0.1")
+    assert "WARN: Package name 'Pkg/0.1' has uppercase, " \
+           "and has been allowed by temporary config." in c.out
+
+
 def test_warn_special_chars_refs():
     c = TestClient()
     c.save({"conanfile.py": GenConanfile()})


### PR DESCRIPTION
Close https://github.com/conan-io/conan/issues/8392

The temporary opt-in to allow uppercase was agreed with the Tribe as a mechanism to help with the migration, and to get approval for forcing lowercase in the general case.
