### PR TITLE
Add cmake install component support #10359

### DIFF
--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -132,7 +132,7 @@ class CMake(object):
     def build(self, build_type=None, target=None, cli_args=None, build_tool_args=None):
         self._build(build_type, target, cli_args, build_tool_args)
 
-    def install(self, build_type=None):
+    def install(self, build_type=None, component=None):
         mkdir(self._conanfile, self._conanfile.package_folder)
 
         bt = build_type or self._conanfile.settings.get_safe("build_type")
@@ -144,6 +144,8 @@ class CMake(object):
         pkg_folder = '"{}"'.format(self._conanfile.package_folder.replace("\\", "/"))
         build_folder = '"{}"'.format(self._conanfile.build_folder)
         arg_list = ["--install", build_folder, build_config, "--prefix", pkg_folder]
+        if component:
+            arg_list.extend(["--component", component])
         arg_list = " ".join(filter(None, arg_list))
         command = "%s %s" % (self._cmake_program, arg_list)
         self._conanfile.output.info("CMake command: %s" % command)

--- a/conans/test/unittests/tools/cmake/test_cmake_install.py
+++ b/conans/test/unittests/tools/cmake/test_cmake_install.py
@@ -42,8 +42,7 @@ def test_run_install_component(generator):
     cmake = CMake(conanfile)
     cmake.install(component="foo")
 
-    search_pattern = "--component foo" if platform.system() == "Windows" else "'--component' 'foo'"
-    assert search_pattern in conanfile.command
+    assert "--component foo" in conanfile.command
 
 
 @pytest.mark.parametrize("generator", [

--- a/conans/test/unittests/tools/cmake/test_cmake_install.py
+++ b/conans/test/unittests/tools/cmake/test_cmake_install.py
@@ -1,0 +1,77 @@
+import platform
+import pytest
+
+from conan.tools.cmake import CMake
+from conan.tools.cmake.presets import write_cmake_presets
+from conans.client.conf import get_default_settings_yml
+from conans.model.conf import Conf
+from conans.model.settings import Settings
+from conans.test.utils.mocks import ConanFileMock
+from conans.test.utils.test_files import temp_folder
+
+
+@pytest.mark.parametrize("generator", [
+    ("NMake Makefiles"),
+    ("Ninja Makefiles"),
+    ("Ninja Multi-Config"),
+    ("Unix Makefiles"),
+    ("Visual Studio 14 2015"),
+    ("Xcode"),
+])
+def test_run_install_component(generator):
+    """
+    Testing that the proper component is installed.
+    Issue related: https://github.com/conan-io/conan/issues/10359
+    """
+    settings = Settings.loads(get_default_settings_yml())
+    settings.os = "Windows"
+    settings.arch = "x86"
+    settings.build_type = "Release"
+    settings.compiler = "Visual Studio"
+    settings.compiler.runtime = "MDd"
+    settings.compiler.version = "14"
+
+    conanfile = ConanFileMock()
+    conanfile.conf = Conf()
+    conanfile.folders.generators = "."
+    conanfile.folders.set_base_generators(temp_folder())
+    conanfile.settings = settings
+    conanfile.folders.set_base_package(temp_folder())
+
+    write_cmake_presets(conanfile, "toolchain", generator, {})
+    cmake = CMake(conanfile)
+    cmake.install(component="foo")
+
+    search_pattern = "--component foo" if platform.system() == "Windows" else "'--component' 'foo'"
+    assert search_pattern in conanfile.command
+
+
+@pytest.mark.parametrize("generator", [
+    ("NMake Makefiles"),
+    ("Ninja Makefiles"),
+    ("Ninja Multi-Config"),
+    ("Unix Makefiles"),
+    ("Visual Studio 14 2015"),
+    ("Xcode"),
+])
+def test_run_install_no_component(generator):
+    settings = Settings.loads(get_default_settings_yml())
+    settings.os = "Windows"
+    settings.arch = "x86"
+    settings.build_type = "Release"
+    settings.compiler = "Visual Studio"
+    settings.compiler.runtime = "MDd"
+    settings.compiler.version = "14"
+
+    conanfile = ConanFileMock()
+    conanfile.conf = Conf()
+    conanfile.folders.generators = "."
+    conanfile.folders.set_base_generators(temp_folder())
+    conanfile.settings = settings
+    conanfile.folders.set_base_package(temp_folder())
+
+    write_cmake_presets(conanfile, "toolchain", generator, {})
+    cmake = CMake(conanfile)
+    cmake.install()
+
+    assert "--component" not in conanfile.command

--- a/conans/test/unittests/tools/cmake/test_cmake_install.py
+++ b/conans/test/unittests/tools/cmake/test_cmake_install.py
@@ -10,19 +10,12 @@ from conans.test.utils.mocks import ConanFileMock
 from conans.test.utils.test_files import temp_folder
 
 
-@pytest.mark.parametrize("generator", [
-    ("NMake Makefiles"),
-    ("Ninja Makefiles"),
-    ("Ninja Multi-Config"),
-    ("Unix Makefiles"),
-    ("Visual Studio 14 2015"),
-    ("Xcode"),
-])
-def test_run_install_component(generator):
+def test_run_install_component():
     """
     Testing that the proper component is installed.
     Issue related: https://github.com/conan-io/conan/issues/10359
     """
+    # Load some generic windows settings
     settings = Settings.loads(get_default_settings_yml())
     settings.os = "Windows"
     settings.arch = "x86"
@@ -38,39 +31,9 @@ def test_run_install_component(generator):
     conanfile.settings = settings
     conanfile.folders.set_base_package(temp_folder())
 
-    write_cmake_presets(conanfile, "toolchain", generator, {})
+    # Choose generator to match generic setttings
+    write_cmake_presets(conanfile, "toolchain", "Visual Studio 14 2015", {})
     cmake = CMake(conanfile)
     cmake.install(component="foo")
 
     assert "--component foo" in conanfile.command
-
-
-@pytest.mark.parametrize("generator", [
-    ("NMake Makefiles"),
-    ("Ninja Makefiles"),
-    ("Ninja Multi-Config"),
-    ("Unix Makefiles"),
-    ("Visual Studio 14 2015"),
-    ("Xcode"),
-])
-def test_run_install_no_component(generator):
-    settings = Settings.loads(get_default_settings_yml())
-    settings.os = "Windows"
-    settings.arch = "x86"
-    settings.build_type = "Release"
-    settings.compiler = "Visual Studio"
-    settings.compiler.runtime = "MDd"
-    settings.compiler.version = "14"
-
-    conanfile = ConanFileMock()
-    conanfile.conf = Conf()
-    conanfile.folders.generators = "."
-    conanfile.folders.set_base_generators(temp_folder())
-    conanfile.settings = settings
-    conanfile.folders.set_base_package(temp_folder())
-
-    write_cmake_presets(conanfile, "toolchain", generator, {})
-    cmake = CMake(conanfile)
-    cmake.install()
-
-    assert "--component" not in conanfile.command


### PR DESCRIPTION
Changelog: Feature: Add the ability to provide a `--component` argument with the `cmake.install` function. 
Docs: https://github.com/conan-io/docs/pull/2893

Related issue #10359

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
