### PR TITLE
[develop2] remove unnecessary xz checks

### DIFF
--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -76,7 +76,6 @@ class RemoteManager(object):
         export_folder = layout.export()
         tgz_file = zipped_files.pop(EXPORT_TGZ_NAME, None)
 
-        check_compressed_files(EXPORT_TGZ_NAME, zipped_files)
         if tgz_file:
             uncompress_file(tgz_file, export_folder)
         mkdir(export_folder)
@@ -101,7 +100,6 @@ class RemoteManager(object):
         log_recipe_sources_download(ref, duration, remote.name, zipped_files)
 
         tgz_file = zipped_files[EXPORT_SOURCES_TGZ_NAME]
-        check_compressed_files(EXPORT_SOURCES_TGZ_NAME, zipped_files)
         uncompress_file(tgz_file, export_sources_folder)
 
     def get_package(self, conanfile, pref, remote):
@@ -129,7 +127,6 @@ class RemoteManager(object):
             log_package_download(pref, duration, remote, zipped_files)
 
             tgz_file = zipped_files.pop(PACKAGE_TGZ_NAME, None)
-            check_compressed_files(PACKAGE_TGZ_NAME, zipped_files)
             package_folder = layout.package()
             if tgz_file:  # This must happen always, but just in case
                 # TODO: The output could be changed to the package one, but
@@ -211,17 +208,6 @@ class RemoteManager(object):
             raise
         except Exception as exc:
             raise ConanException(exc, remote=remote)
-
-
-# TODO: Consider removing this, we are not changing the compression format
-def check_compressed_files(tgz_name, files):
-    bare_name = os.path.splitext(tgz_name)[0]
-    for f in files:
-        if f == tgz_name:
-            continue
-        if bare_name == os.path.splitext(f)[0]:
-            raise ConanException("This Conan version is not prepared to handle '%s' file format. "
-                                 "Please upgrade conan client." % f)
 
 
 def uncompress_file(src_path, dest_folder):

--- a/conans/client/rest/rest_client_v2.py
+++ b/conans/client/rest/rest_client_v2.py
@@ -5,14 +5,13 @@ import time
 from conan.api.output import ConanOutput
 
 from conans.client.downloaders.caching_file_downloader import CachingFileDownloader
-from conans.client.remote_manager import check_compressed_files
 from conans.client.rest.client_routes import ClientV2Router
 from conans.client.rest.file_uploader import FileUploader
 from conans.client.rest.rest_client_common import RestCommonMethods, get_exception_from_error
 from conans.errors import ConanException, NotFoundException, PackageNotFoundException, \
     RecipeNotFoundException, AuthenticationException, ForbiddenException
 from conans.model.package_ref import PkgReference
-from conans.paths import EXPORT_SOURCES_TGZ_NAME, EXPORT_TGZ_NAME, PACKAGE_TGZ_NAME
+from conans.paths import EXPORT_SOURCES_TGZ_NAME
 from conans.util.dates import from_iso8601_to_timestamp
 
 
@@ -47,7 +46,6 @@ class RestV2Methods(RestCommonMethods):
         url = self.router.recipe_snapshot(ref)
         data = self._get_file_list_json(url)
         files = data["files"]
-        check_compressed_files(EXPORT_TGZ_NAME, files)
         if EXPORT_SOURCES_TGZ_NAME in files:
             files.remove(EXPORT_SOURCES_TGZ_NAME)
 
@@ -64,7 +62,6 @@ class RestV2Methods(RestCommonMethods):
         url = self.router.recipe_snapshot(ref)
         data = self._get_file_list_json(url)
         files = data["files"]
-        check_compressed_files(EXPORT_SOURCES_TGZ_NAME, files)
         if EXPORT_SOURCES_TGZ_NAME not in files:
             return None
         files = [EXPORT_SOURCES_TGZ_NAME, ]
@@ -79,7 +76,6 @@ class RestV2Methods(RestCommonMethods):
         url = self.router.package_snapshot(pref)
         data = self._get_file_list_json(url)
         files = data["files"]
-        check_compressed_files(PACKAGE_TGZ_NAME, files)
         # If we didn't indicated reference, server got the latest, use absolute now, it's safer
         urls = {fn: self.router.package_file(pref, fn) for fn in files}
         self._download_and_save_files(urls, dest_folder, files)

--- a/conans/test/unittests/util/xz_test.py
+++ b/conans/test/unittests/util/xz_test.py
@@ -1,86 +1,21 @@
 import os
 import tarfile
-from unittest import TestCase
 
 from conan.tools.files import unzip
-from conans.model.package_ref import PkgReference
-from conans.model.recipe_ref import RecipeReference
-from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.mocks import ConanFileMock
 from conans.test.utils.test_files import temp_folder
-from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, TestServer
-from conans.util.files import load, save_files, save
+from conans.util.files import load, save
 
 
-class XZTest(TestCase):
+def test_unzip_can_xz():
+    tmp_dir = temp_folder()
+    file_path = os.path.join(tmp_dir, "a_file.txt")
+    save(file_path, "my content!")
+    txz = os.path.join(tmp_dir, "sample.tar.xz")
+    with tarfile.open(txz, "w:xz") as tar:
+        tar.add(file_path, "a_file.txt")
 
-    def test_error_xz(self):
-        server = TestServer()
-        ref = RecipeReference.loads("pkg/0.1@user/channel")
-        ref.revision = "myreciperev"
-        export = server.server_store.export(ref)
-        server.server_store.update_last_revision(ref)
-        save_files(export, {"conanfile.py": str(GenConanfile()),
-                            "conanmanifest.txt": "#",
-                            "conan_export.txz": "#"})
-        client = TestClient(servers={"default": server})
-        client.run("install --requires=pkg/0.1@user/channel", assert_error=True)
-        self.assertIn("This Conan version is not prepared to handle "
-                      "'conan_export.txz' file format", client.out)
-
-    def test_error_sources_xz(self):
-        server = TestServer()
-        ref = RecipeReference.loads("pkg/0.1@user/channel")
-        ref.revision = "myreciperev"
-        client = TestClient(servers={"default": server})
-        server.server_store.update_last_revision(ref)
-        export = server.server_store.export(ref)
-        conanfile = """from conan import ConanFile
-class Pkg(ConanFile):
-    exports_sources = "*"
-"""
-        save_files(export, {"conanfile.py": conanfile,
-                            "conanmanifest.txt": "1",
-                            "conan_sources.txz": "#"})
-
-        client.run("install --requires=pkg/0.1@user/channel --build='*'", assert_error=True)
-        self.assertIn("ERROR: This Conan version is not prepared to handle "
-                      "'conan_sources.txz' file format", client.out)
-
-    def test_error_package_xz(self):
-        server = TestServer()
-        ref = RecipeReference.loads("pkg/0.1@user/channel")
-        ref.revision = "myreciperev"
-        client = TestClient(servers={"default": server})
-        server.server_store.update_last_revision(ref)
-        export = server.server_store.export(ref)  # *1 the path can't be known before upload a revision
-        conanfile = """from conan import ConanFile
-class Pkg(ConanFile):
-    exports_sources = "*"
-"""
-        save_files(export, {"conanfile.py": conanfile,
-                            "conanmanifest.txt": "1"})
-        pref = PkgReference(ref, NO_SETTINGS_PACKAGE_ID, "mypackagerev")
-        pref.revision = "mypackagerev"
-        server.server_store.update_last_package_revision(pref)
-
-        package = server.server_store.package(pref)
-        save_files(package, {"conaninfo.txt": "#",
-                             "conanmanifest.txt": "1",
-                             "conan_package.txz": "#"})
-        client.run("install --requires=pkg/0.1@user/channel", assert_error=True)
-        self.assertIn("ERROR: This Conan version is not prepared to handle "
-                      "'conan_package.txz' file format", client.out)
-
-    def test(self):
-        tmp_dir = temp_folder()
-        file_path = os.path.join(tmp_dir, "a_file.txt")
-        save(file_path, "my content!")
-        txz = os.path.join(tmp_dir, "sample.tar.xz")
-        with tarfile.open(txz, "w:xz") as tar:
-            tar.add(file_path, "a_file.txt")
-
-        dest_folder = temp_folder()
-        unzip(ConanFileMock(), txz, dest_folder)
-        content = load(os.path.join(dest_folder, "a_file.txt"))
-        self.assertEqual(content, "my content!")
+    dest_folder = temp_folder()
+    unzip(ConanFileMock(), txz, dest_folder)
+    content = load(os.path.join(dest_folder, "a_file.txt"))
+    assert content == "my content!"


### PR DESCRIPTION
The check of other possible compression formats is dead, we don't plan to change the format in 2.0, and it is not possible to do it in 2.X without breaking and opt-in, so the check doesn't provide any migration path to that potential new feature anyway.