### PR TITLE
Make ConanOutput write methods chainable

### DIFF
--- a/conan/api/output.py
+++ b/conan/api/output.py
@@ -82,11 +82,11 @@ class ConanOutput:
         return hasattr(self.stream, "isatty") and self.stream.isatty()
 
     def writeln(self, data, fg=None, bg=None):
-        self.write(data, fg, bg, newline=True)
+        return self.write(data, fg, bg, newline=True)
 
     def write(self, data, fg=None, bg=None, newline=False):
         if conan_output_level > LEVEL_NOTICE:
-            return
+            return self
         if self._color and (fg or bg):
             data = "%s%s%s%s" % (fg or '', bg or '', data, Style.RESET_ALL)
 
@@ -94,12 +94,13 @@ class ConanOutput:
             data = "%s\n" % data
         self.stream.write(data)
         self.stream.flush()
+        return self
 
     def rewrite_line(self, line):
         tmp_color = self._color
         self._color = False
         TOTAL_SIZE = 70
-        LIMIT_SIZE = 32  # Hard coded instead of TOTAL_SIZE/2-3 that fails in Py3 float division
+        LIMIT_SIZE = TOTAL_SIZE // 2 - 3
         if len(line) > TOTAL_SIZE:
             line = line[0:LIMIT_SIZE] + " ... " + line[-LIMIT_SIZE:]
         self.write("\r%s%s" % (line, " " * (TOTAL_SIZE - len(line))))
@@ -148,18 +149,22 @@ class ConanOutput:
     def trace(self, msg):
         if log_level_allowed(LEVEL_TRACE):
             self._write_message(msg, "TRACE", fg=Color.BRIGHT_WHITE)
+        return self
 
     def debug(self, msg):
         if log_level_allowed(LEVEL_DEBUG):
             self._write_message(msg, "DEBUG")
+        return self
 
     def verbose(self, msg, fg=None, bg=None):
         if log_level_allowed(LEVEL_VERBOSE):
             self._write_message(msg, "VERBOSE", fg=fg, bg=bg)
+        return self
 
     def status(self, msg, fg=None, bg=None):
         if log_level_allowed(LEVEL_STATUS):
             self._write_message(msg, "STATUS", fg=fg, bg=bg)
+        return self
 
     # Remove in a later refactor of all the output.info calls
     info = status
@@ -168,22 +173,27 @@ class ConanOutput:
         if log_level_allowed(LEVEL_NOTICE):
             self._write_message("\n-------- {} --------".format(msg), "NOTICE",
                                 fg=Color.BRIGHT_MAGENTA)
+        return self
 
     def highlight(self, msg):
         if log_level_allowed(LEVEL_NOTICE):
             self._write_message(msg, "NOTICE", fg=Color.BRIGHT_MAGENTA)
+        return self
 
     def success(self, msg):
         if log_level_allowed(LEVEL_NOTICE):
             self._write_message(msg, "NOTICE", fg=Color.BRIGHT_GREEN)
+        return self
 
     def warning(self, msg):
         if log_level_allowed(LEVEL_WARNING):
             self._write_message("WARN: {}".format(msg), "WARN", Color.YELLOW)
+        return self
 
     def error(self, msg):
         if log_level_allowed(LEVEL_ERROR):
             self._write_message("ERROR: {}".format(msg), "ERROR", Color.RED)
+        return self
 
     def flush(self):
         self.stream.flush()

--- a/conans/test/integration/py_requires/python_requires_test.py
+++ b/conans/test/integration/py_requires/python_requires_test.py
@@ -214,14 +214,14 @@ class PyRequiresExtendTest(unittest.TestCase):
             class MyConanfileBase(ConanFile):
                 python_requires = "pkg1/1.0@user/channel", "pkg2/1.0@user/channel"
                 def build(self):
-                    self.output.info("PKG1 N: %s" % self.python_requires["pkg1"].conanfile.name)
-                    self.output.info("PKG1 V: %s" % self.python_requires["pkg1"].conanfile.version)
-                    self.output.info("PKG1 U: %s" % self.python_requires["pkg1"].conanfile.user)
-                    self.output.info("PKG1 C: %s" % self.python_requires["pkg1"].conanfile.channel)
-                    self.output.info("PKG1 : %s" % self.python_requires["pkg1"].module.myvar)
-                    self.output.info("PKG2 : %s" % self.python_requires["pkg2"].module.myvar)
-                    self.output.info("PKG1F : %s" % self.python_requires["pkg1"].module.myfunct())
-                    self.output.info("PKG2F : %s" % self.python_requires["pkg2"].module.myfunct())
+                    self.output.info("PKG1 N: %s" % self.python_requires["pkg1"].conanfile.name)\
+                               .info("PKG1 V: %s" % self.python_requires["pkg1"].conanfile.version)\
+                               .info("PKG1 U: %s" % self.python_requires["pkg1"].conanfile.user)\
+                               .info("PKG1 C: %s" % self.python_requires["pkg1"].conanfile.channel)\
+                               .info("PKG1 : %s" % self.python_requires["pkg1"].module.myvar)\
+                               .info("PKG2 : %s" % self.python_requires["pkg2"].module.myvar)\
+                               .info("PKG1F : %s" % self.python_requires["pkg1"].module.myfunct())\
+                               .info("PKG2F : %s" % self.python_requires["pkg2"].module.myfunct())
             """)
         client.save({"conanfile.py": conanfile})
         client.run("create . --name=consumer --version=0.1 --user=user --channel=testing")

--- a/conans/test/unittests/client/conan_output_test.py
+++ b/conans/test/unittests/client/conan_output_test.py
@@ -51,3 +51,13 @@ def test_output_forced_but_conan_logger():
 
                 assert out.color is False
                 init.assert_not_called()
+
+
+def test_output_chainable():
+    try:
+        ConanOutput(scope="My package")\
+            .title("My title")\
+            .highlight("Worked")\
+            .info("But there was more that needed to be said")
+    except Exception as e:
+        assert False, f"Chained ConanOutput write methods raised an exception {e}"


### PR DESCRIPTION
Changelog: Feature: Allow chaining of `self.output` write methods
Docs: omit

Allows the ConanOutput write methods to be chained, which simplifies some instances where it's used a lot, by removing the need to save it to a variable or initialize the object for every line
