### PR TITLE
fix gcc 12 cppstd

### DIFF
--- a/conan/tools/_compilers.py
+++ b/conan/tools/_compilers.py
@@ -398,6 +398,10 @@ def _cppstd_gcc(gcc_version, cppstd):
         v23 = "c++2b"
         vgnu23 = "gnu++2b"
 
+    if Version(gcc_version) >= "12":
+        v20 = "c++20"
+        vgnu20 = "gnu++20"
+
     flag = {"98": v98, "gnu98": vgnu98,
             "11": v11, "gnu11": vgnu11,
             "14": v14, "gnu14": vgnu14,

--- a/conans/test/unittests/tools/gnu/autotoolschain_test.py
+++ b/conans/test/unittests/tools/gnu/autotoolschain_test.py
@@ -25,6 +25,23 @@ def test_get_gnu_triplet_for_cross_building():
     assert autotoolschain._build == "i686-solaris"
 
 
+def test_get_toolchain_cppstd():
+    settings = MockSettings({"build_type": "Release",
+                             "compiler": "gcc",
+                             "compiler.version": "10",
+                             "compiler.cppstd": "20",
+                             "os": "Linux",
+                             "arch": "x86_64"})
+    conanfile = ConanFileMock()
+    conanfile.settings = settings
+    conanfile.settings_build = settings
+    autotoolschain = AutotoolsToolchain(conanfile)
+    assert autotoolschain.cppstd == "-std=c++2a"
+    settings.values["compiler.version"] = "12"
+    autotoolschain = AutotoolsToolchain(conanfile)
+    assert autotoolschain.cppstd == "-std=c++20"
+
+
 @pytest.mark.parametrize("runtime, runtime_type, expected",
                          [("static", "Debug", "MTd"),
                           ("static", "Release", "MT"),


### PR DESCRIPTION
Changelog: Fix: Deprecate ``c++2a`` for gcc 12, replace with ``c++20``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/12794
