### PR TITLE
Add Fish output for VirtualEnv

### DIFF
--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -130,12 +130,15 @@ def _generate_aggregated_env(conanfile):
         bats = []
         shs = []
         ps1s = []
+        fishes = []
         for env_script in env_scripts:
             path = os.path.join(conanfile.generators_folder, env_script)
             if env_script.endswith(".bat"):
                 bats.append(path)
             elif env_script.endswith(".sh"):
                 shs.append(subsystem_path(subsystem, path))
+            elif env_script.endswith(".fish"):
+                fishes.append(subsystem_path(subsystem, path))
             elif env_script.endswith(".ps1"):
                 ps1s.append(path)
         if shs:
@@ -159,3 +162,12 @@ def _generate_aggregated_env(conanfile):
             save(os.path.join(conanfile.generators_folder, filename), ps1_content(ps1s))
             save(os.path.join(conanfile.generators_folder, "deactivate_{}".format(filename)),
                  ps1_content(deactivates(ps1s)))
+
+        if fishes:
+            def fish_content(files):
+                return ". " + " && . ".join('"{}"'.format(s) for s in files)
+
+            filename = "conan{}.fish".format(group)
+            save(os.path.join(conanfile.generators_folder, filename), fish_content(fishes))
+            save(os.path.join(conanfile.generators_folder, "deactivate_{}".format(filename)),
+                 fish_content(deactivates(fishes)))

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -85,6 +85,7 @@ BUILT_IN_CONFS = {
     "tools.apple:enable_arc": "(boolean) Enable/Disable ARC Apple Clang flags",
     "tools.apple:enable_visibility": "(boolean) Enable/Disable Visibility Apple Clang flags",
     "tools.env.virtualenv:powershell": "If it is set to True it will generate powershell launchers if os=Windows",
+    "tools.env.virtualenv:fish": "If True, generate fish-compatible launchers",
     # Compilers/Flags configurations
     "tools.build:compiler_executables": "Defines a Python dict-like with the compilers path to be used. Allowed keys {'c', 'cpp', 'cuda', 'objc', 'objcxx', 'rc', 'fortran', 'asm', 'hip', 'ispc'}",
     "tools.build:cxxflags": "List of extra CXX flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",


### PR DESCRIPTION
Changelog: (Feature): Add `tools.env.virtualenv:fish` conf to enable creation of Fish-compatible launchers in VirtualEnv
Docs: https://github.com/conan-io/docs/pull/2880

I've been bitten a few times now where I wanted to execute `conanrun.sh` but had to first switch from my fish terminal back to bash, as their syntax is not complatible.

This is a 1-to-1 translation of the sh generation targeted at fish (So specially the is_defined variable could be rewritten more fish-y)

- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
