### PR TITLE
[develop2] test for config home and forbidden errors

### DIFF
--- a/conans/test/integration/command/config_test.py
+++ b/conans/test/integration/command/config_test.py
@@ -1,8 +1,8 @@
 import json
 import os
 
+from conan.api.conan_api import ConanAPI
 from conans.model.conf import BUILT_IN_CONFS
-from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient
 from conans.util.env import environment_update
@@ -16,35 +16,23 @@ def test_missing_subarguments():
     assert "ERROR: Exiting with code: 2" in client.out
 
 
-def test_config_home_default():
-    """ config home MUST show conan home path
+class TestConfigHome:
+    """ The test framework cannot test the CONAN_HOME env-var because it is not using it
+    (it will break tests for maintainers that have the env-var defined)
     """
-    client = TestClient()
-    client.run("config home")
-    assert f"{client.cache.cache_folder}\n" == client.stdout
-
-
-def test_config_home_custom_home_dir():
-    """ config home MUST accept CONAN_HOME as custom home path
-    """
-    cache_folder = os.path.join(temp_folder(), "custom")
-    with environment_update({"CONAN_HOME": cache_folder}):
-        client = TestClient(cache_folder=cache_folder)
+    def test_config_home_default(self):
+        client = TestClient()
         client.run("config home")
-        assert cache_folder in client.out
+        assert f"{client.cache.cache_folder}\n" == client.stdout
+
         client.run("config home --format=text")
         assert f"{client.cache.cache_folder}\n" == client.stdout
 
-
-def test_config_home_custom_install():
-    """ config install MUST accept CONAN_HOME as custom home path
-    """
-    cache_folder = os.path.join(temp_folder(), "custom")
-    with environment_update({"CONAN_HOME": cache_folder}):
-        client = TestClient(cache_folder=cache_folder)
-        client.save({"conanfile.py": GenConanfile()})
-        client.run("install .")
-        assert "Installing (downloading, building) binaries" in client.out
+    def test_api_uses_env_var_home(self):
+        cache_folder = os.path.join(temp_folder(), "custom")
+        with environment_update({"CONAN_HOME": cache_folder}):
+            api = ConanAPI()
+            assert api.cache_folder == cache_folder
 
 
 def test_config_list():


### PR DESCRIPTION
Close https://github.com/conan-io/conan/pull/7284
Close https://github.com/conan-io/conan/issues/7281

I have tested manually with 2.0, when there are no permissions for the folder, and the error trace is not there, and the error message is now more clear:
```
ERROR: Can't write version file in '/home/conan/my_temp/version.txt': [Errno 13] Permission denied: '/home/conan/my_temp/version.txt'
```