### PR TITLE
Test/conan info not check server

### DIFF
--- a/conans/test/integration/command/info/info_test.py
+++ b/conans/test/integration/command/info/info_test.py
@@ -760,6 +760,13 @@ def test_info_not_hit_server():
     c.run("install consumer/0.1@")
     assert "Downloaded" in c.out
     # break the server to make sure it is not being contacted at all
-    c.servers["default"] = {}
+    c.servers["default"] = None
     c.run("info consumer/0.1@")
     assert "Downloaded" not in c.out
+    c.run("remove pkg* -f")
+    c.run("info consumer/0.1@", assert_error=True)
+    assert "ERROR: 'NoneType' object " in c.out
+    c.run("remote disable *")
+    c.run("info consumer/0.1@", assert_error=True)
+    assert "ERROR: 'NoneType' object " not in c.out
+    assert "ERROR: No remote defined" in c.out


### PR DESCRIPTION
Changelog: omit
Docs: omit

Close https://github.com/conan-io/conan/issues/6483
Close https://github.com/conan-io/conan/pull/6487

This tries to close the above discussions, testing that Conan will not hit servers if packages are in the Conan cache. If packages are not in the Conan cache, the ``conan info`` command does a computation of the dependency graph without fetching the binaries. But the binaries have to be computed and checked in servers, ``conan info`` should compute the exact dependency graph that would be installed if ``conan install``. So if the binaries are not in the cache, it will contact the existing, not disabled servers.

It can be discussed in Conan 2.0 if a command that computes the graph without checking binaries at all would make sense and for what use case (it should be pretty straightforward to implement also as a custom command, if it doesn't fit as a built-in one)