### PR TITLE
Add optional requirements fields to all templates

### DIFF
--- a/conan/cli/commands/new.py
+++ b/conan/cli/commands/new.py
@@ -67,8 +67,9 @@ def new(conan_api, parser, *args):
                 ast = env.parse(templ_str)
                 template_vars.extend(meta.find_undeclared_variables(ast))
 
-            injected_vars = {"conan_version", "package_name"}
-            template_vars = list(set(template_vars) - injected_vars)
+            injected_vars = {"conan_version", "package_name", "as_iterable"}
+            optional_vars = {"requires"}
+            template_vars = list(set(template_vars) - injected_vars - optional_vars)
             template_vars.sort()
             return template_vars
 

--- a/conan/internal/api/new/autoools_exe.py
+++ b/conan/internal/api/new/autoools_exe.py
@@ -43,6 +43,13 @@ class {{package_name}}Conan(ConanFile):
     def package(self):
         autotools = Autotools(self)
         autotools.install()
+
+    {% if requires is defined -%}
+    def requirements(self):
+        {% for require in as_iterable(requires) -%}
+        self.requires("{{ require }}")
+        {% endfor %}
+    {%- endif %}
 """
 makefile_am_exe = """
 bin_PROGRAMS = {{name}}

--- a/conan/internal/api/new/autotools_lib.py
+++ b/conan/internal/api/new/autotools_lib.py
@@ -52,6 +52,13 @@ class {{package_name}}Conan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["{{name}}"]
+
+    {% if requires is defined -%}
+    def requirements(self):
+        {% for require in as_iterable(requires) -%}
+        self.requires("{{ require }}")
+        {% endfor %}
+    {%- endif %}
 """
 
 configure_ac = """

--- a/conan/internal/api/new/bazel_exe.py
+++ b/conan/internal/api/new/bazel_exe.py
@@ -34,7 +34,14 @@ class {{package_name}}Recipe(ConanFile):
         build = os.path.join(self.build_folder, "bazel-bin", "main")
         copy(self, "{{name}}", build, dest_bin, keep_path=False)
         copy(self, "{{name}}.exe", build, dest_bin, keep_path=False)
-        """
+
+    {% if requires is defined -%}
+    def requirements(self):
+        {% for require in as_iterable(requires) -%}
+        self.requires("{{ require }}")
+        {% endfor %}
+    {%- endif %}
+"""
 
 test_conanfile_exe_v2 = """from conan import ConanFile
 from conan.tools.build import can_run

--- a/conan/internal/api/new/bazel_lib.py
+++ b/conan/internal/api/new/bazel_lib.py
@@ -45,6 +45,13 @@ class {{package_name}}Recipe(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["{{name}}"]
+
+    {% if requires is defined -%}
+    def requirements(self):
+        {% for require in as_iterable(requires) -%}
+        self.requires("{{ require }}")
+        {% endfor %}
+    {%- endif %}
 """
 
 

--- a/conan/internal/api/new/cmake_exe.py
+++ b/conan/internal/api/new/cmake_exe.py
@@ -37,6 +37,13 @@ class {{package_name}}Recipe(ConanFile):
     def package(self):
         cmake = CMake(self)
         cmake.install()
+
+    {% if requires is defined -%}
+    def requirements(self):
+        {% for require in as_iterable(requires) -%}
+        self.requires("{{ require }}")
+        {% endfor %}
+    {%- endif %}
 '''
 
 cmake_exe_v2 = """cmake_minimum_required(VERSION 3.15)

--- a/conan/internal/api/new/cmake_lib.py
+++ b/conan/internal/api/new/cmake_lib.py
@@ -43,6 +43,13 @@ class {{package_name}}Recipe(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["{{name}}"]
+
+    {% if requires is defined -%}
+    def requirements(self):
+        {% for require in as_iterable(requires) -%}
+        self.requires("{{ require }}")
+        {% endfor %}
+    {%- endif %}
 '''
 
 cmake_v2 = """cmake_minimum_required(VERSION 3.15)

--- a/conan/internal/api/new/meson_exe.py
+++ b/conan/internal/api/new/meson_exe.py
@@ -30,6 +30,13 @@ class {{package_name}}Conan(ConanFile):
     def package(self):
         meson = Meson(self)
         meson.install()
+
+    {% if requires is defined -%}
+    def requirements(self):
+        {% for require in as_iterable(requires) -%}
+        self.requires("{{ require }}")
+        {% endfor %}
+    {%- endif %}
 """
 
 test_conanfile_exe_v2 = """import os

--- a/conan/internal/api/new/meson_lib.py
+++ b/conan/internal/api/new/meson_lib.py
@@ -40,6 +40,13 @@ class {{package_name}}Conan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["{{name}}"]
+
+    {% if requires is defined -%}
+    def requirements(self):
+        {% for require in as_iterable(requires) -%}
+        self.requires("{{ require }}")
+        {% endfor %}
+    {%- endif %}
 """
 
 

--- a/conan/internal/api/new/msbuild_exe.py
+++ b/conan/internal/api/new/msbuild_exe.py
@@ -40,6 +40,13 @@ class {{package_name}}Conan(ConanFile):
     def package(self):
         copy(self, "*{{name}}.exe", src=self.build_folder,
              dst=os.path.join(self.package_folder, "bin"), keep_path=False)
+
+    {% if requires is defined -%}
+    def requirements(self):
+        {% for require in as_iterable(requires) -%}
+        self.requires("{{ require }}")
+        {% endfor %}
+    {%- endif %}
 """
 
 

--- a/conan/internal/api/new/msbuild_lib.py
+++ b/conan/internal/api/new/msbuild_lib.py
@@ -240,6 +240,13 @@ class {{package_name}}Conan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["{{name}}"]
+
+    {% if requires is defined -%}
+    def requirements(self):
+        {% for require in as_iterable(requires) -%}
+        self.requires("{{ require }}")
+        {% endfor %}
+    {%- endif %}
 """
 
 


### PR DESCRIPTION
Changelog: (Feature): Add optional requirements fields to all templates
Docs: https://github.com/conan-io/docs/pull/2881

Just as for the basic template, this now lets you add multiple requirements to your templates if needed, such as:
`conan new cmake_exe -d name=game -d version=1.0 -d requires=maths/1.3 -d requires=ai/2.0`

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
