### PR TITLE
fix XcodeDeps in editable root path

### DIFF
--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -130,6 +130,7 @@ class XcodeDeps(object):
             merged = [var for cpp_info in transitive_cpp_infos for var in getattr(cpp_info, name)]
             return list(OrderedDict.fromkeys(merged).keys())
 
+        # TODO: Investigate if paths can be made relative to "root" folder
         fields = {
             'pkg_name': pkg_name,
             'comp_name': comp_name,
@@ -270,8 +271,10 @@ class XcodeDeps(object):
                     transitive_internal = list(OrderedDict.fromkeys(transitive_internal).keys())
                     transitive_external = list(OrderedDict.fromkeys(transitive_external).keys())
 
+                    # In case dep is editable and package_folder=None
+                    pkg_folder = dep.package_folder or dep.recipe_folder
                     component_content = self.get_content_for_component(dep_name, comp_name,
-                                                                       dep.package_folder,
+                                                                       pkg_folder,
                                                                        transitive_internal,
                                                                        transitive_external)
                     include_components_names.append((dep_name, comp_name))
@@ -289,7 +292,9 @@ class XcodeDeps(object):
                         public_deps.append((_format_name(d.ref.name),) * 2)
 
                 required_components = dep.cpp_info.required_components if dep.cpp_info.required_components else public_deps
-                root_content = self.get_content_for_component(dep_name, dep_name, dep.package_folder, [dep.cpp_info],
+                # In case dep is editable and package_folder=None
+                pkg_folder = dep.package_folder or dep.recipe_folder
+                root_content = self.get_content_for_component(dep_name, dep_name, pkg_folder, [dep.cpp_info],
                                                               required_components)
                 include_components_names.append((dep_name, dep_name))
                 result.update(root_content)

--- a/conans/test/integration/layout/test_layout_paths.py
+++ b/conans/test/integration/layout/test_layout_paths.py
@@ -1,3 +1,4 @@
+import os
 import textwrap
 
 from conans.test.assets.genconanfile import GenConanfile
@@ -6,6 +7,7 @@ from conans.test.utils.tools import TestClient
 
 def test_editable_layout_paths():
     # https://github.com/conan-io/conan/issues/12521
+    # https://github.com/conan-io/conan/issues/12839
     c = TestClient()
     dep = textwrap.dedent("""
         import os
@@ -21,9 +23,10 @@ def test_editable_layout_paths():
             "pkg/conanfile.py": GenConanfile("pkg", "0.1").with_settings("build_type", "arch")
                                                           .with_requires("dep/0.1")
                                                           .with_generator("CMakeDeps")
-                                                          .with_generator("PkgConfigDeps")})
+                                                          .with_generator("PkgConfigDeps")
+                                                          .with_generator("XcodeDeps")})
     c.run("editable add dep dep/0.1")
-    c.run("install pkg")
+    c.run("install pkg -s arch=x86_64")
     # It doesn't crash anymore
     assert "dep/0.1:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 - Editable" in c.out
     arch = c.get_default_host_profile().settings['arch']
@@ -31,3 +34,6 @@ def test_editable_layout_paths():
     assert 'set(dep_INCLUDE_DIRS_RELEASE "${dep_PACKAGE_FOLDER_RELEASE}/include")' in data
     pc = c.load("dep.pc")
     assert "includedir1=${prefix}/include" in pc
+    xcode = c.load("conan_dep_dep_release_x86_64.xcconfig")
+    dep_path = os.path.join(c.current_folder, "dep")
+    assert f"PACKAGE_ROOT_dep[config=Release][arch=x86_64][sdk=*] = {dep_path}" in xcode

--- a/conans/test/integration/layout/test_layout_paths.py
+++ b/conans/test/integration/layout/test_layout_paths.py
@@ -29,8 +29,7 @@ def test_editable_layout_paths():
     c.run("install pkg -s arch=x86_64")
     # It doesn't crash anymore
     assert "dep/0.1:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 - Editable" in c.out
-    arch = c.get_default_host_profile().settings['arch']
-    data = c.load(f"dep-release-{arch}-data.cmake")
+    data = c.load(f"dep-release-x86_64-data.cmake")
     assert 'set(dep_INCLUDE_DIRS_RELEASE "${dep_PACKAGE_FOLDER_RELEASE}/include")' in data
     pc = c.load("dep.pc")
     assert "includedir1=${prefix}/include" in pc


### PR DESCRIPTION
Changelog: Bugfix: Fix XcodeDeps in "editable" mode root package_folder=None.
Docs: Omit

Close https://github.com/conan-io/conan/issues/12839
