### PR TITLE
Allow specifying files/directories to ignore when listing cached profiles.

### DIFF
--- a/conan/api/subapi/profiles.py
+++ b/conan/api/subapi/profiles.py
@@ -68,9 +68,7 @@ class ProfilesAPI:
         profiles = []
         profiles_path = self._cache.profiles_path
         if os.path.exists(profiles_path):
-            for current_directory, directories, files in os.walk(profiles_path, followlinks=True):
-                directories[:] = [dir for dir in directories if os.path.relpath(
-                    os.path.join(current_directory, dir)) not in paths_to_ignore]
+            for current_directory, _, files in os.walk(profiles_path, followlinks=True):
                 files = filter(lambda file: os.path.relpath(
                     os.path.join(current_directory, file), profiles_path) not in paths_to_ignore, files)
 

--- a/conan/api/subapi/profiles.py
+++ b/conan/api/subapi/profiles.py
@@ -62,10 +62,18 @@ class ProfilesAPI:
         List all the profiles file sin the cache
         :return: an alphabetically ordered list of profile files in the default cache location
         """
+        # List is to be extended (directories should not have a trailing slash)
+        paths_to_ignore = ['.DS_Store']
+
         profiles = []
         profiles_path = self._cache.profiles_path
         if os.path.exists(profiles_path):
-            for current_directory, _, files in os.walk(profiles_path, followlinks=True):
+            for current_directory, directories, files in os.walk(profiles_path, followlinks=True):
+                directories[:] = [dir for dir in directories if os.path.relpath(
+                    os.path.join(current_directory, dir)) not in paths_to_ignore]
+                files = list(filter(lambda file: os.path.relpath(
+                    os.path.join(current_directory, file), profiles_path) not in paths_to_ignore, files))
+
                 for filename in files:
                     rel_path = os.path.relpath(os.path.join(current_directory, filename),
                                                profiles_path)

--- a/conan/api/subapi/profiles.py
+++ b/conan/api/subapi/profiles.py
@@ -71,8 +71,8 @@ class ProfilesAPI:
             for current_directory, directories, files in os.walk(profiles_path, followlinks=True):
                 directories[:] = [dir for dir in directories if os.path.relpath(
                     os.path.join(current_directory, dir)) not in paths_to_ignore]
-                files = list(filter(lambda file: os.path.relpath(
-                    os.path.join(current_directory, file), profiles_path) not in paths_to_ignore, files))
+                files = filter(lambda file: os.path.relpath(
+                    os.path.join(current_directory, file), profiles_path) not in paths_to_ignore, files)
 
                 for filename in files:
                     rel_path = os.path.relpath(os.path.join(current_directory, filename),

--- a/conans/test/integration/command/test_profile.py
+++ b/conans/test/integration/command/test_profile.py
@@ -11,21 +11,14 @@ def test_profile_path():
 
 def test_ignore_paths_when_listing_profiles():
     c = TestClient()
-    ignore_paths = ['.DS_Store']
+    ignore_path = '.DS_Store'
 
-    # Create files, dirs if necessary, at the ignore paths
-    for path in ignore_paths:
-        rel_file_path = os.path.join(c.cache.profiles_path, path)
-
-        base_dir = os.path.join(c.cache.profiles_path, os.path.dirname(path))
-        if base_dir:
-            os.makedirs(base_dir, exist_ok=True)
-            open(os.path.join(base_dir, os.path.basename(path)), 'w').close()
-        else:
-            open(rel_file_path, 'w').close()
+    # just in case
+    os.makedirs(c.cache.profiles_path, exist_ok=True)
+    # This a "touch" equivalent
+    open(os.path.join(c.cache.profiles_path, '.DS_Store'), 'w').close()
+    os.utime(os.path.join(c.cache.profiles_path, ".DS_Store"))
 
     c.run("profile list")
 
-    for path in ignore_paths:
-        rel_file_path = os.path.relpath(os.path.join(c.cache.profiles_path, path))
-        assert rel_file_path not in c.out
+    assert ignore_path not in c.out

--- a/conans/test/integration/command/test_profile.py
+++ b/conans/test/integration/command/test_profile.py
@@ -1,3 +1,5 @@
+import os 
+
 from conans.test.utils.tools import TestClient
 
 
@@ -5,3 +7,25 @@ def test_profile_path():
     c = TestClient()
     c.run("profile path default")
     assert "default" in c.out
+
+
+def test_ignore_paths_when_listing_profiles():
+    c = TestClient()
+    ignore_paths = ['.DS_Store']
+
+    # Create files, dirs if necessary, at the ignore paths
+    for path in ignore_paths:
+        rel_file_path = os.path.join(c.cache.profiles_path, path)
+
+        base_dir = os.path.join(c.cache.profiles_path, os.path.dirname(path))
+        if base_dir:
+            os.makedirs(base_dir, exist_ok=True)
+            open(os.path.join(base_dir, os.path.basename(path)), 'w').close()
+        else:
+            open(rel_file_path, 'w').close()
+
+    c.run("profile list")
+
+    for path in ignore_paths:
+        rel_file_path = os.path.relpath(os.path.join(c.cache.profiles_path, path))
+        assert rel_file_path not in c.out


### PR DESCRIPTION
Implements feature requested in #12816.

This is currently set to ignore just '.DS_Store' which was requested in the issue. To extend this behaviour it should be enough to modify `paths_to_ignore` in conan/api/subapi/profiles.py, as well as implementing the tests accordingly.

Changelog: (Feature): Allow specifying files/directories to ignore when listing cached profiles.
Docs: Omit
