### PR TITLE
Also write CMake Test Presets

### DIFF
--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -110,6 +110,14 @@ def _configure_preset(conanfile, generator, cache_variables, toolchain_file, mul
     return ret
 
 
+def _insert_preset(data, preset_name, preset):
+    position = _get_already_existing_preset_index(preset["name"], data[preset_name])
+    if position is not None:
+        data[preset_name][position] = preset
+    else:
+        data[preset_name].append(preset)
+
+
 def _forced_schema_2(conanfile):
     version = conanfile.conf.get("tools.cmake.cmaketoolchain.presets:max_schema_version",
                                  check_type=int)
@@ -177,27 +185,14 @@ def write_cmake_presets(conanfile, toolchain_file, generator, cache_variables,
     if os.path.exists(preset_path):
         data = json.loads(load(preset_path))
         build_preset = _build_preset(conanfile, multiconfig)
-        position = _get_already_existing_preset_index(build_preset["name"], data["buildPresets"])
-        if position is not None:
-            data["buildPresets"][position] = build_preset
-        else:
-            data["buildPresets"].append(build_preset)
+        _insert_preset(data, "buildPresets", build_preset)
 
         test_preset = _test_preset(conanfile, multiconfig)
-        position = _get_already_existing_preset_index(build_preset["name"], data["testPresets"])
-        if position is not None:
-            data["testPresets"][position] = test_preset
-        else:
-            data["testPresets"].append(test_preset)
+        _insert_preset(data, "testPresets", test_preset)
 
         configure_preset = _configure_preset(conanfile, generator, cache_variables, toolchain_file,
                                              multiconfig)
-        position = _get_already_existing_preset_index(configure_preset["name"],
-                                                      data["configurePresets"])
-        if position is not None:
-            data["configurePresets"][position] = configure_preset
-        else:
-            data["configurePresets"].append(configure_preset)
+        _insert_preset(data, "configurePresets", configure_preset)
     else:
         data = _contents(conanfile, toolchain_file, cache_variables, generator)
 

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -588,9 +588,12 @@ def test_cmake_presets_multiple_settings_single_config():
     presets = json.loads(load(user_presets["include"][0]))
     assert len(presets["configurePresets"]) == 1
     assert len(presets["buildPresets"]) == 1
+    assert len(presets["testPresets"]) == 1
     assert presets["configurePresets"][0]["name"] == "apple-clang-12.0-gnu17-release"
     assert presets["buildPresets"][0]["name"] == "apple-clang-12.0-gnu17-release"
     assert presets["buildPresets"][0]["configurePreset"] == "apple-clang-12.0-gnu17-release"
+    assert presets["testPresets"][0]["name"] == "apple-clang-12.0-gnu17-release"
+    assert presets["testPresets"][0]["configurePreset"] == "apple-clang-12.0-gnu17-release"
 
     # If we create the "Debug" one, it has the same toolchain and preset file, that is
     # always multiconfig
@@ -602,12 +605,17 @@ def test_cmake_presets_multiple_settings_single_config():
     presets = json.loads(load(user_presets["include"][0]))
     assert len(presets["configurePresets"]) == 2
     assert len(presets["buildPresets"]) == 2
+    assert len(presets["testPresets"]) == 2
     assert presets["configurePresets"][0]["name"] == "apple-clang-12.0-gnu17-release"
     assert presets["configurePresets"][1]["name"] == "apple-clang-12.0-gnu17-debug"
     assert presets["buildPresets"][0]["name"] == "apple-clang-12.0-gnu17-release"
     assert presets["buildPresets"][1]["name"] == "apple-clang-12.0-gnu17-debug"
     assert presets["buildPresets"][0]["configurePreset"] == "apple-clang-12.0-gnu17-release"
     assert presets["buildPresets"][1]["configurePreset"] == "apple-clang-12.0-gnu17-debug"
+    assert presets["testPresets"][0]["name"] == "apple-clang-12.0-gnu17-release"
+    assert presets["testPresets"][1]["name"] == "apple-clang-12.0-gnu17-debug"
+    assert presets["testPresets"][0]["configurePreset"] == "apple-clang-12.0-gnu17-release"
+    assert presets["testPresets"][1]["configurePreset"] == "apple-clang-12.0-gnu17-debug"
 
     # But If we change, for example, the cppstd and the compiler version, the toolchain
     # and presets will be different, but it will be appended to the UserPresets.json
@@ -623,26 +631,32 @@ def test_cmake_presets_multiple_settings_single_config():
     presets = json.loads(load(user_presets["include"][1]))
     assert len(presets["configurePresets"]) == 1
     assert len(presets["buildPresets"]) == 1
+    assert len(presets["testPresets"]) == 1
     assert presets["configurePresets"][0]["name"] == "apple-clang-13-gnu20-release"
     assert presets["buildPresets"][0]["name"] == "apple-clang-13-gnu20-release"
     assert presets["buildPresets"][0]["configurePreset"] == "apple-clang-13-gnu20-release"
+    assert presets["testPresets"][0]["name"] == "apple-clang-13-gnu20-release"
+    assert presets["testPresets"][0]["configurePreset"] == "apple-clang-13-gnu20-release"
 
     # We can build with cmake manually
     if platform.system() == "Darwin":
         client.run_command("cmake . --preset apple-clang-12.0-gnu17-release")
         client.run_command("cmake --build --preset apple-clang-12.0-gnu17-release")
+        client.run_command("ctest --preset apple-clang-12.0-gnu17-release")
         client.run_command("./build/apple-clang-12.0-gnu17/Release/hello")
         assert "Hello World Release!" in client.out
         assert "__cplusplus2017" in client.out
 
         client.run_command("cmake . --preset apple-clang-12.0-gnu17-debug")
         client.run_command("cmake --build --preset apple-clang-12.0-gnu17-debug")
+        client.run_command("ctest --preset apple-clang-12.0-gnu17-debug")
         client.run_command("./build/apple-clang-12.0-gnu17/Debug/hello")
         assert "Hello World Debug!" in client.out
         assert "__cplusplus2017" in client.out
 
         client.run_command("cmake . --preset apple-clang-13-gnu20-release")
         client.run_command("cmake --build --preset apple-clang-13-gnu20-release")
+        client.run_command("ctest --preset apple-clang-13-gnu20-release")
         client.run_command("./build/apple-clang-13-gnu20/Release/hello")
         assert "Hello World Release!" in client.out
         assert "__cplusplus2020" in client.out
@@ -666,6 +680,7 @@ def test_cmake_presets_duplicated_install(multiconfig):
     assert os.path.exists(presets_path)
     contents = json.loads(load(presets_path))
     assert len(contents["buildPresets"]) == 1
+    assert len(contents["testPresets"]) == 1
 
 
 def test_remove_missing_presets():
@@ -730,6 +745,7 @@ def test_cmake_presets_options_single_config():
             shared_str = "shared_true" if shared else "shared_false"
             client.run_command("cmake . --preset apple-clang-{}-release".format(shared_str))
             client.run_command("cmake --build --preset apple-clang-{}-release".format(shared_str))
+            client.run_command("ctest --preset apple-clang-{}-release".format(shared_str))
             the_lib = "libhello.a" if not shared else "libhello.dylib"
             path = os.path.join(client.current_folder,
                                 "build", "apple-clang-{}".format(shared_str), "release", the_lib)
@@ -757,9 +773,12 @@ def test_cmake_presets_multiple_settings_multi_config():
     presets = json.loads(load(user_presets["include"][0]))
     assert len(presets["configurePresets"]) == 1
     assert len(presets["buildPresets"]) == 1
+    assert len(presets["testPresets"]) == 1
     assert presets["configurePresets"][0]["name"] == "dynamic-14"
     assert presets["buildPresets"][0]["name"] == "dynamic-14-release"
     assert presets["buildPresets"][0]["configurePreset"] == "dynamic-14"
+    assert presets["testPresets"][0]["name"] == "dynamic-14-release"
+    assert presets["testPresets"][0]["configurePreset"] == "dynamic-14"
 
     # If we create the "Debug" one, it has the same toolchain and preset file, that is
     # always multiconfig
@@ -771,11 +790,16 @@ def test_cmake_presets_multiple_settings_multi_config():
     presets = json.loads(load(user_presets["include"][0]))
     assert len(presets["configurePresets"]) == 1
     assert len(presets["buildPresets"]) == 2
+    assert len(presets["testPresets"]) == 2
     assert presets["configurePresets"][0]["name"] == "dynamic-14"
     assert presets["buildPresets"][0]["name"] == "dynamic-14-release"
     assert presets["buildPresets"][1]["name"] == "dynamic-14-debug"
     assert presets["buildPresets"][0]["configurePreset"] == "dynamic-14"
     assert presets["buildPresets"][1]["configurePreset"] == "dynamic-14"
+    assert presets["testPresets"][0]["name"] == "dynamic-14-release"
+    assert presets["testPresets"][1]["name"] == "dynamic-14-debug"
+    assert presets["testPresets"][0]["configurePreset"] == "dynamic-14"
+    assert presets["testPresets"][1]["configurePreset"] == "dynamic-14"
 
     # But If we change, for example, the cppstd and the compiler version, the toolchain
     # and presets will be different, but it will be appended to the UserPresets.json
@@ -790,19 +814,24 @@ def test_cmake_presets_multiple_settings_multi_config():
     presets = json.loads(load(user_presets["include"][1]))
     assert len(presets["configurePresets"]) == 1
     assert len(presets["buildPresets"]) == 1
+    assert len(presets["testPresets"]) == 1
     assert presets["configurePresets"][0]["name"] == "static-17"
     assert presets["buildPresets"][0]["name"] == "static-17-release"
     assert presets["buildPresets"][0]["configurePreset"] == "static-17"
+    assert presets["testPresets"][0]["name"] == "static-17-release"
+    assert presets["testPresets"][0]["configurePreset"] == "static-17"
 
     # We can build with cmake manually
     client.run_command("cmake . --preset dynamic-14")
 
     client.run_command("cmake --build --preset dynamic-14-release")
+    client.run_command("ctest --preset dynamic-14-release")
     client.run_command("build\\dynamic-14\\Release\\hello")
     assert "Hello World Release!" in client.out
     assert "MSVC_LANG2014" in client.out
 
     client.run_command("cmake --build --preset dynamic-14-debug")
+    client.run_command("ctest --preset dynamic-14-debug")
     client.run_command("build\\dynamic-14\\Debug\\hello")
     assert "Hello World Debug!" in client.out
     assert "MSVC_LANG2014" in client.out
@@ -810,6 +839,7 @@ def test_cmake_presets_multiple_settings_multi_config():
     client.run_command("cmake . --preset static-17")
 
     client.run_command("cmake --build --preset static-17-release")
+    client.run_command("ctest --preset static-17-release")
     client.run_command("build\\static-17\\Release\\hello")
     assert "Hello World Release!" in client.out
     assert "MSVC_LANG2017" in client.out
@@ -837,10 +867,12 @@ def test_user_presets_version2():
     if platform.system() == "Windows":
         client.run_command("cmake . --preset 14")
         client.run_command("cmake --build --preset 14-release")
+        client.run_command("ctest --preset 14-release")
         client.run_command(r"build\14\Release\hello.exe")
     else:
         client.run_command("cmake . --preset 14-release")
         client.run_command("cmake --build --preset 14-release")
+        client.run_command("ctest --preset 14-release")
         client.run_command("./build/14/Release/hello")
 
     assert "Hello World Release!" in client.out
@@ -853,10 +885,12 @@ def test_user_presets_version2():
     if platform.system() == "Windows":
         client.run_command("cmake . --preset 17")
         client.run_command("cmake --build --preset 17-release")
+        client.run_command("ctest --preset 17-release")
         client.run_command(r"build\17\Release\hello.exe")
     else:
         client.run_command("cmake . --preset 17-release")
         client.run_command("cmake --build --preset 17-release")
+        client.run_command("ctest --preset 17-release")
         client.run_command("./build/17/Release/hello")
 
     assert "Hello World Release!" in client.out
@@ -943,10 +977,12 @@ def test_cmake_presets_with_conanfile_txt():
     if platform.system() != "Windows":
         c.run_command("cmake --preset debug")
         c.run_command("cmake --build --preset debug")
+        c.run_command("ctest --preset debug")
         c.run_command("./build/Debug/foo")
     else:
         c.run_command("cmake --preset default")
         c.run_command("cmake --build --preset debug")
+        c.run_command("ctest --preset debug")
         c.run_command("build\\Debug\\foo")
 
     assert "Hello World Debug!" in c.out
@@ -954,9 +990,11 @@ def test_cmake_presets_with_conanfile_txt():
     if platform.system() != "Windows":
         c.run_command("cmake --preset release")
         c.run_command("cmake --build --preset release")
+        c.run_command("ctest --preset release")
         c.run_command("./build/Release/foo")
     else:
         c.run_command("cmake --build --preset release")
+        c.run_command("ctest --preset release")
         c.run_command("build\\Release\\foo")
 
     assert "Hello World Release!" in c.out

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -402,12 +402,17 @@ def test_cmake_presets_multiconfig():
     presets = json.loads(client.load("CMakePresets.json"))
     assert len(presets["buildPresets"]) == 1
     assert presets["buildPresets"][0]["configuration"] == "Release"
+    assert len(presets["testPresets"]) == 1
+    assert presets["testPresets"][0]["configuration"] == "Release"
 
     client.run("install mylib/1.0@ -g CMakeToolchain -s build_type=Debug --profile:h=profile")
     presets = json.loads(client.load("CMakePresets.json"))
     assert len(presets["buildPresets"]) == 2
     assert presets["buildPresets"][0]["configuration"] == "Release"
     assert presets["buildPresets"][1]["configuration"] == "Debug"
+    assert len(presets["testPresets"]) == 2
+    assert presets["testPresets"][0]["configuration"] == "Release"
+    assert presets["testPresets"][1]["configuration"] == "Debug"
 
     client.run("install mylib/1.0@ -g CMakeToolchain -s build_type=RelWithDebInfo "
                "--profile:h=profile")
@@ -418,6 +423,11 @@ def test_cmake_presets_multiconfig():
     assert presets["buildPresets"][1]["configuration"] == "Debug"
     assert presets["buildPresets"][2]["configuration"] == "RelWithDebInfo"
     assert presets["buildPresets"][3]["configuration"] == "MinSizeRel"
+    assert len(presets["testPresets"]) == 4
+    assert presets["testPresets"][0]["configuration"] == "Release"
+    assert presets["testPresets"][1]["configuration"] == "Debug"
+    assert presets["testPresets"][2]["configuration"] == "RelWithDebInfo"
+    assert presets["testPresets"][3]["configuration"] == "MinSizeRel"
 
     # Repeat one
     client.run("install mylib/1.0@ -g CMakeToolchain -s build_type=Debug --profile:h=profile")
@@ -427,6 +437,12 @@ def test_cmake_presets_multiconfig():
     assert presets["buildPresets"][1]["configuration"] == "Debug"
     assert presets["buildPresets"][2]["configuration"] == "RelWithDebInfo"
     assert presets["buildPresets"][3]["configuration"] == "MinSizeRel"
+
+    assert len(presets["testPresets"]) == 4
+    assert presets["testPresets"][0]["configuration"] == "Release"
+    assert presets["testPresets"][1]["configuration"] == "Debug"
+    assert presets["testPresets"][2]["configuration"] == "RelWithDebInfo"
+    assert presets["testPresets"][3]["configuration"] == "MinSizeRel"
 
     assert len(presets["configurePresets"]) == 1
     assert presets["configurePresets"][0]["name"] == "default"
@@ -453,6 +469,9 @@ def test_cmake_presets_singleconfig():
     assert len(presets["buildPresets"]) == 1
     assert presets["buildPresets"][0]["configurePreset"] == "release"
 
+    assert len(presets["testPresets"]) == 1
+    assert presets["testPresets"][0]["configurePreset"] == "release"
+
     # Now two configurePreset, but named correctly
     client.run("install mylib/1.0@ -g CMakeToolchain -s build_type=Debug --profile:h=profile")
     presets = json.loads(client.load("CMakePresets.json"))
@@ -461,6 +480,9 @@ def test_cmake_presets_singleconfig():
 
     assert len(presets["buildPresets"]) == 2
     assert presets["buildPresets"][1]["configurePreset"] == "debug"
+
+    assert len(presets["testPresets"]) == 2
+    assert presets["testPresets"][1]["configurePreset"] == "debug"
 
     # Repeat configuration, it shouldn't add a new one
     client.run("install mylib/1.0@ -g CMakeToolchain -s build_type=Debug --profile:h=profile")


### PR DESCRIPTION
Changelog: Feature: CMakeToolchain also write CMake Test Presets.
Docs: https://github.com/conan-io/docs/pull/2889

Right now the `CMakeToolchain` generator only writes configure and build presets. That requires some guesswork to find the build directory in case the `cmake_layout` is used.

My testcase:
```python
from conan import ConanFile
from conan.tools.cmake import cmake_layout

class Pkg(ConanFile):
    settings = "os", "arch", "compiler", "build_type"
    generators = "CMakeToolchain"

    def layout(self):
    	cmake_layout(self)
```

```cmake
cmake_minimum_required(VERSION 3.15)
project(testcase NONE)
enable_testing()
add_test(NAME some_test COMMAND ${CMAKE_COMMAND} -E true)
```

```shell
conan install . 
cmake --preset release
cmake --build --preset release
ctest --preset release # this fails right now but succeeds with this PR
```

If you welcome adding test presets I'll extend add the necessary docs repo PR.

Thanks,
Gregor

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
