### PR TITLE
test for path with special chars

### DIFF
--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -312,7 +312,7 @@ class EnvVars:
                 set foundenvvar=
                 for /f "delims== tokens=1,2" %%a in ('set') do (
                     if /I "%%a" == "%%v" (
-                        echo set "%%a=%%b">> "{deactivate_file}"
+                        echo set "%%a=%%b">> "%~dp0/{deactivate_file}"
                         set foundenvvar=1
                     )
                 )

--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -377,8 +377,8 @@ class EnvVars:
         save(file_location, content)
 
     def save_sh(self, file_location, generate_deactivate=True):
-        _, filename = os.path.split(file_location)
-        deactivate_file = "deactivate_{}".format(filename)
+        filepath, filename = os.path.split(file_location)
+        deactivate_file = os.path.join(filepath, "deactivate_{}".format(filename))
         deactivate = textwrap.dedent("""\
            echo "echo Restoring environment" > "{deactivate_file}"
            for v in {vars}

--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -291,12 +291,14 @@ def _generate_aggregated_env(conanfile):
         ps1s = []
         for env_script in env_scripts:
             path = os.path.join(conanfile.generators_folder, env_script)
+            path = os.path.relpath(path, conanfile.generators_folder)
             if env_script.endswith(".bat"):
-                bats.append(path)
+                bats.append("%~dp0/"+path)
             elif env_script.endswith(".sh"):
                 shs.append(subsystem_path(subsystem, path))
             elif env_script.endswith(".ps1"):
-                ps1s.append(path)
+                # This $PSScriptRoot uses the current script directory
+                ps1s.append("$PSScriptRoot/"+path)
         if shs:
             def sh_content(files):
                 return ". " + " && . ".join('"{}"'.format(s) for s in files)

--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -291,12 +291,14 @@ def _generate_aggregated_env(conanfile):
         ps1s = []
         for env_script in env_scripts:
             path = os.path.join(conanfile.generators_folder, env_script)
-            path = os.path.relpath(path, conanfile.generators_folder)
+            # Only the .bat and .ps1 are made relative to current script
             if env_script.endswith(".bat"):
+                path = os.path.relpath(path, conanfile.generators_folder)
                 bats.append("%~dp0/"+path)
             elif env_script.endswith(".sh"):
                 shs.append(subsystem_path(subsystem, path))
             elif env_script.endswith(".ps1"):
+                path = os.path.relpath(path, conanfile.generators_folder)
                 # This $PSScriptRoot uses the current script directory
                 ps1s.append("$PSScriptRoot/"+path)
         if shs:

--- a/conans/test/integration/cache/test_home_special_char.py
+++ b/conans/test/integration/cache/test_home_special_char.py
@@ -1,16 +1,29 @@
 import os
 
-from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient
 
+import textwrap
 
 def test_home_special_chars():
     path_chars = "päthñç$"
-    cache_folder = os.path.join(temp_folder(), path_chars)
-    current_folder = os.path.join(temp_folder(), path_chars)
+    cache_folder = os.path.join("C:\\Tmp", path_chars)
+    current_folder = os.path.join("C:\\Tmp", path_chars)
     c = TestClient(cache_folder, current_folder)
-    c.save({"conanfile.py": GenConanfile("pkg", "0.1")})
-    c.run("install .")
+
+    conan_file = textwrap.dedent("""
+        from conans import ConanFile
+
+        class App(ConanFile):
+            name="Failure"
+            version="0.1"
+            settings = 'os', 'arch', 'compiler', 'build_type'
+            generators = "MSBuildToolchain"
+
+            def build(self):
+                self.run("git --version")
+    """)
+
+    c.save({"conanfile.py": conan_file})
     c.run("create .")
     assert path_chars in c.out

--- a/conans/test/integration/cache/test_home_special_char.py
+++ b/conans/test/integration/cache/test_home_special_char.py
@@ -7,8 +7,8 @@ import textwrap
 
 def test_home_special_chars():
     path_chars = "päthñç$"
-    cache_folder = os.path.join("C:\\Tmp", path_chars)
-    current_folder = os.path.join("C:\\Tmp", path_chars)
+    cache_folder = os.path.join(temp_folder(), path_chars)
+    current_folder = os.path.join(temp_folder(), path_chars)
     c = TestClient(cache_folder, current_folder)
 
     conan_file = textwrap.dedent("""

--- a/conans/test/integration/cache/test_home_special_char.py
+++ b/conans/test/integration/cache/test_home_special_char.py
@@ -1,0 +1,16 @@
+import os
+
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.test_files import temp_folder
+from conans.test.utils.tools import TestClient
+
+
+def test_home_special_chars():
+    path_chars = "päthñç$"
+    cache_folder = os.path.join(temp_folder(), path_chars)
+    current_folder = os.path.join(temp_folder(), path_chars)
+    c = TestClient(cache_folder, current_folder)
+    c.save({"conanfile.py": GenConanfile("pkg", "0.1")})
+    c.run("install .")
+    c.run("create .")
+    assert path_chars in c.out

--- a/conans/test/integration/cache/test_home_special_char.py
+++ b/conans/test/integration/cache/test_home_special_char.py
@@ -1,4 +1,5 @@
 import os
+import platform
 
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient
@@ -14,19 +15,44 @@ def test_home_special_chars():
     current_folder = os.path.join(temp_folder(), path_chars)
     c = TestClient(cache_folder, current_folder)
 
+    tool = textwrap.dedent(r"""
+        import os
+        from conan import ConanFile
+        from conan.tools.files import save, chdir
+        class Pkg(ConanFile):
+            name = "mytool"
+            version = "1.0"
+            def package(self):
+                with chdir(self, self.package_folder):
+                    echo = "@echo off\necho MYTOOL WORKS!!"
+                    save(self, "bin/mytool.bat", echo)
+                    save(self, "bin/mytool.sh", echo)
+                    os.chmod("bin/mytool.sh", 0o777)
+            """)
+    c.save({"conanfile.py": tool})
+    c.run("create .")
+
     conan_file = textwrap.dedent("""
+        import platform
         from conan import ConanFile
 
         class App(ConanFile):
             name="failure"
             version="0.1"
             settings = 'os', 'arch', 'compiler', 'build_type'
-            generators = "MSBuildToolchain"
-
+            generators = "VirtualBuildEnv"
+            tool_requires = "mytool/1.0"
             def build(self):
-                self.run("git --version")
+                mycmd = "mytool.bat" if platform.system() == "Windows" else "mytool.sh"
+                self.run(mycmd)
         """)
 
     c.save({"conanfile.py": conan_file})
-    c.run("create .")
+    # Need the 2 profile to work correctly buildenv
+    c.run("create . -s:b build_type=Release")
     assert path_chars in c.out
+    assert "MYTOOL WORKS!!" in c.out
+    if platform.system() == "Windows":
+        c.run("create . -s:b build_type=Release -c tools.env.virtualenv:powershell=True")
+        assert path_chars in c.out
+        assert "MYTOOL WORKS!!" in c.out

--- a/conans/test/integration/cache/test_home_special_char.py
+++ b/conans/test/integration/cache/test_home_special_char.py
@@ -5,24 +5,27 @@ from conans.test.utils.tools import TestClient
 
 import textwrap
 
+
 def test_home_special_chars():
+    """ the path with special characters is creating a conanbuild.bat that fails
+    """
     path_chars = "päthñç$"
     cache_folder = os.path.join(temp_folder(), path_chars)
     current_folder = os.path.join(temp_folder(), path_chars)
     c = TestClient(cache_folder, current_folder)
 
     conan_file = textwrap.dedent("""
-        from conans import ConanFile
+        from conan import ConanFile
 
         class App(ConanFile):
-            name="Failure"
+            name="failure"
             version="0.1"
             settings = 'os', 'arch', 'compiler', 'build_type'
             generators = "MSBuildToolchain"
 
             def build(self):
                 self.run("git --version")
-    """)
+        """)
 
     c.save({"conanfile.py": conan_file})
     c.run("create .")

--- a/conans/test/integration/toolchains/env/test_virtualenv_powershell.py
+++ b/conans/test/integration/toolchains/env/test_virtualenv_powershell.py
@@ -14,6 +14,7 @@ from conans.tools import save
 def client():
     # We use special characters and spaces, to check everything works
     # https://github.com/conan-io/conan/issues/12648
+    # FIXME: This path still fails the creation of the deactivation script
     cache_folder = os.path.join(temp_folder(), "[sub] folder")
     client = TestClient(cache_folder)
     conanfile = str(GenConanfile("pkg", "0.1"))
@@ -40,6 +41,7 @@ def test_virtualenv(client):
             name = "app"
             version = "0.1"
             requires = "pkg/0.1"
+            apply_env = False
 
             def build(self):
                 self.output.info("----------BUILD----------------")


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

When a user in Windows have some special char in their username, the path contains them.
Bat scripts (maybe Powershell too? Need to check better) were failing for this reason.
I am proposing here to make the paths from ``conanbuild.bat`` -> other .bat scripts relative to the location of ``conanbuild.bat``, so they don't contain the full path anymore, and doesn't fail.

Close https://github.com/conan-io/conan/issues/2163
