### PR TITLE
AutotoolsToolchain: pass valid GNU triplet when cross-building

### DIFF
--- a/conan/tools/gnu/get_gnu_triplet.py
+++ b/conan/tools/gnu/get_gnu_triplet.py
@@ -68,7 +68,7 @@ def _get_gnu_triplet(os_, arch, compiler=None):
     if compiler == "gcc":
         windows_op = "w64-mingw32"
     elif compiler == "Visual Studio":
-        windows_op = "windows-msvc"
+        windows_op = "unknown-windows"
     else:
         windows_op = "windows"
 


### PR DESCRIPTION
Changelog: Bugfix: Fix bug to pass a valid GNU triplet when using AutotoolsToolchain and cross-building on Windows.
Docs: Omit

Close: https://github.com/conan-io/conan/issues/7460

### Notes:
This targets the 1.x develop branch - the public `tools.get_gnu_triplet` from the legacy tools remains untouched, while this PR only modifies the private implementation used by the AutotoolsToolchain.

### Context:
The current implementation of the _private_ `_get_gnu_triplet` returns `x86_64-windows-msvc`. This results in errors when we are cross-building on Windows, since this is not a valid GNU triplet:
```
config.sub x86-64-windows-msvc    
Invalid configuration `x86-64-windows-msvc': OS `msvc' not recognized
```

Specifically for Autotools, the triplet system type is of the format specified [here](https://www.gnu.org/software/autoconf/manual/autoconf-2.68/html_node/System-Type.html#System-Type), where we can have:
* `cpu-company-os`, or
* `cpu-company-kernel-os`

In this context, `msvc` is not a valid OS. There is no current convention in GNU for a proper target when the OS is Windows, and the C/C++ runtime are provided by Visual C++, this PR falls back to a generic `{arch}-unknown-windows`, where windows is a valid OS. This is the a very generic fallback - while  `x86-64-w64-mingw32` may be preferred in some contexts, we don't have enough context to assume it (but could be done in a separate flag), and when Visual C++ with the Microsoft Visual C++ runtime is used, the binaries produced would not strictly be mingw32 binaries.



