### PR TITLE
add `conan.tools.android.android_abi()`

### DIFF
--- a/conan/tools/android/__init__.py
+++ b/conan/tools/android/__init__.py
@@ -1,0 +1,1 @@
+from conan.tools.android.utils import android_abi

--- a/conan/tools/android/utils.py
+++ b/conan/tools/android/utils.py
@@ -1,0 +1,25 @@
+from conan.errors import ConanException
+
+
+def android_abi(conanfile, context="host"):
+    """
+    Returns Android-NDK ABI
+    :param conanfile: ConanFile instance
+    :param context: either "host", "build" or "target"
+    :return: Android-NDK ABI
+    """
+    if context not in ["host", "build", "target"]:
+        raise ConanException("context argument must be either 'host', 'build' or 'target'")
+
+    settings = getattr(conanfile, f"settings_{context}", conanfile.settings)
+    arch = settings.get_safe("arch")
+    # https://cmake.org/cmake/help/latest/variable/CMAKE_ANDROID_ARCH_ABI.html
+    return {
+        "armv5el": "armeabi",
+        "armv5hf": "armeabi",
+        "armv5": "armeabi",
+        "armv6": "armeabi-v6",
+        "armv7": "armeabi-v7a",
+        "armv7hf": "armeabi-v7a",
+        "armv8": "arm64-v8a",
+    }.get(arch, arch)

--- a/conan/tools/android/utils.py
+++ b/conan/tools/android/utils.py
@@ -9,9 +9,15 @@ def android_abi(conanfile, context="host"):
     :return: Android-NDK ABI
     """
     if context not in ["host", "build", "target"]:
-        raise ConanException("context argument must be either 'host', 'build' or 'target'")
+        raise ConanException(f"context argument must be either 'host', 'build' or 'target', was {context}")
 
-    settings = getattr(conanfile, f"settings_{context}", conanfile.settings)
+    try:
+        settings = getattr(conanfile, f"settings_{context}")
+    except AttributeError:
+        if context == "host":
+            settings = conanfile.settings
+        else:
+            raise ConanException(f"settings_{context} not declared in recipe")
     arch = settings.get_safe("arch")
     # https://cmake.org/cmake/help/latest/variable/CMAKE_ANDROID_ARCH_ABI.html
     return {

--- a/conan/tools/android/utils.py
+++ b/conan/tools/android/utils.py
@@ -8,8 +8,8 @@ def android_abi(conanfile, context="host"):
     :param context: either "host", "build" or "target"
     :return: Android-NDK ABI
     """
-    if context not in ["host", "build", "target"]:
-        raise ConanException(f"context argument must be either 'host', 'build' or 'target', was {context}")
+    if context not in ("host", "build", "target"):
+        raise ConanException(f"context argument must be either 'host', 'build' or 'target', was '{context}'")
 
     try:
         settings = getattr(conanfile, f"settings_{context}")

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 from jinja2 import Template
 
 from conan.tools._compilers import architecture_flag, libcxx_flags
+from conan.tools.android.utils import android_abi
 from conan.tools.apple.apple import is_apple_os, to_apple_arch
 from conan.tools.build import build_jobs
 from conan.tools.build.cross_building import cross_building
@@ -286,11 +287,6 @@ class AndroidSystemBlock(Block):
         if os_ != "Android":
             return
 
-        android_abi = {"x86": "x86",
-                       "x86_64": "x86_64",
-                       "armv7": "armeabi-v7a",
-                       "armv8": "arm64-v8a"}.get(str(self._conanfile.settings.arch))
-
         # TODO: only 'c++_shared' y 'c++_static' supported?
         #  https://developer.android.com/ndk/guides/cpp-support
         libcxx_str = self._conanfile.settings.get_safe("compiler.libcxx")
@@ -302,7 +298,7 @@ class AndroidSystemBlock(Block):
 
         ctxt_toolchain = {
             'android_platform': 'android-' + str(self._conanfile.settings.os.api_level),
-            'android_abi': android_abi,
+            'android_abi': android_abi(self._conanfile),
             'android_stl': libcxx_str,
             'android_ndk_path': android_ndk_path,
         }

--- a/conans/test/unittests/tools/android/test_android_tools.py
+++ b/conans/test/unittests/tools/android/test_android_tools.py
@@ -1,0 +1,36 @@
+from conans.test.utils.mocks import ConanFileMock, MockSettings
+from conan.tools.android import android_abi
+
+
+def test_tools_android_abi():
+    settings_linux = MockSettings({"os": "Linux", "arch": "x86_64"})
+
+    for (arch, expected) in [
+        ("armv5el", "armeabi"),
+        ("armv5hf", "armeabi"),
+        ("armv5", "armeabi"),
+        ("armv6", "armeabi-v6"),
+        ("armv7", "armeabi-v7a"),
+        ("armv7hf", "armeabi-v7a"),
+        ("armv8", "arm64-v8a"),
+        ("x86", "x86"),
+        ("x86_64", "x86_64"),
+        ("mips", "mips"),
+        ("mips_64", "mips_64"),
+    ]:
+        conanfile = ConanFileMock()
+        settings_android = MockSettings({"os": "Android", "arch": arch})
+
+        conanfile.settings = settings_android
+        assert android_abi(conanfile) == expected
+        assert android_abi(conanfile, context="host") == expected
+        assert android_abi(conanfile, context="build") == expected
+        assert android_abi(conanfile, context="target") == expected
+
+        conanfile.settings = settings_linux
+        conanfile.settings_build = settings_android
+        assert android_abi(conanfile, context="build") == expected
+
+        conanfile.settings_build = settings_linux
+        conanfile.settings_target = settings_android
+        assert android_abi(conanfile, context="target") == expected

--- a/conans/test/unittests/tools/android/test_android_tools.py
+++ b/conans/test/unittests/tools/android/test_android_tools.py
@@ -33,6 +33,7 @@ def test_tools_android_abi():
         conanfile.settings = settings_android
         conanfile.settings_host = settings_android
         conanfile.settings_build = settings_android
+        assert android_abi(conanfile) == expected
         assert android_abi(conanfile, context="host") == expected
         assert android_abi(conanfile, context="build") == expected
         assert android_abi(conanfile, context="target") == expected
@@ -41,6 +42,7 @@ def test_tools_android_abi():
         conanfile.settings = settings_linux
         conanfile.settings_host = settings_linux
         conanfile.settings_build = settings_android
+        assert android_abi(conanfile) != expected
         assert android_abi(conanfile, context="host") != expected
         assert android_abi(conanfile, context="build") == expected
         assert android_abi(conanfile, context="target") != expected
@@ -50,6 +52,7 @@ def test_tools_android_abi():
         conanfile.settings = settings_android
         conanfile.settings_host = settings_android
         conanfile.settings_build = settings_linux
+        assert android_abi(conanfile) == expected
         assert android_abi(conanfile, context="host") == expected
         assert android_abi(conanfile, context="build") != expected
         assert android_abi(conanfile, context="target") == expected
@@ -59,6 +62,7 @@ def test_tools_android_abi():
         conanfile.settings_host = settings_linux
         conanfile.settings_build = settings_linux
         conanfile.settings_target = settings_android
+        assert android_abi(conanfile) != expected
         assert android_abi(conanfile, context="host") != expected
         assert android_abi(conanfile, context="build") != expected
         assert android_abi(conanfile, context="target") == expected

--- a/conans/test/unittests/tools/android/test_android_tools.py
+++ b/conans/test/unittests/tools/android/test_android_tools.py
@@ -1,6 +1,8 @@
 from conans.test.utils.mocks import ConanFileMock, MockSettings
+from conans.errors import ConanException
 from conan.tools.android import android_abi
 
+from pytest import raises
 
 def test_tools_android_abi():
     settings_linux = MockSettings({"os": "Linux", "arch": "foo"})
@@ -25,8 +27,12 @@ def test_tools_android_abi():
         conanfile.settings = settings_android
         assert android_abi(conanfile) == expected
         assert android_abi(conanfile, context="host") == expected
-        assert android_abi(conanfile, context="build") == expected
-        assert android_abi(conanfile, context="target") == expected
+
+        with raises(ConanException):
+            assert android_abi(conanfile, context="build") == expected
+
+        with raises(ConanException):
+            assert android_abi(conanfile, context="target") == expected
 
         # 2 profiles
         ## native build
@@ -36,7 +42,9 @@ def test_tools_android_abi():
         assert android_abi(conanfile) == expected
         assert android_abi(conanfile, context="host") == expected
         assert android_abi(conanfile, context="build") == expected
-        assert android_abi(conanfile, context="target") == expected
+
+        with raises(ConanException):
+            assert android_abi(conanfile, context="target") == expected
 
         ## cross-build from Android to Linux (quite hypothetical)
         conanfile.settings = settings_linux
@@ -45,7 +53,9 @@ def test_tools_android_abi():
         assert android_abi(conanfile) != expected
         assert android_abi(conanfile, context="host") != expected
         assert android_abi(conanfile, context="build") == expected
-        assert android_abi(conanfile, context="target") != expected
+
+        with raises(ConanException):
+            assert android_abi(conanfile, context="target")
 
         ## cross-build a recipe from Linux to Android:
         ### test android_abi in recipe itself
@@ -55,7 +65,8 @@ def test_tools_android_abi():
         assert android_abi(conanfile) == expected
         assert android_abi(conanfile, context="host") == expected
         assert android_abi(conanfile, context="build") != expected
-        assert android_abi(conanfile, context="target") == expected
+        with raises(ConanException):
+            android_abi(conanfile, context="target")
 
         ### test android_abi in "compiler recipe" (ie a android-ndk recipe in tool_requires of recipe being cross-build)
         conanfile.settings = settings_linux


### PR DESCRIPTION
Changelog: Feature: Add `conan.tools.android.android_abi()` function to return the Android standard ABI name based on Conan.
Docs: https://github.com/conan-io/docs/pull/2975

closes https://github.com/conan-io/conan/issues/12814

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
