### PR TITLE
Bugfix: fix KeyError 'buildPresets', the field is optional according to the specification

### DIFF
--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -174,7 +174,7 @@ def write_cmake_presets(conanfile, toolchain_file, generator, cache_variables,
     if os.path.exists(preset_path):
         data = json.loads(load(preset_path))
         build_preset = _build_preset(conanfile, multiconfig)
-        position = _get_already_existing_preset_index(build_preset["name"], data["buildPresets"])
+        position = _get_already_existing_preset_index(build_preset["name"], data.setdefault("buildPresets", []))
         if position is not None:
             data["buildPresets"][position] = build_preset
         else:


### PR DESCRIPTION
closes: #12158 

Changelog: Bugfix: Fix KeyError 'buildPresets', the field is optional according to the specification.
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
