### PR TITLE
Add requires for `conan new cmake_{exe,lib}`

### DIFF
--- a/conan/api/subapi/new.py
+++ b/conan/api/subapi/new.py
@@ -9,7 +9,6 @@ from conans import __version__
 
 
 class NewAPI:
-
     _NOT_TEMPLATES = "not_templates"  # Filename containing filenames of files not to be rendered
 
     def __init__(self, conan_api):
@@ -84,17 +83,29 @@ class NewAPI:
 
         return template_files, non_template_files
 
-
     @staticmethod
     def render(template_files, definitions):
         result = {}
         name = definitions.get("name", "Pkg")
         definitions["conan_version"] = __version__
-        definitions["package_name"] = name.replace("-", "_").replace("+", "_").replace(".", "_")
+
+        def as_package_name(n):
+            return n.replace("-", "_").replace("+", "_").replace(".", "_")
+
+        def as_name(ref):
+            ref = as_package_name(ref)
+            if '/' in ref:
+                ref = ref[0:ref.index('/')]
+            return ref
+
+        definitions["package_name"] = as_package_name(name)
         definitions["as_iterable"] = lambda x: [x] if isinstance(x, str) else x
+        definitions["as_name"] = as_name
         for k, v in template_files.items():
-            k = Template(k, keep_trailing_newline=True, undefined=StrictUndefined).render(**definitions)
-            v = Template(v, keep_trailing_newline=True, undefined=StrictUndefined).render(**definitions)
+            k = Template(k, keep_trailing_newline=True, undefined=StrictUndefined).render(
+                **definitions)
+            v = Template(v, keep_trailing_newline=True, undefined=StrictUndefined).render(
+                **definitions)
             if v:
                 result[k] = v
         return result

--- a/conan/cli/commands/new.py
+++ b/conan/cli/commands/new.py
@@ -67,7 +67,7 @@ def new(conan_api, parser, *args):
                 ast = env.parse(templ_str)
                 template_vars.extend(meta.find_undeclared_variables(ast))
 
-            injected_vars = {"conan_version", "package_name"}
+            injected_vars = {"conan_version", "package_name", "as_iterable", "as_name"}
             optional_vars = {"requires"}
             template_vars = list(set(template_vars) - injected_vars - optional_vars)
             template_vars.sort()

--- a/conan/cli/commands/new.py
+++ b/conan/cli/commands/new.py
@@ -68,7 +68,8 @@ def new(conan_api, parser, *args):
                 template_vars.extend(meta.find_undeclared_variables(ast))
 
             injected_vars = {"conan_version", "package_name"}
-            template_vars = list(set(template_vars) - injected_vars)
+            optional_vars = {"requires"}
+            template_vars = list(set(template_vars) - injected_vars - optional_vars)
             template_vars.sort()
             return template_vars
 

--- a/conan/internal/api/new/cmake_exe.py
+++ b/conan/internal/api/new/cmake_exe.py
@@ -1,7 +1,7 @@
 from conan.internal.api.new.cmake_lib import source_cpp, source_h, test_main
 
 conanfile_exe = '''from conan import ConanFile
-from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
+from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
 
 
 class {{package_name}}Recipe(ConanFile):
@@ -26,6 +26,8 @@ class {{package_name}}Recipe(ConanFile):
         cmake_layout(self)
 
     def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
         tc = CMakeToolchain(self)
         tc.generate()
 
@@ -37,12 +39,31 @@ class {{package_name}}Recipe(ConanFile):
     def package(self):
         cmake = CMake(self)
         cmake.install()
+
+    {% if requires is defined -%}
+    def requirements(self):
+        {% for require in as_iterable(requires) -%}
+        self.requires("{{ require }}")
+        {% endfor %}
+    {%- endif %}
 '''
 
 cmake_exe_v2 = """cmake_minimum_required(VERSION 3.15)
 project({{name}} CXX)
 
+{% if requires is defined -%}
+{% for require in as_iterable(requires) -%}
+find_package({{as_name(require)}} CONFIG REQUIRED)
+{% endfor %}
+{%- endif %}
+
 add_executable({{name}} src/{{name}}.cpp src/main.cpp)
+
+{% if requires is defined -%}
+{% for require in as_iterable(requires) -%}
+target_link_libraries({{name}} PRIVATE {{as_name(require)}}::{{as_name(require)}})
+{% endfor %}
+{%- endif %}
 
 install(TARGETS {{name}} DESTINATION "."
         RUNTIME DESTINATION bin

--- a/conan/internal/api/new/cmake_lib.py
+++ b/conan/internal/api/new/cmake_lib.py
@@ -48,7 +48,7 @@ class {{package_name}}Recipe(ConanFile):
 
     {% if requires is defined -%}
     def requirements(self):
-        {% for require in requires -%}
+        {% for require in as_iterable(requires) -%}
         self.requires("{{ require }}")
         {% endfor %}
     {%- endif %}

--- a/conans/test/functional/command/new_test.py
+++ b/conans/test/functional/command/new_test.py
@@ -7,17 +7,17 @@ from conans.test.utils.tools import TestClient
 @pytest.mark.tool("cmake")
 def test_diamonds_cmake_with_new():
     tc = TestClient()
-    tc.run("new cmake_lib -d name=math -d version=3.14")
+    tc.run("new cmake_lib -d name=mathematics -d version=3.14")
     tc.run("create .")
-    tc.run("new cmake_lib -d name=ai -d version=0.1 -d requires=math/3.14 -f")
+    tc.run("new cmake_lib -d name=ai -d version=0.1 -d requires=mathematics/3.14 -f")
     tc.run("create .")
-    assert "math/3.14: Hello World" in tc.out
-    tc.run("new cmake_lib -d name=ui -d version=1.0 -d requires=math/3.14 -f")
+    assert "mathematics/3.14: Hello World" in tc.out
+    tc.run("new cmake_lib -d name=ui -d version=1.0 -d requires=mathematics/3.14 -f")
     tc.run("create .")
-    assert "math/3.14: Hello World" in tc.out
+    assert "mathematics/3.14: Hello World" in tc.out
     tc.run("new cmake_exe -d name=game -d version=0.0 -d requires=ai/0.1 -d requires=ui/1.0 -f")
     tc.run("create .")
-    assert "math/3.14: Hello World" in tc.out
+    assert "mathematics/3.14: Hello World" in tc.out
     assert "ai/0.1: Hello World" in tc.out
     assert "ui/1.0: Hello World" in tc.out
 

--- a/conans/test/functional/command/new_test.py
+++ b/conans/test/functional/command/new_test.py
@@ -1,6 +1,6 @@
 import pytest as pytest
 
-from utils.tools import TestClient
+from conans.test.utils.tools import TestClient
 
 
 @pytest.mark.tool("cmake")

--- a/conans/test/functional/command/new_test.py
+++ b/conans/test/functional/command/new_test.py
@@ -3,6 +3,7 @@ import pytest as pytest
 from conans.test.utils.tools import TestClient
 
 
+# TODO: Remove this test once this feature is used elsewhere to test other things
 @pytest.mark.tool("cmake")
 def test_diamonds_cmake_with_new():
     tc = TestClient()

--- a/conans/test/functional/command/new_test.py
+++ b/conans/test/functional/command/new_test.py
@@ -1,0 +1,26 @@
+import pytest as pytest
+
+from utils.tools import TestClient
+
+
+@pytest.mark.tool("cmake")
+def test_diamonds_cmake_with_new():
+    tc = TestClient()
+    tc.run("new cmake_lib -d name=math -d version=3.14")
+    tc.run("create .")
+    tc.run("new cmake_lib -d name=ai -d version=0.1 -d requires=ai/3.14 -f")
+    tc.run("create .")
+    assert "math/1.3: Hello World" in tc.out
+    tc.run("new cmake_lib -d name=colours -d version=42.0 -f")
+    tc.run("create .")
+    tc.run("new cmake_lib -d name=ui -d version=1.0 -d requires=math/3.14 -d requires=colours/42.0 -f")
+    tc.run("create .")
+    assert "math/1.3: Hello World" in tc.out
+    assert "colours/42.0: Hello World" in tc.out
+    tc.run("new cmake_exe -d name=game -d version=0.0 -d requires=math/3.14 -d requires=ai/0.1 -d requires=ui/1.0 -f")
+    tc.run("create .")
+    assert "math/1.3: Hello World" in tc.out
+    assert "ai/0.1: Hello World" in tc.out
+    assert "ui/1.0: Hello World" in tc.out
+
+

--- a/conans/test/functional/command/new_test.py
+++ b/conans/test/functional/command/new_test.py
@@ -3,23 +3,20 @@ import pytest as pytest
 from utils.tools import TestClient
 
 
-@pytest.mark.tool("cmake")
+#@pytest.mark.tool("cmake")
 def test_diamonds_cmake_with_new():
     tc = TestClient()
     tc.run("new cmake_lib -d name=math -d version=3.14")
     tc.run("create .")
-    tc.run("new cmake_lib -d name=ai -d version=0.1 -d requires=ai/3.14 -f")
+    tc.run("new cmake_lib -d name=ai -d version=0.1 -d requires=math/3.14 -f")
     tc.run("create .")
-    assert "math/1.3: Hello World" in tc.out
-    tc.run("new cmake_lib -d name=colours -d version=42.0 -f")
+    assert "math/3.14: Hello World" in tc.out
+    tc.run("new cmake_lib -d name=ui -d version=1.0 -d requires=math/3.14 -f")
     tc.run("create .")
-    tc.run("new cmake_lib -d name=ui -d version=1.0 -d requires=math/3.14 -d requires=colours/42.0 -f")
+    assert "math/3.14: Hello World" in tc.out
+    tc.run("new cmake_exe -d name=game -d version=0.0 -d requires=ai/0.1 -d requires=ui/1.0 -f")
     tc.run("create .")
-    assert "math/1.3: Hello World" in tc.out
-    assert "colours/42.0: Hello World" in tc.out
-    tc.run("new cmake_exe -d name=game -d version=0.0 -d requires=math/3.14 -d requires=ai/0.1 -d requires=ui/1.0 -f")
-    tc.run("create .")
-    assert "math/1.3: Hello World" in tc.out
+    assert "math/3.14: Hello World" in tc.out
     assert "ai/0.1: Hello World" in tc.out
     assert "ui/1.0: Hello World" in tc.out
 

--- a/conans/test/functional/command/new_test.py
+++ b/conans/test/functional/command/new_test.py
@@ -3,7 +3,7 @@ import pytest as pytest
 from utils.tools import TestClient
 
 
-#@pytest.mark.tool("cmake")
+@pytest.mark.tool("cmake")
 def test_diamonds_cmake_with_new():
     tc = TestClient()
     tc.run("new cmake_lib -d name=math -d version=3.14")


### PR DESCRIPTION
Changelog: Feature: Add requirements to `conan new cmake_{lib,exe}`
Docs: https://github.com/conan-io/docs/pull/2881

This makes it possible to quickly create a dependency graph that actually executes some code, useful for debugging purposes or to check whatever's needed
