### PR TITLE
Add throw flag for `check_min_vs` tool function

### DIFF
--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -9,7 +9,7 @@ from conan.tools.scm import Version
 CONAN_VCVARS_FILE = "conanvcvars.bat"
 
 
-def check_min_vs(conanfile, version, throw = True):
+def check_min_vs(conanfile, version, raise_invalid=True):
     """
     This is a helper method to allow the migration of 1.X -> 2.0 and VisualStudio -> msvc settings
     without breaking recipes.
@@ -17,7 +17,7 @@ def check_min_vs(conanfile, version, throw = True):
 
     :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
     :param version: ``str`` Visual Studio or msvc version number.
-    :param throw: ``bool`` Whether to throw or return False if the version check fails
+    :param raise_invalid: ``bool`` Whether to raise or return False if the version check fails
     """
     compiler = conanfile.settings.get_safe("compiler")
     compiler_version = None
@@ -36,7 +36,7 @@ def check_min_vs(conanfile, version, throw = True):
             compiler_version += ".{}".format(compiler_update)
 
     if compiler_version and Version(compiler_version) < version:
-        if throw:
+        if raise_invalid:
             msg = f"This package doesn't work with VS compiler version '{compiler_version}'" \
                   f", it requires at least '{version}'"
             raise ConanInvalidConfiguration(msg)

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -9,7 +9,7 @@ from conan.tools.scm import Version
 CONAN_VCVARS_FILE = "conanvcvars.bat"
 
 
-def check_min_vs(conanfile, version):
+def check_min_vs(conanfile, version, throw = True):
     """
     This is a helper method to allow the migration of 1.X -> 2.0 and VisualStudio -> msvc settings
     without breaking recipes.
@@ -17,6 +17,7 @@ def check_min_vs(conanfile, version):
 
     :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
     :param version: ``str`` Visual Studio or msvc version number.
+    :param throw: ``bool`` Whether to throw or return False if the version check fails
     """
     compiler = conanfile.settings.get_safe("compiler")
     compiler_version = None
@@ -35,9 +36,13 @@ def check_min_vs(conanfile, version):
             compiler_version += ".{}".format(compiler_update)
 
     if compiler_version and Version(compiler_version) < version:
-        msg = "This package doesn't work with VS compiler version '{}'" \
-              ", it requires at least '{}'".format(compiler_version, version)
-        raise ConanInvalidConfiguration(msg)
+        if throw:
+            msg = f"This package doesn't work with VS compiler version '{compiler_version}'" \
+                  f", it requires at least '{version}'"
+            raise ConanInvalidConfiguration(msg)
+        else:
+            return False
+    return True
 
 
 def msvc_version_to_vs_ide_version(version):

--- a/conans/test/unittests/tools/microsoft/test_check_min_vs.py
+++ b/conans/test/unittests/tools/microsoft/test_check_min_vs.py
@@ -7,6 +7,23 @@ from conans.test.utils.mocks import MockConanfile, MockSettings
 
 class TestCheckMinVS:
 
+    parametrize_vars = "compiler,version,update,minimum"
+    valid_parametrize_values = [
+        ("Visual Studio", "15", None, "191"),
+        ("Visual Studio", "16", None, "192"),
+        ("msvc", "193", None, "193"),
+        ("msvc", "193", None, "192"),
+        ("msvc", "193", "2", "193.1"),
+    ]
+
+    invalid_parametrize_values = [
+        ("Visual Studio", "15", None, "192"),
+        ("Visual Studio", "16", None, "193.1"),
+        ("msvc", "192", None, "193"),
+        ("msvc", "193", None, "193.1"),
+        ("msvc", "193", "1", "193.2"),
+    ]
+
     @staticmethod
     def _create_conanfile(compiler, version, update=None):
         settings = MockSettings({"compiler": compiler,
@@ -15,25 +32,23 @@ class TestCheckMinVS:
         conanfile = MockConanfile(settings)
         return conanfile
 
-    @pytest.mark.parametrize("compiler,version,update,minimum", [
-        ("Visual Studio", "15", None, "191"),
-        ("Visual Studio", "16", None, "192"),
-        ("msvc", "193", None, "193"),
-        ("msvc", "193", None, "192"),
-        ("msvc", "193", "2", "193.1"),
-    ])
+    @pytest.mark.parametrize(parametrize_vars, valid_parametrize_values)
     def test_valid(self, compiler, version, update, minimum):
         conanfile = self._create_conanfile(compiler, version, update)
         check_min_vs(conanfile, minimum)
 
-    @pytest.mark.parametrize("compiler,version,update,minimum", [
-        ("Visual Studio", "15", None, "192"),
-        ("Visual Studio", "16", None, "193.1"),
-        ("msvc", "192", None, "193"),
-        ("msvc", "193", None, "193.1"),
-        ("msvc", "193", "1", "193.2"),
-    ])
+    @pytest.mark.parametrize(parametrize_vars, valid_parametrize_values)
+    def test_valid_nothrows(self, compiler, version, update, minimum):
+        conanfile = self._create_conanfile(compiler, version, update)
+        assert check_min_vs(conanfile, minimum, throw=False)
+
+    @pytest.mark.parametrize(parametrize_vars, invalid_parametrize_values)
     def test_invalid(self, compiler, version, update, minimum):
         conanfile = self._create_conanfile(compiler, version, update)
         with pytest.raises(ConanInvalidConfiguration):
             check_min_vs(conanfile, minimum)
+
+    @pytest.mark.parametrize(parametrize_vars, invalid_parametrize_values)
+    def test_invalid_nothrows(self, compiler, version, update, minimum):
+        conanfile = self._create_conanfile(compiler, version, update)
+        assert not check_min_vs(conanfile, minimum, throw=False)

--- a/conans/test/unittests/tools/microsoft/test_check_min_vs.py
+++ b/conans/test/unittests/tools/microsoft/test_check_min_vs.py
@@ -40,7 +40,7 @@ class TestCheckMinVS:
     @pytest.mark.parametrize(parametrize_vars, valid_parametrize_values)
     def test_valid_nothrows(self, compiler, version, update, minimum):
         conanfile = self._create_conanfile(compiler, version, update)
-        assert check_min_vs(conanfile, minimum, throw=False)
+        assert check_min_vs(conanfile, minimum, raise_invalid=False)
 
     @pytest.mark.parametrize(parametrize_vars, invalid_parametrize_values)
     def test_invalid(self, compiler, version, update, minimum):
@@ -51,4 +51,4 @@ class TestCheckMinVS:
     @pytest.mark.parametrize(parametrize_vars, invalid_parametrize_values)
     def test_invalid_nothrows(self, compiler, version, update, minimum):
         conanfile = self._create_conanfile(compiler, version, update)
-        assert not check_min_vs(conanfile, minimum, throw=False)
+        assert not check_min_vs(conanfile, minimum, raise_invalid=False)


### PR DESCRIPTION
Changelog: Feature: Adds new `raise_invalid` argument for `check_min_vs` to avoid raising if check fails.
Docs: It will automatically be added to the docs

Simplifies instances where a `try/catch` would be needed for cases where custom logic is wanted  (in CCI, this is usually adding `-FS` where necessary)