### PR TITLE
allow skip the generation of conanvcvars.bat

### DIFF
--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -73,7 +73,7 @@ class VCVars:
             return
 
         vs_install_path = conanfile.conf.get("tools.microsoft.msbuild:installation_path")
-        if vs_install_path == "disabled":
+        if vs_install_path == "":  # Empty string means "disable"
             return
 
         if compiler == "clang":

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -72,6 +72,10 @@ class VCVars:
         if compiler not in ("Visual Studio", "msvc", "clang"):
             return
 
+        vs_install_path = conanfile.conf.get("tools.microsoft.msbuild:installation_path")
+        if vs_install_path == "disabled":
+            return
+
         if compiler == "clang":
             # The vcvars only needed for LLVM/Clang and VS ClangCL, who define runtime
             if not conanfile.settings.get_safe("compiler.runtime"):
@@ -93,7 +97,6 @@ class VCVars:
             vcvars_ver = _vcvars_vers(conanfile, compiler, vs_version)
         vcvarsarch = vcvars_arch(conanfile)
 
-        vs_install_path = conanfile.conf.get("tools.microsoft.msbuild:installation_path")
         # The vs_install_path is like
         # C:\Program Files (x86)\Microsoft Visual Studio\2019\Community
         # C:\Program Files (x86)\Microsoft Visual Studio\2017\Community

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -35,7 +35,7 @@ BUILT_IN_CONFS = {
     "tools.microsoft.msbuild:verbosity": "Verbosity level for MSBuild: 'Quiet', 'Minimal', 'Normal', 'Detailed', 'Diagnostic'",
     "tools.microsoft.msbuild:vs_version": "Defines the IDE version when using the new msvc compiler",
     "tools.microsoft.msbuild:max_cpu_count": "Argument for the /m when running msvc to build parallel projects",
-    "tools.microsoft.msbuild:installation_path": "VS install path, to avoid auto-detect via vswhere, like C:/Program Files (x86)/Microsoft Visual Studio/2019/Community",
+    "tools.microsoft.msbuild:installation_path": "VS install path, to avoid auto-detect via vswhere, like C:/Program Files (x86)/Microsoft Visual Studio/2019/Community. Use empty string to disable",
     "tools.microsoft.msbuilddeps:exclude_code_analysis": "Suppress MSBuild code analysis for patterns",
     "tools.microsoft.msbuildtoolchain:compile_options": "Dictionary with MSBuild compiler options",
     "tools.intel:installation_path": "Defines the Intel oneAPI installation root path",

--- a/conans/test/integration/toolchains/microsoft/vcvars_test.py
+++ b/conans/test/integration/toolchains/microsoft/vcvars_test.py
@@ -45,8 +45,12 @@ def test_vcvars_generator_skip():
     client = TestClient()
     client.save({"conanfile.py": GenConanfile().with_generator("VCVars")
                                                .with_settings("os", "compiler",
-                                                              "arch", "build_type")})
-    client.run('install . -c tools.microsoft.msbuild:installation_path=disabled')
+                                                              "arch", "build_type"),
+                 "profile": 'include(default)\n[conf]\ntools.microsoft.msbuild:installation_path='})
+
+    client.run('install . -c tools.microsoft.msbuild:installation_path=""')
+    assert not os.path.exists(os.path.join(client.current_folder, "conanvcvars.bat"))
+    client.run('install . -pr=profile')
     assert not os.path.exists(os.path.join(client.current_folder, "conanvcvars.bat"))
 
 

--- a/conans/test/integration/toolchains/microsoft/vcvars_test.py
+++ b/conans/test/integration/toolchains/microsoft/vcvars_test.py
@@ -4,6 +4,7 @@ import os
 
 import pytest
 
+from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
 
 
@@ -34,6 +35,19 @@ def test_vcvars_generator(scope):
         assert "conanvcvars.bat" in bat_contents
     else:
         assert not os.path.exists(os.path.join(client.current_folder, "conanbuild.bat"))
+
+
+@pytest.mark.skipif(platform.system() not in ["Windows"], reason="Requires Windows")
+def test_vcvars_generator_skip():
+    """
+    tools.microsoft.msbuild:installation_path=disabled avoids creation of conanvcvars.bat
+    """
+    client = TestClient()
+    client.save({"conanfile.py": GenConanfile().with_generator("VCVars")
+                                               .with_settings("os", "compiler",
+                                                              "arch", "build_type")})
+    client.run('install . -c tools.microsoft.msbuild:installation_path=disabled')
+    assert not os.path.exists(os.path.join(client.current_folder, "conanvcvars.bat"))
 
 
 @pytest.mark.skipif(platform.system() not in ["Windows"], reason="Requires Windows")


### PR DESCRIPTION
Changelog: Feature: Allow skip the generation of conanvcvars.bat with empty ``tools.microsoft.msbuild:installation_path``
Docs: https://github.com/conan-io/docs/pull/2892

I am proposing the use of ``tools.microsoft.msbuild:installation_path='`` to skip the generation of the conanvcvars.bat. I am reusing the ``tools.microsoft.msbuild:installation_path`` conf, because it is used exclusively already for the ``VCVars`` functionality, and to avoid the proliferation of tons of ``confs`` for minor functionalities like this one.

Close https://github.com/conan-io/conan/issues/12855
