### PR TITLE
[AutotoolsToolchain] Added helpers `update_xxxx_args`

### DIFF
--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -187,9 +187,10 @@ class AutotoolsToolchain:
         configure_args = []
         configure_args.extend(self.configure_args)
         user_args_str = args_to_string(self.configure_args)
-        for flag, var in (("host", self._host), ("build", self._build), ("target", self._target)):
+        for flag, var in (("--host=", self._host), ("--build=", self._build),
+                          ("--target=", self._target)):
             if var and flag not in user_args_str:
-                configure_args.append('--{}={}'.format(flag, var))
+                configure_args.append('{}{}'.format(flag, var))
 
         args = {"configure_args": args_to_string(configure_args),
                 "make_args":  args_to_string(self.make_args),

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -201,43 +201,48 @@ class AutotoolsToolchain:
                 triplets.append(f'{flag}{value}')
         return triplets
 
-    def update_configure_args(self, **updated_flags):
+    def update_configure_args(self, updated_flags):
         """
         Helper to update/prune flags from ``self.configure_args``.
 
         :param updated_flags: ``dict`` with arguments as keys and their argument values.
                               Notice that if argument value is ``None``, this one will be pruned.
         """
-        self._update_flags("configure_args", **updated_flags)
+        self._update_flags("configure_args", updated_flags)
 
-    def update_make_args(self, **updated_flags):
+    def update_make_args(self, updated_flags):
         """
         Helper to update/prune arguments from ``self.make_args``.
 
         :param updated_flags: ``dict`` with arguments as keys and their argument values.
                               Notice that if argument value is ``None``, this one will be pruned.
         """
-        self._update_flags("make_args", **updated_flags)
+        self._update_flags("make_args", updated_flags)
 
-    def update_autoreconf_args(self, **updated_flags):
+    def update_autoreconf_args(self, updated_flags):
         """
         Helper to update/prune arguments from ``self.autoreconf_args``.
 
         :param updated_flags: ``dict`` with arguments as keys and their argument values.
                               Notice that if argument value is ``None``, this one will be pruned.
         """
-        self._update_flags("autoreconf_args", **updated_flags)
+        self._update_flags("autoreconf_args", updated_flags)
 
-    def _update_flags(self, attr_name, **updated_flags):
+    # FIXME: Remove all these update_xxxx whenever xxxx_args are dicts or new ones replace them
+    def _update_flags(self, attr_name, updated_flags):
         _new_flags = []
         self_args = getattr(self, attr_name)
         for index, flag in enumerate(self_args):
-            flag_name = flag.split("=")[0].replace("--", "")
+            flag_name = flag.split("=")[0]
             if flag_name in updated_flags:
                 new_flag_value = updated_flags[flag_name]
                 # if {"build": None} is passed, then "--build=xxxx" will be pruned
-                if new_flag_value is not None:
-                    _new_flags.append(f"--{flag_name}={new_flag_value}")
+                if new_flag_value is None:
+                    continue
+                elif not new_flag_value:
+                    _new_flags.append(flag_name)
+                else:
+                    _new_flags.append(f"{flag_name}={new_flag_value}")
             else:
                 _new_flags.append(flag)
         # Update the current ones

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -58,12 +58,6 @@ class AutotoolsToolchain:
                 self._host = _get_gnu_triplet(os_host, arch_host, compiler=compiler)
             # Build triplet
             self._build = _get_gnu_triplet(os_build, arch_build, compiler=compiler)
-            # Target triplet
-            if hasattr(conanfile, 'settings_target') and conanfile.settings_target:
-                settings_target = conanfile.settings_target
-                os_target = settings_target.get_safe("os")
-                arch_target = settings_target.get_safe("arch")
-                self._target = _get_gnu_triplet(os_target, arch_target, compiler=compiler)
             # Apple Stuff
             if os_build == "Macos":
                 sdk_path = apple_sdk_path(conanfile)

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -55,12 +55,19 @@ class AutotoolsToolchain:
         self.sysroot_flag = None
 
         if cross_building(self._conanfile):
+            # Host triplet
             os_build, arch_build, os_host, arch_host = get_cross_building_settings(self._conanfile)
             compiler = self._conanfile.settings.get_safe("compiler")
             if not self._host:
                 self._host = _get_gnu_triplet(os_host, arch_host, compiler=compiler)
+            # Build triplet
             self._build = _get_gnu_triplet(os_build, arch_build, compiler=compiler)
-
+            # Target triplet
+            if hasattr(conanfile, 'settings_target') and conanfile.settings_target:
+                settings_target = conanfile.settings_target
+                os_target = settings_target.get_safe("os")
+                arch_target = settings_target.get_safe("arch")
+                self._target = _get_gnu_triplet(os_target, arch_target, compiler=compiler)
             # Apple Stuff
             if os_build == "Macos":
                 sdk_path = apple_sdk_path(conanfile)
@@ -73,6 +80,12 @@ class AutotoolsToolchain:
         sysroot = self._conanfile.conf.get("tools.build:sysroot")
         sysroot = sysroot.replace("\\", "/") if sysroot is not None else None
         self.sysroot_flag = "--sysroot {}".format(sysroot) if sysroot else None
+
+        # Initializing the triplets values
+        for flag, value in (("--host=", self._host), ("--build=", self._build),
+                            ("--target=", self._target)):
+            if value:
+                self.configure_args.append(f"{flag}{value}")
 
         check_using_build_profile(self._conanfile)
 
@@ -184,16 +197,7 @@ class AutotoolsToolchain:
         return ["--force", "--install"]
 
     def generate_args(self):
-        configure_args = []
-        configure_args.extend(self.configure_args)
-        user_args_str = args_to_string(self.configure_args)
-        for flag, var in (("--host=", self._host), ("--build=", self._build),
-                          ("--target=", self._target)):
-            if var and flag not in user_args_str:
-                configure_args.append('{}{}'.format(flag, var))
-
-        args = {"configure_args": args_to_string(configure_args),
+        args = {"configure_args": args_to_string(self.configure_args),
                 "make_args":  args_to_string(self.make_args),
                 "autoreconf_args": args_to_string(self.autoreconf_args)}
-
         save_toolchain_args(args, namespace=self._namespace)

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -18,10 +18,6 @@ class AutotoolsToolchain:
         self._namespace = namespace
         self._prefix = prefix
 
-        self.configure_args = self._default_configure_shared_flags() + self._default_configure_install_flags()
-        self.autoreconf_args = self._default_autoreconf_flags()
-        self.make_args = []
-
         # Flags
         self.extra_cxxflags = []
         self.extra_cflags = []
@@ -81,11 +77,11 @@ class AutotoolsToolchain:
         sysroot = sysroot.replace("\\", "/") if sysroot is not None else None
         self.sysroot_flag = "--sysroot {}".format(sysroot) if sysroot else None
 
-        # Initializing the triplets values
-        for flag, value in (("--host=", self._host), ("--build=", self._build),
-                            ("--target=", self._target)):
-            if value:
-                self.configure_args.append(f"{flag}{value}")
+        self.configure_args = self._default_configure_shared_flags() + \
+                              self._default_configure_install_flags() + \
+                              self._get_triplets()
+        self.autoreconf_args = self._default_autoreconf_flags()
+        self.make_args = []
 
         check_using_build_profile(self._conanfile)
 
@@ -195,6 +191,14 @@ class AutotoolsToolchain:
 
     def _default_autoreconf_flags(self):
         return ["--force", "--install"]
+
+    def _get_triplets(self):
+        triplets = []
+        for flag, value in (("--host=", self._host), ("--build=", self._build),
+                            ("--target=", self._target)):
+            if value:
+                triplets.append(f'{flag}{value}')
+        return triplets
 
     def generate_args(self):
         args = {"configure_args": args_to_string(self.configure_args),

--- a/conans/test/unittests/tools/gnu/autotoolschain_test.py
+++ b/conans/test/unittests/tools/gnu/autotoolschain_test.py
@@ -171,19 +171,19 @@ def test_check_configure_args_overwriting_and_deletion(save_args, cross_building
     ])
     at.generate_args()
     configure_args = save_args.call_args[0][0]['configure_args']
-    assert "'--build=x86_64-linux-gnu'" in configure_args
-    assert "'--host=wasm32-local-emscripten'" in configure_args
-    assert "'--with-cross-build=my_path'" in configure_args
-    assert "'--something-host=my_host'" in configure_args
+    assert "--build=x86_64-linux-gnu" in configure_args
+    assert "--host=wasm32-local-emscripten" in configure_args
+    assert "--with-cross-build=my_path" in configure_args
+    assert "--something-host=my_host" in configure_args
     # https://github.com/conan-io/conan/issues/12431
     at.configure_args.remove("--build=x86_64-linux-gnu")
     at.configure_args.remove("--host=wasm32-local-emscripten")
     at.generate_args()
     configure_args = save_args.call_args[0][0]['configure_args']
-    assert "'--build=x86_64-linux-gnu'" not in configure_args  # removed
-    assert "'--host=wasm32-local-emscripten'" not in configure_args  # removed
-    assert "'--with-cross-build=my_path'" in configure_args
-    assert "'--something-host=my_host'" in configure_args
+    assert "--build=x86_64-linux-gnu" not in configure_args  # removed
+    assert "--host=wasm32-local-emscripten" not in configure_args  # removed
+    assert "--with-cross-build=my_path" in configure_args
+    assert "--something-host=my_host" in configure_args
 
 
 def test_update_or_prune_any_args(cross_building_conanfile):
@@ -195,14 +195,14 @@ def test_update_or_prune_any_args(cross_building_conanfile):
                               "--build": None,  # prune value
                               "--enable-flag1": ""})
     new_configure_args = args_to_string(at.configure_args)
-    assert "'--prefix=/my/other/prefix'" in new_configure_args
-    assert "'--build=" not in new_configure_args  # pruned
-    assert "'--enable-flag1'" in new_configure_args  # flag without value
+    assert "--prefix=/my/other/prefix" in new_configure_args
+    assert "--build=" not in new_configure_args  # pruned
+    assert "--enable-flag1" in new_configure_args  # flag without value
     # Update autoreconf_args
     at.update_autoreconf_args({"--force": None})
     new_autoreconf_args = args_to_string(at.autoreconf_args)
-    assert "'--force'" not in new_autoreconf_args
+    assert "'--force" not in new_autoreconf_args
     # Update make_args
     at.update_make_args({"--complex-flag": "new-value"})
     new_make_args = args_to_string(at.make_args)
-    assert "'--complex-flag=new-value'" in new_make_args
+    assert "--complex-flag=new-value" in new_make_args

--- a/conans/test/unittests/tools/gnu/autotoolschain_test.py
+++ b/conans/test/unittests/tools/gnu/autotoolschain_test.py
@@ -6,6 +6,24 @@ from conan.tools.gnu import AutotoolsToolchain
 from conans.errors import ConanException
 from conans.model.conf import Conf
 from conans.test.utils.mocks import ConanFileMock, MockSettings
+from conans.tools import args_to_string
+
+
+@pytest.fixture()
+def cross_building_conanfile():
+    settings_build = MockSettings({"os": "Linux",
+                                   "arch": "x86_64",
+                                   "compiler": "gcc",
+                                   "compiler.version": "11",
+                                   "compiler.libcxx": "libstdc++",
+                                   "build_type": "Release"})
+    settings_target = MockSettings({"os": "Android", "arch": "armv8"})
+    settings = MockSettings({"os": "Emscripten", "arch": "wasm"})
+    conanfile = ConanFileMock()
+    conanfile.settings = settings
+    conanfile.settings_build = settings_build
+    conanfile.settings_target = settings_target
+    return conanfile
 
 
 def test_get_gnu_triplet_for_cross_building():
@@ -144,21 +162,9 @@ def test_linker_scripts():
 
 
 @patch("conan.tools.gnu.autotoolstoolchain.save_toolchain_args")
-def test_check_configure_args_overwriting_and_deletion(save_args):
+def test_check_configure_args_overwriting_and_deletion(save_args, cross_building_conanfile):
     # Issue: https://github.com/conan-io/conan/issues/12642
-    settings_build = MockSettings({"os": "Linux",
-                                   "arch": "x86_64",
-                                   "compiler": "gcc",
-                                   "compiler.version": "11",
-                                   "compiler.libcxx": "libstdc++",
-                                   "build_type": "Release"})
-    settings_target = MockSettings({"os": "Android", "arch": "armv8"})
-    settings = MockSettings({"os": "Emscripten", "arch": "wasm"})
-    conanfile = ConanFileMock()
-    conanfile.settings = settings
-    conanfile.settings_build = settings_build
-    conanfile.settings_target = settings_target
-    at = AutotoolsToolchain(conanfile)
+    at = AutotoolsToolchain(cross_building_conanfile)
     at.configure_args.extend([
         "--with-cross-build=my_path",
         "--something-host=my_host"
@@ -179,3 +185,19 @@ def test_check_configure_args_overwriting_and_deletion(save_args):
     assert "--host=wasm32-local-emscripten" not in configure_args  # removed
     assert "--with-cross-build=my_path" in configure_args
     assert "--something-host=my_host" in configure_args
+
+
+def test_update_or_prune_any_args(cross_building_conanfile):
+    at = AutotoolsToolchain(cross_building_conanfile)
+    at.update_configure_args(prefix="/my/other/prefix", build=None, target=None, host=None)
+    new_configure_args = args_to_string(at.configure_args)
+    assert "--prefix=/my/other/prefix" in new_configure_args
+    assert "--host=" not in new_configure_args
+    assert "--build=" not in new_configure_args
+    assert "--target=" not in new_configure_args
+    at.update_autoreconf_args(**{"force": None})
+    new_autoreconf_args = args_to_string(at.autoreconf_args)
+    assert "--force" not in new_autoreconf_args
+    at.make_args.append("--complex-flag=complex-value")
+    at.update_autoreconf_args(**{"complex-flag": "new-value"})
+    assert "--complex-flag=new-value" not in new_autoreconf_args

--- a/conans/test/unittests/tools/gnu/autotoolschain_test.py
+++ b/conans/test/unittests/tools/gnu/autotoolschain_test.py
@@ -144,7 +144,7 @@ def test_linker_scripts():
 
 
 @patch("conan.tools.gnu.autotoolstoolchain.save_toolchain_args")
-def test_check_configure_args_overwriting(save_args):
+def test_check_configure_args_overwriting_and_deletion(save_args):
     # Issue: https://github.com/conan-io/conan/issues/12642
     settings_build = MockSettings({"os": "Linux",
                                    "arch": "x86_64",
@@ -152,11 +152,12 @@ def test_check_configure_args_overwriting(save_args):
                                    "compiler.version": "11",
                                    "compiler.libcxx": "libstdc++",
                                    "build_type": "Release"})
-    settings = MockSettings({"os": "Emscripten",
-                             "arch": "wasm"})
+    settings_target = MockSettings({"os": "Android", "arch": "armv8"})
+    settings = MockSettings({"os": "Emscripten", "arch": "wasm"})
     conanfile = ConanFileMock()
     conanfile.settings = settings
     conanfile.settings_build = settings_build
+    conanfile.settings_target = settings_target
     at = AutotoolsToolchain(conanfile)
     at.configure_args.extend([
         "--with-cross-build=my_path",
@@ -166,5 +167,15 @@ def test_check_configure_args_overwriting(save_args):
     configure_args = save_args.call_args[0][0]['configure_args']
     assert "--build=x86_64-linux-gnu" in configure_args
     assert "--host=wasm32-local-emscripten" in configure_args
+    assert "--target=aarch64-linux-android" in configure_args
+    assert "--with-cross-build=my_path" in configure_args
+    assert "--something-host=my_host" in configure_args
+    # https://github.com/conan-io/conan/issues/12431
+    at.configure_args.remove("--build=x86_64-linux-gnu")
+    at.configure_args.remove("--host=wasm32-local-emscripten")
+    at.generate_args()
+    configure_args = save_args.call_args[0][0]['configure_args']
+    assert "--build=x86_64-linux-gnu" not in configure_args  # removed
+    assert "--host=wasm32-local-emscripten" not in configure_args  # removed
     assert "--with-cross-build=my_path" in configure_args
     assert "--something-host=my_host" in configure_args

--- a/conans/test/unittests/tools/gnu/autotoolschain_test.py
+++ b/conans/test/unittests/tools/gnu/autotoolschain_test.py
@@ -199,5 +199,6 @@ def test_update_or_prune_any_args(cross_building_conanfile):
     new_autoreconf_args = args_to_string(at.autoreconf_args)
     assert "--force" not in new_autoreconf_args
     at.make_args.append("--complex-flag=complex-value")
-    at.update_autoreconf_args(**{"complex-flag": "new-value"})
-    assert "--complex-flag=new-value" not in new_autoreconf_args
+    at.update_make_args(**{"complex-flag": "new-value"})
+    new_make_args = args_to_string(at.make_args)
+    assert "--complex-flag=new-value" in new_make_args


### PR DESCRIPTION
Changelog: Fix: `AutotoolsToolchain.configure_args` are adequately initialized.
Changelog: Feature: Added to AutotoolsToolchain helper functions: `update_configure_args`, `update_make_args`, and `update_autoreconf_args` to update/prune flags effortlessly.
Changelog: Bugfix: `AutotoolsToolchain.configure_args` was overwriting Conan's pre-calculated arguments.
Docs: https://github.com/conan-io/docs/pull/2895

Closes: https://github.com/conan-io/conan/issues/12431
Closes: https://github.com/conan-io/conan/issues/12642
Closes: https://github.com/conan-io/conan/issues/12705
Closes: https://github.com/conan-io/conan/issues/12546

Taking back the first approach of https://github.com/conan-io/conan/pull/12645

See also https://github.com/conan-io/conan/pull/12889 (adding the add-new-flags capability)
