### PR TITLE
Add unix_path_package_info_legacy compatibility function

### DIFF
--- a/conan/tools/microsoft/__init__.py
+++ b/conan/tools/microsoft/__init__.py
@@ -1,7 +1,7 @@
 from conan.tools.microsoft.layout import vs_layout
 from conan.tools.microsoft.msbuild import MSBuild
 from conan.tools.microsoft.msbuilddeps import MSBuildDeps
-from conan.tools.microsoft.subsystems import unix_path
+from conan.tools.microsoft.subsystems import unix_path, unix_path_package_info_legacy
 from conan.tools.microsoft.toolchain import MSBuildToolchain
 from conan.tools.microsoft.nmaketoolchain import NMakeToolchain
 from conan.tools.microsoft.nmakedeps import NMakeDeps

--- a/conan/tools/microsoft/subsystems.py
+++ b/conan/tools/microsoft/subsystems.py
@@ -4,3 +4,10 @@ from conans.client.subsystems import deduce_subsystem, subsystem_path
 def unix_path(conanfile, path, scope="build"):
     subsystem = deduce_subsystem(conanfile, scope=scope)
     return subsystem_path(subsystem, path)
+
+def unix_path_package_info_legacy(conanfile, path, path_flavor=None):
+    message = f"The use of 'unix_path_legacy_compat' is deprecated in Conan 2.0 and does not " \
+              f"perform path conversions. This is retained for compatibility with Conan 1.x " \
+              f"and will be removed in a future version."
+    conanfile.output.warning(message)
+    return path

--- a/conans/test/unittests/tools/microsoft/test_subsystem.py
+++ b/conans/test/unittests/tools/microsoft/test_subsystem.py
@@ -2,7 +2,7 @@ import textwrap
 
 import pytest
 
-from conan.tools.microsoft import unix_path
+from conan.tools.microsoft import unix_path, unix_path_package_info_legacy
 from conans.model.conf import ConfDefinition
 from conans.test.utils.mocks import MockSettings, ConanFileMock
 
@@ -27,5 +27,9 @@ def test_unix_path(subsystem, expected_path):
     conanfile.settings = settings
     conanfile.settings_build = settings
 
-    path = unix_path(conanfile, "c:/path/to/stuff")
+    test_path = "c:/path/to/stuff"
+    path = unix_path(conanfile, test_path)
     assert expected_path == path
+
+    package_info_legacy_path = unix_path_package_info_legacy(conanfile, test_path, path_flavor=subsystem)
+    assert package_info_legacy_path == test_path


### PR DESCRIPTION
Changelog: Feature: Add `unix_path_package_info_legacy` function for those cases in which it is used in `package_info` in recipes that require compatibility with Conan 1.x. In Conan 2, path conversions should not be performed in the `package_info` method.

Docs: https://github.com/conan-io/docs/pull/XXXX
