### PR TITLE
Add unix_path_package_info_legacy compatibility function

### DIFF
--- a/conan/tools/microsoft/__init__.py
+++ b/conan/tools/microsoft/__init__.py
@@ -1,7 +1,7 @@
 from conan.tools.microsoft.layout import vs_layout
 from conan.tools.microsoft.msbuild import MSBuild
 from conan.tools.microsoft.msbuilddeps import MSBuildDeps
-from conan.tools.microsoft.subsystems import unix_path
+from conan.tools.microsoft.subsystems import unix_path, unix_path_package_info_legacy
 from conan.tools.microsoft.toolchain import MSBuildToolchain
 from conan.tools.microsoft.nmaketoolchain import NMakeToolchain
 from conan.tools.microsoft.nmakedeps import NMakeDeps

--- a/conan/tools/microsoft/subsystems.py
+++ b/conan/tools/microsoft/subsystems.py
@@ -6,7 +6,7 @@ def unix_path(conanfile, path, scope="build"):
     subsystem = deduce_subsystem(conanfile, scope=scope)
     return subsystem_path(subsystem, path)
 
-def unix_path_legacy_compat(conanfile, path, path_flavor=None):
+def unix_path_package_info_legacy(conanfile, path, path_flavor=None):
     # Call legacy implementation, which has different logic
     # to autodeduce the subsystem type for the conversion.
-    unix_path_legacy_tools(path, path_flavor)
+    return unix_path_legacy_tools(path, path_flavor)

--- a/conan/tools/microsoft/subsystems.py
+++ b/conan/tools/microsoft/subsystems.py
@@ -1,6 +1,12 @@
 from conans.client.subsystems import deduce_subsystem, subsystem_path
+from conans.client.tools.win import unix_path as unix_path_legacy_tools
 
 
 def unix_path(conanfile, path, scope="build"):
     subsystem = deduce_subsystem(conanfile, scope=scope)
     return subsystem_path(subsystem, path)
+
+def unix_path_legacy_compat(conanfile, path, path_flavor=None):
+    # Call legacy implementation, which has different logic
+    # to autodeduce the subsystem type for the conversion.
+    unix_path_legacy_tools(path, path_flavor)

--- a/conans/test/unittests/tools/microsoft/test_subsystem.py
+++ b/conans/test/unittests/tools/microsoft/test_subsystem.py
@@ -1,19 +1,20 @@
+import mock
 import textwrap
-
 import pytest
 
-from conan.tools.microsoft import unix_path
+from conan.tools.microsoft import unix_path, unix_path_package_info_legacy
 from conans.model.conf import ConfDefinition
 from conans.test.utils.mocks import MockSettings, ConanFileMock
 
-
-@pytest.mark.parametrize("subsystem, expected_path", [
+expected_results = [
     ("msys2", '/c/path/to/stuff'),
     ("msys", '/c/path/to/stuff'),
     ("cygwin", '/cygdrive/c/path/to/stuff'),
     ("wsl", '/mnt/c/path/to/stuff'),
     ("sfu", '/dev/fs/C/path/to/stuff')
-])
+]
+
+@pytest.mark.parametrize("subsystem, expected_path", expected_results)
 def test_unix_path(subsystem, expected_path):
     c = ConfDefinition()
     c.loads(textwrap.dedent("""\
@@ -29,3 +30,19 @@ def test_unix_path(subsystem, expected_path):
 
     path = unix_path(conanfile, "c:/path/to/stuff")
     assert expected_path == path
+
+@mock.patch("platform.system", mock.MagicMock(return_value='Windows'))
+@pytest.mark.parametrize("subsystem, expected_path", expected_results)
+def test_unix_path_package_info_legacy_windows(subsystem, expected_path):
+    test_path = "c:/path/to/stuff"
+    conanfile = ConanFileMock()
+    package_info_legacy_path = unix_path_package_info_legacy(conanfile, test_path, path_flavor=subsystem)
+    assert expected_path == package_info_legacy_path
+
+@mock.patch("platform.system", mock.MagicMock(return_value='Darwin'))
+@pytest.mark.parametrize("subsystem, expected_path", expected_results)
+def test_unix_path_package_info_legacy_not_windows(subsystem, expected_path):
+    test_path = "c:/path/to/stuff"
+    conanfile = ConanFileMock()
+    package_info_legacy_path = unix_path_package_info_legacy(conanfile, test_path, path_flavor=subsystem)
+    assert test_path == package_info_legacy_path


### PR DESCRIPTION
Changelog: Feature: Add `unix_path_package_info_legacy` function for those cases in which it is used in `package_info` in recipes that require compatibility with Conan 1.x. In Conan 2, path conversions should not be performed in the `package_info` method.

Docs: https://github.com/conan-io/docs/pull/2894