### PR TITLE
[develop2] finalizing TODOs of ``conan list``

### DIFF
--- a/conan/api/model.py
+++ b/conan/api/model.py
@@ -1,5 +1,6 @@
 from collections import OrderedDict
 
+from conans.model.package_ref import PkgReference
 from conans.util.dates import timestamp_to_str
 
 
@@ -68,6 +69,10 @@ class _PackageUploadData:
 class SelectBundle:
     def __init__(self):
         self.recipes = OrderedDict()
+        self.confs = {}
+
+    def add_configurations(self, confs):
+        self.confs = {PkgReference(k.ref, k.package_id): v for k, v in confs.items()}
 
     def add_refs(self, refs):
         for ref in refs:
@@ -82,9 +87,9 @@ class SelectBundle:
             prefs.extend(v)
         return prefs
 
-    def add_prefs(self, prefs, configurations=None):
+    def add_prefs(self, prefs):
         for pref in prefs:
-            binary_info = configurations.get(pref) if configurations is not None else None
+            binary_info = self.confs.get(PkgReference(pref.ref, pref.package_id))
             self.recipes.setdefault(pref.ref, []).append((pref, binary_info))
 
     def serialize(self):

--- a/conan/api/subapi/list.py
+++ b/conan/api/subapi/list.py
@@ -96,8 +96,13 @@ class ListAPI:
             raise ConanException("Cannot specify '-p' package queries, "
                                  "if 'package_id' is not a pattern")
         select_bundle = SelectBundle()
-        refs = self.conan_api.search.recipes(pattern.ref, remote=remote)
-        pattern.check_refs(refs)
+        # Avoid doing a ``search`` of recipes if it is an exact ref and it will be used later
+        if "*" in pattern.ref or not pattern.version or \
+                (pattern.package_id is None and pattern.rrev is None):
+            refs = self.conan_api.search.recipes(pattern.ref, remote=remote)
+            pattern.check_refs(refs)
+        else:
+            refs = [RecipeReference(pattern.name, pattern.version, pattern.user, pattern.channel)]
 
         # Show only the recipe references
         if pattern.package_id is None and pattern.rrev is None:

--- a/conan/api/subapi/list.py
+++ b/conan/api/subapi/list.py
@@ -100,7 +100,7 @@ class ListAPI:
         pattern.check_refs(refs)
 
         # Show only the recipe references
-        if pattern.show_only_refs():
+        if pattern.package_id is None and pattern.rrev is None:
             select_bundle.add_refs(refs)
             return select_bundle
 

--- a/conan/api/subapi/list.py
+++ b/conan/api/subapi/list.py
@@ -1,7 +1,6 @@
 from typing import Dict
 
 from conan.api.model import Remote, SelectBundle
-from conan.internal.api.select_pattern import ListPatternMode
 from conan.internal.conan_app import ConanApp
 from conans.errors import ConanException, NotFoundException
 from conans.model.package_ref import PkgReference
@@ -92,17 +91,17 @@ class ListAPI:
         return filter_packages(query, pkg_configurations)
 
     # TODO: could it be possible to merge this with subapi.search.select?
-    def select(self, pattern, package_query=None, remote=None, search_mode=None):
+    def select(self, pattern, package_query=None, remote=None):
         if package_query and pattern.package_id and "*" not in pattern.package_id:
             raise ConanException("Cannot specify '-p' package queries, "
                                  "if 'package_id' is not a pattern")
-        search_mode = search_mode or pattern.mode
+        search_mode = pattern.mode
         select_bundle = SelectBundle()
         refs = self.conan_api.search.recipes(pattern.ref, remote=remote)
         pattern.check_refs(refs)
 
         # Show only the recipe references
-        if search_mode == ListPatternMode.SHOW_REFS:
+        if pattern.show_only_refs():
             select_bundle.add_refs(refs)
             return select_bundle
 
@@ -114,14 +113,13 @@ class ListAPI:
                 rrevs = pattern.filter_rrevs(rrevs)
             select_bundle.add_refs(rrevs)
 
-            # Show only the latest recipe revision or all of them
-            if search_mode in (ListPatternMode.SHOW_ALL_RREVS, ListPatternMode.SHOW_LATEST_RREV):
+            if pattern.package_id is None:  # Stop if not displaying binaries
                 continue
 
             for rrev in rrevs:
                 packages = None
                 prefs = []
-                if pattern.package_id and "*" not in pattern.package_id:
+                if "*" not in pattern.package_id:
                     prefs.append(PkgReference(rrev, package_id=pattern.package_id))
                 else:
                     packages = self.conan_api.list.packages_configurations(rrev, remote)
@@ -129,29 +127,20 @@ class ListAPI:
                         packages = self.conan_api.list.filter_packages_configurations(packages,
                                                                                       package_query)
                     prefs = packages.keys()
-                    if pattern.package_id is not None:
-                        prefs = pattern.filter_prefs(prefs)
+                    prefs = pattern.filter_prefs(prefs)
 
-                # Show all the package IDs and their configurations
-                if search_mode == ListPatternMode.SHOW_PACKAGE_IDS:
-                    # add pref and its package configuration
-                    # remove timestamp, as server does not provide it
-                    for p in prefs:
-                        p.timestamp = None
-                    select_bundle.add_prefs(prefs, configurations=packages)
-                    continue
-
-                for pref in prefs:
-                    if search_mode in (ListPatternMode.SHOW_LATEST_PREV,
-                                       ListPatternMode.SHOW_ALL_PREVS):
+                if pattern.show_prevs():
+                    for pref in prefs:
+                        # Maybe the package_configurations returned timestamp
                         if pattern.is_latest_prev:
-                            prev = self.conan_api.list.latest_package_revision(pref, remote)
-                            if prev is None:
-                                raise NotFoundException(f"Binary package not found: '{pref}")
-                            prevs = [prev]
+                            if not pref.timestamp:
+                                prev = self.conan_api.list.latest_package_revision(pref, remote)
+                                if prev is None:
+                                    raise NotFoundException(f"Binary package not found: '{pref}")
+                                pref.revision, pref.timestamp = prev.revision, prev.timestamp
                         else:
                             prevs = self.conan_api.list.package_revisions(pref, remote)
                             prevs = pattern.filter_prevs(prevs)
-                            # add the prev
-                        select_bundle.add_prefs(prevs)
+
+                select_bundle.add_prefs(prefs, packages)
         return select_bundle

--- a/conan/api/subapi/list.py
+++ b/conan/api/subapi/list.py
@@ -111,7 +111,10 @@ class ListAPI:
 
         for r in refs:
             if pattern.is_latest_rrev or pattern.rrev is None:
-                rrevs = [self.conan_api.list.latest_recipe_revision(r, remote)]
+                rrev = self.conan_api.list.latest_recipe_revision(r, remote)
+                if rrev is None:
+                    raise NotFoundException(f"Recipe '{r}' not found")
+                rrevs = [rrev]
             else:
                 rrevs = self.conan_api.list.recipe_revisions(r, remote)
                 rrevs = pattern.filter_rrevs(rrevs)

--- a/conan/cli/commands/list.py
+++ b/conan/cli/commands/list.py
@@ -4,9 +4,10 @@ from conan.api.conan_api import ConanAPI
 from conan.api.output import Color, cli_out_write
 from conan.cli.command import conan_command, OnceArgument
 from conan.cli.formatters.list import list_packages_html
-from conan.internal.api.select_pattern import ListPattern
 
 # Keep them so we don't break other commands that import them, but TODO: Remove later
+from conan.internal.api.select_pattern import SelectPattern
+
 remote_color = Color.BRIGHT_BLUE
 recipe_name_color = Color.GREEN
 recipe_color = Color.BRIGHT_WHITE
@@ -103,7 +104,7 @@ def list(conan_api: ConanAPI, parser, *args):
     parser.add_argument("-c", "--cache", action='store_true', help="Search in the local cache")
 
     args = parser.parse_args(*args)
-    ref_pattern = ListPattern(args.reference, rrev=None, prev=None)
+    ref_pattern = SelectPattern(args.reference, rrev=None, prev=None)
     # If neither remote nor cache are defined, show results only from cache
     remotes = []
     if args.cache or not args.remote:

--- a/conan/cli/commands/list.py
+++ b/conan/cli/commands/list.py
@@ -103,7 +103,7 @@ def list(conan_api: ConanAPI, parser, *args):
     parser.add_argument("-c", "--cache", action='store_true', help="Search in the local cache")
 
     args = parser.parse_args(*args)
-    ref_pattern = ListPattern(args.reference)
+    ref_pattern = ListPattern(args.reference, rrev=None, prev=None)
     # If neither remote nor cache are defined, show results only from cache
     remotes = []
     if args.cache or not args.remote:
@@ -121,6 +121,5 @@ def list(conan_api: ConanAPI, parser, *args):
             results[name] = list_bundle.serialize()
     return {
         "results": results,
-        "search_mode": ref_pattern.mode,
         "conan_api": conan_api
     }

--- a/conan/cli/commands/search.py
+++ b/conan/cli/commands/search.py
@@ -20,8 +20,8 @@ def search(conan_api: ConanAPI, parser, *args):
                         help="Remote names. Accepts wildcards. If not specified it searches "
                              "in all the remotes")
     args = parser.parse_args(*args)
-    ref_pattern = ListPattern(args.reference)
-    if ref_pattern.package_id is not None or "#" in ref_pattern.raw:
+    ref_pattern = ListPattern(args.reference, rrev=None)
+    if ref_pattern.package_id is not None or ref_pattern.rrev is not None:
         raise ConanException("Incorrect search pattern")
 
     remotes = conan_api.remotes.list(args.remote)

--- a/conan/cli/commands/search.py
+++ b/conan/cli/commands/search.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from conan.api.conan_api import ConanAPI
 from conan.cli.command import conan_command
 from conan.cli.commands.list import print_list_text, print_list_json
-from conan.internal.api.select_pattern import ListPattern, ListPatternMode
+from conan.internal.api.select_pattern import ListPattern
 from conans.errors import ConanException
 
 
@@ -21,7 +21,8 @@ def search(conan_api: ConanAPI, parser, *args):
                              "in all the remotes")
     args = parser.parse_args(*args)
     ref_pattern = ListPattern(args.reference)
-    search_mode = ListPatternMode.SHOW_REFS
+    if ref_pattern.package_id is not None or "#" in ref_pattern.raw:
+        raise ConanException("Incorrect search pattern")
 
     remotes = conan_api.remotes.list(args.remote)
     if not remotes:
@@ -30,14 +31,11 @@ def search(conan_api: ConanAPI, parser, *args):
     results = OrderedDict()
     for remote in remotes:
         try:
-            list_bundle = conan_api.list.select(ref_pattern, package_query=None,
-                                                remote=remote, search_mode=search_mode)
+            list_bundle = conan_api.list.select(ref_pattern, package_query=None, remote=remote)
         except Exception as e:
             results[remote.name] = {"error": str(e)}
         else:
             results[remote.name] = list_bundle.serialize()
     return {
-        "results": results,
-        "search_mode": search_mode,
-        "conan_api": conan_api
+        "results": results
     }

--- a/conan/cli/commands/search.py
+++ b/conan/cli/commands/search.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 from conan.api.conan_api import ConanAPI
 from conan.cli.command import conan_command
 from conan.cli.commands.list import print_list_text, print_list_json
-from conan.internal.api.select_pattern import ListPattern
+from conan.internal.api.select_pattern import SelectPattern
 from conans.errors import ConanException
 
 
@@ -20,7 +20,7 @@ def search(conan_api: ConanAPI, parser, *args):
                         help="Remote names. Accepts wildcards. If not specified it searches "
                              "in all the remotes")
     args = parser.parse_args(*args)
-    ref_pattern = ListPattern(args.reference, rrev=None)
+    ref_pattern = SelectPattern(args.reference, rrev=None)
     if ref_pattern.package_id is not None or ref_pattern.rrev is not None:
         raise ConanException("Incorrect search pattern")
 

--- a/conan/internal/api/select_pattern.py
+++ b/conan/internal/api/select_pattern.py
@@ -63,16 +63,17 @@ class SelectPattern:
 
 
 class ListPatternMode(Enum):
-    SHOW_REFS = 1
-    SHOW_LATEST_RREV = 2
     SHOW_LATEST_PREV = 3
     SHOW_PACKAGE_IDS = 4
-    SHOW_ALL_RREVS = 5
     SHOW_ALL_PREVS = 6
-    UNDEFINED = 7
 
 
 class ListPattern(SelectPattern):
+
+    def show_only_refs(self):
+        if self.package_id is None and self.is_latest_rrev and "#latest" not in self.raw:
+            if "*" in self.raw or not self.version:
+                return True
 
     @property
     def mode(self):
@@ -80,35 +81,12 @@ class ListPattern(SelectPattern):
         if no_regex:
             # FIXME: now, the server is returning for "conan search zlib" all the zlib versions,
             #        but "conan search zli" is raising and error. Inconsistency?
-            if not (self.name and self.version):
-                # # zlib (server is going to get all the versions for zlib)
-                if self.package_id is None:
-                    return ListPatternMode.SHOW_REFS
-                # zlib:PID -> it will fail on server side! Nothing to do here
-            else:
-                if self.package_id is None:
-                    # zlib/1.2.11 | zlib/1.2.11#latest
-                    if self.is_latest_rrev:
-                        return ListPatternMode.SHOW_LATEST_RREV
-                    # zlib/1.2.11#RREV
-                    elif self.rrev:
-                        return ListPatternMode.SHOW_PACKAGE_IDS
-                else:
-                    # zlib/1.2.11#RREV:PID | zlib/1.2.11#RREV:PID#PREV
-                    if self.is_latest_prev or self.prev:
-                        return ListPatternMode.SHOW_LATEST_PREV
+            if self.name and self.version:
+                # zlib/1.2.11#RREV:PID | zlib/1.2.11#RREV:PID#PREV
+                if self.is_latest_prev or self.prev:
+                    return ListPatternMode.SHOW_LATEST_PREV
         else:
-            if self.package_id is None:
-                # zlib/* | zlib*
-                if self.is_latest_rrev and "#latest" not in self.raw:
-                    return ListPatternMode.SHOW_REFS
-                # zlib/*#latest
-                elif "#latest" in self.raw:
-                    return ListPatternMode.SHOW_LATEST_RREV
-                # zlib/1.2.11#*
-                elif "*" in self.rrev:
-                    return ListPatternMode.SHOW_ALL_RREVS
-            else:
+            if self.package_id is not None:
                 # zlib/1.2.11#latest:* | zlib/1.2.11#RREV:*
                 if self.is_latest_prev and "#latest" not in self.raw:
                     return ListPatternMode.SHOW_PACKAGE_IDS
@@ -118,4 +96,3 @@ class ListPattern(SelectPattern):
                 # zlib/1.2.11#latest:*#* | zlib/1.2.11#RREV:PID#*
                 elif "*" in self.prev:
                     return ListPatternMode.SHOW_ALL_PREVS
-        return ListPatternMode.UNDEFINED

--- a/conan/internal/api/select_pattern.py
+++ b/conan/internal/api/select_pattern.py
@@ -55,7 +55,7 @@ class SelectPattern:
     def filter_prevs(self, prevs):
         prevs = [p for p in prevs if fnmatch.fnmatch(p.revision, self.prev)]
         if not prevs:
-            refs_str = f'{self.ref}#{self.rrev}:{self.package_id}'
+            refs_str = f'{self.ref}#{self.rrev}:{self.package_id}#{self.prev}'
             if "*" not in refs_str:
                 raise ConanException(f"Package revision '{self.raw}' not found")
         return prevs

--- a/conan/internal/api/select_pattern.py
+++ b/conan/internal/api/select_pattern.py
@@ -55,14 +55,7 @@ class SelectPattern:
     def filter_prevs(self, prevs):
         prevs = [p for p in prevs if fnmatch.fnmatch(p.revision, self.prev)]
         if not prevs:
-            if "*" not in self.raw:
+            refs_str = f'{self.ref}#{self.rrev}:{self.package_id}'
+            if "*" not in refs_str:
                 raise ConanException(f"Package revision '{self.raw}' not found")
         return prevs
-
-
-class ListPattern(SelectPattern):
-
-    def show_only_refs(self):
-        if self.package_id is None and self.rrev is None:
-            if "*" in self.raw or not self.version:
-                return True

--- a/conans/test/integration/command/remove_test.py
+++ b/conans/test/integration/command/remove_test.py
@@ -162,7 +162,7 @@ class RemovePackageRevisionsTest(unittest.TestCase):
         self.client.run("upload foobar/0.1@user/testing -r default -c")
         ref = self.client.cache.get_latest_recipe_reference(
                RecipeReference.loads("foobar/0.1@user/testing"))
-        self.client.run("list foobar/0.1@user/testing#{} -r default".format(ref.revision))
+        self.client.run("list foobar/0.1@user/testing#{}:* -r default".format(ref.revision))
         default_arch = self.client.get_default_host_profile().settings['arch']
         self.assertIn(f"arch: {default_arch}", self.client.out)
         self.assertIn("arch: x86", self.client.out)

--- a/conans/test/integration/command_v2/list_test.py
+++ b/conans/test/integration/command_v2/list_test.py
@@ -155,9 +155,10 @@ class TestListRefs:
         self.check_json(client, pattern, remote, expected_json)
 
     @pytest.mark.parametrize("remote", [True, False])
-    def test_list_recipe_latest_revision(self, client, remote):
+    @pytest.mark.parametrize("pattern", ["zli/1.0.0", "zli/1.0.0#latest",
+                                         "zli/1.0.0#b58eeddfe2fd25ac3a105f72836b3360"])
+    def test_list_recipe_latest_revision(self, client, remote, pattern):
         # by default, when a reference is complete, we show latest recipe revision
-        pattern = "zli/1.0.0"
         expected = textwrap.dedent(f"""\
           zli
             zli/1.0.0

--- a/conans/test/integration/command_v2/list_test.py
+++ b/conans/test/integration/command_v2/list_test.py
@@ -138,6 +138,20 @@ class TestListRefs:
         self.check_json(client, pattern, remote, expected_json)
 
     @pytest.mark.parametrize("remote", [True, False])
+    def test_list_recipe_versions_exact(self, client, remote):
+        pattern = "zli/1.0.0"
+        # by default, when a reference is complete, we show latest recipe revision
+        expected = textwrap.dedent(f"""\
+          zli
+            zli/1.0.0
+          """)
+        self.check(client, pattern, remote, expected)
+        expected_json = {
+            "zli/1.0.0": {}
+        }
+        self.check_json(client, pattern, remote, expected_json)
+
+    @pytest.mark.parametrize("remote", [True, False])
     @pytest.mark.parametrize("pattern", ["nomatch", "nomatch*", "nomatch/*"])
     def test_list_recipe_no_match(self, client, pattern, remote):
         if pattern == "nomatch":  # EXACT IS AN ERROR
@@ -153,7 +167,7 @@ class TestListRefs:
         self.check_json(client, pattern, remote, expected_json)
 
     @pytest.mark.parametrize("remote", [True, False])
-    @pytest.mark.parametrize("pattern", ["zli/1.0.0", "zli/1.0.0#latest",
+    @pytest.mark.parametrize("pattern", ["zli/1.0.0#latest",
                                          "zli/1.0.0#b58eeddfe2fd25ac3a105f72836b3360"])
     def test_list_recipe_latest_revision(self, client, remote, pattern):
         # by default, when a reference is complete, we show latest recipe revision
@@ -506,8 +520,21 @@ class TestListPrefs:
         expected = "ERROR: Package ID 'zli/1.0.0:nonexists_id' not found\n"
         self.check(client, pattern, remote, expected)
 
-    def test_query(self):
-        pass
+    @pytest.mark.parametrize("remote", [True, False])
+    def test_query(self, client, remote):
+        pattern = "zli/1.0.0:* -p os=Linux"
+        expected = textwrap.dedent(f"""\
+          zli
+            zli/1.0.0
+              revisions
+                b58eeddfe2fd25ac3a105f72836b3360 (10-11-2023 10:13:13)
+                  packages
+                    9a4eb3c8701508aa9458b1a73d0633783ecc2270
+                      info
+                        settings
+                          os: Linux
+          """)
+        self.check(client, pattern, remote, expected)
 
 
 class TestListRemotes:

--- a/conans/test/integration/command_v2/list_test.py
+++ b/conans/test/integration/command_v2/list_test.py
@@ -86,7 +86,6 @@ class TestListRefs:
         r = "-r=default" if remote else ""
         r_msg = "default" if remote else "Local Cache"
         client.run(f"list {pattern} {r}")
-        print(client.out)
         expected = textwrap.indent(expected, "  ")
         expected_output = f"{r_msg}\n" + expected
         expected_output = re.sub(r"\(.*\)", "", expected_output)
@@ -99,7 +98,6 @@ class TestListRefs:
         r_msg = "default" if remote else "Local Cache"
         client.run(f"list {pattern} {r} --format=json", redirect_stdout="file.json")
         list_json = client.load("file.json")
-        print(list_json)
         list_json = json.loads(list_json)
         assert remove_timestamps(list_json[r_msg]) == remove_timestamps(expected)
 
@@ -236,7 +234,6 @@ class TestListPrefs:
         r = "-r=default" if remote else ""
         r_msg = "default" if remote else "Local Cache"
         client.run(f"list {pattern} {r}")
-        print(client.out)
         expected = textwrap.indent(expected, "  ")
         expected_output = f"{r_msg}\n" + expected
         expected_output = re.sub(r"\(.*\)", "", expected_output)
@@ -249,7 +246,6 @@ class TestListPrefs:
         r_msg = "default" if remote else "Local Cache"
         client.run(f"list {pattern} {r} --format=json", redirect_stdout="file.json")
         list_json = client.load("file.json")
-        print(list_json)
         list_json = json.loads(list_json)
         assert remove_timestamps(list_json[r_msg]) == remove_timestamps(expected)
 
@@ -401,7 +397,6 @@ class TestListPrefs:
     @pytest.mark.parametrize("remote", [True, False])
     def test_list_latest_prevs(self, client, remote):
         pattern = "zli/1.0.0:*#latest"
-        # TODO: This is doing a package_id search, but not showing info
         expected = textwrap.dedent(f"""\
           zli
             zli/1.0.0
@@ -409,9 +404,15 @@ class TestListPrefs:
                 b58eeddfe2fd25ac3a105f72836b3360 (2023-01-10 22:27:34 UTC)
                   packages
                     9a4eb3c8701508aa9458b1a73d0633783ecc2270
+                      info
+                        settings
+                          os: Linux
                       revisions
                         9beff32b8c94ea0ce5a5e67dad95f525 (10-11-2023 10:13:13)
                     ebec3dc6d7f6b907b3ada0c3d3cdc83613a2b715
+                      info
+                        settings
+                          os: Windows
                       revisions
                         d9b1e9044ee265092e81db7028ae10e0 (10-11-2023 10:13:13)
           """)
@@ -428,9 +429,15 @@ class TestListPrefs:
                 b58eeddfe2fd25ac3a105f72836b3360 (2023-01-10 22:41:09 UTC)
                   packages
                     9a4eb3c8701508aa9458b1a73d0633783ecc2270
+                      info
+                        settings
+                          os: Linux
                       revisions
                         9beff32b8c94ea0ce5a5e67dad95f525 (2023-01-10 22:41:09 UTC)
                     ebec3dc6d7f6b907b3ada0c3d3cdc83613a2b715
+                      info
+                        settings
+                          os: Windows
                       revisions
                         d9b1e9044ee265092e81db7028ae10e0 (2023-01-10 22:41:10 UTC)
                         24532a030b4fcdfed699511f6bfe35d3 (2023-01-10 22:41:09 UTC)
@@ -478,7 +485,7 @@ class TestListPrefs:
         self.check(client, pattern, remote, expected)
 
     @pytest.mark.parametrize("remote", [True, False])
-    def test_list_package_id_latest_prev(self, client, remote):
+    def test_list_package_id_single(self, client, remote):
         pattern = "zli/1.0.0:ebec3dc6d7f6b907b3ada0c3d3cdc83613a2b715"
         expected = textwrap.dedent(f"""\
           zli
@@ -487,20 +494,16 @@ class TestListPrefs:
                 b58eeddfe2fd25ac3a105f72836b3360 (2023-01-10 23:13:12 UTC)
                   packages
                     ebec3dc6d7f6b907b3ada0c3d3cdc83613a2b715
-                      revisions
-                        d9b1e9044ee265092e81db7028ae10e0 (2023-01-10 23:13:12 UTC)
+                      info
+                        settings
+                          os: Windows
           """)
         self.check(client, pattern, remote, expected)
 
     @pytest.mark.parametrize("remote", [True, False])
     def test_list_missing_package_id(self, client, remote):
         pattern = "zli/1.0.0:nonexists_id"
-        # TODO: The message is still different in the server
-        if remote:
-            expected = "ERROR: Binary package not found: 'zli/1.0.0@_/_#" \
-                       "b58eeddfe2fd25ac3a105f72836b3360:nonexists_id'. [Remote: default]\n"
-        else:
-            expected = "ERROR: Binary package not found: 'zli/1.0.0:nonexists_id\n"
+        expected = "ERROR: Package ID 'zli/1.0.0:nonexists_id' not found\n"
         self.check(client, pattern, remote, expected)
 
     def test_query(self):

--- a/conans/test/integration/command_v2/list_test.py
+++ b/conans/test/integration/command_v2/list_test.py
@@ -123,6 +123,17 @@ class TestListRefs:
         self.check_json(client, pattern, remote, expected_json)
 
     @pytest.mark.parametrize("remote", [True, False])
+    def test_list_recipes_without_user_channel(self, client, remote):
+        pattern = "z*@"
+        expected = textwrap.dedent(f"""\
+              zli
+                zli/1.0.0
+              zlix
+                zlix/1.0.0
+            """)
+        self.check(client, pattern, remote, expected)
+
+    @pytest.mark.parametrize("remote", [True, False])
     @pytest.mark.parametrize("pattern", ["zlib", "zlib/*", "*@user/channel"])
     def test_list_recipe_versions(self, client, pattern, remote):
         expected = textwrap.dedent(f"""\

--- a/conans/test/integration/remote/test_conaninfo_parsing.py
+++ b/conans/test/integration/remote/test_conaninfo_parsing.py
@@ -29,5 +29,5 @@ def test_conaninfo_special_chars():
 
     t.run("upload * -c -r default")
     # TODO: I have struggled with this, it was not accepting "latest", revision needs explicit one
-    t.run('list weird_info/1.0#8c9e59246220eef8ca3bd4ac4f39ceb3 -r default')
+    t.run('list weird_info/1.0#8c9e59246220eef8ca3bd4ac4f39ceb3:* -r default')
     assert 'ññ¨¨&是: ][{}"是是是' in t.out


### PR DESCRIPTION
Changelog: omit


Solving some minor pending TODOs in the ``conan list``:
- Showing ``info`` in relevant cases that were missing
- Removing pending "prints()"
- Extended some tests equivalents (zlib/1.0 == zlib/1.0#latest)

Also some simplifications in the processing of ``select()``
