### PR TITLE
[develop2] Improving system_requirements

### DIFF
--- a/conan/api/subapi/install.py
+++ b/conan/api/subapi/install.py
@@ -2,7 +2,7 @@ from conan.api.subapi import api_method
 from conan.internal.conan_app import ConanApp
 from conan.internal.deploy import do_deploys
 from conans.client.generators import write_generators
-from conans.client.installer import BinaryInstaller, call_system_requirements
+from conans.client.installer import BinaryInstaller
 from conans.errors import ConanInvalidConfiguration
 from conans.util.files import mkdir
 
@@ -22,7 +22,17 @@ class InstallAPI:
         app = ConanApp(self.conan_api.cache_folder)
         installer = BinaryInstaller(app)
         # TODO: Extract this from the GraphManager, reuse same object, check args earlier
+        installer.install_system_requires(deps_graph)  # TODO: Optimize InstallGraph computation
         installer.install(deps_graph, remotes)
+
+    @api_method
+    def install_system_requires(self, graph):
+        """ Install binaries for dependency graph
+        :param graph: Dependency graph to intall packages for
+        """
+        app = ConanApp(self.conan_api.cache_folder)
+        installer = BinaryInstaller(app)
+        installer.install_system_requires(graph)
 
     # TODO: Look for a better name
     def install_consumer(self, deps_graph, generators=None, source_folder=None, output_folder=None,
@@ -55,4 +65,3 @@ class InstallAPI:
         conanfile.generators = list(set(conanfile.generators).union(generators or []))
         app = ConanApp(self.conan_api.cache_folder)
         write_generators(conanfile, app.hook_manager)
-        call_system_requirements(conanfile)

--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -156,7 +156,7 @@ def graph_info(conan_api, parser, subparser, *args):
         conan_api.graph.analyze_binaries(deps_graph, args.build, remotes=remotes, update=args.update,
                                          lockfile=lockfile)
         print_graph_packages(deps_graph)
-        if profile_host.conf.get("tools.system.package_manager:mode") == "collect":
+        if profile_host.conf.get("tools.system.package_manager:mode") in ("check", "report"):
             conan_api.install.install_system_requires(deps_graph)
 
         lockfile = conan_api.lockfile.update_lockfile(lockfile, deps_graph, args.lockfile_packages,

--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -156,7 +156,9 @@ def graph_info(conan_api, parser, subparser, *args):
         conan_api.graph.analyze_binaries(deps_graph, args.build, remotes=remotes, update=args.update,
                                          lockfile=lockfile)
         print_graph_packages(deps_graph)
-        if profile_host.conf.get("tools.system.package_manager:mode") in ("check", "report"):
+        # TODO: Refactor magic strings and use _SystemPackageManagerTool.mode_xxx ones
+        if profile_host.conf.get("tools.system.package_manager:mode") \
+                in ("check", "report", "report-installed"):
             conan_api.install.install_system_requires(deps_graph)
 
         lockfile = conan_api.lockfile.update_lockfile(lockfile, deps_graph, args.lockfile_packages,

--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -156,6 +156,8 @@ def graph_info(conan_api, parser, subparser, *args):
         conan_api.graph.analyze_binaries(deps_graph, args.build, remotes=remotes, update=args.update,
                                          lockfile=lockfile)
         print_graph_packages(deps_graph)
+        if profile_host.conf.get("tools.system.package_manager:mode") == "collect":
+            conan_api.install.install_system_requires(deps_graph)
 
         lockfile = conan_api.lockfile.update_lockfile(lockfile, deps_graph, args.lockfile_packages,
                                                       clean=args.lockfile_clean)

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -150,11 +150,12 @@ class _SystemPackageManagerTool(object):
     def _install(self, packages, update=False, check=True, **kwargs):
         pkgs = self._conanfile.system_requires.setdefault(self._active_tool, [])
         pkgs.extend(p for p in packages if p not in pkgs)
-        if check:
-            packages = self.check(packages)
-
         if self._mode == self.mode_collect:
             return
+
+        if check or self._mode == self.mode_check:
+            packages = self.check(packages)
+
         if self._mode == self.mode_check and packages:
             raise ConanException("System requirements: '{0}' are missing but can't install "
                                  "because tools.system.package_manager:mode is '{1}'."

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -8,7 +8,7 @@ from conans.errors import ConanException
 class _SystemPackageManagerTool(object):
     mode_check = "check"
     mode_install = "install"
-    mode_collect = "collect"
+    mode_report = "report"
     tool_name = None
     install_command = ""
     update_command = ""
@@ -150,7 +150,7 @@ class _SystemPackageManagerTool(object):
     def _install(self, packages, update=False, check=True, **kwargs):
         pkgs = self._conanfile.system_requires.setdefault(self._active_tool, [])
         pkgs.extend(p for p in packages if p not in pkgs)
-        if self._mode == self.mode_collect:
+        if self._mode == self.mode_report:
             return
 
         if check or self._mode == self.mode_check:
@@ -191,7 +191,7 @@ class _SystemPackageManagerTool(object):
     def _check(self, packages):
         pkgs = self._conanfile.system_requires.setdefault(self._active_tool, [])
         pkgs.extend(p for p in packages if p not in pkgs)
-        if self._mode == self.mode_collect:
+        if self._mode == self.mode_report:
             return
         missing = [pkg for pkg in packages if self.check_package(self.get_package_name(pkg)) != 0]
         return missing

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -257,6 +257,7 @@ class ConanFile:
             self.virtualrunenv = True
 
         self.env_scripts = {}  # Accumulate the env scripts generated in order
+        self.system_requires = {}  # Read only, internal {"apt": []}
 
         # layout() method related variables:
         self.folders = Folders()
@@ -274,6 +275,7 @@ class ConanFile:
         result["settings"] = self.settings.serialize()
         if hasattr(self, "python_requires"):
             result["python_requires"] = [r.repr_notime() for r in self.python_requires.all_refs()]
+        result["system_requires"] = self.system_requires
         result["options"] = self.options.serialize()
         result["source_folder"] = self.source_folder
         result["build_folder"] = self.build_folder

--- a/conans/test/functional/tools/system/package_manager_test.py
+++ b/conans/test/functional/tools/system/package_manager_test.py
@@ -172,6 +172,7 @@ def test_collect_system_requirements():
                 apt = Apt(self)
                 apt.install(["pkg1", "pkg2"])
         """)})
+
     with patch.object(_SystemPackageManagerTool, '_conanfile_run', MagicMock(return_value=False)):
         client.run("install . -c tools.system.package_manager:tool=apt-get --format=json",
                    redirect_stdout="graph.json")
@@ -180,8 +181,12 @@ def test_collect_system_requirements():
 
     # How to do it without installing
     client.run("graph info . -c tools.system.package_manager:tool=apt-get "
-               "-c tools.system.package_manager:mode=collect --format=json",
+               "-c tools.system.package_manager:mode=report --format=json",
                redirect_stdout="graph2.json")
     graph2 = json.loads(client.load("graph2.json"))
     # TODO: Unify format of ``graph info`` and ``install``
     assert {"apt-get": ["pkg1", "pkg2"]} == graph2["nodes"][0]["system_requires"]
+
+    client.run("graph info . -c tools.system.package_manager:tool=apt-get "
+               "-c tools.system.package_manager:mode=check", assert_error=True)
+    assert "ERROR: conanfile.py: Error in system_requirements() method, line 11" in client.out

--- a/conans/test/utils/mocks.py
+++ b/conans/test/utils/mocks.py
@@ -126,6 +126,7 @@ class ConanFileMock(ConanFile):
         self._conan_user = None
         self._conan_channel = None
         self.env_scripts = {}
+        self.system_requires = {}
         self.win_bash = None
         self.conf = ConfDefinition().get_conanfile_conf(None)
         self._conan_helpers = ConanFileHelpers(None, None)


### PR DESCRIPTION
Changelog: Fix: Improving system_requirements.

Allow collecting the ``system_requires`` of the graph:
- In ``create`` and ``install`` commands
- In ``graph info`` commands, without installing anything
- Added new ``collect`` mode for system-requires
- Decouple the installation of system_requires (doing it first) from the installation of the graph packages.

Close https://github.com/conan-io/conan/issues/5959