### PR TITLE
Enable authentication against a disabled remote

### DIFF
--- a/conan/cli/commands/remote.py
+++ b/conan/cli/commands/remote.py
@@ -177,7 +177,7 @@ def remote_login(conan_api, parser, subparser, *args):
                                 'requested interactively (not exposed)')
 
     args = parser.parse_args(*args)
-    remotes = conan_api.remotes.list(pattern=args.remote)
+    remotes = conan_api.remotes.list(pattern=args.remote, only_enabled=False)
     if not remotes:
         raise ConanException("There are no remotes matching the '{}' pattern".format(args.remote))
 

--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -458,17 +458,21 @@ class EnvVars:
 
     def save_sh(self, file_location, generate_deactivate=True):
         filepath, filename = os.path.split(file_location)
+        deactivate_file = os.path.join(filepath, "deactivate_{}".format(filename))
         deactivate = textwrap.dedent("""\
-            deactivate_conanrun () {{
-                echo "Restoring environment"
-                for v in {vars}
-                do
-                    export $v="$_CONAN_OLD_${{v}}"
-                    unset "_CONAN_OLD_${{v}}"
-                done
-                unset -f deactivate
-            }}
-            """.format(vars=" ".join(self._values.keys())))
+           echo "echo Restoring environment" > "{deactivate_file}"
+           for v in {vars}
+           do
+               is_defined="true"
+               value=$(printenv $v) || is_defined="" || true
+               if [ -n "$value" ] || [ -n "$is_defined" ]
+               then
+                   echo export "$v='$value'" >> "{deactivate_file}"
+               else
+                   echo unset $v >> "{deactivate_file}"
+               fi
+           done
+           """.format(deactivate_file=deactivate_file, vars=" ".join(self._values.keys())))
         capture = textwrap.dedent("""\
               {deactivate}
               """).format(deactivate=deactivate if generate_deactivate else "")
@@ -476,9 +480,8 @@ class EnvVars:
         for varname, varvalues in self._values.items():
             value = varvalues.get_str("${name}", self._subsystem, pathsep=self._pathsep)
             value = value.replace('"', '\\"')
-            result.append(f'export _CONAN_OLD_{varname}=$(printenv ${varname})')
             if value:
-                result.append(f'export {varname}="{value}"')
+                result.append('export {}="{}"'.format(varname, value))
             else:
                 result.append('unset {}'.format(varname))
 

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -160,7 +160,7 @@ class RemoteManager(object):
         return self._call_remote(remote, "remove_all_packages", ref)
 
     def authenticate(self, remote, name, password):
-        return self._call_remote(remote, 'authenticate', name, password)
+        return self._call_remote(remote, 'authenticate', name, password, check_disabled=False)
 
     def get_recipe_revisions_references(self, ref, remote):
         assert ref.revision is None, "get_recipe_revisions_references of a reference with revision"
@@ -197,9 +197,9 @@ class RemoteManager(object):
         assert pref.revision is not None, "get_package_revision_reference needs a revision"
         return self._call_remote(remote, "get_package_revision_reference", pref)
 
-    def _call_remote(self, remote, method, *args, **kwargs):
+    def _call_remote(self, remote, method, check_disabled=True, *args, **kwargs):
         assert (isinstance(remote, Remote))
-        if remote.disabled:
+        if remote.disabled and enforce_disabled:
             raise ConanException("Remote '%s' is disabled" % remote.name)
         try:
             return self._auth_manager.call_rest_api_method(remote, method, *args, **kwargs)

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -197,8 +197,9 @@ class RemoteManager(object):
         assert pref.revision is not None, "get_package_revision_reference needs a revision"
         return self._call_remote(remote, "get_package_revision_reference", pref)
 
-    def _call_remote(self, remote, method, enforce_disabled=True, *args, **kwargs):
+    def _call_remote(self, remote, method, *args, **kwargs):
         assert (isinstance(remote, Remote))
+        enforce_disabled = kwargs.pop("enforce_disabled", True)
         if remote.disabled and enforce_disabled:
             raise ConanException("Remote '%s' is disabled" % remote.name)
         try:

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -160,7 +160,7 @@ class RemoteManager(object):
         return self._call_remote(remote, "remove_all_packages", ref)
 
     def authenticate(self, remote, name, password):
-        return self._call_remote(remote, 'authenticate', name, password, check_disabled=False)
+        return self._call_remote(remote, 'authenticate', name, password, enforce_disabled=False)
 
     def get_recipe_revisions_references(self, ref, remote):
         assert ref.revision is None, "get_recipe_revisions_references of a reference with revision"
@@ -197,7 +197,7 @@ class RemoteManager(object):
         assert pref.revision is not None, "get_package_revision_reference needs a revision"
         return self._call_remote(remote, "get_package_revision_reference", pref)
 
-    def _call_remote(self, remote, method, check_disabled=True, *args, **kwargs):
+    def _call_remote(self, remote, method, enforce_disabled=True, *args, **kwargs):
         assert (isinstance(remote, Remote))
         if remote.disabled and enforce_disabled:
             raise ConanException("Remote '%s' is disabled" % remote.name)

--- a/conans/test/integration/remote/auth_test.py
+++ b/conans/test/integration/remote/auth_test.py
@@ -129,6 +129,15 @@ class AuthorizeTest(unittest.TestCase):
         self.assertTrue(os.path.exists(self.test_server.server_store.export(ref)))
         self.assertIn('Please enter a password for "some_random.special!characters"', client.out)
 
+    def test_authorize_disabled_remote(self):
+        tc = TestClient(servers=self.servers)
+        # Sanity check, this should not fail
+        tc.run("remote login default pepe -p pepepass")
+        tc.run("remote logout default")
+        # This used to fail when the authentication was not possible for disabled remotes
+        tc.run("remote disable default")
+        tc.run("remote login default pepe -p pepepass")
+        self.assertIn("Changed user of remote 'default' from 'None' (anonymous) to 'pepe' (authenticated)", tc.out)
 
 class AuthenticationTest(unittest.TestCase):
 


### PR DESCRIPTION
Changelog: Fix: Enable authentication against disabled remotes.
Docs: Omit

There's no need to force a remote to be enabled for it to be able to be authenticated against, as disabling a remote should only affect if they are used for dependency resolving
Part 1 of 2 for #12909