### PR TITLE
Adds tracebacks for failing tests

### DIFF
--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -135,7 +135,7 @@ class Cli:
         cli_out_write("")
         cli_out_write('Conan commands. Type "conan <command> -h" for help', Color.BRIGHT_YELLOW)
 
-    def run(self, *args):
+    def run(self, *args, **kwargs):
         """ Entry point for executing commands, dispatcher to class
         methods
         """
@@ -165,7 +165,7 @@ class Cli:
         except ConanException as exc:
             output.error(exc)
             return ERROR_GENERAL
-
+        reraise_exception = kwargs.get("reraise_exceptions", False)
         try:
             command.run(self._conan_api, self._commands[command_argument].parser, args[0][1:])
             exit_error = SUCCESS
@@ -173,21 +173,31 @@ class Cli:
             if exc.code != 0:
                 output.error("Exiting with code: %d" % exc.code)
             exit_error = exc.code
+            if reraise_exception:
+                raise exc
         except ConanInvalidConfiguration as exc:
             exit_error = ERROR_INVALID_CONFIGURATION
             output.error(exc)
+            if reraise_exception:
+                raise exc
         except ConanInvalidSystemRequirements as exc:
             exit_error = ERROR_INVALID_SYSTEM_REQUIREMENTS
             output.error(exc)
+            if reraise_exception:
+                raise exc
         except ConanException as exc:
             exit_error = ERROR_GENERAL
             output.error(exc)
+            if reraise_exception:
+                raise exc
         except Exception as exc:
             import traceback
             print(traceback.format_exc())
             exit_error = ERROR_GENERAL
             msg = exception_message_safe(exc)
             output.error(msg)
+            if reraise_exception:
+                raise exc
 
         return exit_error
 

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -560,6 +560,7 @@ class TestClient(object):
                 msg = " Command succeeded (failure expected): "
             else:
                 msg = " Command failed (unexpectedly): "
+            trace = None
             if exception is not None:
                 from traceback import format_exception
                 trace = format_exception(Exception, exception, exception.__traceback__)
@@ -572,7 +573,7 @@ class TestClient(object):
                 output_footer='-' * 80,
                 cmd=command,
                 output=str(self.stderr) + str(self.stdout) + "\n" + str(self.out),
-                traceback='{:-^80}'.format("Trace back") + "\n" + "".join(trace)
+                traceback='{:-^80}'.format("Trace back") + "\n" + "".join(trace) if trace is not None else ""
             )
             raise Exception(exc_message)
 


### PR DESCRIPTION
Changelog: omit
Docs: omit

Locally I was not finding a way to get traceback for failing tests other than the code in test utils itself. 

As this change is a bit risky as it touches the api of the cli entrypoint, and maybe there's a better way to do what this PR sets out to do, I've set it as a draft until we can discuss it further.

This clearly breaks any test that relies on the exit code of any command that raises any exception, so maybe a better way to rely this information is needed (26 tests in the whole integration suitcase)

This changes outputs such as:
![image](https://user-images.githubusercontent.com/5364255/213004389-189d640d-f898-45f1-8223-c660db2248d3.png)

to
![image](https://user-images.githubusercontent.com/5364255/213004473-522ecb73-2394-4647-8960-50418208888a.png)
(In fact the new screenshot is out-of-date, and the first 2 entries are now skipped as they'll always be `TestClient` code)