### PR TITLE
MesonToolchain: guess Apple SDK path in case of cross-build on macOS if `tools.apple:sdk_path` not set, instead of raising an error

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -5,7 +5,7 @@ from jinja2 import Template
 
 from conan.tools._check_build_profile import check_using_build_profile
 from conan.tools._compilers import libcxx_flags
-from conan.tools.apple.apple import to_apple_arch, is_apple_os, apple_min_version_flag
+from conan.tools.apple.apple import to_apple_arch, is_apple_os, apple_min_version_flag, apple_sdk_path
 from conan.tools.build.cross_building import cross_building, get_cross_building_settings
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.meson.helpers import *
@@ -242,9 +242,12 @@ class MesonToolchain(object):
         if not self._is_apple_system:
             return
         # SDK path is mandatory for cross-building
-        sdk_path = self._conanfile.conf.get("tools.apple:sdk_path")
+        sdk_path = apple_sdk_path(self._conanfile)
         if not sdk_path and self.cross_build:
-            raise ConanException("You must provide a valid SDK path for cross-compilation.")
+            raise ConanException(
+                "Apple SDK path not found. For cross-compilation, you must "
+                "provide a valid SDK path in 'tools.apple:sdk_path' config."
+            )
 
         # TODO: Delete this os_sdk check whenever the _guess_apple_sdk_name() function disappears
         os_sdk = self._conanfile.settings.get_safe('os.sdk')

--- a/conans/test/functional/toolchains/meson/test_cross_compilation.py
+++ b/conans/test/functional/toolchains/meson/test_cross_compilation.py
@@ -71,13 +71,7 @@ def test_apple_meson_toolchain_cross_compiling(arch, os_, os_version, sdk):
     compiler = apple-clang
     compiler.version = 12.0
     compiler.libcxx = libc++
-
-    [conf]
-    tools.apple:sdk_path={sdk_path}
     """)
-
-    xcrun = XCRun(None, sdk)
-    sdk_path = xcrun.sdk_path
 
     hello_h = gen_function_h(name="hello")
     hello_cpp = gen_function_cpp(name="hello", preprocessor=["STRING_DEFINITION"])
@@ -86,8 +80,7 @@ def test_apple_meson_toolchain_cross_compiling(arch, os_, os_version, sdk):
         os=os_,
         os_version=os_version,
         os_sdk=sdk,
-        arch=arch,
-        sdk_path=sdk_path)
+        arch=arch)
 
     t = TestClient()
     t.save({"conanfile.py": _conanfile_py,
@@ -106,6 +99,7 @@ def test_apple_meson_toolchain_cross_compiling(arch, os_, os_version, sdk):
     demo = os.path.join(t.current_folder, "build", "demo")
     assert os.path.isfile(demo) is True
 
+    xcrun = XCRun(None, sdk)
     lipo = xcrun.find('lipo')
 
     t.run_command('"%s" -info "%s"' % (lipo, libhello))

--- a/conans/test/functional/toolchains/meson/test_meson_and_objc.py
+++ b/conans/test/functional/toolchains/meson/test_meson_and_objc.py
@@ -98,13 +98,8 @@ def test_apple_meson_toolchain_cross_compiling_and_objective_c(arch, os_, os_ver
     compiler = apple-clang
     compiler.version = 12.0
     compiler.libcxx = libc++
-
-    [conf]
-    tools.apple:sdk_path={sdk_path}
     """)
 
-    xcrun = XCRun(None, sdk)
-    sdk_path = xcrun.sdk_path
     app = textwrap.dedent("""
     #import <Foundation/Foundation.h>
 
@@ -120,8 +115,7 @@ def test_apple_meson_toolchain_cross_compiling_and_objective_c(arch, os_, os_ver
         os=os_,
         os_version=os_version,
         os_sdk=sdk,
-        arch=arch,
-        sdk_path=sdk_path)
+        arch=arch)
 
     t = TestClient()
     t.save({"conanfile.py": _conanfile_py,
@@ -136,6 +130,7 @@ def test_apple_meson_toolchain_cross_compiling_and_objective_c(arch, os_, os_ver
     demo = os.path.join(t.current_folder, "build", "demo")
     assert os.path.isfile(demo) is True
 
+    xcrun = XCRun(None, sdk)
     lipo = xcrun.find('lipo')
     t.run_command('"%s" -info "%s"' % (lipo, demo))
     assert "architecture: %s" % to_apple_arch(arch) in t.out


### PR DESCRIPTION
Changelog: Feature: Guess Apple SDK path in `MesonToolchain` in case of cross-build on macOS if `tools.apple:sdk_path` is not set by user.
Docs: omit

closes https://github.com/conan-io/conan/issues/12921

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
