### PR TITLE
Fix fail in packages parallel download due to database concurrency issues

### DIFF
--- a/conan/internal/cache/db/cache_database.py
+++ b/conan/internal/cache/db/cache_database.py
@@ -14,9 +14,6 @@ class CacheDatabase:
         self._recipes = RecipesDBTable(filename)
         self._packages = PackagesDBTable(filename)
 
-    def close(self):
-        pass
-
     def exists_rrev(self, ref):
         # TODO: This logic could be done directly against DB
         matching_rrevs = self.get_recipe_revisions_references(ref)

--- a/conan/internal/cache/db/cache_database.py
+++ b/conan/internal/cache/db/cache_database.py
@@ -11,13 +11,11 @@ CONNECTION_TIMEOUT_SECONDS = 1  # Time a connection will wait when the database 
 class CacheDatabase:
 
     def __init__(self, filename):
-        self._conn = sqlite3.connect(filename, isolation_level=None,
-                                     timeout=CONNECTION_TIMEOUT_SECONDS, check_same_thread=False)
-        self._recipes = RecipesDBTable(self._conn)
-        self._packages = PackagesDBTable(self._conn)
+        self._recipes = RecipesDBTable(filename)
+        self._packages = PackagesDBTable(filename)
 
     def close(self):
-        self._conn.close()
+        pass
 
     def exists_rrev(self, ref):
         # TODO: This logic could be done directly against DB

--- a/conan/internal/cache/db/packages_table.py
+++ b/conan/internal/cache/db/packages_table.py
@@ -58,7 +58,7 @@ class PackagesDBTable(BaseDbTable):
         query = f'SELECT * FROM {self.table_name} ' \
                 f'WHERE {where_clause};'
 
-        with self.connect_db() as conn:
+        with self.db_connection() as conn:
             r = conn.execute(query)
             row = r.fetchone()
 
@@ -73,7 +73,7 @@ class PackagesDBTable(BaseDbTable):
         # are saved with the temporary uuid one, we don't want to consider these
         # not yet built packages for search and so on
         placeholders = ', '.join(['?' for _ in range(len(self.columns))])
-        with self.connect_db() as conn:
+        with self.db_connection() as conn:
             try:
                 conn.execute(f'INSERT INTO {self.table_name} '
                                    f'VALUES ({placeholders})',
@@ -90,7 +90,7 @@ class PackagesDBTable(BaseDbTable):
         query = f"UPDATE {self.table_name} " \
                 f"SET {set_clause} " \
                 f"WHERE {where_clause};"
-        with self.connect_db() as conn:
+        with self.db_connection() as conn:
             try:
                 conn.execute(query)
             except sqlite3.IntegrityError:
@@ -101,14 +101,14 @@ class PackagesDBTable(BaseDbTable):
         query = f"DELETE FROM {self.table_name} " \
                 f'WHERE {self.columns.reference} = "{str(ref)}" ' \
                 f'AND {self.columns.rrev} = "{ref.revision}" '
-        with self.connect_db() as conn:
+        with self.db_connection() as conn:
             conn.execute(query)
 
     def remove(self, pref: PkgReference):
         where_clause = self._where_clause(pref)
         query = f"DELETE FROM {self.table_name} " \
                 f"WHERE {where_clause};"
-        with self.connect_db() as conn:
+        with self.db_connection() as conn:
             conn.execute(query)
 
     def get_package_revisions_references(self, pref: PkgReference, only_latest_prev=False):
@@ -138,7 +138,7 @@ class PackagesDBTable(BaseDbTable):
                     f'{check_prev} ' \
                     f'AND {self.columns.prev} IS NOT NULL ' \
                     f'ORDER BY {self.columns.timestamp} DESC'
-        with self.connect_db() as conn:
+        with self.db_connection() as conn:
             r = conn.execute(query)
             for row in r.fetchall():
                 yield self._as_dict(self.row_type(*row))
@@ -165,7 +165,7 @@ class PackagesDBTable(BaseDbTable):
                     f'AND {self.columns.reference} = "{str(ref)}" ' \
                     f'AND {self.columns.prev} IS NOT NULL ' \
                     f'ORDER BY {self.columns.timestamp} DESC'
-        with self.connect_db() as conn:
+        with self.db_connection() as conn:
             r = conn.execute(query)
             for row in r.fetchall():
                 yield self._as_dict(self.row_type(*row))

--- a/conan/internal/cache/db/packages_table.py
+++ b/conan/internal/cache/db/packages_table.py
@@ -57,8 +57,10 @@ class PackagesDBTable(BaseDbTable):
         where_clause = self._where_clause(pref)
         query = f'SELECT * FROM {self.table_name} ' \
                 f'WHERE {where_clause};'
-        r = self._conn.execute(query)
+        conn = self.opendb()
+        r = conn.execute(query)
         row = r.fetchone()
+        conn.close()
         if not row:
             raise ConanReferenceDoesNotExistInDB(f"No entry for package '{repr(pref)}'")
         return self._as_dict(self.row_type(*row))
@@ -70,13 +72,16 @@ class PackagesDBTable(BaseDbTable):
         # are saved with the temporary uuid one, we don't want to consider these
         # not yet built packages for search and so on
         placeholders = ', '.join(['?' for _ in range(len(self.columns))])
+        conn = self.opendb()
         try:
-            self._conn.execute(f'INSERT INTO {self.table_name} '
+            conn.execute(f'INSERT INTO {self.table_name} '
                                f'VALUES ({placeholders})',
                                [str(pref.ref), pref.ref.revision, pref.package_id, pref.revision,
                                 path, pref.timestamp, build_id])
         except sqlite3.IntegrityError:
             raise ConanReferenceAlreadyExistsInDB(f"Reference '{repr(pref)}' already exists")
+        finally:
+            conn.close()
 
     def update_timestamp(self, pref: PkgReference):
         assert pref.revision
@@ -86,23 +91,30 @@ class PackagesDBTable(BaseDbTable):
         query = f"UPDATE {self.table_name} " \
                 f"SET {set_clause} " \
                 f"WHERE {where_clause};"
+        conn = self.opendb()
         try:
-            self._conn.execute(query)
+            conn.execute(query)
         except sqlite3.IntegrityError:
             raise ConanReferenceAlreadyExistsInDB(f"Reference '{repr(pref)}' already exists")
+        finally:
+            conn.close()
 
     def remove_recipe(self, ref: RecipeReference):
         # can't use the _where_clause, because that is an exact match on the package_id, etc
         query = f"DELETE FROM {self.table_name} " \
                 f'WHERE {self.columns.reference} = "{str(ref)}" ' \
                 f'AND {self.columns.rrev} = "{ref.revision}" '
-        self._conn.execute(query)
+        conn = self.opendb()
+        conn.execute(query)
+        conn.close()
 
     def remove(self, pref: PkgReference):
         where_clause = self._where_clause(pref)
         query = f"DELETE FROM {self.table_name} " \
                 f"WHERE {where_clause};"
-        self._conn.execute(query)
+        conn = self.opendb()
+        conn.execute(query)
+        conn.close()
 
     def get_package_revisions_references(self, pref: PkgReference, only_latest_prev=False):
         assert pref.ref.revision, "To search package revisions you must provide a recipe revision."
@@ -131,9 +143,11 @@ class PackagesDBTable(BaseDbTable):
                     f'{check_prev} ' \
                     f'AND {self.columns.prev} IS NOT NULL ' \
                     f'ORDER BY {self.columns.timestamp} DESC'
-        r = self._conn.execute(query)
+        conn = self.opendb()
+        r = conn.execute(query)
         for row in r.fetchall():
             yield self._as_dict(self.row_type(*row))
+        conn.close()
 
     def get_package_references(self, ref: RecipeReference, only_latest_prev=True):
         # Return the latest revisions
@@ -157,6 +171,8 @@ class PackagesDBTable(BaseDbTable):
                     f'AND {self.columns.reference} = "{str(ref)}" ' \
                     f'AND {self.columns.prev} IS NOT NULL ' \
                     f'ORDER BY {self.columns.timestamp} DESC'
-        r = self._conn.execute(query)
+        conn = self.opendb()
+        r = conn.execute(query)
         for row in r.fetchall():
             yield self._as_dict(self.row_type(*row))
+        conn.close()

--- a/conan/internal/cache/db/packages_table.py
+++ b/conan/internal/cache/db/packages_table.py
@@ -57,10 +57,11 @@ class PackagesDBTable(BaseDbTable):
         where_clause = self._where_clause(pref)
         query = f'SELECT * FROM {self.table_name} ' \
                 f'WHERE {where_clause};'
-        conn = self.opendb()
-        r = conn.execute(query)
-        row = r.fetchone()
-        conn.close()
+
+        with self.connect_db() as conn:
+            r = conn.execute(query)
+            row = r.fetchone()
+
         if not row:
             raise ConanReferenceDoesNotExistInDB(f"No entry for package '{repr(pref)}'")
         return self._as_dict(self.row_type(*row))
@@ -72,16 +73,14 @@ class PackagesDBTable(BaseDbTable):
         # are saved with the temporary uuid one, we don't want to consider these
         # not yet built packages for search and so on
         placeholders = ', '.join(['?' for _ in range(len(self.columns))])
-        conn = self.opendb()
-        try:
-            conn.execute(f'INSERT INTO {self.table_name} '
-                               f'VALUES ({placeholders})',
-                               [str(pref.ref), pref.ref.revision, pref.package_id, pref.revision,
-                                path, pref.timestamp, build_id])
-        except sqlite3.IntegrityError:
-            raise ConanReferenceAlreadyExistsInDB(f"Reference '{repr(pref)}' already exists")
-        finally:
-            conn.close()
+        with self.connect_db() as conn:
+            try:
+                conn.execute(f'INSERT INTO {self.table_name} '
+                                   f'VALUES ({placeholders})',
+                                   [str(pref.ref), pref.ref.revision, pref.package_id, pref.revision,
+                                    path, pref.timestamp, build_id])
+            except sqlite3.IntegrityError:
+                raise ConanReferenceAlreadyExistsInDB(f"Reference '{repr(pref)}' already exists")
 
     def update_timestamp(self, pref: PkgReference):
         assert pref.revision
@@ -91,30 +90,26 @@ class PackagesDBTable(BaseDbTable):
         query = f"UPDATE {self.table_name} " \
                 f"SET {set_clause} " \
                 f"WHERE {where_clause};"
-        conn = self.opendb()
-        try:
-            conn.execute(query)
-        except sqlite3.IntegrityError:
-            raise ConanReferenceAlreadyExistsInDB(f"Reference '{repr(pref)}' already exists")
-        finally:
-            conn.close()
+        with self.connect_db() as conn:
+            try:
+                conn.execute(query)
+            except sqlite3.IntegrityError:
+                raise ConanReferenceAlreadyExistsInDB(f"Reference '{repr(pref)}' already exists")
 
     def remove_recipe(self, ref: RecipeReference):
         # can't use the _where_clause, because that is an exact match on the package_id, etc
         query = f"DELETE FROM {self.table_name} " \
                 f'WHERE {self.columns.reference} = "{str(ref)}" ' \
                 f'AND {self.columns.rrev} = "{ref.revision}" '
-        conn = self.opendb()
-        conn.execute(query)
-        conn.close()
+        with self.connect_db() as conn:
+            conn.execute(query)
 
     def remove(self, pref: PkgReference):
         where_clause = self._where_clause(pref)
         query = f"DELETE FROM {self.table_name} " \
                 f"WHERE {where_clause};"
-        conn = self.opendb()
-        conn.execute(query)
-        conn.close()
+        with self.connect_db() as conn:
+            conn.execute(query)
 
     def get_package_revisions_references(self, pref: PkgReference, only_latest_prev=False):
         assert pref.ref.revision, "To search package revisions you must provide a recipe revision."
@@ -143,11 +138,10 @@ class PackagesDBTable(BaseDbTable):
                     f'{check_prev} ' \
                     f'AND {self.columns.prev} IS NOT NULL ' \
                     f'ORDER BY {self.columns.timestamp} DESC'
-        conn = self.opendb()
-        r = conn.execute(query)
-        for row in r.fetchall():
-            yield self._as_dict(self.row_type(*row))
-        conn.close()
+        with self.connect_db() as conn:
+            r = conn.execute(query)
+            for row in r.fetchall():
+                yield self._as_dict(self.row_type(*row))
 
     def get_package_references(self, ref: RecipeReference, only_latest_prev=True):
         # Return the latest revisions
@@ -171,8 +165,7 @@ class PackagesDBTable(BaseDbTable):
                     f'AND {self.columns.reference} = "{str(ref)}" ' \
                     f'AND {self.columns.prev} IS NOT NULL ' \
                     f'ORDER BY {self.columns.timestamp} DESC'
-        conn = self.opendb()
-        r = conn.execute(query)
-        for row in r.fetchall():
-            yield self._as_dict(self.row_type(*row))
-        conn.close()
+        with self.connect_db() as conn:
+            r = conn.execute(query)
+            for row in r.fetchall():
+                yield self._as_dict(self.row_type(*row))

--- a/conan/internal/cache/db/recipes_table.py
+++ b/conan/internal/cache/db/recipes_table.py
@@ -49,7 +49,7 @@ class RecipesDBTable(BaseDbTable):
         query = f'SELECT * FROM {self.table_name} ' \
                 f'WHERE {where_clause};'
 
-        with self.connect_db() as conn:
+        with self.db_connection() as conn:
             r = conn.execute(query)
             row = r.fetchone()
 
@@ -61,7 +61,7 @@ class RecipesDBTable(BaseDbTable):
         assert ref is not None
         assert ref.revision is not None
         placeholders = ', '.join(['?' for _ in range(len(self.columns))])
-        with self.connect_db() as conn:
+        with self.db_connection() as conn:
             try:
                 conn.execute(f'INSERT INTO {self.table_name} '
                                  f'VALUES ({placeholders})',
@@ -76,14 +76,14 @@ class RecipesDBTable(BaseDbTable):
         query = f"UPDATE {self.table_name} " \
                 f'SET {self.columns.timestamp} = "{ref.timestamp}" ' \
                 f"WHERE {where_clause};"
-        with self.connect_db() as conn:
+        with self.db_connection() as conn:
             conn.execute(query)
 
     def remove(self, ref: RecipeReference):
         where_clause = self._where_clause(ref)
         query = f"DELETE FROM {self.table_name} " \
                 f"WHERE {where_clause};"
-        with self.connect_db() as conn:
+        with self.db_connection() as conn:
             conn.execute(query)
 
     # returns all different conan references (name/version@user/channel)
@@ -94,7 +94,7 @@ class RecipesDBTable(BaseDbTable):
                     f'{self.columns.timestamp} ' \
                     f'FROM {self.table_name} ' \
                     f'ORDER BY {self.columns.timestamp} DESC'
-        with self.connect_db() as conn:
+        with self.db_connection() as conn:
             r = conn.execute(query)
             result = [self._as_dict(self.row_type(*row)) for row in r.fetchall()]
         return result
@@ -119,7 +119,7 @@ class RecipesDBTable(BaseDbTable):
                     f'{check_rrev} ' \
                     f'ORDER BY {self.columns.timestamp} DESC'
 
-        with self.connect_db() as conn:
+        with self.db_connection() as conn:
             r = conn.execute(query)
             ret = [self._as_dict(self.row_type(*row)) for row in r.fetchall()]
         return ret

--- a/conan/internal/cache/db/recipes_table.py
+++ b/conan/internal/cache/db/recipes_table.py
@@ -49,10 +49,10 @@ class RecipesDBTable(BaseDbTable):
         query = f'SELECT * FROM {self.table_name} ' \
                 f'WHERE {where_clause};'
 
-        conn = self.opendb()
-        r = conn.execute(query)
-        row = r.fetchone()
-        conn.close()
+        with self.connect_db() as conn:
+            r = conn.execute(query)
+            row = r.fetchone()
+
         if not row:
             raise ConanReferenceDoesNotExistInDB(f"No entry for recipe '{repr(ref)}'")
         return self._as_dict(self.row_type(*row))
@@ -61,15 +61,13 @@ class RecipesDBTable(BaseDbTable):
         assert ref is not None
         assert ref.revision is not None
         placeholders = ', '.join(['?' for _ in range(len(self.columns))])
-        conn = self.opendb()
-        try:
-            conn.execute(f'INSERT INTO {self.table_name} '
-                         f'VALUES ({placeholders})',
-                         [str(ref), ref.revision, path, ref.timestamp])
-        except sqlite3.IntegrityError as e:
-            raise ConanReferenceAlreadyExistsInDB(f"Reference '{repr(ref)}' already exists")
-        finally:
-            conn.close()
+        with self.connect_db() as conn:
+            try:
+                conn.execute(f'INSERT INTO {self.table_name} '
+                                 f'VALUES ({placeholders})',
+                                 [str(ref), ref.revision, path, ref.timestamp])
+            except sqlite3.IntegrityError as e:
+                raise ConanReferenceAlreadyExistsInDB(f"Reference '{repr(ref)}' already exists")
 
     def update_timestamp(self, ref: RecipeReference):
         assert ref.revision is not None
@@ -78,17 +76,15 @@ class RecipesDBTable(BaseDbTable):
         query = f"UPDATE {self.table_name} " \
                 f'SET {self.columns.timestamp} = "{ref.timestamp}" ' \
                 f"WHERE {where_clause};"
-        conn = self.opendb()
-        conn.execute(query)
-        conn.close()
+        with self.connect_db() as conn:
+            conn.execute(query)
 
     def remove(self, ref: RecipeReference):
         where_clause = self._where_clause(ref)
         query = f"DELETE FROM {self.table_name} " \
                 f"WHERE {where_clause};"
-        conn = self.opendb()
-        conn.execute(query)
-        conn.close()
+        with self.connect_db() as conn:
+            conn.execute(query)
 
     # returns all different conan references (name/version@user/channel)
     def all_references(self):
@@ -98,10 +94,9 @@ class RecipesDBTable(BaseDbTable):
                     f'{self.columns.timestamp} ' \
                     f'FROM {self.table_name} ' \
                     f'ORDER BY {self.columns.timestamp} DESC'
-        conn = self.opendb()
-        r = conn.execute(query)
-        result = [self._as_dict(self.row_type(*row)) for row in r.fetchall()]
-        conn.close()
+        with self.connect_db() as conn:
+            r = conn.execute(query)
+            result = [self._as_dict(self.row_type(*row)) for row in r.fetchall()]
         return result
 
     def get_recipe_revisions_references(self, ref: RecipeReference, only_latest_rrev=False):
@@ -124,8 +119,7 @@ class RecipesDBTable(BaseDbTable):
                     f'{check_rrev} ' \
                     f'ORDER BY {self.columns.timestamp} DESC'
 
-        conn = self.opendb()
-        r = conn.execute(query)
-        ret = [self._as_dict(self.row_type(*row)) for row in r.fetchall()]
-        conn.close()
+        with self.connect_db() as conn:
+            r = conn.execute(query)
+            ret = [self._as_dict(self.row_type(*row)) for row in r.fetchall()]
         return ret

--- a/conan/internal/cache/db/recipes_table.py
+++ b/conan/internal/cache/db/recipes_table.py
@@ -48,8 +48,11 @@ class RecipesDBTable(BaseDbTable):
         where_clause = self._where_clause(ref)
         query = f'SELECT * FROM {self.table_name} ' \
                 f'WHERE {where_clause};'
-        r = self._conn.execute(query)
+
+        conn = self.opendb()
+        r = conn.execute(query)
         row = r.fetchone()
+        conn.close()
         if not row:
             raise ConanReferenceDoesNotExistInDB(f"No entry for recipe '{repr(ref)}'")
         return self._as_dict(self.row_type(*row))
@@ -58,12 +61,15 @@ class RecipesDBTable(BaseDbTable):
         assert ref is not None
         assert ref.revision is not None
         placeholders = ', '.join(['?' for _ in range(len(self.columns))])
+        conn = self.opendb()
         try:
-            self._conn.execute(f'INSERT INTO {self.table_name} '
-                               f'VALUES ({placeholders})',
-                               [str(ref), ref.revision, path, ref.timestamp])
+            conn.execute(f'INSERT INTO {self.table_name} '
+                         f'VALUES ({placeholders})',
+                         [str(ref), ref.revision, path, ref.timestamp])
         except sqlite3.IntegrityError as e:
             raise ConanReferenceAlreadyExistsInDB(f"Reference '{repr(ref)}' already exists")
+        finally:
+            conn.close()
 
     def update_timestamp(self, ref: RecipeReference):
         assert ref.revision is not None
@@ -72,13 +78,17 @@ class RecipesDBTable(BaseDbTable):
         query = f"UPDATE {self.table_name} " \
                 f'SET {self.columns.timestamp} = "{ref.timestamp}" ' \
                 f"WHERE {where_clause};"
-        self._conn.execute(query)
+        conn = self.opendb()
+        conn.execute(query)
+        conn.close()
 
     def remove(self, ref: RecipeReference):
         where_clause = self._where_clause(ref)
         query = f"DELETE FROM {self.table_name} " \
                 f"WHERE {where_clause};"
-        self._conn.execute(query)
+        conn = self.opendb()
+        conn.execute(query)
+        conn.close()
 
     # returns all different conan references (name/version@user/channel)
     def all_references(self):
@@ -88,8 +98,10 @@ class RecipesDBTable(BaseDbTable):
                     f'{self.columns.timestamp} ' \
                     f'FROM {self.table_name} ' \
                     f'ORDER BY {self.columns.timestamp} DESC'
-        r = self._conn.execute(query)
+        conn = self.opendb()
+        r = conn.execute(query)
         result = [self._as_dict(self.row_type(*row)) for row in r.fetchall()]
+        conn.close()
         return result
 
     def get_recipe_revisions_references(self, ref: RecipeReference, only_latest_rrev=False):
@@ -112,5 +124,8 @@ class RecipesDBTable(BaseDbTable):
                     f'{check_rrev} ' \
                     f'ORDER BY {self.columns.timestamp} DESC'
 
-        r = self._conn.execute(query)
-        return [self._as_dict(self.row_type(*row)) for row in r.fetchall()]
+        conn = self.opendb()
+        r = conn.execute(query)
+        ret = [self._as_dict(self.row_type(*row)) for row in r.fetchall()]
+        conn.close()
+        return ret

--- a/conan/internal/cache/db/table.py
+++ b/conan/internal/cache/db/table.py
@@ -20,7 +20,7 @@ class BaseDbTable:
         self.create_table()
 
     @contextmanager
-    def connect_db(self):
+    def db_connection(self):
         connection = sqlite3.connect(self.filename, isolation_level=None,
                                      timeout=1, check_same_thread=False)
         yield connection
@@ -54,12 +54,12 @@ class BaseDbTable:
         fields = ', '.join([field(*it) for it in self.columns_description])
         guard = 'IF NOT EXISTS'
         table_checks = f", UNIQUE({', '.join(self.unique_together)})" if self.unique_together else ''
-        with self.connect_db() as conn:
+        with self.db_connection() as conn:
             conn.execute(f"CREATE TABLE {guard} {self.table_name} ({fields} {table_checks});")
 
     def dump(self):
         print(f"********* BEGINTABLE {self.table_name}*************")
-        with self.connect_db() as conn:
+        with self.db_connection() as conn:
             r = conn.execute(f'SELECT rowid, * FROM {self.table_name}')
             for it in r.fetchall():
                 print(str(it))

--- a/conan/internal/cache/db/table.py
+++ b/conan/internal/cache/db/table.py
@@ -1,7 +1,6 @@
 import sqlite3
 from collections import namedtuple
 from contextlib import contextmanager
-from io import StringIO
 from typing import Tuple, List, Optional
 
 

--- a/conan/internal/cache/db/table.py
+++ b/conan/internal/cache/db/table.py
@@ -20,9 +20,9 @@ class BaseDbTable:
 
     @contextmanager
     def db_connection(self):
-        connection = sqlite3.connect(self.filename, isolation_level=None,
-                                     timeout=1, check_same_thread=False)
         try:
+            connection = sqlite3.connect(self.filename, isolation_level=None,
+                                        timeout=1, check_same_thread=False)
             yield connection
         finally:
             connection.close()

--- a/conan/internal/cache/db/table.py
+++ b/conan/internal/cache/db/table.py
@@ -23,8 +23,10 @@ class BaseDbTable:
     def db_connection(self):
         connection = sqlite3.connect(self.filename, isolation_level=None,
                                      timeout=1, check_same_thread=False)
-        yield connection
-        connection.close()
+        try:
+            yield connection
+        finally:
+            connection.close()
 
     def create_table(self):
         def field(name, typename, nullable=False, check_constraints: Optional[List] = None,

--- a/conans/test/integration/command/install/install_parallel_test.py
+++ b/conans/test/integration/command/install/install_parallel_test.py
@@ -8,7 +8,7 @@ class InstallParallelTest(unittest.TestCase):
 
     def test_basic_parallel_install(self):
         client = TestClient(default_server_user=True)
-        threads = 4  # At the moment, not really parallel until output implements mutex
+        threads = 4
         counter = 8
 
         client.save({"global.conf": f"core.download:parallel={threads}"},

--- a/conans/test/integration/command/install/install_parallel_test.py
+++ b/conans/test/integration/command/install/install_parallel_test.py
@@ -8,7 +8,7 @@ class InstallParallelTest(unittest.TestCase):
 
     def test_basic_parallel_install(self):
         client = TestClient(default_server_user=True)
-        threads = 1  # At the moment, not really parallel until output implements mutex
+        threads = 4  # At the moment, not really parallel until output implements mutex
         counter = 4
 
         client.save({"global.conf": f"core.download:parallel={threads}"},

--- a/conans/test/integration/command/install/install_parallel_test.py
+++ b/conans/test/integration/command/install/install_parallel_test.py
@@ -9,7 +9,7 @@ class InstallParallelTest(unittest.TestCase):
     def test_basic_parallel_install(self):
         client = TestClient(default_server_user=True)
         threads = 4  # At the moment, not really parallel until output implements mutex
-        counter = 4
+        counter = 8
 
         client.save({"global.conf": f"core.download:parallel={threads}"},
                     path=client.cache.cache_folder)


### PR DESCRIPTION
Changelog: Fix: Fix fail in parallel packages download due to database concurrency issues.
Docs: omit

Downloading packages in paralell was failing, the test test_basic_parallel_install that covered it was forcing the number of threads to 1 waiting for the implementation of some mutex mechanism in the cache. This PR fixes the issue with the most simple solution that is opening a new database connection for each query. The usage of the database in Conan is not so intensive compared with other operations and some preliminar performance tests seems to indicate that it's not affecting performance so much. Let's try this and if we have performance problems use another way of solving the db concurrency issues.