### PR TITLE
[bugfix] Version int comparison

### DIFF
--- a/conan/tools/scm/__init__.py
+++ b/conan/tools/scm/__init__.py
@@ -165,7 +165,7 @@ class Version:
     def __eq__(self, other):
         if other is None:
             return False
-        if isinstance(other, str):
+        if not isinstance(other, Version):
             other = Version(other)
 
         return (self._nonzero_items, self._pre, self._build) ==\


### PR DESCRIPTION
Changelog: Bugfix: `Version` comparison (greater than) with integer was raising an error.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/12907

Tests in develop2 branch (https://github.com/conan-io/conan/pull/12934)
