### PR TITLE
[develop2] merge SelectBundle and UploadBundle

### DIFF
--- a/conan/api/model.py
+++ b/conan/api/model.py
@@ -35,7 +35,8 @@ class SelectBundle:
         self.recipes = {}
 
     def add_refs(self, refs):
-        for ref in sorted(refs):  # Make sure older recipe revisions go first
+        # RREVS alreday come in ASCENDING order, so upload does older revisions first
+        for ref in refs:
             ref_dict = self.recipes.setdefault(str(ref), {})
             if ref.revision:
                 revs_dict = ref_dict.setdefault("revisions", {})
@@ -44,9 +45,8 @@ class SelectBundle:
                     rev_dict["timestamp"] = ref.timestamp
 
     def add_prefs(self, prefs):
-        # FIXME: We need to guarantee the upload order is from older to newer
-        # The reversed does that, because Conan informs in the newer->older order
-        for pref in reversed(prefs):  # Older revisions go first
+        # Prevs already come in ASCENDING order, so upload does older revisions first
+        for pref in prefs:
             revs_dict = self.recipes[str(pref.ref)]["revisions"]
             rev_dict = revs_dict[pref.ref.revision]
             packages_dict = rev_dict.setdefault("packages", {})

--- a/conan/api/model.py
+++ b/conan/api/model.py
@@ -1,7 +1,5 @@
-from collections import OrderedDict
-
 from conans.model.package_ref import PkgReference
-from conans.util.dates import timestamp_to_str
+from conans.model.recipe_ref import RecipeReference
 
 
 class Remote:
@@ -32,107 +30,58 @@ class Remote:
         return str(self)
 
 
-class _RecipeUploadData:
-    def __init__(self, prefs):
-        self.upload = True
-        self.force = None
-        self.dirty = None
-        self.files = None
-        self.packages = [_PackageUploadData(pref) for pref in prefs]
-
-    def serialize(self):
-        return {
-            "dirty": self.dirty,
-            "upload": self.upload,
-            "force": self.force,
-            "files": self.files,
-            "packages": [r.serialize() for r in self.packages]
-        }
-
-
-class _PackageUploadData:
-    def __init__(self, pref):
-        self.pref = pref
-        self.upload = True
-        self.files = None
-        self.force = None
-
-    def serialize(self):
-        return {
-            "pref": repr(self.pref),
-            "upload": self.upload,
-            "force": self.force,
-            "files": self.files
-        }
-
-
 class SelectBundle:
     def __init__(self):
-        self.recipes = OrderedDict()
-        self.confs = {}
-
-    def add_configurations(self, confs):
-        self.confs = {PkgReference(k.ref, k.package_id): v for k, v in confs.items()}
+        self.recipes = {}
 
     def add_refs(self, refs):
-        for ref in refs:
-            self.recipes.setdefault(ref, [])
-
-    def refs(self):
-        return self.recipes.keys()
-
-    def prefs(self):
-        prefs = []
-        for v in self.recipes.values():
-            prefs.extend(v)
-        return prefs
+        for ref in sorted(refs):  # Make sure older recipe revisions go first
+            ref_dict = self.recipes.setdefault(str(ref), {})
+            if ref.revision:
+                revs_dict = ref_dict.setdefault("revisions", {})
+                rev_dict = revs_dict.setdefault(ref.revision, {})
+                if ref.timestamp:
+                    rev_dict["timestamp"] = ref.timestamp
 
     def add_prefs(self, prefs):
-        for pref in prefs:
-            binary_info = self.confs.get(PkgReference(pref.ref, pref.package_id))
-            self.recipes.setdefault(pref.ref, []).append((pref, binary_info))
+        # FIXME: We need to guarantee the upload order is from older to newer
+        # The reversed does that, because Conan informs in the newer->older order
+        for pref in reversed(prefs):  # Older revisions go first
+            revs_dict = self.recipes[str(pref.ref)]["revisions"]
+            rev_dict = revs_dict[pref.ref.revision]
+            packages_dict = rev_dict.setdefault("packages", {})
+            package_dict = packages_dict.setdefault(pref.package_id, {})
+            if pref.revision:
+                prevs_dict = package_dict.setdefault("revisions", {})
+                prev_dict = prevs_dict.setdefault(pref.revision, {})
+                if pref.timestamp:
+                    prev_dict["timestamp"] = pref.timestamp
+
+    def add_configurations(self, confs):
+        # Listed confs must already exist in bundle
+        for pref, conf in confs.items():
+            rev_dict = self.recipes[str(pref.ref)]["revisions"][pref.ref.revision]
+            rev_dict["packages"][pref.package_id]["info"] = conf
+
+    def refs(self):
+        result = {}
+        for ref, ref_dict in self.recipes.items():
+            for rrev, rrev_dict in ref_dict.get("revisions", {}).items():
+                t = rrev_dict.get("timestamp")
+                recipe = RecipeReference.loads(f"{ref}#{rrev}%{t}")  # TODO: optimize this
+                result[recipe] = rrev_dict
+        return result.items()
+
+    @staticmethod
+    def prefs(ref, recipe_bundle):
+        result = {}
+        for package_id, pkg_bundle in recipe_bundle.get("packages", {}).items():
+            prevs = pkg_bundle.get("revisions", {})
+            for prev, prev_bundle in prevs.items():
+                t = prev_bundle.get("timestamp")
+                pref = PkgReference(ref, package_id, prev, t)
+                result[pref] = prev_bundle
+        return result.items()
 
     def serialize(self):
-        ret = {}
-        for ref, prefs in sorted(self.recipes.items()):
-            ref_dict = ret.setdefault(str(ref), {})
-            if ref.revision:
-                revisions_dict = ref_dict.setdefault("revisions", {})
-                rev_dict = revisions_dict.setdefault(ref.revision, {})
-                if ref.timestamp:
-                    rev_dict["timestamp"] = timestamp_to_str(ref.timestamp)
-                if prefs:
-                    packages_dict = rev_dict.setdefault("packages", {})
-                    for pref_info in prefs:
-                        pref, info = pref_info
-                        pid_dict = packages_dict.setdefault(pref.package_id, {})
-                        if info is not None:
-                            pid_dict["info"] = info
-                        if pref.revision:
-                            prevs_dict = pid_dict.setdefault("revisions", {})
-                            prev_dict = prevs_dict.setdefault(pref.revision, {})
-                            if pref.timestamp:
-                                prev_dict["timestamp"] = timestamp_to_str(pref.timestamp)
-        return ret
-
-
-class UploadBundle:
-    def __init__(self, select_bundle):
-        self.recipes = OrderedDict()
-        # We reverse the bundle so older revisions are uploaded first
-        for ref, prefs in reversed(select_bundle.recipes.items()):
-            reversed_prefs = reversed([pref for pref, _ in prefs])
-            self.recipes[ref] = _RecipeUploadData(reversed_prefs)
-
-    def serialize(self):
-        return {r.repr_notime(): v.serialize() for r, v in self.recipes.items()}
-
-    @property
-    def any_upload(self):
-        for r in self.recipes.values():
-            if r.upload:
-                return True
-            for p in r.packages:
-                if p.upload:
-                    return True
-        return False
+        return self.recipes

--- a/conan/api/subapi/list.py
+++ b/conan/api/subapi/list.py
@@ -127,6 +127,7 @@ class ListAPI:
                 prefs = []
                 if "*" not in pattern.package_id and pattern.prev is not None:
                     prefs.append(PkgReference(rrev, package_id=pattern.package_id))
+                    packages = {}
                 else:
                     packages = self.conan_api.list.packages_configurations(rrev, remote)
                     if package_query is not None:
@@ -134,7 +135,7 @@ class ListAPI:
                                                                                       package_query)
                     prefs = packages.keys()
                     prefs = pattern.filter_prefs(prefs)
-                    select_bundle.add_configurations(packages)
+                    packages = {pref: conf for pref, conf in packages.items() if pref in prefs}
 
                 if pattern.prev is not None:
                     new_prefs = []
@@ -152,4 +153,5 @@ class ListAPI:
                     prefs = new_prefs
 
                 select_bundle.add_prefs(prefs)
+                select_bundle.add_configurations(packages)
         return select_bundle

--- a/conan/api/subapi/list.py
+++ b/conan/api/subapi/list.py
@@ -100,6 +100,7 @@ class ListAPI:
         if "*" in pattern.ref or not pattern.version or \
                 (pattern.package_id is None and pattern.rrev is None):
             refs = self.conan_api.search.recipes(pattern.ref, remote=remote)
+            refs = sorted(refs)  # Order alphabetical and older versions first
             pattern.check_refs(refs)
         else:
             refs = [RecipeReference(pattern.name, pattern.version, pattern.user, pattern.channel)]
@@ -109,7 +110,7 @@ class ListAPI:
             select_bundle.add_refs(refs)
             return select_bundle
 
-        for r in refs:
+        for r in refs:  # Older versions first
             if pattern.is_latest_rrev or pattern.rrev is None:
                 rrev = self.conan_api.list.latest_recipe_revision(r, remote)
                 if rrev is None:
@@ -118,6 +119,7 @@ class ListAPI:
             else:
                 rrevs = self.conan_api.list.recipe_revisions(r, remote)
                 rrevs = pattern.filter_rrevs(rrevs)
+                rrevs = list(reversed(rrevs))  # Order older revisions first
             select_bundle.add_refs(rrevs)
 
             if pattern.package_id is None:  # Stop if not displaying binaries
@@ -149,6 +151,7 @@ class ListAPI:
                         else:
                             prevs = self.conan_api.list.package_revisions(pref, remote)
                             prevs = pattern.filter_prevs(prevs)
+                            prevs = list(reversed(prevs))  # Older revisions first
                             new_prefs.extend(prevs)
                     prefs = new_prefs
 

--- a/conan/api/subapi/search.py
+++ b/conan/api/subapi/search.py
@@ -44,6 +44,7 @@ class SearchAPI:
         select_bundle = SelectBundle()
         refs = self.conan_api.search.recipes(pattern.ref, remote=remote)
         pattern.check_refs(refs)
+        refs = sorted(refs)
 
         for r in refs:
             if pattern.is_latest_rrev:
@@ -51,6 +52,7 @@ class SearchAPI:
             else:
                 rrevs = self.conan_api.list.recipe_revisions(r, remote)
                 rrevs = pattern.filter_rrevs(rrevs)
+                rrevs = list(reversed(rrevs))
 
             select_bundle.add_refs(rrevs)
             # Add recipe revisions to bundle
@@ -70,5 +72,6 @@ class SearchAPI:
                     else:
                         prevs = self.conan_api.list.package_revisions(pref, remote)
                         prevs = pattern.filter_prevs(prevs)
+                        prevs = list(reversed(prevs))
                     select_bundle.add_prefs(prevs)
         return select_bundle

--- a/conan/api/subapi/upload.py
+++ b/conan/api/subapi/upload.py
@@ -1,4 +1,3 @@
-from conan.api.model import UploadBundle
 from conan.api.output import ConanOutput
 from conan.api.subapi import api_method
 from conan.internal.conan_app import ConanApp
@@ -17,11 +16,10 @@ class UploadAPI:
     def get_bundle(self, expression, package_query=None, only_recipe=False):
         ref_pattern = SelectPattern(expression)
         select_bundle = self.conan_api.search.select(ref_pattern, only_recipe, package_query)
-        upload_bundle = UploadBundle(select_bundle)
 
         # This is necessary to upload_policy = "skip"
         app = ConanApp(self.conan_api.cache_folder)
-        for ref, bundle in upload_bundle.recipes.items():
+        for ref, bundle in select_bundle.refs():
             layout = app.cache.ref_layout(ref)
             conanfile_path = layout.conanfile()
             conanfile = app.loader.load_basic(conanfile_path)
@@ -30,7 +28,7 @@ class UploadAPI:
                                    "because upload_policy='skip'")
                 bundle.packages = []
 
-        return upload_bundle
+        return select_bundle
 
     @api_method
     def check_integrity(self, upload_data):

--- a/conan/api/subapi/upload.py
+++ b/conan/api/subapi/upload.py
@@ -26,7 +26,7 @@ class UploadAPI:
             if conanfile.upload_policy == "skip":
                 ConanOutput().info(f"{ref}: Skipping upload of binaries, "
                                    "because upload_policy='skip'")
-                bundle.packages = []
+                bundle["packages"] = {}
 
         return select_bundle
 

--- a/conan/cli/commands/download.py
+++ b/conan/cli/commands/download.py
@@ -32,13 +32,17 @@ def download(conan_api: ConanAPI, parser, *args):
     ref_pattern = SelectPattern(args.reference)
     select_bundle = conan_api.search.select(ref_pattern, args.only_recipe, args.package_query,
                                             remote)
-    refs = select_bundle.refs()
-    prefs = select_bundle.prefs()
+    refs = []
+    prefs = []
+    for ref, recipe_bundle in select_bundle.refs():
+        refs.append(ref)
+        for pref, _ in select_bundle.prefs(ref, recipe_bundle):
+            prefs.append(pref)
 
     if parallel <= 1:
         for ref in refs:
             conan_api.download.recipe(ref, remote)
-        for pref, _ in prefs:
+        for pref in prefs:
             conan_api.download.package(pref, remote)
     else:
         _download_parallel(parallel, conan_api, refs, prefs, remote)
@@ -58,6 +62,6 @@ def _download_parallel(parallel, conan_api, refs, prefs, remote):
     if prefs:
         thread_pool = ThreadPool(parallel)
         ConanOutput().info("Downloading binary packages in %s parallel threads" % parallel)
-        thread_pool.starmap(conan_api.download.package,  [(pref, remote) for pref, _ in prefs])
+        thread_pool.starmap(conan_api.download.package,  [(pref, remote) for pref in prefs])
         thread_pool.close()
         thread_pool.join()

--- a/conan/cli/commands/remove.py
+++ b/conan/cli/commands/remove.py
@@ -36,11 +36,12 @@ def remove(conan_api: ConanAPI, parser, *args):
     select_bundle = conan_api.search.select(ref_pattern, only_recipe, args.package_query, remote)
 
     if only_recipe:
-        for ref in select_bundle.refs():
+        for ref, _ in select_bundle.refs():
             if confirmation("Remove the recipe and all the packages of '{}'?"
                             "".format(ref.repr_notime())):
                 conan_api.remove.recipe(ref, remote=remote)
     else:
-        for pref, _ in select_bundle.prefs():
-            if confirmation("Remove the package '{}'?".format(pref.repr_notime())):
-                conan_api.remove.package(pref, remote=remote)
+        for ref, ref_bundle in select_bundle.refs():
+            for pref, _ in select_bundle.prefs(ref, ref_bundle):
+                if confirmation("Remove the package '{}'?".format(pref.repr_notime())):
+                    conan_api.remove.package(pref, remote=remote)

--- a/conans/client/pkg_sign.py
+++ b/conans/client/pkg_sign.py
@@ -28,13 +28,12 @@ class PkgSignaturesPlugin:
             for f in os.listdir(metadata_sign):
                 files[f"{METADATA}/sign/{f}"] = os.path.join(metadata_sign, f)
 
-        for ref, bundle in upload_data.recipes.items():
-            if bundle.upload:
-                _sign(ref, bundle.files, self._cache.ref_layout(ref).download_export())
-            for package in bundle.packages:
-                if package.upload:
-                    _sign(package.pref, package.files,
-                          self._cache.pkg_layout(package.pref).download_package())
+        for rref, recipe_bundle in upload_data.refs():
+            if recipe_bundle["upload"]:
+                _sign(rref, recipe_bundle["files"], self._cache.ref_layout(rref).download_export())
+            for pref, pkg_bundle in upload_data.prefs(rref, recipe_bundle):
+                if pkg_bundle["upload"]:
+                    _sign(pref, pkg_bundle["files"], self._cache.pkg_layout(pref).download_package())
 
     def verify(self, ref, folder):
         if self._plugin_verify_function is None:

--- a/conans/model/package_ref.py
+++ b/conans/model/package_ref.py
@@ -71,7 +71,8 @@ class PkgReference:
         #    at "graph_binaries" to check: cache_latest_prev != pref
         #    at "installer" to check: if pkg_layout.reference != pref (probably just optimization?)
         #    at "revisions_test"
-        return self.ref == other.ref and self.revision == other.revision
+        return self.ref == other.ref and self.package_id == other.package_id and \
+               self.revision == other.revision
 
     def __hash__(self):
         # Used in dicts of PkgReferences as keys like the cached nodes in the graph binaries

--- a/conans/test/integration/command/upload/test_upload_bundle.py
+++ b/conans/test/integration/command/upload/test_upload_bundle.py
@@ -39,10 +39,6 @@ def test_upload_bundle():
 
             # Check if the recipes/packages are in the remote
             conan_api.upload.check_upstream(upload_bundle, remote)
-
-            if not upload_bundle.any_upload:
-                return
-
             conan_api.upload.prepare(upload_bundle, enabled_remotes)
             cli_out_write(json.dumps(upload_bundle.serialize(), indent=4))
         """)
@@ -55,4 +51,4 @@ def test_upload_bundle():
     c.run('upload-bundle "*" -r=default', redirect_stdout="mybundle.json")
     bundle = c.load("mybundle.json")
     bundle = json.loads(bundle)
-    assert bundle["pkg/0.1#485dad6cb11e2fa99d9afbe44a57a164"]["upload"] is True
+    assert bundle["pkg/0.1"]["revisions"]["485dad6cb11e2fa99d9afbe44a57a164"]["upload"] is True

--- a/conans/test/integration/command_v2/list_test.py
+++ b/conans/test/integration/command_v2/list_test.py
@@ -429,17 +429,17 @@ class TestListPrefs:
                 b58eeddfe2fd25ac3a105f72836b3360 (2023-01-10 22:27:34 UTC)
                   packages
                     9a4eb3c8701508aa9458b1a73d0633783ecc2270
+                      revisions
+                        9beff32b8c94ea0ce5a5e67dad95f525 (10-11-2023 10:13:13)
                       info
                         settings
                           os: Linux
-                      revisions
-                        9beff32b8c94ea0ce5a5e67dad95f525 (10-11-2023 10:13:13)
                     ebec3dc6d7f6b907b3ada0c3d3cdc83613a2b715
+                      revisions
+                        d9b1e9044ee265092e81db7028ae10e0 (10-11-2023 10:13:13)
                       info
                         settings
                           os: Windows
-                      revisions
-                        d9b1e9044ee265092e81db7028ae10e0 (10-11-2023 10:13:13)
           """)
         self.check(client, pattern, remote, expected)
 
@@ -454,18 +454,18 @@ class TestListPrefs:
                 b58eeddfe2fd25ac3a105f72836b3360 (2023-01-10 22:41:09 UTC)
                   packages
                     9a4eb3c8701508aa9458b1a73d0633783ecc2270
+                      revisions
+                        9beff32b8c94ea0ce5a5e67dad95f525 (2023-01-10 22:41:09 UTC)
                       info
                         settings
                           os: Linux
-                      revisions
-                        9beff32b8c94ea0ce5a5e67dad95f525 (2023-01-10 22:41:09 UTC)
                     ebec3dc6d7f6b907b3ada0c3d3cdc83613a2b715
+                      revisions
+                        24532a030b4fcdfed699511f6bfe35d3 (2023-01-10 22:41:09 UTC)
+                        d9b1e9044ee265092e81db7028ae10e0 (2023-01-10 22:41:10 UTC)
                       info
                         settings
                           os: Windows
-                      revisions
-                        d9b1e9044ee265092e81db7028ae10e0 (2023-01-10 22:41:10 UTC)
-                        24532a030b4fcdfed699511f6bfe35d3 (2023-01-10 22:41:09 UTC)
           """)
         self.check(client, pattern, remote, expected)
 
@@ -504,8 +504,8 @@ class TestListPrefs:
                   packages
                     ebec3dc6d7f6b907b3ada0c3d3cdc83613a2b715
                       revisions
-                        d9b1e9044ee265092e81db7028ae10e0 (2023-01-10 22:41:10 UTC)
                         24532a030b4fcdfed699511f6bfe35d3 (2023-01-10 22:41:09 UTC)
+                        d9b1e9044ee265092e81db7028ae10e0 (2023-01-10 22:41:10 UTC)
           """)
         self.check(client, pattern, remote, expected)
 


### PR DESCRIPTION
Changelog: omit

``UploadBundle`` is very similar to ``SelectBundle``, but with minor changes to store other fields like the ``files`` paths. It has different serialization format, different printing and different management.

As the ``select()`` patterns are used for ``upload`` and we want to unify the ``select()`` of ``remove, upload, download``, this is a first step. 
It also reduces the API surface to just 1 object with an already discussed serialization format, so that will reduce necessary documentation, examples, and maintenance in general.