### PR TITLE
NMakeDeps: inject defines & system_libs of dependencies

### DIFF
--- a/conan/tools/microsoft/nmakedeps.py
+++ b/conan/tools/microsoft/nmakedeps.py
@@ -41,6 +41,7 @@ class NMakeDeps(object):
             ret.extend(cpp_info.exelinkflags or [])
             ret.extend(cpp_info.sharedlinkflags or [])
             ret.extend([format_lib(lib) for lib in cpp_info.libs or []])
+            ret.extend([format_lib(lib) for lib in cpp_info.system_libs or []])
             link_args = " ".join(ret)
 
             cl_flags = [f'-I"{p}"' for p in cpp_info.includedirs or []]

--- a/conan/tools/microsoft/nmakedeps.py
+++ b/conan/tools/microsoft/nmakedeps.py
@@ -44,9 +44,20 @@ class NMakeDeps(object):
             ret.extend([format_lib(lib) for lib in cpp_info.system_libs or []])
             link_args = " ".join(ret)
 
+            def format_define(define):
+                if "=" in define:
+                    # CL env-var can't accept '=' sign in /D option, it can be replaced by '#' sign:
+                    # https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables
+                    macro, value = define.split("=", 1)
+                    if value and not value.isnumeric():
+                        value = f'\\"{value}\\"'
+                    define = f"{macro}#{value}"
+                return f"/D{define}"
+
             cl_flags = [f'-I"{p}"' for p in cpp_info.includedirs or []]
             cl_flags.extend(cpp_info.cflags or [])
             cl_flags.extend(cpp_info.cxxflags or [])
+            cl_flags.extend([format_define(define) for define in cpp_info.defines or []])
 
             env = Environment()
             env.append("CL", " ".join(cl_flags))

--- a/conans/test/integration/toolchains/microsoft/test_nmakedeps.py
+++ b/conans/test/integration/toolchains/microsoft/test_nmakedeps.py
@@ -28,7 +28,7 @@ def test_nmakedeps():
                 self.cpp_info.components["pkg-3"].defines = ["TEST_DEFINITION3="]
                 self.cpp_info.components["pkg-3"].requires = ["pkg-1", "pkg-2"]
                 self.cpp_info.components["pkg-4"].libs = ["pkg-4"]
-                self.cpp_info.components["pkg-4"].defines = ["TEST_DEFINITION4=test-cmakedeps"]
+                self.cpp_info.components["pkg-4"].defines = ["TEST_DEFINITION4=foo"]
     """)
     client.save({"conanfile.py": conanfile})
     client.run("create . -s arch=x86_64")
@@ -38,7 +38,7 @@ def test_nmakedeps():
     # Checking that defines are added to CL
     for flag in (
         r"/DTEST_DEFINITION1", r"/DTEST_DEFINITION2#0",
-        r"/DTEST_DEFINITION3#", r'/DTEST_DEFINITION4#\\"test-cmakedeps\\"',
+        r"/DTEST_DEFINITION3#", r'/DTEST_DEFINITION4#\\"foo\\"',
     ):
         assert re.search(fr'set "CL=%CL%.*\s{flag}(?:\s|")', bat_file)
     # Checking that libs and system libs are added to _LINK_

--- a/conans/test/integration/toolchains/microsoft/test_nmakedeps.py
+++ b/conans/test/integration/toolchains/microsoft/test_nmakedeps.py
@@ -32,7 +32,6 @@ def test_nmakedeps():
     """)
     client.save({"conanfile.py": conanfile})
     client.run("create . -s arch=x86_64")
-    # Issue: https://github.com/conan-io/conan/issues/11822
     client.run("install test-nmakedeps/1.0@ -g NMakeDeps -s build_type=Release -s arch=x86_64")
     # Checking that NMakeDeps builds correctly .bat file
     bat_file = client.load("conannmakedeps.bat")

--- a/conans/test/integration/toolchains/microsoft/test_nmakedeps.py
+++ b/conans/test/integration/toolchains/microsoft/test_nmakedeps.py
@@ -1,0 +1,47 @@
+import platform
+import re
+import textwrap
+
+import pytest
+
+from conans.test.utils.tools import TestClient
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
+def test_nmakedeps():
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        class Pkg(ConanFile):
+            settings = "os", "arch", "compiler", "build_type"
+            name = "test-nmakedeps"
+            version = "1.0"
+
+            def package_info(self):
+                self.cpp_info.components["pkg-1"].libs = ["pkg-1"]
+                self.cpp_info.components["pkg-1"].defines = ["TEST_DEFINITION1"]
+                self.cpp_info.components["pkg-1"].system_libs = ["ws2_32"]
+                self.cpp_info.components["pkg-2"].libs = ["pkg-2"]
+                self.cpp_info.components["pkg-2"].defines = ["TEST_DEFINITION2=0"]
+                self.cpp_info.components["pkg-2"].requires = ["pkg-1"]
+                self.cpp_info.components["pkg-3"].libs = ["pkg-3"]
+                self.cpp_info.components["pkg-3"].defines = ["TEST_DEFINITION3="]
+                self.cpp_info.components["pkg-3"].requires = ["pkg-1", "pkg-2"]
+                self.cpp_info.components["pkg-4"].libs = ["pkg-4"]
+                self.cpp_info.components["pkg-4"].defines = ["TEST_DEFINITION4=test-cmakedeps"]
+    """)
+    client.save({"conanfile.py": conanfile})
+    client.run("create . -s arch=x86_64")
+    # Issue: https://github.com/conan-io/conan/issues/11822
+    client.run("install test-nmakedeps/1.0@ -g NMakeDeps -s build_type=Release -s arch=x86_64")
+    # Checking that NMakeDeps builds correctly .bat file
+    bat_file = client.load("conannmakedeps.bat")
+    # Checking that defines are added to CL
+    for flag in (
+        r"/DTEST_DEFINITION1", r"/DTEST_DEFINITION2#0",
+        r"/DTEST_DEFINITION3#", r'/DTEST_DEFINITION4#\\"test-cmakedeps\\"',
+    ):
+        assert re.search(fr'set "CL=%CL%.*\s{flag}[\s|"]', bat_file)
+    # Checking that libs and system libs are added to _LINK_
+    for flag in (r"pkg-1\.lib", r"pkg-2\.lib", r"pkg-3\.lib", r"pkg-4\.lib", r"ws2_32\.lib"):
+        assert re.search(fr'set "_LINK_=%_LINK_%.*\s{flag}(?:\s|"$)', bat_file)

--- a/conans/test/integration/toolchains/microsoft/test_nmakedeps.py
+++ b/conans/test/integration/toolchains/microsoft/test_nmakedeps.py
@@ -40,7 +40,7 @@ def test_nmakedeps():
         r"/DTEST_DEFINITION1", r"/DTEST_DEFINITION2#0",
         r"/DTEST_DEFINITION3#", r'/DTEST_DEFINITION4#\\"test-cmakedeps\\"',
     ):
-        assert re.search(fr'set "CL=%CL%.*\s{flag}[\s|"]', bat_file)
+        assert re.search(fr'set "CL=%CL%.*\s{flag}(?:\s|")', bat_file)
     # Checking that libs and system libs are added to _LINK_
     for flag in (r"pkg-1\.lib", r"pkg-2\.lib", r"pkg-3\.lib", r"pkg-4\.lib", r"ws2_32\.lib"):
-        assert re.search(fr'set "_LINK_=%_LINK_%.*\s{flag}(?:\s|"$)', bat_file)
+        assert re.search(fr'set "_LINK_=%_LINK_%.*\s{flag}(?:\s|")', bat_file)


### PR DESCRIPTION
Changelog: Fix: NMakeDeps support cpp_info.defines and cpp_info.system_libs of dependencies.
Docs: Omit

closes https://github.com/conan-io/conan/issues/12943

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
