### PR TITLE
fix_apple_shared_install_name: fix binaries regardless of shared option

### DIFF
--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -258,7 +258,7 @@ def fix_apple_shared_install_name(conanfile):
                     command = f"install_name_tool {executable} -add_rpath {entry}"
                     conanfile.run(command)
 
-    if is_apple_os(conanfile) and conanfile.options.get_safe("shared", False):
+    if is_apple_os(conanfile):
         substitutions = _fix_dylib_files(conanfile)
 
         # Only "fix" executables if dylib files were patched, otherwise


### PR DESCRIPTION
Changelog: Fix: `fix_apple_shared_install_name()` now fixes all dylib in libdirs and executables in bindirs regardless of shared option.
Docs: omit

closes https://github.com/conan-io/conan/issues/12959

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
