### PR TITLE
[develop2] Propose new settings_user.yml

### DIFF
--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -2,6 +2,7 @@ import os
 import platform
 from typing import List
 
+import yaml
 from jinja2 import Template
 
 
@@ -10,6 +11,7 @@ from conans.client.cache.editable import EditablePackages
 from conans.client.cache.remote_registry import RemoteRegistry
 from conans.client.conf import default_settings_yml
 from conans.client.store.localdb import LocalDB
+from conans.errors import ConanException
 from conans.model.conf import ConfDefinition
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
@@ -202,8 +204,34 @@ class ClientCache(object):
         """Returns {setting: [value, ...]} defining all the possible
            settings without values"""
         self.initialize_settings()
-        content = load(self.settings_path)
-        return Settings.loads(content)
+
+        def _load_settings(path):
+            try:
+                return yaml.safe_load(load(path)) or {}
+            except (yaml.YAMLError, AttributeError) as ye:
+                raise ConanException("Invalid settings.yml format: {}".format(ye))
+
+        settings = _load_settings(self.settings_path)
+        user_settings_file = os.path.join(self.cache_folder, "settings_user.yml")
+        if os.path.exists(user_settings_file):
+            settings_user = _load_settings(user_settings_file)
+
+            def appending_recursive_dict_update(d, u):
+                # Not the same behavior as conandata_update, because this append lists
+                for k, v in u.items():
+                    if isinstance(v, list):
+                        current = d.get(k) or []
+                        d[k] = current + [value for value in v if value not in current]
+                    elif isinstance(v, dict):
+                        current = d.get(k) or {}
+                        d[k] = appending_recursive_dict_update(current, v)
+                    else:
+                        d[k] = v
+                return d
+
+            appending_recursive_dict_update(settings, settings_user)
+
+        return Settings(settings)
 
     def initialize_settings(self):
         # TODO: This is called by ConfigAPI.init(), maybe move everything there?

--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -208,7 +208,7 @@ class ClientCache(object):
         def _load_settings(path):
             try:
                 return yaml.safe_load(load(path)) or {}
-            except (yaml.YAMLError, AttributeError) as ye:
+            except yaml.YAMLError as ye:
                 raise ConanException("Invalid settings.yml format: {}".format(ye))
 
         settings = _load_settings(self.settings_path)
@@ -231,7 +231,10 @@ class ClientCache(object):
 
             appending_recursive_dict_update(settings, settings_user)
 
-        return Settings(settings)
+        try:
+            return Settings(settings)
+        except AttributeError as e:
+            raise ConanException("Invalid settings.yml format: {}".format(e))
 
     def initialize_settings(self):
         # TODO: This is called by ConfigAPI.init(), maybe move everything there?

--- a/conans/test/integration/settings/test_settings_user.py
+++ b/conans/test/integration/settings/test_settings_user.py
@@ -35,3 +35,20 @@ def test_settings_user():
     c.run("install . -s os=Macos -s new_global=42")
     assert "os=Macos" in c.out
     assert "new_global=42" in c.out
+
+
+def test_settings_user_subdict():
+    c = TestClient()
+    settings_user = textwrap.dedent("""\
+        other_new:
+            other1:
+            other2:
+                version: [1, 2, 3]
+        """)
+    save(os.path.join(c.cache_folder, "settings_user.yml"), settings_user)
+    c.save({"conanfile.py": GenConanfile().with_settings("other_new")})
+    c.run("install . -s other_new=other1")
+    assert "other_new=other1" in c.out
+    c.run("install . -s other_new=other2 -s other_new.version=2")
+    assert "other_new=other2" in c.out
+    assert "other_new.version=2" in c.out

--- a/conans/test/integration/settings/test_settings_user.py
+++ b/conans/test/integration/settings/test_settings_user.py
@@ -1,0 +1,37 @@
+import os
+import textwrap
+
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.tools import TestClient
+from conans.util.files import save
+
+
+def test_settings_user():
+    c = TestClient()
+    settings_user = textwrap.dedent("""\
+        os:
+            Windows:
+                subsystem: [new_sub]
+            Linux:
+                new_versions: ["a", "b", "c"]
+            new_os:
+        new_global: ["42", "21"]
+        """)
+    save(os.path.join(c.cache_folder, "settings_user.yml"), settings_user)
+    c.save({"conanfile.py": GenConanfile().with_settings("os").with_settings("new_global")})
+    # New settings are there
+    c.run("install . -s os=Windows -s os.subsystem=new_sub -s new_global=42")
+    assert "new_global=42" in c.out
+    assert "os.subsystem=new_sub" in c.out
+    # Existing values of subsystem are still there
+    c.run("install . -s os=Windows -s os.subsystem=msys2 -s new_global=42")
+    assert "new_global=42" in c.out
+    assert "os.subsystem=msys2" in c.out
+    # Completely new values, not appended, but new, are there
+    c.run("install . -s os=Linux -s os.new_versions=a -s new_global=42")
+    assert "new_global=42" in c.out
+    assert "os.new_versions=a" in c.out
+    # Existing values of OSs are also there
+    c.run("install . -s os=Macos -s new_global=42")
+    assert "os=Macos" in c.out
+    assert "new_global=42" in c.out


### PR DESCRIPTION
Changelog: Feature: Users can define their own settings in `settings_user.yml` that will be merged with the Conan `settings.yml`.

Close https://github.com/conan-io/conan/issues/8261
Close https://github.com/conan-io/conan/issues/12422

The main blocker for https://github.com/conan-io/conan/issues/8261 was the idea that it is necessary to do the round-trip for the ``yml`` file. It seems that is more doable to update the in-memory dictionaries, this is a proof of concept.