### PR TITLE
[cmake_layout] Add mechanism to create different test build folders

### DIFF
--- a/conan/tools/cmake/layout.py
+++ b/conan/tools/cmake/layout.py
@@ -1,6 +1,4 @@
 import os
-import shutil
-from pathlib import Path
 
 from conans.errors import ConanException
 from conans.model.ref import ConanFileReference
@@ -71,7 +69,7 @@ def get_build_folder_custom_vars(conanfile):
 
 def get_root_test_build_folder(conanfile):
     """
-    Get a different root test build folder path (or the test_package/ one) if
+    Gets a different root test build folder path (or the test_package/ one) if
     tools.cmake.cmake_layout:test_build_folder is specified.
 
     If specified the test output build folder could look like this:

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -25,6 +25,7 @@ BUILT_IN_CONFS = {
     "tools.cmake.cmaketoolchain.presets:max_schema_version": "Generate CMakeUserPreset.json compatible with the supplied schema version",
     "tools.env.virtualenv:auto_use": "Automatically activate virtualenv file generation",
     "tools.cmake.cmake_layout:build_folder_vars": "Settings and Options that will produce a different build folder and different CMake presets names",
+    "tools.cmake.cmake_layout:test_build_folder": "Root path to create each test build folder. ",
     "tools.files.download:retry": "Number of retries in case of failure when downloading",
     "tools.files.download:retry_wait": "Seconds to wait between download attempts",
     "tools.gnu:make_program": "Indicate path to make program",

--- a/conans/test/functional/command/test_command_test.py
+++ b/conans/test/functional/command/test_command_test.py
@@ -1,11 +1,14 @@
 import os
 import platform
+import textwrap
 import time
 import unittest
 
 import pytest
 
 from conans.test.utils.tools import TestClient
+from conans.util.files import mkdir
+from utils.test_files import temp_folder
 
 
 @pytest.mark.slow
@@ -30,3 +33,10 @@ class ConanTestTest(unittest.TestCase):
         subfolder = "Release" if platform.system() != "Windows" else ""
         assert os.path.exists(os.path.join(client.current_folder, "test_package",
                                            "build", subfolder, "generators", "conaninfo.txt"))
+
+    def test_whateverrr(self):
+        tc = TestClient()
+        tc.run("new hello/1.0 -m=cmake_lib")
+        test_root_folder_output = temp_folder()
+        tc.run(f"create . hello/1.0@ -c user.test_build_folder='{test_root_folder_output}'")
+        os.listdir(test_root_folder_output)

--- a/conans/test/functional/command/test_command_test.py
+++ b/conans/test/functional/command/test_command_test.py
@@ -1,14 +1,11 @@
 import os
 import platform
-import textwrap
 import time
 import unittest
 
 import pytest
 
 from conans.test.utils.tools import TestClient
-from conans.util.files import mkdir
-from utils.test_files import temp_folder
 
 
 @pytest.mark.slow
@@ -33,10 +30,3 @@ class ConanTestTest(unittest.TestCase):
         subfolder = "Release" if platform.system() != "Windows" else ""
         assert os.path.exists(os.path.join(client.current_folder, "test_package",
                                            "build", subfolder, "generators", "conaninfo.txt"))
-
-    def test_whateverrr(self):
-        tc = TestClient()
-        tc.run("new hello/1.0 -m=cmake_lib")
-        test_root_folder_output = temp_folder()
-        tc.run(f"create . hello/1.0@ -c user.test_build_folder='{test_root_folder_output}'")
-        os.listdir(test_root_folder_output)


### PR DESCRIPTION
Changelog: Feature: Add new configuration `tools.cmake.cmake_layout:test_build_folder` to indicate a different root test build folder.
Changelog: Feature: Adding to `cmake_layout()` a new mechanism to create different test build folders based (mainly) on the settings.
Docs: WIP
Closes: https://github.com/conan-io/conan/issues/10201