### PR TITLE
[develop2] Fixing issues with test_package output folder

### DIFF
--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -131,13 +131,14 @@ def test_package(conan_api, deps_graph, test_conanfile_path, tested_python_requi
                              "package being created.".format(test_conanfile_path))
     conanfile_folder = os.path.dirname(test_conanfile_path)
     conanfile = deps_graph.root.conanfile
-    output_folder = os.path.join(conanfile_folder, conanfile.folders.test_output)
-    if conanfile.folders.test_output:
-        shutil.rmtree(output_folder, ignore_errors=True)
-        mkdir(output_folder)
+    if conanfile.build_folder and conanfile.build_folder != conanfile.source_folder:
+        # should be the same as build folder, but we can remove it
+        shutil.rmtree(conanfile.build_folder, ignore_errors=True)
+        mkdir(conanfile.build_folder)
+    conanfile.output.info(f"Test package build: {conanfile.folders.build}")
+    conanfile.output.info(f"Test package build folder: {conanfile.build_folder}")
     conan_api.install.install_consumer(deps_graph=deps_graph,
-                                       source_folder=conanfile_folder,
-                                       output_folder=output_folder)
+                                       source_folder=conanfile_folder)
 
     out.title("Testing the package: Building")
     app = ConanApp(conan_api.cache_folder)

--- a/conan/tools/cmake/layout.py
+++ b/conan/tools/cmake/layout.py
@@ -41,7 +41,7 @@ def cmake_layout(conanfile, generator=None, src_folder=".", build_folder="build"
 
     conanfile.cpp.source.includedirs = ["include"]
 
-    if multi and not user_defined_build:
+    if multi:
         conanfile.cpp.build.libdirs = ["{}".format(build_type)]
         conanfile.cpp.build.bindirs = ["{}".format(build_type)]
     else:
@@ -51,8 +51,12 @@ def cmake_layout(conanfile, generator=None, src_folder=".", build_folder="build"
 
 def get_build_folder_custom_vars(conanfile):
 
-    build_vars = conanfile.conf.get("tools.cmake.cmake_layout:build_folder_vars",
-                                    default=[], check_type=list)
+    if conanfile.tested_reference_str:
+        build_vars = ["settings.compiler", "settings.compiler.version", "settings.arch",
+                      "settings.compiler.cppstd", "settings.build_type", "options.shared"]
+    else:
+        build_vars = conanfile.conf.get("tools.cmake.cmake_layout:build_folder_vars",
+                                        default=[], check_type=list)
     ret = []
     for s in build_vars:
         group, var = s.split(".", 1)

--- a/conan/tools/google/layout.py
+++ b/conan/tools/google/layout.py
@@ -4,7 +4,6 @@ def bazel_layout(conanfile, generator=None, src_folder="."):
     """The layout for bazel is very limited, it builds in the root folder even specifying
        "bazel --output_base=xxx" in the other hand I don't know how to inject a custom path so
        the build can load the dependencies.bzl from the BazelDeps"""
-    conanfile.folders.test_output = ""
     conanfile.folders.build = ""
     conanfile.folders.generators = ""
     # used in test package for example, to know where the binaries are (editables not supported yet)

--- a/conan/tools/microsoft/layout.py
+++ b/conan/tools/microsoft/layout.py
@@ -10,7 +10,6 @@ def vs_layout(conanfile):
 
     :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
     """
-    conanfile.folders.test_output = ""
     subproject = conanfile.folders.subproject
     conanfile.folders.source = subproject or "."
     conanfile.folders.generators = os.path.join(subproject, "conan") if subproject else "conan"

--- a/conans/model/layout.py
+++ b/conans/model/layout.py
@@ -50,7 +50,6 @@ class Folders(object):
         # Relative location of the project root, if the conanfile is not in that project root, but
         # in a subfolder: e.g: If the conanfile is in a subfolder then self.root = ".."
         self.root = None
-        self.test_output = "test_output"
         # The relative location with respect to the project root of the subproject containing the
         # conanfile.py, that makes most of the output folders defined in layouts (cmake_layout, etc)
         # start from the subproject again

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_and_linker_flags.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_and_linker_flags.py
@@ -53,7 +53,8 @@ def test_shared_link_flags():
     client.save({"conanfile.py": conanfile})
     client.run("create .")
     host_arch = client.get_default_host_profile().settings['arch']
-    t = os.path.join("test_package", "test_output", "build", "Release", "generators",
+    build_folder = client.created_test_build_folder("hello/1.0")
+    t = os.path.join("test_package", build_folder, "generators",
                      f"hello-release-{host_arch}-data.cmake")
     target_data_cmake_content = client.load(t)
     assert 'set(hello_SHARED_LINK_FLAGS_RELEASE "-z now;-z relro")' in target_data_cmake_content

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -34,11 +34,12 @@ def test_simple_cmake_mingw():
         compiler.cppstd=17
         """})
     client.run("create . --profile=mingw")
+    build_folder = client.created_test_build_folder("hello/1.0")
     # FIXME: Note that CI contains 10.X, so it uses another version rather than the profile one
     #  and no one notices. It would be good to have some details in confuser.py to be consistent
     check_exe_run(client.out, "hello/1.0:", "gcc", None, "Release", "x86_64", "17",
                   subsystem="mingw64", extra_msg="Hello World", cxx11_abi="1")
-    check_vs_runtime("test_package/test_output/build/Release/example.exe", client, "15",
+    check_vs_runtime(f"test_package/{build_folder}/example.exe", client, "15",
                      build_type="Release", static_runtime=False, subsystem="mingw64")
 
 # TODO: How to link with mingw statically?

--- a/conans/test/functional/toolchains/cmake/test_shared_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_shared_cmake.py
@@ -90,7 +90,9 @@ def test_client_shared():
 
     # We can run the exe from the test package directory also, without environment
     # because there is an internal RPATH in the exe with an abs path to the "hello"
-    exe_folder = os.path.join("test_package", "test_output", "build", "release")
+    build_folder = client.created_test_build_folder("hello/0.1")
+    exe_folder = os.path.join("test_package", build_folder)
+    client.test_exe_folder = exe_folder
     assert os.path.exists(os.path.join(client.current_folder, exe_folder, "example"))
     client.run_command(os.path.join(exe_folder, "example"))
 
@@ -108,7 +110,7 @@ def test_shared_same_dir_using_tool(test_client_shared):
     If we build an executable in Mac and we want it to locate the shared libraries in the same
     directory, we have different alternatives, here we use the "install_name_tool"
     """
-    exe_folder = os.path.join("test_package", "test_output", "build", "release")
+    exe_folder = test_client_shared.test_exe_folder
     # Alternative 1, add the "." to the rpaths so the @rpath from the exe can be replaced with "."
     test_client_shared.current_folder = os.path.join(test_client_shared.current_folder, exe_folder)
     test_client_shared.run_command("install_name_tool -add_rpath '.' example")
@@ -182,7 +184,7 @@ def test_shared_same_dir_using_cmake(test_client_shared):
     test_client_shared.save({"test_package/CMakeLists.txt": cmake, "test_package/conanfile.py": cf})
     test_client_shared.run("create . -o hello*:shared=True")
     test_client_shared.run("remove '*' -c")
-    exe_folder = os.path.join("test_package", "test_output", "bin")
+    exe_folder = os.path.join(test_client_shared.test_exe_folder, "bin")
     test_client_shared.run_command(os.path.join(exe_folder, "test"))
 
 
@@ -196,7 +198,7 @@ def test_shared_same_dir_using_env_var_current_dir(test_client_shared):
     """
 
     # Alternative 3, FAILING IN CI, set DYLD_LIBRARY_PATH in the current dir
-    exe_folder = os.path.join("test_package", "test_output", "build", "release")
+    exe_folder = test_client_shared.test_exe_folder
     rmdir(os.path.join(test_client_shared.current_folder, exe_folder))
     test_client_shared.run("create . -o hello*:shared=True")
     test_client_shared.run("remove '*' -c")

--- a/conans/test/functional/toolchains/cmake/test_shared_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_shared_cmake.py
@@ -185,7 +185,7 @@ def test_shared_same_dir_using_cmake(test_client_shared):
     test_client_shared.run("create . -o hello*:shared=True")
     build_folder = test_client_shared.created_test_build_folder("hello/0.1")
     test_client_shared.run("remove '*' -c")
-    exe_folder = os.path.join(build_folder, "bin")
+    exe_folder = os.path.join("test_package", build_folder, "bin")
     test_client_shared.run_command(os.path.join(exe_folder, "test"))
 
 

--- a/conans/test/functional/toolchains/cmake/test_shared_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_shared_cmake.py
@@ -183,8 +183,9 @@ def test_shared_same_dir_using_cmake(test_client_shared):
                 """)
     test_client_shared.save({"test_package/CMakeLists.txt": cmake, "test_package/conanfile.py": cf})
     test_client_shared.run("create . -o hello*:shared=True")
+    build_folder = test_client_shared.created_test_build_folder("hello/0.1")
     test_client_shared.run("remove '*' -c")
-    exe_folder = os.path.join(test_client_shared.test_exe_folder, "bin")
+    exe_folder = os.path.join(build_folder, "bin")
     test_client_shared.run_command(os.path.join(exe_folder, "test"))
 
 

--- a/conans/test/functional/toolchains/cmake/test_shared_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_shared_cmake.py
@@ -157,8 +157,7 @@ def test_shared_same_dir_using_cmake(test_client_shared):
 
                     def generate(self):
                         # The exe is installed by cmake at test_package/bin
-                        # FIXME: This is a bit weird folder management
-                        dest = os.path.join(self.build_folder, "bin")
+                        dest = os.path.join(self.recipe_folder, "bin")
                         for dep in self.dependencies.values():
                             copy(self, "*.dylib", dep.cpp_info.libdirs[0], dest)
 
@@ -183,9 +182,8 @@ def test_shared_same_dir_using_cmake(test_client_shared):
                 """)
     test_client_shared.save({"test_package/CMakeLists.txt": cmake, "test_package/conanfile.py": cf})
     test_client_shared.run("create . -o hello*:shared=True")
-    build_folder = test_client_shared.created_test_build_folder("hello/0.1")
     test_client_shared.run("remove '*' -c")
-    exe_folder = os.path.join("test_package", build_folder, "bin")
+    exe_folder = os.path.join("test_package", "bin")
     test_client_shared.run_command(os.path.join(exe_folder, "test"))
 
 

--- a/conans/test/functional/toolchains/cmake/test_shared_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_shared_cmake.py
@@ -158,7 +158,7 @@ def test_shared_same_dir_using_cmake(test_client_shared):
                     def generate(self):
                         # The exe is installed by cmake at test_package/bin
                         # FIXME: This is a bit weird folder management
-                        dest = os.path.join(self.folders.base_build, "bin")
+                        dest = os.path.join(self.build_folder, "bin")
                         for dep in self.dependencies.values():
                             copy(self, "*.dylib", dep.cpp_info.libdirs[0], dest)
 

--- a/conans/test/functional/toolchains/cmake/test_shared_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_shared_cmake.py
@@ -185,7 +185,7 @@ def test_shared_same_dir_using_cmake(test_client_shared):
     test_client_shared.run("create . -o hello*:shared=True")
     build_folder = test_client_shared.created_test_build_folder("hello/0.1")
     test_client_shared.run("remove '*' -c")
-    exe_folder = os.path.join("test_package", build_folder)
+    exe_folder = os.path.join("test_package", build_folder, "bin")
     test_client_shared.run_command(os.path.join(exe_folder, "test"))
 
 

--- a/conans/test/functional/toolchains/cmake/test_shared_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_shared_cmake.py
@@ -176,6 +176,8 @@ def test_shared_same_dir_using_cmake(test_client_shared):
 
                     def test(self):
                         cmd = os.path.join(self.cpp.build.bindirs[0], "test")
+                        self.output.info(f"CMD: {cmd}")
+                        self.output.info(f"CWD: {os.getcwd()}")
                         # This is working without runenv because CMake is puting an internal rpath
                         # to the executable pointing to the dylib of hello, internally is doing something
                         # like: install_name_tool -add_rpath /path/to/hello/lib/libhello.dylib test

--- a/conans/test/functional/toolchains/cmake/test_shared_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_shared_cmake.py
@@ -176,8 +176,6 @@ def test_shared_same_dir_using_cmake(test_client_shared):
 
                     def test(self):
                         cmd = os.path.join(self.cpp.build.bindirs[0], "test")
-                        self.output.info(f"CMD: {cmd}")
-                        self.output.info(f"CWD: {os.getcwd()}")
                         # This is working without runenv because CMake is puting an internal rpath
                         # to the executable pointing to the dylib of hello, internally is doing something
                         # like: install_name_tool -add_rpath /path/to/hello/lib/libhello.dylib test
@@ -185,10 +183,9 @@ def test_shared_same_dir_using_cmake(test_client_shared):
                 """)
     test_client_shared.save({"test_package/CMakeLists.txt": cmake, "test_package/conanfile.py": cf})
     test_client_shared.run("create . -o hello*:shared=True")
-    print(test_client_shared.out)
     build_folder = test_client_shared.created_test_build_folder("hello/0.1")
     test_client_shared.run("remove '*' -c")
-    exe_folder = os.path.join("test_package", build_folder, "bin")
+    exe_folder = os.path.join("test_package", build_folder)
     test_client_shared.run_command(os.path.join(exe_folder, "test"))
 
 

--- a/conans/test/functional/toolchains/cmake/test_shared_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_shared_cmake.py
@@ -185,6 +185,7 @@ def test_shared_same_dir_using_cmake(test_client_shared):
                 """)
     test_client_shared.save({"test_package/CMakeLists.txt": cmake, "test_package/conanfile.py": cf})
     test_client_shared.run("create . -o hello*:shared=True")
+    print(test_client_shared.out)
     build_folder = test_client_shared.created_test_build_folder("hello/0.1")
     test_client_shared.run("remove '*' -c")
     exe_folder = os.path.join("test_package", build_folder, "bin")

--- a/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
+++ b/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
@@ -111,7 +111,7 @@ def test_autotools_relocatable_libs_darwin():
         assert package_folder in client.out
 
     # will work because rpath set
-    client.run_command("test_package/test_output/build-release/main")
+    client.run_command(f"test_package/{build_folder}/main")
     assert "hello/0.1: Hello World Release!" in client.out
 
     # move to another location so that the path set in the rpath does not exist

--- a/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
+++ b/conans/test/functional/toolchains/gnu/test_v2_autotools_template.py
@@ -57,6 +57,7 @@ def test_autotools_lib_template():
     client.save({}, clean_first=True)
     client.run("new autotools_lib -d name=hello -d version=0.1")
     client.run("create . -o hello/*:shared=True")
+    build_folder = client.created_test_build_folder("hello/0.1")
     assert "hello/0.1: Hello World Release!" in client.out
     if platform.system() == "Darwin":
         client.run_command("otool -l test_package/test_output/build-release/main")

--- a/conans/test/integration/command/test_package_test.py
+++ b/conans/test/integration/command/test_package_test.py
@@ -298,4 +298,4 @@ def test_folder_output():
     # c.run("create .")
     c.run("test test_package hello/0.1@")
     assert os.path.exists(os.path.join(c.current_folder,
-                                       "test_package/test_output/hello-config.cmake"))
+                                       "test_package/hello-config.cmake"))

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -964,10 +964,9 @@ def test_test_package_layout():
                  "test_package/conanfile.py": test_conanfile})
     config = "-c tools.cmake.cmake_layout:build_folder_vars='[\"settings.compiler.cppstd\"]'"
     client.run(f"create . {config} -s compiler.cppstd=14")
-    assert os.path.exists(os.path.join(client.current_folder, "test_package/test_output/build/14"))
+    build_folder = client.created_test_build_folder("pkg/0.1")
+    assert os.path.exists(os.path.join(client.current_folder, "test_package", build_folder))
     client.run(f"create . {config} -s compiler.cppstd=17")
-    assert os.path.exists(os.path.join(client.current_folder, "test_package/test_output/build/17"))
-    # FIXME: We need to review this, it is counter-intuitive that you define a layout and it is
-    #  simply erased at every conan create invocation
-    assert not os.path.exists(os.path.join(client.current_folder,
-                                           "test_package/test_output/build/14"))
+    build_folder2 = client.created_test_build_folder("pkg/0.1")
+    assert os.path.exists(os.path.join(client.current_folder, "test_package", build_folder2))
+    assert build_folder != build_folder2

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -719,6 +719,11 @@ class TestClient(object):
             else:
                 raise AssertionError(f"Cant find {r}-{kind} in {reqs}")
 
+    def created_test_build_folder(self, ref):
+        build_folder = re.search(r"{} \(test package\): Test package build: (.*)".format(str(ref)),
+                                 str(self.out)).group(1)
+        return build_folder.replace("\\", "/")
+
     def created_package_id(self, ref):
         package_id = re.search(r"{}: Package '(\S+)' created".format(str(ref)),
                                str(self.out)).group(1)


### PR DESCRIPTION
Changelog: Fix: Fixing issues with test_package output folder.

New proposal to deal with the ``test_package`` issues:

- It is almost impossible to fix it in 1.X, so giving up, will propose another alternatives below
- in 2.0, remove the artificial ``test_output`` folder
- ``test_package`` can remove the ``build_folder`` if it is different than the ``source_folder``, and it will remove it before reusing
- ``test_package`` defines a new, more complete folder name like ``gcc10x86release14static`` to avoid collisions. 

TODOs:
- Add a more complete hash to the test_package build_folder name to completely avoid collisions
- Allow defining more parameters for ``build_folder_vars`` in ``cmake_layout()`` directly