### PR TITLE
[develop2] fixing transitive linux libraries cmake

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -108,6 +108,10 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
             set_property(TARGET {{root_target_name}}
                          PROPERTY INTERFACE_INCLUDE_DIRECTORIES
                          $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_INCLUDE_DIRS{{config_suffix}}}> APPEND)
+            # Necessary to find LINK shared libraries in Linux
+            set_property(TARGET {{root_target_name}}
+                         PROPERTY INTERFACE_LINK_DIRECTORIES
+                         $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_LIB_DIRS{{config_suffix}}}> APPEND)
             set_property(TARGET {{root_target_name}}
                          PROPERTY INTERFACE_COMPILE_DEFINITIONS
                          $<$<CONFIG:{{configuration}}>:${{'{'}}{{pkg_name}}_COMPILE_DEFINITIONS{{config_suffix}}}> APPEND)

--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -188,6 +188,8 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
                              $<$<CONFIG:{{ configuration }}>:{{tvalue(pkg_name, comp_variable_name, 'LINKER_FLAGS', config_suffix)}}> APPEND)
                 set_property(TARGET {{ comp_target_name }} PROPERTY INTERFACE_INCLUDE_DIRECTORIES
                              $<$<CONFIG:{{ configuration }}>:{{tvalue(pkg_name, comp_variable_name, 'INCLUDE_DIRS', config_suffix)}}> APPEND)
+                set_property(TARGET {{comp_target_name }} PROPERTY INTERFACE_LINK_DIRECTORIES
+                             $<$<CONFIG:{{ configuration }}>:{{tvalue(pkg_name, comp_variable_name, 'LIB_DIRS', config_suffix)}}> APPEND)
                 set_property(TARGET {{ comp_target_name }} PROPERTY INTERFACE_COMPILE_DEFINITIONS
                              $<$<CONFIG:{{ configuration }}>:{{tvalue(pkg_name, comp_variable_name, 'COMPILE_DEFINITIONS', config_suffix)}}> APPEND)
                 set_property(TARGET {{ comp_target_name }} PROPERTY INTERFACE_COMPILE_OPTIONS

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -320,7 +320,8 @@ class _TargetDataContext(object):
         if require and not require.headers:
             self.include_paths = ""
         if require and not require.libs:
-            self.lib_paths = ""
+            # self.lib_paths = ""  IMPORTANT! LINKERS IN LINUX FOR SHARED MIGHT NEED IT EVEN IF
+            #                      NOT REALLY LINKING LIB
             self.libs = ""
             self.system_libs = ""
             self.frameworks = ""


### PR DESCRIPTION
Changelog: Fix: Fixing transitive shared linux libraries in CMakeDeps.

Close https://github.com/conan-io/conan/issues/13000

There were an issue where building against transitive shared dependencies in Linux (several transitive levels), was failing when this happens in different machines (need to upload & install in a different machine to reproduce), because the linker wants information about the libs, even if not strictly necessary to the final consumer application.

The approach that seems to work is:

- Add INTERFACE_LINK_DIRECTORIES to each target creation
- Make sure that the traits in CMakeDeps do not invalidate ``self.lib_paths``, only ``libs`` to still avoiding direct linking.

This might need to extend to components too.