### PR TITLE
[develop2] add pkg name in new cache path hashes

### DIFF
--- a/conan/internal/cache/db/cache_database.py
+++ b/conan/internal/cache/db/cache_database.py
@@ -1,5 +1,3 @@
-import sqlite3
-
 from conan.internal.cache.db.packages_table import PackagesDBTable
 from conan.internal.cache.db.recipes_table import RecipesDBTable
 from conans.model.package_ref import PkgReference

--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -52,9 +52,6 @@ class ClientCache(object):
         # The cache is first thing instantiated, we can remove this from env now
         self._localdb_encryption_key = os.environ.pop('CONAN_LOGIN_ENCRYPTION_KEY', None)
 
-    def closedb(self):
-        self._data_cache.closedb()
-
     def create_export_recipe_layout(self, ref: RecipeReference):
         return self._data_cache.create_export_recipe_layout(ref)
 

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -488,10 +488,6 @@ class TestClient(object):
             trace = traceback.format_exc()
             error = command.exception_exit_error(e)
         finally:
-            try:
-                self.api.app.cache.closedb()
-            except AttributeError:
-                pass
             sys.path = old_path
             os.chdir(current_dir)
             # Reset sys.modules to its prev state. A .copy() DOES NOT WORK


### PR DESCRIPTION
Changelog: Feature: Add package names in Conan cache hash paths.

Today I have missed hints in paths while debugging...

I am trying this approach:
- Reducing the hash length in 3 characters 16=>13
- Adding first 5 characters of package name => total unique identifier = 13+5 = 18
- Given that package names are also distinct, the entropy should be equal, or even better
- The 2 extra characters in length, can be removed from the identifier "tmp" used for temporal builds "tmp"->"t". Given that packages store is just "p", I don't think this will worsen debuggability. So the total path length remains the same.

(also removing some closedb code, apparently dead)

Close https://github.com/conan-io/conan/issues/12952