### PR TITLE
[develop2] transitivity fixes in PkgConfigDeps for components

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -186,7 +186,6 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
         sorted_comps = self.conanfile.cpp_info.get_sorted_components()
         pfolder_var_name = "{}_PACKAGE_FOLDER{}".format(self.pkg_name, self.config_suffix)
         transitive_requires = get_transitive_requires(self.cmakedeps._conanfile, self.conanfile)
-        pkg_deps = self.conanfile.dependencies.filter({"direct": True})
         for comp_name, comp in sorted_comps.items():
             deps_cpp_cmake = _TargetDataContext(comp, pfolder_var_name, self._root_folder,
                                                 self.require, self.cmake_package_type,

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -7,6 +7,7 @@ from jinja2 import Template, StrictUndefined
 from conan.internal import check_duplicated_generator
 from conan.tools.gnu.gnudeps_flags import GnuDepsFlags
 from conans.errors import ConanException
+from conans.model.dependencies import get_transitive_requires
 from conans.util.files import save
 
 
@@ -212,6 +213,7 @@ class _PCGenerator:
         self._build_context_suffix = build_context_suffix or {}
         self._dep = dep
         self._content_generator = _PCContentGenerator(self._conanfile, self._dep)
+        self._transitive_reqs = get_transitive_requires(self._conanfile, dep)
 
     def _get_cpp_info_requires_names(self, cpp_info):
         """
@@ -226,13 +228,8 @@ class _PCGenerator:
 
             def package_info(self):
                 self.cpp_info.requires = ["other::cmp1"]
-        ```
-        Or:
 
-        ```python
-        from conan import ConanFile
-        class PkgConfigConan(ConanFile):
-            requires = "other/1.0"
+            # Or:
 
             def package_info(self):
                 self.cpp_info.components["cmp"].requires = ["other::cmp1"]
@@ -244,7 +241,10 @@ class _PCGenerator:
             pkg_ref_name, comp_ref_name = req.split("::") if "::" in req else (dep_ref_name, req)
             # For instance, dep == "hello/1.0" and req == "other::cmp1" -> hello != other
             if dep_ref_name != pkg_ref_name:
-                req_conanfile = self._dep.dependencies.host[pkg_ref_name]
+                try:
+                    req_conanfile = self._transitive_reqs[pkg_ref_name]
+                except KeyError:
+                    continue  # If the dependency is not in the transitive, might be skipped
             else:  # For instance, dep == "hello/1.0" and req == "hello::cmp1" -> hello == hello
                 req_conanfile = self._dep
             comp_name = _get_component_name(req_conanfile, comp_ref_name, self._build_context_suffix)
@@ -296,7 +296,7 @@ class _PCGenerator:
             # If no requires were found, let's try to get all the direct dependencies,
             # e.g., requires = "other_pkg/1.0"
             requires = [_get_package_name(req, self._build_context_suffix)
-                        for req in self._dep.dependencies.direct_host.values()]
+                        for req in self._transitive_reqs.values()]
         description = "Conan package: %s" % pkg_name
         aliases = _get_package_aliases(self._dep)
         cpp_info = self._dep.cpp_info


### PR DESCRIPTION
Changelog: Fix: PkgConfiDeps is using the wrong ``dependencies.host`` from dependencies instead of ``get_transitive_requires()`` computation.


