### PR TITLE
Expose conanfile.output to ConanFileInterface

### DIFF
--- a/conans/model/conanfile_interface.py
+++ b/conans/model/conanfile_interface.py
@@ -118,3 +118,7 @@ class ConanFileInterface:
     @property
     def url(self):
         return self._conanfile.url
+
+    @property
+    def output(self):
+        return self._conanfile.output


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

For https://github.com/conan-io/examples2/pull/61, the `copy` method in `tools.files` expects a ConanFile as its first argument, but there's not much stopping us form also using a `ConanFileInterface`, so that for example copy can be called on files from `self.depenencies`. The only issue was a missing exposed property, so this adds that to the interface.

This might not be a good solution as it expands the public surface of this file, and there's a possible workaround in passing None as the argument which suppresses all output, so I'm happy to close if desired :)