### PR TITLE
Add CONAN_DISABLE_STRICT_MODE to be able to build old packages (#13037)

### DIFF
--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -47,8 +47,12 @@ class CMake(object):
         :param generator_platform: Generator platform name or none to autodetect (-A cmake option)
         """
         if getattr(conanfile, "must_use_new_helpers", None):
-            raise ConanException("Using the wrong 'CMake' helper. To use CMakeDeps, CMakeToolchain "
-                                 "you should use 'from conan.tools.cmake import CMake'")
+            wrong_helper_msg = "Using the wrong 'CMake' helper. To use CMakeDeps, CMakeToolchain "\
+                               "you should use 'from conan.tools.cmake import CMake'"
+            if get_env("CONAN_DISABLE_STRICT_MODE", False):
+                conanfile.output.warning(wrong_helper_msg)
+            else:
+                raise ConanException(wrong_helper_msg)
         self._append_vcvars = append_vcvars
         self._conanfile = conanfile
         self._settings = conanfile.settings

--- a/conans/client/build/cmake.py
+++ b/conans/client/build/cmake.py
@@ -48,7 +48,9 @@ class CMake(object):
         """
         if getattr(conanfile, "must_use_new_helpers", None):
             wrong_helper_msg = "Using the wrong 'CMake' helper. To use CMakeDeps, CMakeToolchain "\
-                               "you should use 'from conan.tools.cmake import CMake'"
+                               "you should use 'from conan.tools.cmake import CMake'. "\
+                               "Set environment variable CONAN_DISABLE_STRICT_MODE=1 to override "\
+                               "this check (should only be used to build old packages)."
             if get_env("CONAN_DISABLE_STRICT_MODE", False):
                 conanfile.output.warning(wrong_helper_msg)
             else:

--- a/conans/client/build/msbuild.py
+++ b/conans/client/build/msbuild.py
@@ -24,7 +24,9 @@ class MSBuild(object):
         if isinstance(conanfile, ConanFile):
             if getattr(conanfile, "must_use_new_helpers", None):
                 wrong_helper_msg = "Using the wrong 'MSBuild' helper. To use MSBuildDeps, MSBuildToolchain "\
-                                   "you should use 'from conan.tools.microsoft import MSBuild'"
+                                   "you should use 'from conan.tools.microsoft import MSBuild'. "\
+                                   "Set environment variable CONAN_DISABLE_STRICT_MODE=1 to override "\
+                                   "this check (should only be used to build old packages)."
                 if get_env("CONAN_DISABLE_STRICT_MODE", False):
                     conanfile.output.warning(wrong_helper_msg)
                 else:

--- a/conans/client/build/msbuild.py
+++ b/conans/client/build/msbuild.py
@@ -23,9 +23,12 @@ class MSBuild(object):
     def __init__(self, conanfile):
         if isinstance(conanfile, ConanFile):
             if getattr(conanfile, "must_use_new_helpers", None):
-                raise ConanException(
-                    "Using the wrong 'MSBuild' helper. To use MSBuildDeps, MSBuildToolchain "
-                    "you should use 'from conan.tools.microsoft import MSBuild'")
+                wrong_helper_msg = "Using the wrong 'MSBuild' helper. To use MSBuildDeps, MSBuildToolchain "\
+                                   "you should use 'from conan.tools.microsoft import MSBuild'"
+                if get_env("CONAN_DISABLE_STRICT_MODE", False):
+                    conanfile.output.warning(wrong_helper_msg)
+                else:
+                    raise ConanException(wrong_helper_msg)
             self._conanfile = conanfile
             self._settings = self._conanfile.settings
             self._output = self._conanfile.output


### PR DESCRIPTION
Changelog: Feature: Add a `CONAN_DISABLE_STRICT_MODE`  environment variable as a workaround to be able to build old packages which used CMakeDeps or MSBuildDeps without switching to the new CMakeToolchain or MSBuildToolchain generator as well. 
Docs: https://github.com/conan-io/docs/pull/2950

Closes: https://github.com/conan-io/conan/issues/13037


- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
