### PR TITLE
Add the ability of changing cmake path

### DIFF
--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -60,7 +60,7 @@ class CMake(object):
         self._toolchain_file = configure_preset.get("toolchainFile")
         self._cache_variables = configure_preset["cacheVariables"]
 
-        self._cmake_program = "cmake"  # Path to CMake should be handled by environment
+        self._cmake_program = conanfile.conf.get("tools.cmake:path", check_type=str, default="cmake")
 
     def configure(self, variables=None, build_script_folder=None, cli_args=None):
         cmakelist_folder = self._conanfile.source_folder

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -15,6 +15,7 @@ BUILT_IN_CONFS = {
     "tools.build:skip_test": "Do not execute CMake.test() and Meson.test() when enabled",
     "tools.build:jobs": "Default compile jobs number -jX Ninja, Make, /MP VS (default: max CPUs)",
     "tools.build:sysroot": "Pass the --sysroot=<tools.build:sysroot> flag if available. (None by default)",
+    "tools.cmake:path": "Path to the CMake executable. Default: 'cmake'",
     "tools.cmake.cmaketoolchain:generator": "User defined CMake generator to use instead of default",
     "tools.cmake.cmaketoolchain:find_package_prefer_config": "Argument for the CMAKE_FIND_PACKAGE_PREFER_CONFIG",
     "tools.cmake.cmaketoolchain:toolchain_file": "Use other existing file rather than conan_toolchain.cmake one",

--- a/conans/test/unittests/tools/cmake/test_cmake_path.py
+++ b/conans/test/unittests/tools/cmake/test_cmake_path.py
@@ -1,0 +1,44 @@
+import pytest
+
+from conan.tools.cmake import CMake
+from conan.tools.cmake.presets import write_cmake_presets
+from conans.client.conf import get_default_settings_yml
+from conans.model.conf import Conf
+from conans.model.settings import Settings
+from conans.test.utils.mocks import ConanFileMock
+from conans.test.utils.test_files import temp_folder
+
+
+@pytest.mark.parametrize("cmake_path", [None, "cmake", "/opt/cmake-3.21/bin/cmake"])
+def test_cmake_binary_path(cmake_path):
+    """
+    Testing that the proper CMake binary path is configured
+    """
+    settings = Settings.loads(get_default_settings_yml())
+    settings.os = "Windows"
+    settings.arch = "x86"
+    settings.build_type = "Release"
+    settings.compiler = "Visual Studio"
+    settings.compiler.runtime = "MDd"
+    settings.compiler.version = "14"
+
+    conanfile = ConanFileMock()
+    conf = Conf()
+    if cmake_path:
+        conf.define("tools.cmake:path", cmake_path)
+    conanfile.conf = conf
+    conanfile.folders.generators = "."
+    conanfile.folders.set_base_generators(temp_folder())
+    conanfile.settings = settings
+    conanfile.folders.set_base_package(temp_folder())
+
+    # Choose generator to match generic setttings
+    write_cmake_presets(conanfile, "toolchain", "Visual Studio 14 2015", {})
+    cmake = CMake(conanfile)
+    cmake.configure()
+
+    # When there is no configuration for CMake bin path, "cmake" is expected by default
+    if not cmake_path:
+        cmake_path = "cmake"
+
+    assert conanfile.command.startswith(f"{cmake_path} -G")


### PR DESCRIPTION
Changelog: Feature: Default CMake binary path can be configured by tools.cmake:path config
Docs: https://github.com/conan-io/docs/pull/2949

As checking CMake version is becoming more popular on CCI, we could provide the option of choosing which CMake should be used by the user, which means, once configured, people could skip installing CMake as tool requirement:

Plus, CMake 3.15 is expected by Conan 2.0, but some projects are using newer versions, so they really need an update version of CMake.

```python
def build_requirements(self):
    if not self.config.get('tools.cmake:path', check_type=str):
        tool_requires('cmake/3.21.5')
```

Also, in case user has more than one CMake installed (cross-building case), it will be much to choose which version should be used. 


- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
