### PR TITLE
[develop2] clean legacy compatible_packages

### DIFF
--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -223,7 +223,6 @@ class ConanFile:
         self.display_name = display_name
         # something that can run commands, as os.sytem
 
-        self.compatible_packages = []
         self._conan_helpers = None
         from conan.tools.env import Environment
         self.buildenv_info = Environment()

--- a/conans/test/integration/configuration/conf/test_conf_package_id.py
+++ b/conans/test/integration/configuration/conf/test_conf_package_id.py
@@ -13,7 +13,7 @@ def client():
 
         class Pkg(ConanFile):
             def package_id(self):
-                self.info.conf = self.conf
+                self.info.conf.define("user.myconf:myitem", self.conf.get("user.myconf:myitem"))
         """)
     client.save({"conanfile.py": conanfile})
     return client
@@ -22,13 +22,13 @@ def client():
 def test_package_id(client):
     profile1 = textwrap.dedent("""\
         [conf]
-        tools.microsoft.msbuild:verbosity=Quiet""")
+        user.myconf:myitem=1""")
     profile2 = textwrap.dedent("""\
         [conf]
-        tools.microsoft.msbuild:verbosity=Minimal""")
+        user.myconf:myitem=2""")
     client.save({"profile1": profile1,
                  "profile2": profile2})
     client.run("create . --name=pkg --version=0.1 -pr=profile1")
-    client.assert_listed_binary({"pkg/0.1": ("bf9f277ff9c5ce88c27d42e2de02d8ee3433ddd9", "Build")})
+    client.assert_listed_binary({"pkg/0.1": ("7501c16e6c5c93e534dd760829859340e2dc73bc", "Build")})
     client.run("create . --name=pkg --version=0.1 -pr=profile2")
-    client.assert_listed_binary({"pkg/0.1": ("aafb08585a95c8a51b765f758507cbee1e680867", "Build")})
+    client.assert_listed_binary({"pkg/0.1": ("4eb2bd276f75d2df8fa0f4b58bd86014b7f51693", "Build")})

--- a/conans/test/integration/package_id/compatible_test.py
+++ b/conans/test/integration/package_id/compatible_test.py
@@ -82,53 +82,6 @@ class CompatibleIDsTest(unittest.TestCase):
         client.assert_listed_binary({"pkg/0.1@user/stable":
                                      ("1ded27c9546219fbd04d4440e05b2298f8230047", "Build")})
 
-    def test_compatible_setting_debug_release(self):
-        # From issue https://github.com/conan-io/conan/issues/9398
-        client = TestClient(default_server_user=True)
-        conanfile = textwrap.dedent("""\
-            from conan import ConanFile
-            class Pkg(ConanFile):
-                name = "pkga"
-                version = "0.1"
-                settings = "build_type"
-
-                def package_id(self):
-                    compatible_pkg = self.info.clone()
-                    compatible_pkg.settings.build_type = "Release"
-                    self.compatible_packages.append(compatible_pkg)
-            """)
-        client.save({"conanfile.py": conanfile})
-        # Create the recipe and upload it into the remote
-        client.run("create . -s build_type=Release")
-        client.run("upload pkg* -r=default --confirm")
-        client.run("remove * -c")
-
-        # Install locally the uploaded package
-        client.run("install --requires=pkga/0.1")
-
-        # Create a middle package and export it
-        conanfile = textwrap.dedent("""\
-            from conan import ConanFile
-
-            class PkgB(ConanFile):
-                name = "pkgb"
-                version = "0.1"
-                build_requires = "pkga/0.1"
-               """)
-        client.save({"conanfile.py": conanfile}, clean_first=True)
-        client.run("export .")
-
-        # Create a final package and install it changing the "build_type"
-        conanfile = textwrap.dedent("""\
-            from conan import ConanFile
-
-            class PkgC(ConanFile):
-               requires = "pkgb/0.1"
-               build_requires = "pkga/0.1"
-               """)
-        client.save({"conanfile.py": conanfile}, clean_first=True)
-        client.run("install . -s build_type=Debug --build=missing")
-
     def test_compatible_setting_no_user_channel(self):
         client = TestClient()
         conanfile = textwrap.dedent("""


### PR DESCRIPTION
Changelog: omit 

Superseded in 1.X by the ``compatibility()`` method
