### PR TITLE
remove option.fPIC for shared in conan new templates

### DIFF
--- a/conan/internal/api/new/autotools_lib.py
+++ b/conan/internal/api/new/autotools_lib.py
@@ -30,7 +30,11 @@ class {{package_name}}Conan(ConanFile):
 
     def config_options(self):
         if self.settings.os == "Windows":
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
 
     def layout(self):
         basic_layout(self)

--- a/conan/internal/api/new/bazel_lib.py
+++ b/conan/internal/api/new/bazel_lib.py
@@ -21,7 +21,11 @@ class {{package_name}}Recipe(ConanFile):
 
     def config_options(self):
         if self.settings.os == "Windows":
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
 
     def layout(self):
         bazel_layout(self)

--- a/conan/internal/api/new/cmake_lib.py
+++ b/conan/internal/api/new/cmake_lib.py
@@ -23,7 +23,11 @@ class {{package_name}}Recipe(ConanFile):
 
     def config_options(self):
         if self.settings.os == "Windows":
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
 
     def layout(self):
         cmake_layout(self)

--- a/conan/internal/api/new/meson_lib.py
+++ b/conan/internal/api/new/meson_lib.py
@@ -20,7 +20,11 @@ class {{package_name}}Conan(ConanFile):
 
     def config_options(self):
         if self.settings.os == "Windows":
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
 
     def layout(self):
         basic_layout(self)

--- a/conans/test/assets/pkg_cmake.py
+++ b/conans/test/assets/pkg_cmake.py
@@ -28,7 +28,11 @@ def pkg_cmake(name, version, requires=None, exe=False):
 
             def config_options(self):
                 if self.settings.os == "Windows":
-                    del self.options.fPIC
+                    self.options.rm_safe("fPIC")
+
+            def configure(self):
+                if self.options.shared:
+                    self.options.rm_safe("fPIC")
 
             def layout(self):
                 cmake_layout(self)

--- a/conans/test/functional/toolchains/gnu/autotools/test_apple_toolchain.py
+++ b/conans/test/functional/toolchains/gnu/autotools/test_apple_toolchain.py
@@ -23,7 +23,11 @@ conanfile_py = textwrap.dedent("""
 
         def config_options(self):
             if self.settings.os == "Windows":
-                del self.options.fPIC
+                self.options.rm_safe("fPIC")
+
+        def configure(self):
+            if self.options.shared:
+                self.options.rm_safe("fPIC")
 
         def build(self):
             env_build = Autotools(self)

--- a/conans/test/functional/toolchains/gnu/autotools/test_basic.py
+++ b/conans/test/functional/toolchains/gnu/autotools/test_basic.py
@@ -327,10 +327,6 @@ def test_autotools_arguments_override():
                 if self.settings.os == "Windows":
                     self.options.rm_safe("fPIC")
 
-            def configure(self):
-                if self.options.shared:
-                    self.options.rm_safe("fPIC")
-
             def layout(self):
                 basic_layout(self)
 

--- a/conans/test/functional/toolchains/gnu/autotools/test_basic.py
+++ b/conans/test/functional/toolchains/gnu/autotools/test_basic.py
@@ -325,7 +325,11 @@ def test_autotools_arguments_override():
 
             def config_options(self):
                 if self.settings.os == "Windows":
-                    del self.options.fPIC
+                    self.options.rm_safe("fPIC")
+
+            def configure(self):
+                if self.options.shared:
+                    self.options.rm_safe("fPIC")
 
             def layout(self):
                 basic_layout(self)

--- a/conans/test/functional/toolchains/meson/test_backend.py
+++ b/conans/test/functional/toolchains/meson/test_backend.py
@@ -25,7 +25,11 @@ def test_cross_x86():
 
             def config_options(self):
                 if self.settings.os == "Windows":
-                    del self.options.fPIC
+                    self.options.rm_safe("fPIC")
+
+            def configure(self):
+                if self.options.shared:
+                    self.options.rm_safe("fPIC")
 
             def layout(self):
                 self.folders.build = "build"

--- a/conans/test/functional/toolchains/meson/test_cross_compilation.py
+++ b/conans/test/functional/toolchains/meson/test_cross_compilation.py
@@ -24,7 +24,11 @@ class App(ConanFile):
 
     def config_options(self):
         if self.settings.os == "Windows":
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
 
     def generate(self):
         tc = MesonToolchain(self)

--- a/conans/test/functional/toolchains/meson/test_install.py
+++ b/conans/test/functional/toolchains/meson/test_install.py
@@ -23,7 +23,11 @@ class MesonInstall(TestMesonBase):
 
             def config_options(self):
                 if self.settings.os == "Windows":
-                    del self.options.fPIC
+                    self.options.rm_safe("fPIC")
+
+            def configure(self):
+                if self.options.shared:
+                    self.options.rm_safe("fPIC")
 
             def layout(self):
                 self.folders.build = "build"

--- a/conans/test/functional/toolchains/meson/test_meson.py
+++ b/conans/test/functional/toolchains/meson/test_meson.py
@@ -25,7 +25,11 @@ class MesonToolchainTest(TestMesonBase):
 
         def config_options(self):
             if self.settings.os == "Windows":
-                del self.options.fPIC
+                self.options.rm_safe("fPIC")
+
+        def configure(self):
+            if self.options.shared:
+                self.options.rm_safe("fPIC")
 
         def layout(self):
             self.folders.generators = 'build/gen_folder'

--- a/conans/test/functional/toolchains/meson/test_meson_and_objc.py
+++ b/conans/test/functional/toolchains/meson/test_meson_and_objc.py
@@ -23,7 +23,11 @@ class App(ConanFile):
 
     def config_options(self):
         if self.settings.os == "Windows":
-            del self.options.fPIC
+            self.options.rm_safe("fPIC")
+
+    def configure(self):
+        if self.options.shared:
+            self.options.rm_safe("fPIC")
 
     def generate(self):
         tc = MesonToolchain(self)


### PR DESCRIPTION
Changelog: Feature: Remove option.fPIC for shared in `conan new` templates.

This is already common practice in ConanCenter, in practically all recipes:

- Update our templates to reflect it
- Update some tests with same pattern to further test it

