### PR TITLE
[develop2] fix package_type=header-library deduction

### DIFF
--- a/conans/model/pkg_type.py
+++ b/conans/model/pkg_type.py
@@ -27,6 +27,14 @@ class PackageType(Enum):
 
         def deduce_from_options():
             try:
+                header = conanfile.options.header_only
+            except ConanException:
+                pass
+            else:
+                if header:
+                    return PackageType.HEADER
+
+            try:
                 shared = conanfile.options.shared
             except ConanException:
                 pass
@@ -34,13 +42,6 @@ class PackageType(Enum):
                 if shared:
                     return PackageType.SHARED
                 else:
-                    try:
-                        header = conanfile.options.header_only
-                    except ConanException:
-                        pass
-                    else:
-                        if header:
-                            return PackageType.HEADER
                     return PackageType.STATIC
             return PackageType.UNKNOWN
 

--- a/conans/test/integration/graph/core/test_auto_package_type.py
+++ b/conans/test/integration/graph/core/test_auto_package_type.py
@@ -1,0 +1,45 @@
+import pytest
+
+from conans.test.utils.tools import TestClient
+
+simple = """
+from conan import ConanFile
+class Pkg(ConanFile):
+    options = {"shared": [True, False],
+               "header_only": [True, False]}
+"""
+
+pkg_type = """
+from conan import ConanFile
+class Pkg(ConanFile):
+    package_type = "library"
+    options = {"shared": [True, False],
+               "header_only": [True, False]}
+"""
+
+remove = """
+from conan import ConanFile
+class Pkg(ConanFile):
+    package_type = "library"
+    options = {"shared": [True, False],
+               "header_only": [True, False]}
+    def configure(self):
+        if self.options.header_only:
+            self.options.rm_safe("shared")
+"""
+
+
+@pytest.mark.parametrize("conanfile", [simple, pkg_type, remove])
+def test_auto_package_type(conanfile):
+    c = TestClient()
+    c.save({"conanfile.py": conanfile})
+    c.run("graph info . --filter package_type")
+    assert "package_type: static-library" in c.out
+    c.run("graph info . --filter package_type -o shared=True")
+    assert "package_type: shared-library" in c.out
+    c.run("graph info . --filter package_type -o shared=True -o header_only=False")
+    assert "package_type: shared-library" in c.out
+    c.run("graph info . --filter package_type -o header_only=True")
+    assert "package_type: header-library" in c.out
+    c.run("graph info . --filter package_type -o header_only=True -o shared=False")
+    assert "package_type: header-library" in c.out


### PR DESCRIPTION
Changelog: omit 

It was broken when recipes removed the ``shared`` option in ``configure()`` for 2.0