### PR TITLE
Git.fetch_commit

### DIFF
--- a/conan/tools/scm/git.py
+++ b/conan/tools/scm/git.py
@@ -84,6 +84,19 @@ class Git(object):
         self._conanfile.output.info("Cloning git repo")
         self.run('clone "{}" {} {}'.format(url, " ".join(args), target))
 
+    def fetch_commit(self, url, commit):
+        """
+        Experimental: does a 1 commit fetch and checkout, instead of a full clone,
+        should be faster.
+        """
+        if os.path.exists(url):
+            url = url.replace("\\", "/")  # Windows local directory
+        self._conanfile.output.info("Shallow fetch of git repo")
+        self.run('init')
+        self.run(f'remote add origin "{url}"')
+        self.run(f'fetch --depth 1 origin {commit}')
+        self.run(f'checkout FETCH_HEAD')
+
     def checkout(self, commit):
         self._conanfile.output.info("Checkout: {}".format(commit))
         self.run('checkout {}'.format(commit))

--- a/conans/test/functional/tools/scm/test_git.py
+++ b/conans/test/functional/tools/scm/test_git.py
@@ -209,6 +209,51 @@ class TestGitBasicClone:
         assert c.load("source/CMakeLists.txt") == "mycmake"
 
 
+class TestGitShallowClone:
+    """ base Git cloning operations
+    """
+    conanfile = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+        from conan.tools.scm import Git
+        from conan.tools.files import load
+
+        class Pkg(ConanFile):
+            name = "pkg"
+            version = "0.1"
+
+            def layout(self):
+                self.folders.source = "source"
+
+            def source(self):
+                git = Git(self)
+                git.fetch_commit(url="{url}", commit="{commit}")
+                self.output.info("MYCMAKE: {{}}".format(load(self, "CMakeLists.txt")))
+                self.output.info("MYFILE: {{}}".format(load(self, "src/myfile.h")))
+        """)
+
+    def test_clone_checkout(self):
+        folder = os.path.join(temp_folder(), "myrepo")
+        url, commit = create_local_git_repo(files={"src/myfile.h": "myheader!",
+                                                   "CMakeLists.txt": "mycmake"}, folder=folder)
+        # This second commit will NOT be used, as I will use the above commit in the conanfile
+        save_files(path=folder, files={"src/myfile.h": "my2header2!"})
+        git_add_changes_commit(folder=folder)
+
+        c = TestClient()
+        c.save({"conanfile.py": self.conanfile.format(url=url, commit=commit)})
+        c.run("create .")
+        assert "pkg/0.1: MYCMAKE: mycmake" in c.out
+        assert "pkg/0.1: MYFILE: myheader!" in c.out
+
+        # It also works in local flow
+        c.run("source .")
+        assert "conanfile.py (pkg/0.1): MYCMAKE: mycmake" in c.out
+        assert "conanfile.py (pkg/0.1): MYFILE: myheader!" in c.out
+        assert c.load("source/src/myfile.h") == "myheader!"
+        assert c.load("source/CMakeLists.txt") == "mycmake"
+
+
 class TestGitCloneWithArgs:
     """ Git cloning passing additional arguments
     """

--- a/conans/test/functional/tools/scm/test_git.py
+++ b/conans/test/functional/tools/scm/test_git.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import re
 import textwrap
 
@@ -232,6 +233,7 @@ class TestGitShallowClone:
                 self.output.info("MYFILE: {{}}".format(load(self, "src/myfile.h")))
         """)
 
+    @pytest.mark.skipif(platform.system() != "Linux", reason="Git version in Linux not support it")
     def test_clone_checkout(self):
         folder = os.path.join(temp_folder(), "myrepo")
         url, commit = create_local_git_repo(files={"src/myfile.h": "myheader!",

--- a/conans/test/functional/tools/scm/test_git.py
+++ b/conans/test/functional/tools/scm/test_git.py
@@ -233,7 +233,7 @@ class TestGitShallowClone:
                 self.output.info("MYFILE: {{}}".format(load(self, "src/myfile.h")))
         """)
 
-    @pytest.mark.skipif(platform.system() != "Linux", reason="Git version in Linux not support it")
+    @pytest.mark.skipif(platform.system() == "Linux", reason="Git version in Linux not support it")
     def test_clone_checkout(self):
         folder = os.path.join(temp_folder(), "myrepo")
         url, commit = create_local_git_repo(files={"src/myfile.h": "myheader!",


### PR DESCRIPTION
Changelog: Feature: Add new ``Git.fetch_commit`` method, for a faster alternative than clone.
Docs: https://github.com/conan-io/docs/pull/2974

Close https://github.com/conan-io/conan/issues/13081