### PR TITLE
refactor: Replace deprecated imp.load_source with importlib

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -1,5 +1,6 @@
 import fnmatch
-import imp
+from importlib.machinery import SourceFileLoader
+from importlib.util import spec_from_loader, module_from_spec
 import inspect
 import os
 import re
@@ -439,8 +440,10 @@ def _parse_conanfile(conan_file_path):
             old_dont_write_bytecode = sys.dont_write_bytecode
             try:
                 sys.dont_write_bytecode = True
-                # FIXME: imp is deprecated in favour of implib
-                loaded = imp.load_source(module_id, conan_file_path)
+                loader = SourceFileLoader(module_id, conan_file_path)
+                spec = spec_from_loader(loader.name, loader)
+                loaded = module_from_spec(spec)
+                loader.exec_module(loaded)
                 sys.dont_write_bytecode = old_dont_write_bytecode
             except ImportError:
                 version_txt = _get_required_conan_version_without_loading(conan_file_path)


### PR DESCRIPTION
When you running the model unit tests, I see the following deprecation warning:

```
conans/client/loader.py:2
  /Users/gyula.gubacsi/Contrib/conan/conans/client/loader.py:2: DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses
    import imp
```

In Python 3.12 the imp module will be officially removed as it was deprecated since 3.3. The test run already exposes a warning about this and this can break as soon as we switch to Python 3.12 which is already in alpha phase.

The code is more complex because the imp.load_source function is now decomposed in a more flexible, powerful import customisation system but that comes with a more verbose usage too.

The key here is to set up a loader that brings in the arbitrary file as a python module code and then we need to create the module from the spec of the loaded code. After that's done, we also have to execute the module in order to have all the contents of the module available.

Running the unit tests after the patch I no longer see the DeprecationWarning and the unit tests pass all the same.

Fixes #13106

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
