### PR TITLE
[develop2] improve build_folder_vars, only affecting in user space

### DIFF
--- a/conan/tools/cmake/layout.py
+++ b/conan/tools/cmake/layout.py
@@ -1,5 +1,6 @@
 import os
 
+from conans.client.graph.graph import RECIPE_CONSUMER
 from conans.errors import ConanException
 
 
@@ -50,13 +51,22 @@ def cmake_layout(conanfile, generator=None, src_folder=".", build_folder="build"
 
 
 def get_build_folder_custom_vars(conanfile):
-
+    conanfile_vars = conanfile.folders.build_folder_vars
+    build_vars = conanfile.conf.get("tools.cmake.cmake_layout:build_folder_vars", check_type=list)
     if conanfile.tested_reference_str:
-        build_vars = ["settings.compiler", "settings.compiler.version", "settings.arch",
+        build_vars = build_vars or conanfile_vars or \
+                     ["settings.compiler", "settings.compiler.version", "settings.arch",
                       "settings.compiler.cppstd", "settings.build_type", "options.shared"]
     else:
-        build_vars = conanfile.conf.get("tools.cmake.cmake_layout:build_folder_vars",
-                                        default=[], check_type=list)
+        try:
+            is_consumer = conanfile._conan_node.recipe == RECIPE_CONSUMER
+        except AttributeError:
+            is_consumer = False
+        if is_consumer:
+            build_vars = build_vars or conanfile_vars or []
+        else:
+            build_vars = conanfile_vars or []
+
     ret = []
     for s in build_vars:
         group, var = s.split(".", 1)
@@ -66,7 +76,10 @@ def get_build_folder_custom_vars(conanfile):
         elif group == "options":
             value = conanfile.options.get_safe(var)
             if value is not None:
-                tmp = "{}_{}".format(var, value)
+                if var == "shared":
+                    tmp = "shared" if value else "static"
+                else:
+                    tmp = "{}_{}".format(var, value)
         else:
             raise ConanException("Invalid 'tools.cmake.cmake_layout:build_folder_vars' value, it has"
                                  " to start with 'settings.' or 'options.': {}".format(s))

--- a/conans/model/layout.py
+++ b/conans/model/layout.py
@@ -54,6 +54,7 @@ class Folders(object):
         # conanfile.py, that makes most of the output folders defined in layouts (cmake_layout, etc)
         # start from the subproject again
         self.subproject = None
+        self.build_folder_vars = None
 
     def __repr__(self):
         return str(self.__dict__)

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -744,14 +744,14 @@ def test_cmake_presets_options_single_config():
 
     for shared in (True, False):
         client.run("install . {} -o shared={}".format(conf_layout, shared))
-        shared_str = "shared_true" if shared else "shared_false"
+        shared_str = "shared" if shared else "static"
         assert os.path.exists(os.path.join(client.current_folder,
                                            "build", "{}-release-{}".format(default_compiler, shared_str),
                                            "generators"))
 
     client.run("install . {}".format(conf_layout))
     assert os.path.exists(os.path.join(client.current_folder,
-                                       "build", "{}-release-shared_false".format(default_compiler),
+                                       "build", "{}-release-static".format(default_compiler),
                                        "generators"))
 
     user_presets_path = os.path.join(client.current_folder, "CMakeUserPresets.json")
@@ -760,7 +760,7 @@ def test_cmake_presets_options_single_config():
     # We can build with cmake manually
     if platform.system() == "Darwin":
         for shared in (True, False):
-            shared_str = "shared_true" if shared else "shared_false"
+            shared_str = "shared" if shared else "static"
             client.run_command("cmake . --preset conan-apple-clang-release-{}".format(shared_str))
             client.run_command("cmake --build --preset conan-apple-clang-release-{}".format(shared_str))
             client.run_command("ctest --preset conan-apple-clang-release-{}".format(shared_str))


### PR DESCRIPTION
Changelog: Feature: Allow defining ``self.folders.build_folder_vars`` in recipes ``layout()``.

- Avoid using ``build_folder_vars`` in the cache
- Allow defining ``self.folders.build_folder_vars`` in recipes ``layout()``