### PR TITLE
[develop2] remove duplicated validates

### DIFF
--- a/conan/api/subapi/export.py
+++ b/conan/api/subapi/export.py
@@ -2,8 +2,6 @@ from conan.api.output import ConanOutput
 from conan.internal.conan_app import ConanApp
 from conans.client.cmd.export import cmd_export
 from conans.client.conanfile.package import run_package_method
-from conans.client.graph.graph import BINARY_INVALID
-from conans.errors import ConanInvalidConfiguration
 from conans.model.package_ref import PkgReference
 
 
@@ -29,10 +27,6 @@ class ExportAPI:
         ref = pkg_node.ref
         out = ConanOutput(scope=pkg_node.conanfile.display_name)
         out.info("Exporting binary from user folder to Conan cache")
-        if pkg_node.binary == BINARY_INVALID:
-            binary, reason = "Invalid", pkg_node.conanfile.info.invalid
-            msg = "{}: Invalid ID: {}: {}".format(ref, binary, reason)
-            raise ConanInvalidConfiguration(msg)
         conanfile = pkg_node.conanfile
 
         package_id = pkg_node.package_id

--- a/conan/cli/commands/export_pkg.py
+++ b/conan/cli/commands/export_pkg.py
@@ -5,7 +5,6 @@ from conan.api.output import cli_out_write
 from conan.cli.command import conan_command
 from conan.cli.args import add_lockfile_args, add_profiles_args, add_reference_args
 from conan.cli.commands import make_abs_path
-from conans.errors import ConanInvalidConfiguration
 
 
 def json_export_pkg(info):
@@ -56,20 +55,8 @@ def export_pkg(conan_api, parser, *args):
     conan_api.graph.analyze_binaries(deps_graph, build_mode=[ref.name], lockfile=lockfile)
     deps_graph.report_graph_error()
 
-    # FIXME: This code is duplicated from install_consumer() from InstallAPI
     root_node = deps_graph.root
     root_node.ref = ref
-    conanfile = root_node.conanfile
-
-    if conanfile.info is not None and conanfile.info.invalid:
-        binary, reason = "Invalid", conanfile.info.invalid
-        msg = "{}: Invalid ID: {}: {}".format(conanfile, binary, reason)
-        raise ConanInvalidConfiguration(msg)
-
-    if root_node.cant_build:
-        binary, reason = "Cannot build for this configuration", root_node.cant_build
-        msg = "{}: {}: {}".format(conanfile, binary, reason)
-        raise ConanInvalidConfiguration(msg)
 
     # It is necessary to install binaries, in case there are build_requires necessary to export
     # But they should be local, if this was built here


### PR DESCRIPTION
Changelog: omit

``conan export-pkg`` was running extra validations that were already executed inside the ``install_consumer()`` API call, removing them.
