### PR TITLE
[MesonToolchain] Removed `package_folder` check

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -211,9 +211,6 @@ class MesonToolchain(object):
             elements = getattr(self._conanfile.cpp.package, name)
             return elements[0] if elements else None
 
-        if not self._conanfile.package_folder:
-            return {}
-
         ret = {}
         bindir = _get_cpp_info_value("bindirs")
         datadir = _get_cpp_info_value("resdirs")

--- a/conans/test/functional/toolchains/meson/test_install.py
+++ b/conans/test/functional/toolchains/meson/test_install.py
@@ -106,6 +106,11 @@ class MesonInstall(TestMesonBase):
                      os.path.join("test_package", "CMakeLists.txt"): self._test_package_cmake_lists,
                      os.path.join("test_package", "test_package.cpp"): test_package_cpp})
 
-        self.t.run("create . hello/0.1@ %s" % self._settings_str)
+        # FIXME: Remove this and run a "conan create ..." instead whenever there will be tests with
+        #        export-pkg command running automatically the test_package as well.
+        self.t.run("install .")
+        self.t.run("build .")
+        self.t.run("export-pkg . hello/0.1@ %s" % self._settings_str)
+        self.t.run("test test_package/conanfile.py hello/0.1@ %s" % self._settings_str)
 
         self._check_binary()


### PR DESCRIPTION
Changelog: Bugfix: Local build was not adding default dirs in MesonToolchain (only in Linux).
Docs: omit

Related to https://github.com/conan-io/conan/pull/13118