### PR TITLE
Add basic html output to conan list

### DIFF
--- a/conan/cli/formatters/list/list.py
+++ b/conan/cli/formatters/list/list.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 from jinja2 import Template, select_autoescape
@@ -15,6 +16,6 @@ def list_packages_html(result):
     user_template = os.path.join(template_folder, "list_packages.html")
     template = load(user_template) if os.path.isfile(user_template) else list_packages_html_template
     template = Template(template, autoescape=select_autoescape(['html', 'xml']))
-    content = template.render(results=results, base_template_path=template_folder,
+    content = template.render(results=json.dumps(results), base_template_path=template_folder,
                               version=client_version)
     cli_out_write(content)

--- a/conan/cli/formatters/list/search_table_html.py
+++ b/conan/cli/formatters/list/search_table_html.py
@@ -1,57 +1,28 @@
 list_packages_html_template = r"""
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <title>Conan | {{ reference }}</title>
-        <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"/>
-        <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.10.21/css/dataTables.bootstrap.min.css"/>
-        <style>
-            tr td {
-                white-space:nowrap;
-            }
-        </style>
-    </head>
-    <body>
-        <div class="container-fluid">
-        <h1>{{ reference }}</h1>
-        <div class="info">
-            <p>
-                Depending on your package_id_mode, any combination of settings, options and requirements
-                can give you a different packageID. Take into account that your configuration might be
-                different from the one used to generate the packages.
-            </p>
-        </div>
+  <head>
+    <title>conan list results</title>
+    <script>
+      var list_results = {{ results|safe }};
+      document.addEventListener("DOMContentLoaded", function () {
+        var divContainer = document.getElementById("showResults");
+        divContainer.innerHTML = JSON.stringify(list_results, null, 2);
+      });
+    </script>
+  </head>
 
-
-        <table id="results" class="table table-striped table-bordered" style="width:100%">
-            <thead>
-
-            </thead>
-            <tbody>
-
-            </tbody>
-            <tfoot>
-
-            </tfoot>
-        </table>
-
-        <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js" integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj" crossorigin="anonymous"></script>
-        <script src="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js" integrity="sha384-aJ21OjlMXNL5UyIl/XNwTMqvzeRMZH2w8c5cRVpzpU8Y5bApTppSuUkhZXN0VxHd" crossorigin="anonymous"></script>
-        <script type="text/javascript" src="https://cdn.datatables.net/v/dt/dt-1.10.20/datatables.min.js"></script>
-        <script type="text/javascript" src="https://cdn.datatables.net/1.10.21/js/dataTables.bootstrap.min.js"></script>
-        <script>
-
-        </script>
-    </div>
-    </body>
-    <footer>
-        <div class="container-fluid">
-            <div class="info">
-                <p>
-                      Conan <b>v{{ version }}</b> <script>document.write(new Date().getFullYear())</script> JFrog LTD. <a>https://conan.io</a>
-                </p>
-            </div>
-        </div>
-    </footer>
+  <body>
+  <pre id="showResults"></pre>
+  </body>
+  <footer>
+    <p>
+      Conan <b>{{ version }}</b>
+      <script>
+        document.write(new Date().getFullYear());
+      </script>
+      JFrog LTD. <a href="https://conan.io">https://conan.io</a>
+    </p>
+  </footer>
 </html>
 """

--- a/conans/client/graph/install_graph.py
+++ b/conans/client/graph/install_graph.py
@@ -285,10 +285,8 @@ class InstallGraph:
         else:
             build_str = " ".join(list(sorted(["--build=%s" % str(pref.ref) for pref in missing_prefs])))
 
-        raise ConanException(textwrap.dedent('''\
-           Missing prebuilt package for '%s'
-           Use 'conan list packages %s --format=html -r=remote > table.html' and open the table.html file to see available packages
-           Or try to build locally from sources with '%s'
-
-           More Info at 'https://docs.conan.io/en/latest/faq/troubleshooting.html#error-missing-prebuilt-package'
-           ''' % (missing_pkgs, ref, build_str)))
+        raise ConanException(textwrap.dedent(f'''\
+           Missing prebuilt package for '{missing_pkgs}'
+           Check the available packages using the 'conan list' command
+           or try to build locally from sources using the '{build_str}' argument
+           '''))

--- a/conans/client/graph/install_graph.py
+++ b/conans/client/graph/install_graph.py
@@ -287,6 +287,8 @@ class InstallGraph:
 
         raise ConanException(textwrap.dedent(f'''\
            Missing prebuilt package for '{missing_pkgs}'
-           Check the available packages using the 'conan list' command
+           Check the available packages using 'conan list {ref}:* -r=remote'
            or try to build locally from sources using the '{build_str}' argument
+
+           More Info at 'https://docs.conan.io/en/2/knowledge/faq.html#error-missing-prebuilt-package'
            '''))

--- a/conans/test/functional/only_source_test.py
+++ b/conans/test/functional/only_source_test.py
@@ -26,18 +26,18 @@ class OnlySourceTest(unittest.TestCase):
         # Will Fail because hello0/0.0 and hello1/1.1 has not built packages
         # and by default no packages are built
         client.run("create . --user=lasote --channel=stable", assert_error=True)
-        self.assertIn("Or try to build locally from sources with '--build=hello0/0.0@lasote/stable "
+        self.assertIn("or try to build locally from sources using the '--build=hello0/0.0@lasote/stable "
                       "--build=hello1/1.1@lasote/stable'",
                       client.out)
         # Only 1 reference!
-        assert "Use 'conan list packages hello0/0.0@lasote/stable" in client.out
+        assert "Check the available packages using 'conan list hello0/0.0@lasote/stable:* -r=remote'" in client.out
 
         # We generate the package for hello0/0.0
         client.run("install --requires=hello0/0.0@lasote/stable --build hello0*")
 
         # Still missing hello1/1.1
         client.run("create . --user=lasote --channel=stable", assert_error=True)
-        self.assertIn("Or try to build locally from sources with "
+        self.assertIn("or try to build locally from sources using the "
                       "'--build=hello1/1.1@lasote/stable'", client.out)
 
         # We generate the package for hello1/1.1

--- a/conans/test/integration/command/install/install_missing_dep_test.py
+++ b/conans/test/integration/command/install/install_missing_dep_test.py
@@ -50,4 +50,4 @@ class InstallMissingDependency(unittest.TestCase):
         client.save({"conanfile.py": conanfile}, clean_first=True)
         client.run("create . --name=pkg --version=1.0", assert_error=True)
         self.assertIn("ERROR: Missing prebuilt package for 'dep1/1.0', 'dep2/1.0'", client.out)
-        self.assertIn("Or try to build locally from sources with '--build=dep1/1.0 --build=dep2/1.0'", client.out)
+        self.assertIn("or try to build locally from sources using the '--build=dep1/1.0 --build=dep2/1.0'", client.out)


### PR DESCRIPTION
Changelog: Feature: Add basic html output to `conan list` command.
Docs: omit

Adding the simplest html output to conan list command, just rendering the json as it is in the html
Also fixing a broken message when missing packages

Closes: https://github.com/conan-io/conan/issues/13022
Closes: https://github.com/conan-io/conan/issues/13021
