### PR TITLE
`[tool_requires]` from conanfiles are preferred over `[tool_requires]` from profiles

### DIFF
--- a/conans/client/graph/graph_manager.py
+++ b/conans/client/graph/graph_manager.py
@@ -375,6 +375,10 @@ class GraphManager(object):
                                              profile_host, profile_build, graph_lock,
                                              nodes_subset=nodessub, root=node)
 
+            # add build_requires from profiles first
+            if new_profile_build_requires and node.conanfile.override_profiles: 
+                _recurse_build_requires(new_profile_build_requires, {})
+            
             if package_build_requires:
                 if default_context == CONTEXT_BUILD:
                     br_build, br_host = [], []
@@ -391,7 +395,7 @@ class GraphManager(object):
                     br_all = [(it, ctxt) for (_, ctxt), it in package_build_requires.items()]
                     _recurse_build_requires(br_all, profile_build_requires)
 
-            if new_profile_build_requires:
+            if new_profile_build_requires and not node.conanfile.override_profiles:
                 _recurse_build_requires(new_profile_build_requires, {})
 
             if graph_lock and node.recipe != RECIPE_VIRTUAL:

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -117,6 +117,7 @@ class ConanFile(object):
     exports_sources = None
     generators = ["txt"]
     revision_mode = "hash"
+    override_profiles = False
 
     # Vars to control the build steps (build(), package())
     should_configure = True


### PR DESCRIPTION
Changelog: Fix: Prefer build_requires from conanfile over profiles

This PR Solves #13150 

Docs: https://github.com/conan-io/docs/pull/XXXX

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
