### PR TITLE
[develop2] allow test_requires options

### DIFF
--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -408,8 +408,8 @@ class TestRequirements:
     def __init__(self, requires):
         self._requires = requires
 
-    def __call__(self, ref, run=None):
-        self._requires.test_require(ref, run=run)
+    def __call__(self, ref, run=None, options=None):
+        self._requires.test_require(ref, run=run, options=options)
 
 
 class Requirements:


### PR DESCRIPTION
Changelog: Fix: allow defining options trait in ``test_requires(..., options={})``
Docs: Omit