### PR TITLE
Improve more wording for some of the help commands

### DIFF
--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -30,7 +30,8 @@ def add_lockfile_args(parser):
                         help="Filename of the updated lockfile")
     parser.add_argument("--lockfile-packages", action="store_true",
                         help="Lock package-id and package-revision information")
-    parser.add_argument("--lockfile-clean", action="store_true", help="remove unused")
+    parser.add_argument("--lockfile-clean", action="store_true",
+                        help="Remove unused entries from the lockfile")
 
 
 def add_common_install_arguments(parser):

--- a/conan/cli/commands/build.py
+++ b/conan/cli/commands/build.py
@@ -12,7 +12,7 @@ from conans.client.conanfile.build import run_build_method
 @conan_command(group='Creator')
 def build(conan_api, parser, *args):
     """
-    Install dependencies and calls the build() method.
+    Install dependencies and call the build() method.
     """
     parser.add_argument("path", nargs="?",
                         help="Path to a folder containing a recipe (conanfile.py "

--- a/conan/cli/commands/download.py
+++ b/conan/cli/commands/download.py
@@ -9,12 +9,12 @@ from conan.cli.command import conan_command, OnceArgument
 @conan_command(group="Creator")
 def download(conan_api: ConanAPI, parser, *args):
     """
-    Download (without install) a single conan package from a remote server.
+    Download (without installing) a single conan package from a remote server.
 
     It downloads just the package, but not its transitive dependencies, and it will not call
     any generate, generators or deployers.
-    It can download multiple packages if patterns are used, and also queries over the package
-    binaries can be provided.
+    It can download multiple packages if patterns are used, and also works with
+    queries over the package binaries.
     """
 
     parser.add_argument('reference', help="Recipe reference or package reference, can contain * as "

--- a/conan/cli/commands/editable.py
+++ b/conan/cli/commands/editable.py
@@ -9,7 +9,7 @@ from conan.cli.command import conan_command, conan_subcommand
 @conan_command(group="Creator")
 def editable(conan_api, parser, *args):
     """
-    Allows working with a package in user folder.
+    Allow working with a package that resides in user folder.
     """
 
 
@@ -17,7 +17,7 @@ def editable(conan_api, parser, *args):
 def editable_add(conan_api, parser, subparser, *args):
     """
     Define the given <path> location as the package <reference>, so when this
-    package is required, it is used from this <path> location instead of from the cache.
+    package is required, it is used from this <path> location instead of the cache.
     """
     subparser.add_argument('path', help='Path to the package folder in the user workspace')
     add_reference_args(subparser)

--- a/conan/cli/commands/export.py
+++ b/conan/cli/commands/export.py
@@ -18,7 +18,7 @@ def json_export(ref):
 @conan_command(group="Creator", formatters={"json": json_export})
 def export(conan_api, parser, *args):
     """
-    Export recipe to the Conan package cache.
+    Export a recipe to the Conan package cache.
     """
     common_args_export(parser)
     group = parser.add_mutually_exclusive_group()

--- a/conan/cli/commands/inspect.py
+++ b/conan/cli/commands/inspect.py
@@ -21,7 +21,7 @@ def inspect_text_formatter(data):
 @conan_command(group="Consumer", formatters={"text": inspect_text_formatter, "json": default_json_formatter})
 def inspect(conan_api, parser, *args):
     """
-    Inspect a conanfile.py to return the public fields.
+    Inspect a conanfile.py to return its public fields.
     """
     parser.add_argument("path", help="Path to a folder containing a recipe (conanfile.py)")
 

--- a/conan/cli/commands/lock.py
+++ b/conan/cli/commands/lock.py
@@ -13,7 +13,7 @@ from conans.model.recipe_ref import RecipeReference
 @conan_command(group="Consumer")
 def lock(conan_api, parser, *args):
     """
-    Create or manages lockfiles.
+    Create or manage lockfiles.
     """
 
 
@@ -85,10 +85,11 @@ def lock_merge(conan_api, parser, subparser, *args):
 @conan_subcommand()
 def lock_add(conan_api, parser, subparser, *args):
     """
-    Add requires, build-requires or python-requires to existing or new lockfile. Resulting lockfile
-    will be ordereded, newer versions/revisions first.
-    References can be with our without revisions like "--requires=pkg/version", but they
-    must be package references, including at least the version, they cannot contain a version range.
+    Add requires, build-requires or python-requires to an existing or new lockfile.
+    The resulting lockfile will be ordered, newer versions/revisions first.
+    References can be supplied with and without revisions like "--requires=pkg/version",
+    but they must be package references, including at least the version,
+    and they cannot contain a version range.
     """
     subparser.add_argument('--requires', action="append", help='Add references to lockfile.')
     subparser.add_argument('--build-requires', action="append",

--- a/conan/cli/commands/profile.py
+++ b/conan/cli/commands/profile.py
@@ -30,7 +30,7 @@ def detected_profile_cli_output(detect_profile):
 @conan_subcommand(formatters={"text": print_profiles})
 def profile_show(conan_api, parser, subparser, *args):
     """
-    Show profiles.
+    Show aggregated profiles from the passed arguments.
     """
     add_profiles_args(subparser)
     args = parser.parse_args(*args)
@@ -52,7 +52,7 @@ def profile_path(conan_api, parser, subparser, *args):
 @conan_subcommand()
 def profile_detect(conan_api, parser, subparser, *args):
     """
-    Detect default profile.
+    Generate a default profile using auto-detected values.
     """
     subparser.add_argument("--name", help="Profile name, 'default' if not specified")
     subparser.add_argument("-f", "--force", action='store_true', help="Overwrite if exists")

--- a/conan/cli/commands/profile.py
+++ b/conan/cli/commands/profile.py
@@ -52,7 +52,7 @@ def profile_path(conan_api, parser, subparser, *args):
 @conan_subcommand()
 def profile_detect(conan_api, parser, subparser, *args):
     """
-    Generate a default profile using auto-detected values.
+    Generate a profile using auto-detected values.
     """
     subparser.add_argument("--name", help="Profile name, 'default' if not specified")
     subparser.add_argument("-f", "--force", action='store_true', help="Overwrite if exists")

--- a/conan/cli/commands/remote.py
+++ b/conan/cli/commands/remote.py
@@ -54,7 +54,7 @@ def output_remotes_json(results):
 @conan_subcommand(formatters={"text": print_remote_list, "json": formatter_remote_list_json})
 def remote_list(conan_api: ConanAPI, parser, subparser, *args):
     """
-    List current remotes
+    List current remotes.
     """
     return conan_api.remotes.list(only_enabled=False)
 
@@ -94,7 +94,7 @@ def remote_remove(conan_api, parser, subparser, *args):
 @conan_subcommand()
 def remote_update(conan_api, parser, subparser, *args):
     """
-    Update the remote.
+    Update a remote.
     """
     subparser.add_argument("remote", help="Name of the remote to update")
     subparser.add_argument("--url", action=OnceArgument, help="New url for the remote")
@@ -157,7 +157,7 @@ def remote_disable(conan_api, parser, subparser, *args):
 @conan_subcommand(formatters={"text": print_remote_user_list, "json": output_remotes_json})
 def remote_list_users(conan_api, parser, subparser, *args):
     """
-    List the users logged into the remotes.
+    List the users logged into all the remotes.
     """
     remotes = conan_api.remotes.list()
     ret = OrderedDict()
@@ -172,7 +172,7 @@ def remote_list_users(conan_api, parser, subparser, *args):
 @conan_subcommand(formatters={"text": print_remote_user_set, "json": output_remotes_json})
 def remote_login(conan_api, parser, subparser, *args):
     """
-    Login into the specified remotes.
+    Login into the specified remotes matching a pattern.
     """
     subparser.add_argument("remote", help="Pattern or name of the remote to login into. "
                                           "The pattern uses 'fnmatch' style wildcards.")
@@ -205,7 +205,7 @@ def remote_login(conan_api, parser, subparser, *args):
 @conan_subcommand(formatters={"text": print_remote_user_set, "json": output_remotes_json})
 def remote_set_user(conan_api, parser, subparser, *args):
     """
-    Associate a username with a remote without performing the authentication.
+    Associate a username with a remote matching a pattern without performing the authentication.
     """
     subparser.add_argument("remote", help="Pattern or name of the remote. "
                                           "The pattern uses 'fnmatch' style wildcards.")
@@ -229,7 +229,7 @@ def remote_set_user(conan_api, parser, subparser, *args):
 @conan_subcommand(formatters={"text": print_remote_user_set, "json": output_remotes_json})
 def remote_logout(conan_api, parser, subparser, *args):
     """
-    Clear the existing credentials for the specified remotes.
+    Clear the existing credentials for the specified remotes matching a pattern.
     """
     subparser.add_argument("remote", help="Pattern or name of the remote to logout. "
                                           "The pattern uses 'fnmatch' style wildcards.")


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Updates the help wording in a few places that I found while making sure all of them were present in the docu