### PR TITLE
[develop2] change default profile apple-clang to gnu17

### DIFF
--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -179,8 +179,7 @@ class Cli:
             error = "*********************************************************\n" \
                     f"Recipe '{pkg}' seems broken.\n" \
                     f"It is possible that this recipe is not Conan 2.0 ready\n"\
-                    "If the recipe comes from ConanCenter check: \n" \
-                    "https://github.com/conan-io/conan-center-index/blob/master/docs/v2_migration.md\n" \
+                    "If the recipe comes from ConanCenter check: https://conan.io/cci-v2.html\n" \
                     "If it is your recipe, check it is updated to 2.0\n" \
                     "*********************************************************\n"
             ConanOutput().writeln(error, fg=Color.BRIGHT_MAGENTA)
@@ -190,8 +189,7 @@ class Cli:
             error = "*********************************************************\n" \
                     f"Recipe '{pkg}' cannot build its binary\n" \
                     f"It is possible that this recipe is not Conan 2.0 ready\n" \
-                    "If the recipe comes from ConanCenter check: \n" \
-                    "https://github.com/conan-io/conan-center-index/blob/master/docs/v2_migration.md\n" \
+                    "If the recipe comes from ConanCenter check: https://conan.io/cci-v2.html\n" \
                     "If it is your recipe, check it is updated to 2.0\n" \
                     "*********************************************************\n"
             ConanOutput().writeln(error, fg=Color.BRIGHT_MAGENTA)

--- a/conan/cli/commands/profile.py
+++ b/conan/cli/commands/profile.py
@@ -67,8 +67,11 @@ def profile_detect(conan_api, parser, subparser, *args):
     detected_profile_cli_output(detected_profile)
     contents = detected_profile.dumps()
     ConanOutput().warning("This profile is a guess of your environment, please check it.")
+    if detected_profile.settings.get("os") == "Macos":
+        ConanOutput().warning("Defaulted to cppstd='gnu17' for apple-clang.")
     ConanOutput().warning("The output of this command is not guaranteed to be stable and can "
-                          "change in future Conan versions")
+                          "change in future Conan versions.")
+    ConanOutput().warning("Use your own profile files for stability.")
     ConanOutput().success(f"Saving detected profile to {profile_pathname}")
     save(profile_pathname, contents)
 

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -228,6 +228,9 @@ def _detect_compiler_version(result):
 
     if compiler != "msvc":
         cppstd = _cppstd_default(compiler, version)
+        if compiler == "apple-clang" and version >= "11":
+            # forced auto-detection, gnu98 is too old
+            cppstd = "gnu17"
         result.append(("compiler.cppstd", cppstd))
 
 
@@ -375,7 +378,7 @@ def _cppstd_default(compiler, compiler_version):
     assert isinstance(compiler_version, Version)
     default = {"gcc": _gcc_cppstd_default(compiler_version),
                "clang": _clang_cppstd_default(compiler_version),
-               "apple-clang": "gnu17",
+               "apple-clang": "gnu98",
                "msvc": _visual_cppstd_default(compiler_version),
                "mcst-lcc": _mcst_lcc_cppstd_default(compiler_version)}.get(str(compiler), None)
     return default

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -375,7 +375,7 @@ def _cppstd_default(compiler, compiler_version):
     assert isinstance(compiler_version, Version)
     default = {"gcc": _gcc_cppstd_default(compiler_version),
                "clang": _clang_cppstd_default(compiler_version),
-               "apple-clang": "gnu98",  # Confirmed in apple-clang 9.1 with a simple "auto i=1;"
+               "apple-clang": "gnu17",
                "msvc": _visual_cppstd_default(compiler_version),
                "mcst-lcc": _mcst_lcc_cppstd_default(compiler_version)}.get(str(compiler), None)
     return default


### PR DESCRIPTION
Changelog: Feature: Change default profile cppstd for apple-clang to gnu17.
Docs: https://github.com/conan-io/docs/pull/3002

The gnu98 default for apple-clang in OSX is clearly not sufficient for many cases, not enough for ConanCenter development, many modern open sources libraries will require a modern c++17.

Other modern compilers like MSVC > 2015 default to c++14, and gcc defaults to gnu14 or gnu17 depending on the compiler version (gcc 11 defaults to gnu17), so better if apple-clang is aligned.