### PR TITLE
better error message for wrong options definition

### DIFF
--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -338,7 +338,10 @@ class Options:
         result = Options()
         result._package_options = self._package_options.copy_conaninfo_options()
         # In most scenarios this should be empty at this stage, because it was cleared
-        assert not self._deps_package_options
+        if self._deps_package_options:
+            raise ConanException("Dependencies options were defined incorrectly. Maybe you"
+                                 " tried to define options values in 'requirements()' or other"
+                                 " invalid place")
         return result
 
     def update(self, options=None, options_values=None):

--- a/conans/test/integration/conanfile/conanfile_errors_test.py
+++ b/conans/test/integration/conanfile/conanfile_errors_test.py
@@ -175,3 +175,20 @@ def test_notduplicate_requires_py():
     client.save(files)
     client.run("export .")
     assert "hello/0.1: Exported" in client.out
+
+
+def test_requirements_change_options():
+    c = TestClient()
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+
+        class HelloConan(ConanFile):
+            name = "hello"
+            version = "0.1"
+
+            def requirements(self):
+                self.options["mydep"].myoption = 3
+        """)
+    c.save({"conanfile.py": conanfile})
+    c.run("create .", assert_error=True)
+    assert "Dependencies options were defined incorrectly." in c.out


### PR DESCRIPTION
Changelog: Fix: Better error message when dependencies ``options`` are defined in ``requirements()`` method.
Docs: Omit