### PR TITLE
Correct conan build path arg description

### DIFF
--- a/conan/cli/commands/build.py
+++ b/conan/cli/commands/build.py
@@ -15,9 +15,9 @@ def build(conan_api, parser, *args):
     Install dependencies and call the build() method.
     """
     parser.add_argument("path", nargs="?",
-                        help="Path to a folder containing a recipe (conanfile.py "
-                             "or conanfile.txt) or to a recipe file. e.g., "
-                             "./my_project/conanfile.txt.")
+                        help='Path to a python-based recipe file or a folder '
+                             'containing a conanfile.py recipe. conanfile.txt '
+                             'cannot be used with conan build.')
     add_reference_args(parser)
     # TODO: Missing --build-require argument and management
     parser.add_argument("-of", "--output-folder",


### PR DESCRIPTION
Changelog: Fix: Change `conan build` argument description for "path" to indicate it is only for conanfile.py and explicitly state that it does not work with conanfile.txt.
Docs: https://github.com/conan-io/docs/pull/3046

Resolves #13198