### PR TITLE
Restore printing of profiles for build command

### DIFF
--- a/conan/cli/commands/build.py
+++ b/conan/cli/commands/build.py
@@ -5,6 +5,7 @@ from conan.cli.command import conan_command
 from conan.cli.commands import make_abs_path
 from conan.cli.args import add_lockfile_args, add_common_install_arguments, add_reference_args
 from conan.internal.conan_app import ConanApp
+from conan.cli.printers import print_profiles
 from conan.cli.printers.graph import print_graph_packages, print_graph_basic
 from conans.client.conanfile.build import run_build_method
 
@@ -36,6 +37,7 @@ def build(conan_api, parser, *args):
                                                cwd=cwd,
                                                partial=args.lockfile_partial)
     profile_host, profile_build = conan_api.profiles.get_profiles_from_args(args)
+    print_profiles(profile_host, profile_build)
 
     deps_graph = conan_api.graph.load_graph_consumer(path, args.name, args.version,
                                                      args.user, args.channel,


### PR DESCRIPTION
Changelog: Fix: Restore printing of profiles for build command. 
Docs: Omit

Closes #13212

- [X] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
