### PR TITLE
verbose tracebacks

### DIFF
--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -11,7 +11,7 @@ from difflib import get_close_matches
 from inspect import getmembers
 
 from conan.api.conan_api import ConanAPI
-from conan.api.output import ConanOutput, Color, cli_out_write
+from conan.api.output import ConanOutput, Color, cli_out_write, LEVEL_TRACE
 from conan.cli.command import ConanSubCommand
 from conan.cli.exit_codes import SUCCESS, ERROR_MIGRATION, ERROR_GENERAL, USER_CTRL_C, \
     ERROR_SIGTERM, USER_CTRL_BREAK, ERROR_INVALID_CONFIGURATION, ERROR_UNEXPECTED
@@ -166,6 +166,10 @@ class Cli:
         try:
             command.run(self._conan_api, self._commands[command_argument].parser, args[0][1:])
         except Exception as e:
+            # must be a local-import to get updated value
+            from conan.api.output import conan_output_level
+            if conan_output_level <= LEVEL_TRACE:
+                print(traceback.format_exc())
             self._conan2_migrate_recipe_msg(e)
             raise
 

--- a/conans/errors.py
+++ b/conans/errors.py
@@ -10,8 +10,6 @@
 """
 from contextlib import contextmanager
 
-from conans.util.env import get_env
-
 
 @contextmanager
 def conanfile_remove_attr(conanfile, names, method):
@@ -42,6 +40,10 @@ def conanfile_exception_formatter(conanfile_name, func_name):
     """
 
     def _raise_conanfile_exc(e):
+        from conan.api.output import LEVEL_DEBUG, conan_output_level
+        if conan_output_level <= LEVEL_DEBUG:
+            import traceback
+            raise ConanExceptionInUserConanfileMethod(traceback.format_exc())
         m = _format_conanfile_exception(conanfile_name, func_name, e)
         raise ConanExceptionInUserConanfileMethod(m)
 
@@ -72,8 +74,6 @@ def _format_conanfile_exception(scope, method, exception):
     """
     import sys
     import traceback
-    if get_env("CONAN_VERBOSE_TRACEBACK", False):
-        return traceback.format_exc()
     try:
         conanfile_reached = False
         tb = sys.exc_info()[2]

--- a/conans/test/integration/conanfile/test_exception_printing.py
+++ b/conans/test/integration/conanfile/test_exception_printing.py
@@ -1,15 +1,9 @@
 import pytest
-from parameterized import parameterized
 
-from conans.paths import CONANFILE
 from conans.test.utils.tools import TestClient
-from conans.util.env import environment_update
 
 conanfile = """
 from conan import ConanFile
-
-class DRLException(Exception):
-    pass
 
 class ExceptionsTest(ConanFile):
     name = "exceptions"
@@ -19,34 +13,46 @@ class ExceptionsTest(ConanFile):
         {method_contents}
 
     def _aux_method(self):
-        raise DRLException('Oh! an error!')
+        raise Exception('Oh! an error!')
 """
 
 
-@parameterized.expand([(True,), (False,)])
-@pytest.mark.xfail(reason="cache2.0 build_id not working, revisit")
-def test_all_methods(direct):
+@pytest.mark.parametrize("direct", [True, False])
+@pytest.mark.parametrize("method",
+                         ["source", "build", "package", "package_info", "configure", "build_id",
+                          "package_id", "requirements", "config_options", "layout", "generate",
+                          "export", "export_sources", "build_requirements", "init"])
+def test_all_methods(direct, method):
     client = TestClient()
     if direct:
-        throw = "raise DRLException('Oh! an error!')"
+        throw = "raise Exception('Oh! an error!')"
     else:
         throw = "self._aux_method()"
-    for method in ["source", "build", "package", "package_info", "configure", "build_id",
-                   "package_id", "requirements", "config_options", "layout", "generate", "export",
-                   "export_sources"]:
-        client.save({CONANFILE: conanfile.format(method=method, method_contents=throw)})
-        client.run("create . ", assert_error=True)
-        assert "exceptions/0.1: Error in %s() method, line 12" % method in client.out
-        assert "DRLException: Oh! an error!" in client.out
-        if not direct:
-            assert "while calling '_aux_method', line 15" in client.out
+
+    client.save({"conanfile.py": conanfile.format(method=method, method_contents=throw)})
+    client.run("create . ", assert_error=True)
+    assert "Error in %s() method, line 9" % method in client.out
+    assert "Oh! an error!" in client.out
+    if not direct:
+        assert "while calling '_aux_method', line 12" in client.out
 
 
-def test_complete_traceback():
+def test_complete_traceback_debug():
+    """
+    in debug level (-vv), the trace is shown (this is for recipe methods exceptions)
+    """
     client = TestClient()
     throw = "self._aux_method()"
-    client.save({CONANFILE: conanfile.format(method="source", method_contents=throw)})
-    with environment_update({"CONAN_VERBOSE_TRACEBACK": "1"}):
-        client.run("create . ", assert_error=True)
-        assert "DRLException: Oh! an error!" in client.out
-        assert "ERROR: Traceback (most recent call last):" in client.out
+    client.save({"conanfile.py": conanfile.format(method="source", method_contents=throw)})
+    client.run("create . -vv", assert_error=True)
+    assert "Exception: Oh! an error!" in client.out
+    assert "ERROR: Traceback (most recent call last):" in client.out
+
+
+def test_complete_traceback_trace():
+    """
+    in debug level (-vvv), the full trace is shown for ConanExceptions
+    """
+    client = TestClient()
+    client.run("install --requires=pkg/1.0 -vvv", assert_error=True)
+    assert "Traceback (most recent call last)" in client.out


### PR DESCRIPTION
Changelog: Feature: Make verbose tracebacks on exception be shown for ``-vv`` and ``-vvv``, instead of custom env-var used in 1.X.
Docs: Omit

Notes:
-vv: is able to show local traces of methods, more intended for users
-vvv: is able to show the complete full trace including Conan internals of any exception, including ConanException. For maintainers.