### PR TITLE
Fix macOS <-> Linux cross cflags resolution

### DIFF
--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -1,5 +1,5 @@
 from conan.internal import check_duplicated_generator
-from conan.tools.apple.apple import apple_min_version_flag, to_apple_arch, apple_sdk_path
+from conan.tools.apple.apple import apple_min_version_flag, is_apple_os, to_apple_arch, apple_sdk_path
 from conan.tools.apple.apple import get_apple_sdk_fullname
 from conan.tools.build import cmd_args_to_string, save_toolchain_args
 from conan.tools.build.cross_building import cross_building
@@ -76,7 +76,7 @@ class AutotoolsToolchain:
             # Build triplet
             self._build = _get_gnu_triplet(os_build, arch_build, compiler=compiler)
             # Apple Stuff
-            if os_host in ["Macos", "iOS", "watchOS", "tvOS"]:
+            if os_build == "Macos" and is_apple_os(conanfile):
                 # SDK path is mandatory for cross-building
                 sdk_path = apple_sdk_path(self._conanfile)
                 if not sdk_path:

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -76,7 +76,7 @@ class AutotoolsToolchain:
             # Build triplet
             self._build = _get_gnu_triplet(os_build, arch_build, compiler=compiler)
             # Apple Stuff
-            if os_build == "Macos":
+            if os_host == "Macos":
                 # SDK path is mandatory for cross-building
                 sdk_path = apple_sdk_path(self._conanfile)
                 if not sdk_path:

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -76,7 +76,7 @@ class AutotoolsToolchain:
             # Build triplet
             self._build = _get_gnu_triplet(os_build, arch_build, compiler=compiler)
             # Apple Stuff
-            if os_host == "Macos":
+            if os_host in ["Macos", "iOS", "watchOS", "tvOS"]:
                 # SDK path is mandatory for cross-building
                 sdk_path = apple_sdk_path(self._conanfile)
                 if not sdk_path:

--- a/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -328,6 +328,19 @@ def test_apple_min_os_flag():
     assert expected in env["LDFLAGS"]
 
 
+def test_crossbuild_from_macos_to_non_apple_os():
+    """Check we are not adding Apple-specific flags
+        when the os_build is Macos, but we are targetting
+        a non-Apple OS (e.g. Linux, Android, QNX)"""
+    conanfile = ConanFileMock()
+    conanfile.settings = MockSettings({"os": "Android", "arch": "armv8"})
+    conanfile.settings_build = MockSettings({"os": "Macos", "arch": "armv8"})
+    be = AutotoolsToolchain(conanfile)
+    assert be.apple_min_version_flag == ''
+    assert be.apple_arch_flag is None
+    assert be.apple_isysroot_flag is None
+
+
 def test_apple_isysrootflag():
     """Even when no cross building it is adjusted because it could target a Mac version"""
     conanfile = ConanFileMock()


### PR DESCRIPTION
Changelog: Fix: Fix flags passed by AutotoolsToolchain when cross compiling from macOS to a non-Apple OS.
Docs: Omit

Fixes #13219 

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
