### PR TITLE
fix cmaketoolchain error when output folder in different Win drive

### DIFF
--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -253,8 +253,11 @@ def _save_cmake_user_presets(conanfile, preset_path, user_presets_path, preset_p
     data = _append_user_preset_path(conanfile, data, preset_path)
 
     data = json.dumps(data, indent=4)
-    relpath = os.path.relpath(user_presets_path, conanfile.generators_folder)
-    ConanOutput(str(conanfile)).info(f"CMakeToolchain generated: {relpath}")
+    try:
+        presets_path = os.path.relpath(user_presets_path, conanfile.generators_folder)
+    except ValueError:  # in Windows this fails if in another drive
+        presets_path = user_presets_path
+    ConanOutput(str(conanfile)).info(f"CMakeToolchain generated: {presets_path}")
     save(user_presets_path, data)
 
 


### PR DESCRIPTION
Changelog: Bugfix: Fix CMakeToolchain error when output folder in different Win drive.
Docs: Omit

This is not possible to test in CI, not easy to have another drive there. But fix is about message, low risk.

Close https://github.com/conan-io/conan/issues/13243
