### PR TITLE
allow remote add with existing name

### DIFF
--- a/conans/client/cache/remote_registry.py
+++ b/conans/client/cache/remote_registry.py
@@ -46,8 +46,11 @@ class _Remotes(object):
         assert isinstance(new_remote, Remote)
         current = self.get_by_name(new_remote.name)
         if current:
-            raise ConanException("Remote '%s' already exists in remotes (use update to modify)"
-                                 % new_remote.name)
+            if force:
+                ConanOutput().warning(f"Remote '{new_remote.name}' already exists in remotes")
+            else:
+                raise ConanException(f"Remote '{new_remote.name}' already exists in remotes "
+                                     "(use --force to continue)")
         for r in self._remotes:
             if r.url == new_remote.url:
                 msg = f"Remote url already existing in remote '{r.name}'. " \

--- a/conans/test/integration/command/remote_test.py
+++ b/conans/test/integration/command/remote_test.py
@@ -250,11 +250,16 @@ class RemoteTest(unittest.TestCase):
         """ check remote name are not duplicated
         """
         self.client.run("remote add remote1 http://otherurl", assert_error=True)
-        self.assertIn("ERROR: Remote 'remote1' already exists in remotes (use update to modify)",
+        self.assertIn("ERROR: Remote 'remote1' already exists in remotes (use --force to continue)",
                       self.client.out)
 
         self.client.run("remote list")
         assert "otherurl" not in self.client.out
+        self.client.run("remote add remote1 http://otherurl --force")
+        self.assertIn("WARN: Remote 'remote1' already exists in remotes", self.client.out)
+
+        self.client.run("remote list")
+        assert "remote1: http://otherurl" in self.client.out
 
     def test_missing_subarguments(self):
         self.client.run("remote", assert_error=True)
@@ -274,7 +279,7 @@ class RemoteTest(unittest.TestCase):
         self.assertIn("pepe.org", self.client.out)
 
 
-def test_duplicated_url():
+def test_add_duplicated_url():
     """ allow duplicated URL with --force
     """
     c = TestClient()
@@ -286,5 +291,6 @@ def test_duplicated_url():
     assert "remote2" not in c.out
     c.run("remote add remote2 http://url --force")
     assert "WARN: Remote url already existing in remote 'remote1'." in c.out
+    c.run("remote list")
     assert "remote1" in c.out
-    assert "remote2" not in c.out
+    assert "remote2" in c.out


### PR DESCRIPTION
Changelog: Fix: Allow ``conan remote add --force`` to force re-definition of an existing remote name.
Docs: Omit

Close https://github.com/conan-io/conan/issues/13222
Close https://github.com/conan-io/conan/issues/13208