### PR TITLE
fix CMakeDeps for tool_requires without build_type

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -60,18 +60,11 @@ class CMakeDepsFileTemplate(object):
 
     @property
     def configuration(self):
-        if not self.require.build:
-            return self.cmakedeps.configuration \
-                if self.cmakedeps.configuration else None
-        else:
-            return self.conanfile.settings_build.get_safe("build_type")
+        return self.cmakedeps.configuration
 
     @property
     def arch(self):
-        if not self.require.build:
-            return self.cmakedeps.arch if self.cmakedeps.arch else None
-        else:
-            return self.conanfile.settings_build.get_safe("arch")
+        return self.cmakedeps.arch
 
     @property
     def config_suffix(self):

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -339,7 +339,7 @@ def test_do_not_mix_cflags_cxxflags():
 
 
 def test_custom_configuration(client):
-    """  The configuration may differ from the build context and the host context"""
+    """  The configuration in the build context is still the same than the host context"""
     conanfile = textwrap.dedent("""
        from conans import ConanFile
        from conan.tools.cmake import CMakeDeps
@@ -364,12 +364,12 @@ def test_custom_configuration(client):
     client.run("install . -pr:h default -s:b build_type=RelWithDebInfo"
                " -pr:b default -s:b arch=x86 --build missing")
     curdir = client.current_folder
-    data_name_context_build = "liba_build-relwithdebinfo-x86-data.cmake"
+    data_name_context_build = f"liba_build-debug-{host_arch}-data.cmake"
     data_name_context_host = f"liba-debug-{host_arch}-data.cmake"
     assert os.path.exists(os.path.join(curdir, data_name_context_build))
     assert os.path.exists(os.path.join(curdir, data_name_context_host))
 
-    assert "set(liba_build_INCLUDE_DIRS_RELWITHDEBINFO" in \
+    assert "set(liba_build_INCLUDE_DIRS_DEBUG" in \
            open(os.path.join(curdir, data_name_context_build)).read()
     assert "set(liba_INCLUDE_DIRS_DEBUG" in \
            open(os.path.join(curdir, data_name_context_host)).read()


### PR DESCRIPTION
Changelog: Bugfix: Fix ``CMakeDeps`` for ``tool_requires`` when ``build_type`` doesn't exist in the "build" profile
Docs: Omit

This is exploratory, not sure what other things it could break, to be investigated.
Close https://github.com/conan-io/conan/issues/13209

