### PR TITLE
fix definition of patterns for dependencies options in configure()

### DIFF
--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -1,5 +1,5 @@
 from conans.errors import ConanException
-from conans.model.recipe_ref import RecipeReference, ref_matches
+from conans.model.recipe_ref import ref_matches
 
 _falsey_options = ["false", "none", "0", "off", ""]
 
@@ -308,22 +308,7 @@ class Options:
         self._package_options.__delattr__(field)
 
     def __getitem__(self, item):
-        # FIXME: Kept for configure => self.options["xxx"].shared = True
-        # To access dependencies options like ``options["mydep"]``. This will no longer be
-        # a read case, only for defining values. Read access will be via self.dependencies["dep"]
-        if isinstance(item, str):
-            if "/" not in item:  # FIXME: To allow patterns like "*" or "foo*"
-                item += "/*"
-            item = RecipeReference.loads(item)
-
-        return self.get(item, is_consumer=False)
-
-    def get(self, ref, is_consumer):
-        ret = _PackageOptions()
-        for pattern, options in self._deps_package_options.items():
-            if ref_matches(ref, pattern, is_consumer):
-                ret.update(options)
-        return self._deps_package_options.setdefault(ref.repr_notime(), ret)
+        return self._deps_package_options.setdefault(item, _PackageOptions())
 
     def scope(self, ref):
         """ when there are free options like "shared=True", they apply to the "consumer" package

--- a/conans/test/integration/package_id/transitive_options_affect_id_test.py
+++ b/conans/test/integration/package_id/transitive_options_affect_id_test.py
@@ -35,7 +35,7 @@ class TestTransitiveOptionsAffectPackageID:
                     if self.dependencies["pkg"].package_type == "static-library":
                         self.output.info("EMBED MODE!!")
                         self.info.requires["pkg"].package_id = None
-                        self.info.options["pkg"].affect = self.dependencies["pkg"].options.affect
+                        self.info.options["pkg/*"].affect = self.dependencies["pkg"].options.affect
             """)
         client.save({"conanfile.py": app})
         client.run("create . -o pkg*:noaffect=1 -o pkg*:affect=False")

--- a/conans/test/unittests/client/profile_loader/profile_loader_test.py
+++ b/conans/test/unittests/client/profile_loader/profile_loader_test.py
@@ -103,8 +103,8 @@ def test_profiles_includes():
     profile = profile_loader.load_profile("./profile4.txt", tmp)
 
     assert profile.settings == {"os": "1"}
-    assert profile.options["zlib/1.2.11"].aoption == 1
-    assert profile.options["zlib/*"].otheroption == 12
+    assert profile.options["zlib*"].aoption == 1
+    assert profile.options["zlib*"].otheroption == 12
     assert profile.tool_requires == {"*": [RecipeReference.loads("one/1.5@lasote/stable"),
                                            RecipeReference.loads("two/1.2@lasote/stable")]}
 

--- a/conans/test/unittests/model/options_test.py
+++ b/conans/test/unittests/model/options_test.py
@@ -129,10 +129,8 @@ class TestOptionsLoad:
         assert sut.path != "whatever"  # Non validating
         assert sut.static == "True"
         assert sut.static != "whatever"  # Non validating
-        assert sut["zlib/1*"].option == 8
-        assert sut["zlib/1.2.11"].option == 8
-        assert sut["zlib/*"].option != "whatever"  # Non validating
-        assert sut["*/*"].common == "value"
+        assert sut["zlib*"].option == 8
+        assert sut["zlib*"].option != "whatever"  # Non validating
         assert sut["*"].common == "value"
         assert sut["*"].common != "whatever"  # Non validating
 


### PR DESCRIPTION
Changelog: Bugfix: Fix definition of patterns for dependencies options in configure().
Docs: Omit

Close https://github.com/conan-io/conan/issues/13240
