### PR TITLE
Improve error message for unified patterns in options

### DIFF
--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -230,8 +230,8 @@ class Options:
                         package, option = tokens
                         if "/" not in package and "*" not in package and "&" not in package:
                             msg = "The usage of package names `{}` in options is " \
-                                  "deprecated, use a pattern like `{}/*` or `{}*` " \
-                                  "instead".format(k, package, package)
+                                  "deprecated, use a pattern like `{}/*:{}` " \
+                                  "instead".format(k, package, option)
                             raise ConanException(msg)
                         self._deps_package_options.setdefault(package, _PackageOptions())[option] = v
                     else:

--- a/conans/test/functional/toolchains/env/test_complete.py
+++ b/conans/test/functional/toolchains/env/test_complete.py
@@ -116,7 +116,7 @@ def test_complete():
                  "main.cpp": mycmake_main}, clean_first=True)
     client.run("create . --name=mycmake --version=1.0", assert_error=True)
     assert "The usage of package names `myopenssl:shared` in options is deprecated, " \
-           "use a pattern like `myopenssl/*` or `myopenssl*` instead" in client.out
+           "use a pattern like `myopenssl/*:shared` instead" in client.out
 
     # Fix the default options and repeat the create
     fixed_cf = mycmake_conanfile.replace('default_options = {"myopenssl:shared": True}',


### PR DESCRIPTION
Changelog: Fix: Improve error message for unified patterns in options.
Docs: omit

Include the option in the proposed solution to make it easier for the user to understand the new unified pattern syntax.

Also, avoid advocating `pkg*:option` to prevent ambiguities with libraries with the same prefix, e.g. `pkg-ng`. Only propose using the more explicit
 `pkg/*:option` notation.

See https://github.com/conan-io/conan/issues/13233#issuecomment-1447664410