### PR TITLE
Fix conanfile.txt options parsing error message

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -238,8 +238,8 @@ class ConanFileLoader:
         try:
             conanfile.options = Options.loads(parser.options)
         except Exception:
-            raise ConanException("Error while parsing [options] in conanfile\n"
-                                 "Options should be specified as 'pkg:option=value'")
+            raise ConanException("Error while parsing [options] in conanfile.txt\n"
+                                 "Options should be specified as 'pkg/*:option=value'")
 
         return conanfile
 

--- a/conans/test/unittests/client/conanfile_loader_test.py
+++ b/conans/test/unittests/client/conanfile_loader_test.py
@@ -144,8 +144,8 @@ OpenCV/2.4.10@phil/stable1111111111111111111111111111111111111111111111111111111
         save(file_path, conanfile_txt)
         loader = ConanFileLoader(None, None)
         with self.assertRaisesRegex(ConanException,
-                                   r"Error while parsing \[options\] in conanfile\n"
-                                   "Options should be specified as 'pkg:option=value'"):
+                                   r"Error while parsing \[options\] in conanfile.txt\n"
+                                   "Options should be specified as 'pkg/\*:option=value'"):
             loader.load_conanfile_txt(file_path)
 
     def test_layout_not_predefined(self):


### PR DESCRIPTION
Changelog: Fix: Fix conanfile.txt options parsing error message.
Docs: Omit

Close https://github.com/conan-io/conan/issues/13233
