### PR TITLE
Add `--insecure` alias to `--verify-ssl` in config install

### DIFF
--- a/conan/cli/commands/config.py
+++ b/conan/cli/commands/config.py
@@ -27,8 +27,10 @@ def config_install(conan_api, parser, subparser, *args):
     ssl_subgroup = subparser.add_mutually_exclusive_group()
     ssl_subgroup.add_argument("--verify-ssl", nargs="?", default="True",
                               help='Verify SSL connection when downloading file')
-    ssl_subgroup.add_argument("--insecure", action="store_true", default=None,
-                              help="Allow insecure server connections when using SSL")
+    ssl_subgroup.add_argument("--insecure", action="store_false", default=None,
+                              help="Allow insecure server connections when using SSL. "
+                                   "Equivalent to --verify-ssl=False",
+                              dest="verify_ssl")
     subparser.add_argument("-t", "--type", choices=["git", "dir", "file", "url"],
                            help='Type of remote config')
     subparser.add_argument("-a", "--args",
@@ -39,7 +41,7 @@ def config_install(conan_api, parser, subparser, *args):
     subparser.add_argument("-tf", "--target-folder",
                            help='Install to that path in the conan cache')
     args = parser.parse_args(*args)
-    verify_ssl = not args.insecure if args.insecure is not None else get_bool_from_text(args.verify_ssl)
+    verify_ssl = args.verify_ssl if isinstance(args.verify_ssl, bool) else get_bool_from_text(args.verify_ssl)
     conan_api.config.install(args.item, verify_ssl, args.type, args.args,
                              source_folder=args.source_folder,
                              target_folder=args.target_folder)

--- a/conan/cli/commands/config.py
+++ b/conan/cli/commands/config.py
@@ -24,8 +24,11 @@ def config_install(conan_api, parser, subparser, *args):
                            help="git repository, local file or folder or zip file (local or "
                                 "http) where the configuration is stored")
 
-    subparser.add_argument("--verify-ssl", nargs="?", default="True",
-                           help='Verify SSL connection when downloading file')
+    ssl_subgroup = subparser.add_mutually_exclusive_group()
+    ssl_subgroup.add_argument("--verify-ssl", nargs="?", default="True",
+                              help='Verify SSL connection when downloading file')
+    ssl_subgroup.add_argument("--insecure", action="store_true", default=None,
+                              help="Allow insecure server connections when using SSL")
     subparser.add_argument("-t", "--type", choices=["git", "dir", "file", "url"],
                            help='Type of remote config')
     subparser.add_argument("-a", "--args",
@@ -36,8 +39,7 @@ def config_install(conan_api, parser, subparser, *args):
     subparser.add_argument("-tf", "--target-folder",
                            help='Install to that path in the conan cache')
     args = parser.parse_args(*args)
-
-    verify_ssl = get_bool_from_text(args.verify_ssl)
+    verify_ssl = not args.insecure if args.insecure is not None else get_bool_from_text(args.verify_ssl)
     conan_api.config.install(args.item, verify_ssl, args.type, args.args,
                              source_folder=args.source_folder,
                              target_folder=args.target_folder)

--- a/conans/test/functional/command/config_install_test.py
+++ b/conans/test/functional/command/config_install_test.py
@@ -470,6 +470,12 @@ class ConfigInstallTest(unittest.TestCase):
         with patch.object(FileDownloader, 'download', new=download_verify_true):
             self.client.run("config install %s --verify-ssl=True" % fake_url)
 
+        with patch.object(FileDownloader, 'download', new=download_verify_true):
+            self.client.run(f"config install {fake_url}")
+
+        with patch.object(FileDownloader, 'download', new=download_verify_false):
+            self.client.run(f"config install {fake_url} --insecure")
+
     @pytest.mark.tool("git")
     def test_git_checkout_is_possible(self):
         folder = self._create_profile_folder()

--- a/conans/test/integration/command/config_test.py
+++ b/conans/test/integration/command/config_test.py
@@ -45,3 +45,13 @@ def test_config_list():
         assert f"{k}: {v}" in client.out
     client.run("config list --format=json")
     assert f"{json.dumps(BUILT_IN_CONFS, indent=4)}\n" == client.stdout
+
+
+def test_config_install():
+    tc = TestClient()
+    tc.save({'config/foo': ''})
+    # This should not fail (insecure flag exists)
+    tc.run("config install config --insecure")
+    assert "foo" in os.listdir(tc.cache_folder)
+    # Negative test, ensure we would be catching a missing arg if it did not exist
+    tc.run("config install config --superinsecure", assert_error=True)


### PR DESCRIPTION
Changelog: Feature: Add `--insecure` alias to `--verify-ssl` in config install.
Docs: https://github.com/conan-io/docs/pull/3035
