### PR TITLE
Remove all modules (which are imported in conanfile.py) from modules cache

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -454,6 +454,7 @@ def _parse_conanfile(conan_file_path):
 
         # These lines are necessary, otherwise local conanfile imports with same name
         # collide, but no error, and overwrite other packages imports!!
+        cached_imports = getattr(loaded, "cached_imports", sys.modules.values())
         added_modules = set(sys.modules).difference(old_modules)
         for added in added_modules:
             module = sys.modules[added]
@@ -469,7 +470,7 @@ def _parse_conanfile(conan_file_path):
                 except AttributeError:  # In case the module.__path__ doesn't exist
                     pass
                 else:
-                    if folder.startswith(current_dir):
+                    if folder.startswith(current_dir) or module not in cached_imports:
                         module = sys.modules.pop(added)
                         sys.modules["%s.%s" % (module_id, added)] = module
     except ConanException:

--- a/conans/test/integration/conanfile/conanfile_export_test.py
+++ b/conans/test/integration/conanfile/conanfile_export_test.py
@@ -1,0 +1,114 @@
+import unittest
+import sys
+import os
+import textwrap
+from conans.test.utils.tools import TestClient
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.mocks import RedirectedTestOutput
+
+conanfile = textwrap.dedent("""
+    from conan import ConanFile
+    import myfile
+    from myfile import MyClass
+    from myfile import number as number
+    
+    class Pkg(ConanFile):
+        name = "{name}"
+        version = "0.1"
+        exports = "myfile.py"
+
+        def package_info(self):
+            self.output.info(f"NUMBER1: {{myfile.number}}")
+            self.output.info(f"NUMBER2: {{MyClass.number}}")
+            self.output.info(f"NUMBER3: {{number}}")
+        """)
+myfile = textwrap.dedent("""\
+    number = {number}
+
+    class MyClass:
+        number = {number}
+    """)
+
+conanfile_main = GenConanfile().with_requires("pkg1/0.1","pkg2/0.1")
+conanfile_main._imports.append("import myfile")
+conanfile_main._imports.append("from myfile import MyClass")
+conanfile_main._imports.append("from myfile import number as number")
+
+class ExportTest(unittest.TestCase):
+    def test_local_imports(self):
+        c = TestClient()
+        c.save({"pkg1/conanfile.py": conanfile.format(name="pkg1"),
+                "pkg1/myfile.py": myfile.format(number="42"),
+                "pkg2/conanfile.py": conanfile.format(name="pkg2"),
+                "pkg2/myfile.py": myfile.format(number="123"),
+                "app/conanfile.py": GenConanfile().with_requires("pkg1/0.1", "pkg2/0.1")})
+    
+        c.run("create pkg1")
+        c.run("create pkg2")
+        c.run("install app")
+        
+        # do not take any cached module
+        assert "pkg1/0.1: NUMBER1: 42" in c.out
+        assert "pkg1/0.1: NUMBER2: 42" in c.out
+        assert "pkg1/0.1: NUMBER3: 42" in c.out
+        assert "pkg2/0.1: NUMBER1: 123" in c.out
+        assert "pkg2/0.1: NUMBER2: 123" in c.out
+        assert "pkg2/0.1: NUMBER3: 123" in c.out
+        
+    def test_imports_sys_path(self):
+        c = TestClient()
+        
+        c.save({"pkg1/conanfile.py": conanfile.format(name="pkg1"),
+                "pkg1/myfile.py": myfile.format(number="42"),
+                "pkg2/conanfile.py": conanfile.format(name="pkg2"),
+                "pkg2/myfile.py": myfile.format(number="123"),
+                "base/myfile.py": myfile.format(number="666"),
+                "app/conanfile.py": conanfile_main})
+    
+        c.run("create pkg1")
+        c.run("create pkg2")
+
+        c.out = RedirectedTestOutput()
+        base_path = os.path.join(c.current_folder, "base")
+        try:
+            sys.path.insert(0, base_path)
+            c.run("install app")
+        finally:
+            sys.path.remove(base_path)
+            
+        # take the cached module from sys.path
+        assert "pkg1/0.1: NUMBER1: 666" in c.out
+        assert "pkg1/0.1: NUMBER2: 666" in c.out
+        assert "pkg1/0.1: NUMBER3: 666" in c.out
+        assert "pkg2/0.1: NUMBER1: 666" in c.out
+        assert "pkg2/0.1: NUMBER2: 666" in c.out
+        assert "pkg2/0.1: NUMBER3: 666" in c.out
+        
+    def test_export_cached_imports_variable(self):
+        c = TestClient()
+        
+        conanfile_app = "cached_imports = []\n" + str(conanfile_main)
+        
+        c.save({"pkg1/conanfile.py": conanfile.format(name="pkg1"),
+                "pkg1/myfile.py": myfile.format(number="42"),
+                "pkg2/conanfile.py": conanfile.format(name="pkg2"),
+                "pkg2/myfile.py": myfile.format(number="123"),
+                "base/myfile.py": myfile.format(number="666"),
+                "app/conanfile.py": conanfile_app})
+    
+        c.run("create pkg1")
+        c.run("create pkg2")
+        
+        base_path = os.path.join(c.current_folder, "base")
+        try:
+            sys.path.insert(0, base_path)
+            c.run("install app")
+        finally:
+            sys.path.remove(base_path)
+            
+        assert "pkg1/0.1: NUMBER1: 42" in c.out
+        assert "pkg1/0.1: NUMBER2: 42" in c.out
+        assert "pkg1/0.1: NUMBER3: 42" in c.out
+        assert "pkg2/0.1: NUMBER1: 123" in c.out
+        assert "pkg2/0.1: NUMBER2: 123" in c.out
+        assert "pkg2/0.1: NUMBER3: 123" in c.out

--- a/conans/test/integration/conanfile/conanfile_export_test.py
+++ b/conans/test/integration/conanfile/conanfile_export_test.py
@@ -70,11 +70,14 @@ class ExportTest(unittest.TestCase):
 
         c.out = RedirectedTestOutput()
         base_path = os.path.join(c.current_folder, "base")
+        
         try:
             sys.path.insert(0, base_path)
+            __import__("myfile")
             c.run("install app")
         finally:
             sys.path.remove(base_path)
+            sys.modules.pop("myfile")
             
         # take the cached module from sys.path
         assert "pkg1/0.1: NUMBER1: 666" in c.out
@@ -167,19 +170,21 @@ class ExportTest(unittest.TestCase):
             c.run("export pkg1")
             c.run("export pkg2")
             c.run("install app --build=missing")
-            print(c.out)
         finally:
             sys.path.remove(base_path)
             
         
         assert f"pkg1/0.1: build of pkg1" in c.out
         assert f"pkg1/0.1: package_info of pkg1" in c.out
-        assert f"pkg1/0.1: using conanfile_base {c.cache_folder}/data/pkg1/0.1/_/_/export/conanfile_base.py" in c.out
+        expected_pkg1_base = os.path.join(c.cache_folder, "data", "pkg1", "0.1", "_", "_", "export", "conanfile_base.py")
+        assert f"pkg1/0.1: using conanfile_base {expected_pkg1_base}" in c.out
         
         assert f"pkg2/0.1: package_info of pkg2" in c.out
         assert f"pkg2/0.1: build of pkg2" in c.out
-        assert f"pkg2/0.1: using conanfile_base {c.cache_folder}/data/pkg2/0.1/_/_/export/conanfile_base.py" in c.out
+        expected_pkg2_base = os.path.join(c.cache_folder, "data", "pkg2", "0.1", "_", "_", "export", "conanfile_base.py")
+        assert f"pkg2/0.1: using conanfile_base {expected_pkg2_base}" in c.out
         
-        assert f"conanfile.py (app/0.1): using conanfile_base {base_path}/conanfile_base.py" in c.out
+        expected_base = os.path.join(base_path, "conanfile_base.py")
+        assert f"conanfile.py (app/0.1): using conanfile_base {expected_base}" in c.out
         
         


### PR DESCRIPTION
Ref: #13272

Changelog: (Fix): Remove all modules (which are imported in conanfile.py) from modules cache
Docs: https://github.com/conan-io/docs/pull/XXXX

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
