### PR TITLE
Fix/detect visual runtime type

### DIFF
--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -224,7 +224,6 @@ def _detect_compiler_version(result):
         # Add default mandatory fields for MSVC compiler
         result.append(("compiler.cppstd", "14"))
         result.append(("compiler.runtime", "dynamic"))
-        result.append(("compiler.runtime_type", "Release"))
 
     if compiler != "msvc":
         cppstd = _cppstd_default(compiler, version)

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -10,7 +10,7 @@ from conans.client.conf.detect import detect_defaults_settings
 from conans.test.utils.mocks import RedirectedTestOutput
 from conans.test.utils.tools import TestClient, redirect_output
 from conans.util.env import environment_update
-from conans.util.files import load, save
+from conans.util.files import save
 from conans.util.runners import check_output_runner
 
 
@@ -118,12 +118,13 @@ class DetectCompilersTest(unittest.TestCase):
         self.assertIn("gcc detected as a frontend using apple-clang", output)
 
     def test_profile_new(self):
-        client = TestClient()
+        c = TestClient()
+        c.run("profile detect --name=./MyProfile2")
+        profile = c.load("MyProfile2")
+        assert "os=" in profile
+        assert "compiler.runtime_type" not in profile  # Even in Windows
 
-        client.run("profile detect --name=./MyProfile2")
-        pr_path = os.path.join(client.current_folder, "MyProfile2")
-        self.assertTrue(os.path.exists(os.path.join(client.current_folder, "MyProfile2")))
-        self.assertIn("os=", load(pr_path))
+        c.run("profile detect --name=./MyProfile2", assert_error=True)
+        assert "MyProfile2' already exists" in c.out
 
-        client.run("profile detect --name=./MyProfile2", assert_error=True)
-        self.assertIn("MyProfile2' already exists", client.out)
+        c.run("profile detect --name=./MyProfile2 --force")  # will not raise error


### PR DESCRIPTION
Changelog: Fix: Do not auto-detect ``compiler.runtime_type`` for ``msvc``, rely on profile plugin.
Docs: Omit

Close https://github.com/conan-io/conan/issues/13232
