### PR TITLE
fix msvc cppstd checks

### DIFF
--- a/conan/tools/build/cppstd.py
+++ b/conan/tools/build/cppstd.py
@@ -205,9 +205,11 @@ def _msvc_supported_cppstd(version):
     """
     [14, 17, 20, 23]
     """
-    if version < "190":
+    if version < "190":  # pre VS 2015
         return []
-    if version < "191":
+    if version < "191":  # VS 2015
+        return ["14"]
+    if version < "192":  # VS 2017
         return ["14", "17"]
     if version < "193":
         return ["14", "17", "20"]

--- a/conan/tools/build/cppstd.py
+++ b/conan/tools/build/cppstd.py
@@ -203,6 +203,10 @@ def _gcc_supported_cppstd(version):
 
 def _msvc_supported_cppstd(version):
     """
+    https://learn.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version?view=msvc-170
+    - /std:c++14 starting in Visual Studio 2015 Update 3 (190)
+    - /std:c++17 starting in Visual Studio 2017 version 15.3. (191)
+    - /std:c++20 starting in Visual Studio 2019 version 16.11 (192)
     [14, 17, 20, 23]
     """
     if version < "190":  # pre VS 2015

--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -68,7 +68,8 @@ def _check_correct_cppstd(settings):
                     "14": "5.1",
                     "11": "4.5"}.get(cppstd)
         elif compiler == "msvc":
-            mver = {"20": "193",
+            mver = {"23": "193",
+                    "20": "192",
                     "17": "191",
                     "14": "190"}.get(cppstd)
         if mver and version < mver:

--- a/conans/test/unittests/tools/build/test_cppstd.py
+++ b/conans/test/unittests/tools/build/test_cppstd.py
@@ -79,8 +79,9 @@ def test_supported_cppstd_apple_clang(compiler, compiler_version, values):
 
 @pytest.mark.parametrize("compiler,compiler_version,values", [
     ("msvc", "180", []),
-    ("msvc", "190", ['14', '17']),
-    ("msvc", "191", ['14', '17', '20']),
+    ("msvc", "190", ['14']),
+    ("msvc", "191", ['14', '17']),
+    ("msvc", "192", ['14', '17', '20']),
     ("msvc", "193", ['14', '17', '20', '23']),
 ])
 def test_supported_cppstd_msvc(compiler, compiler_version, values):


### PR DESCRIPTION
Changelog: Bugfix: Fix supported ``cppstd`` values for ``msvc`` compiler.
Docs: Omit

Closes https://github.com/conan-io/conan/issues/13213