### PR TITLE
missing parseargs

### DIFF
--- a/conan/cli/commands/config.py
+++ b/conan/cli/commands/config.py
@@ -1,5 +1,3 @@
-import sys
-
 from conan.api.output import cli_out_write
 from conan.cli.command import conan_command, conan_subcommand
 from conan.cli.commands import default_json_formatter, default_text_formatter
@@ -57,6 +55,7 @@ def config_home(conan_api, parser, subparser, *args):
     """
     Show the Conan home folder.
     """
+    parser.parse_args(*args)
     return conan_api.config.home()
 
 
@@ -65,4 +64,5 @@ def config_list(conan_api, parser, subparser, *args):
     """
     Show all the Conan available configurations: core and tools.
     """
+    parser.parse_args(*args)
     return BUILT_IN_CONFS

--- a/conans/test/integration/command/config_test.py
+++ b/conans/test/integration/command/config_test.py
@@ -47,6 +47,9 @@ def test_config_list():
     client.run("config list --format=json")
     assert f"{json.dumps(BUILT_IN_CONFS, indent=4)}\n" == client.stdout
 
+    client.run("config list unexpectedarg", assert_error=True)
+    assert "unrecognized arguments: unexpectedarg" in client.out
+
 
 def test_config_install():
     tc = TestClient()

--- a/conans/test/integration/command/config_test.py
+++ b/conans/test/integration/command/config_test.py
@@ -26,8 +26,9 @@ class TestConfigHome:
         client.run("config home")
         assert f"{client.cache.cache_folder}\n" == client.stdout
 
-        client.run("config home --format=text")
-        assert f"{client.cache.cache_folder}\n" == client.stdout
+        client.run("config home --format=text", assert_error=True)
+        # It is not possible to use --format=text explicitly
+        assert "--format=text" in client.out
 
     def test_api_uses_env_var_home(self):
         cache_folder = os.path.join(temp_folder(), "custom")


### PR DESCRIPTION
Changelog: Fix: Raise arg error if ``conan config list unexpected-arg``.
Docs: Omit