### PR TITLE
Fixed parsing the output of vswhere

### DIFF
--- a/conans/client/conf/detect_vs.py
+++ b/conans/client/conf/detect_vs.py
@@ -151,7 +151,7 @@ def vswhere(all_=False, prerelease=False, products=None, requires=None, version=
     try:
         from conans.util.runners import check_output_runner
         cmd = cmd_args_to_string(arguments)
-        output = check_output_runner(cmd).strip()
+        output = check_output_runner(cmd, encoding="ansi").strip()
         # Ignore the "description" field, that even decoded contains non valid charsets for json
         # (ignored ones)
         output = "\n".join([line for line in output.splitlines()

--- a/conans/util/runners.py
+++ b/conans/util/runners.py
@@ -79,7 +79,7 @@ def detect_runner(command):
     return proc.returncode, "".join(output_buffer)
 
 
-def check_output_runner(cmd, stderr=None):
+def check_output_runner(cmd, stderr=None, encoding="utf-8"):
     # Used to run several utilities, like Pacman detect, AIX version, uname, SCM
     assert isinstance(cmd, str)
     d = tempfile.mkdtemp()
@@ -96,7 +96,7 @@ def check_output_runner(cmd, stderr=None):
             msg = f"Command '{cmd}' failed with errorcode '{process.returncode}'\n{stderr}"
             raise ConanException(msg)
 
-        output = load(tmp_file)
+        output = load(tmp_file, encoding=encoding)
         return output
     finally:
         try:


### PR DESCRIPTION


Changelog: (Bugfix): Fixed the detection of certain visual c++ installations
Docs: https://github.com/conan-io/docs/pull/XXXX

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

The output of vswhere uses "Ansi" encoding. It was though decoded via "Utf-8", which raised an exception in certain cases (i.e. letters like 'ö').

Thus, some visual studio installation could not be found.

Fixes #13281

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
