### PR TITLE
Fixed parsing the output of vswhere

### DIFF
--- a/conans/client/conf/detect_vs.py
+++ b/conans/client/conf/detect_vs.py
@@ -114,6 +114,7 @@ def vswhere(all_=False, prerelease=False, products=None, requires=None, version=
     arguments.append(vswhere_path)
 
     # Output json format
+    arguments.append("-utf8")
     arguments.append("-format")
     arguments.append("json")
 


### PR DESCRIPTION
Changelog: Bugfix: Fixed the detection of certain visual c++ installations.
Docs: Omit

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

The output of vswhere uses "Ansi" encoding. It was though decoded via "Utf-8", which raised an exception in certain cases (i.e. letters like 'ö').

This PR forces the output of vswhere to be utf-8, resolving the issue.

Thus, some visual studio installation could not be found.

Fixes #13281

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
