### PR TITLE
Fix typo in conan remote auth help

### DIFF
--- a/conan/cli/commands/remote.py
+++ b/conan/cli/commands/remote.py
@@ -262,8 +262,8 @@ def remote_auth(conan_api, parser, subparser, *args):
     """
     Authenticate in the defined remotes
     """
-    subparser.add_argument("remote", help="Pattern of the remote/s to disable. "
-                                          "The pattern uses 'fnmatch' style wildcards.")
+    subparser.add_argument("remote", help="Pattern or name of the remote/s to authenticate against."
+                                          " The pattern uses 'fnmatch' style wildcards.")
     subparser.add_argument("--with-user", action="store_true",
                            help="Only try to auth in those remotes that already "
                                 "have a username or a CONAN_LOGIN_ env-var defined")


### PR DESCRIPTION
Changelog: Fix: Fix typo in `conan remote auth` help.
Docs: https://github.com/conan-io/docs/pull/3039

Fix typo in `conan remote auth`

Closes #13221 
