### PR TITLE
Do not copy conan_server to conan folder when generating binaries with pyinstaller

### DIFF
--- a/pyinstaller.py
+++ b/pyinstaller.py
@@ -102,7 +102,6 @@ def pyinstall(source_folder):
         print("Unable to remove old folder", e)
 
     conan_path = os.path.join(source_folder, 'conans', 'conan.py')
-    conan_server_path = os.path.join(source_folder, 'conans', 'conan_server.py')
     hidden = ("--hidden-import=glob "  # core stdlib
               "--hidden-import=pathlib "
               "--hidden-import=distutils.dir_util "

--- a/pyinstaller.py
+++ b/pyinstaller.py
@@ -139,10 +139,6 @@ def pyinstall(source_folder):
                     % (command, source_folder, conan_server_path, win_ver),
                     cwd=pyinstaller_path, shell=True)
 
-    conan_bin = os.path.join(pyinstaller_path, 'dist', 'conan')
-    conan_server_folder = os.path.join(pyinstaller_path, 'dist', 'conan_server')
-
-    dir_util.copy_tree(conan_server_folder, conan_bin)
     _run_bin(pyinstaller_path)
 
     return os.path.abspath(os.path.join(pyinstaller_path, 'dist', 'conan'))

--- a/pyinstaller.py
+++ b/pyinstaller.py
@@ -135,12 +135,6 @@ def pyinstall(source_folder):
 
     _run_bin(pyinstaller_path)
 
-    subprocess.call('%s -y -p "%s" --console "%s" %s'
-                    % (command, source_folder, conan_server_path, win_ver),
-                    cwd=pyinstaller_path, shell=True)
-
-    _run_bin(pyinstaller_path)
-
     return os.path.abspath(os.path.join(pyinstaller_path, 'dist', 'conan'))
 
 


### PR DESCRIPTION
Changelog: omit
Docs: omit

When generating binaries with pyinstaller do not copy conan_server to conan folder.
