### PR TITLE
Ensure topics and provides are always serialized as lists

### DIFF
--- a/conans/client/graph/provides.py
+++ b/conans/client/graph/provides.py
@@ -15,8 +15,6 @@ def check_graph_provides(dep_graph):
             dep_provides = dep_node.conanfile.provides
             if dep_provides is None:
                 continue
-            if isinstance(dep_provides, str):
-                dep_provides = dep_provides,  # convert to tuple to iterate
             for provide in dep_provides:
                 # First check if collides with current node
                 if current_provides is not None and provide in current_provides:

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -115,11 +115,18 @@ class ConanFile:
 
     def serialize(self):
         result = {}
+
+        # Some fields are requested in the docs to be tuples, but we accept single strings too,
+        # ensure those fields are serialized as lists so things like CIs don't break unexpectedly,
+        # as it did for cci
+        def _ensure_iterable_if_needed(k, value):
+            return [value] if k in ("topics", "provides") and isinstance(value, str) else value
+
         for a in ("url", "license", "author", "description", "topics", "homepage", "build_policy",
                   "revision_mode", "provides", "deprecated", "win_bash"):
             v = getattr(self, a)
             if v is not None:
-                result[a] = v
+                result[a] = _ensure_iterable_if_needed(a, v)
         result["package_type"] = str(self.package_type)
         result["settings"] = self.settings.serialize()
         if hasattr(self, "python_requires"):

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -95,6 +95,11 @@ class ConanFile:
 
         self.options = Options(self.options or {}, self.default_options)
 
+        if isinstance(self.topics, str):
+            self.topics = [self.topics]
+        if isinstance(self.provides, str):
+            self.provides = [self.provides]
+
         # user declared variables
         self.user_info = MockInfoProperty("user_info")
         self.env_info = MockInfoProperty("env_info")
@@ -115,18 +120,11 @@ class ConanFile:
 
     def serialize(self):
         result = {}
-
-        # Some fields are requested in the docs to be tuples, but we accept single strings too,
-        # ensure those fields are serialized as lists so things like CIs don't break unexpectedly,
-        # as it did for cci
-        def _ensure_iterable_if_needed(k, value):
-            return [value] if k in ("topics", "provides") and isinstance(value, str) else value
-
         for a in ("url", "license", "author", "description", "topics", "homepage", "build_policy",
                   "revision_mode", "provides", "deprecated", "win_bash"):
             v = getattr(self, a)
             if v is not None:
-                result[a] = _ensure_iterable_if_needed(a, v)
+                result[a] = v
         result["package_type"] = str(self.package_type)
         result["settings"] = self.settings.serialize()
         if hasattr(self, "python_requires"):

--- a/conans/test/integration/command/info/info_test.py
+++ b/conans/test/integration/command/info/info_test.py
@@ -55,6 +55,49 @@ class TestBasicCliOutput:
               package_id: {pref.package_id}
               prev: {pref.revision}""") in client.out
 
+    def test_nontuple_topics(self):
+        client = TestClient()
+        # This is the representation that should always happen,
+        # we wouldn't expect topics not to be a tuple here
+        conanfile = textwrap.dedent("""
+                            from conan import ConanFile
+
+                            class MyTest(ConanFile):
+                                name = "pkg"
+                                version = "0.2"
+                                provides = ("bar",)
+                                topics = ("foo",)
+                            """)
+        client.save({"conanfile.py": conanfile})
+        client.run("graph info . --format=json")
+        recipe = json.loads(client.stdout)["nodes"][0]
+        assert type(recipe["topics"]) == list
+        assert recipe["topics"] == ["foo"]
+        assert type(recipe["provides"]) == list
+        assert recipe["provides"] == ["bar"]
+
+        # But this used to fail,
+        # topics were not converted to a list internally if one was not provided
+        client2 = TestClient()
+        conanfile2 = textwrap.dedent("""
+                    from conan import ConanFile
+
+                    class MyTest(ConanFile):
+                        name = "pkg"
+                        version = "0.2"
+                        provides = "bar"
+                        topics = "foo"
+                    """)
+        client2.save({"conanfile.py": conanfile2})
+        client2.run("graph info . --format=json")
+        recipe = json.loads(client2.stdout)["nodes"][0]
+        assert type(recipe["topics"]) == list
+        assert recipe["topics"] == ["foo"]
+        assert type(recipe["provides"]) == list
+        assert recipe["provides"] == ["bar"]
+
+
+
 
 class TestConanfilePath:
     def test_cwd(self):


### PR DESCRIPTION
Changelog: Bugfix: Ensure that `topics` are always serialized as lists.
Docs: omit
Changelog: Bugfix: Ensure that `provides` are always serialized as lists.
Docs: omit


This came about with cci's CI breaking due to a broken logic that assumed topics were always a list, which was not the case for some of the recipes. After hotfixing its code, this PR now aims to ensure that both `topics` and `provides` are always serialized as lists, even if the recipe defines only a string for those attributes.
