### PR TITLE
Start reducing exposure of internal imports to Command layer

### DIFF
--- a/conan/api/subapi/local.py
+++ b/conan/api/subapi/local.py
@@ -2,8 +2,13 @@ import os
 
 from conan.cli import make_abs_path
 from conan.internal.conan_app import ConanApp
-from conans.errors import ConanException
+from conans.client.conanfile.build import run_build_method
+from conans.client.graph.graph import CONTEXT_HOST
+from conans.client.graph.profile_node_definer import initialize_conanfile_profile
+from conans.client.source import run_source_method
+from conans.errors import ConanException, conanfile_exception_formatter
 from conans.model.recipe_ref import RecipeReference
+from conans.util.files import chdir
 
 
 class LocalAPI:
@@ -58,3 +63,41 @@ class LocalAPI:
     def editable_list(self):
         app = ConanApp(self._conan_api.cache_folder)
         return app.cache.editable_packages.edited_refs
+
+    def source(self, path, name=None, version=None, user=None, channel=None):
+        """ calls the 'source()' method of the current (user folder) conanfile.py
+        """
+        app = ConanApp(self._conan_api.cache_folder)
+        conanfile = app.loader.load_consumer(path, name=name, version=version,
+                                             user=user, channel=channel, graph_lock=None)
+        # This profile is empty, but with the conf from global.conf
+        profile = self._conan_api.profiles.get_profile([])
+        initialize_conanfile_profile(conanfile, profile, profile, CONTEXT_HOST, False)
+        # This is important, otherwise the ``conan source`` doesn't define layout and fails
+        if hasattr(conanfile, "layout"):
+            with conanfile_exception_formatter(conanfile, "layout"):
+                conanfile.layout()
+
+        folder = conanfile.recipe_folder
+        conanfile.folders.set_base_source(folder)
+        conanfile.folders.set_base_export_sources(folder)
+        conanfile.folders.set_base_build(None)
+        conanfile.folders.set_base_package(None)
+
+        app = ConanApp(self._conan_api.cache_folder)
+        run_source_method(conanfile, app.hook_manager)
+
+    def build(self, conanfile):
+        """ calls the 'build()' method of the current (user folder) conanfile.py
+        """
+        app = ConanApp(self._conan_api.cache_folder)
+        conanfile.folders.set_base_package(conanfile.folders.base_build)
+        run_build_method(conanfile, app.hook_manager)
+
+    @staticmethod
+    def test(conanfile):
+        """ calls the 'test()' method of the current (user folder) test_package/conanfile.py
+        """
+        with conanfile_exception_formatter(conanfile, "test"):
+            with chdir(conanfile.build_folder):
+                conanfile.test()

--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -1,5 +1,5 @@
 from conan.cli.command import OnceArgument
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 _help_build_policies = '''Optional, specify which packages to build from source. Combining multiple
     '--build' options on one command line is allowed.

--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -17,7 +17,7 @@ from conan.cli.exit_codes import SUCCESS, ERROR_MIGRATION, ERROR_GENERAL, USER_C
     ERROR_SIGTERM, USER_CTRL_BREAK, ERROR_INVALID_CONFIGURATION, ERROR_UNEXPECTED
 from conans import __version__ as client_version
 from conans.client.cache.cache import ClientCache
-from conans.errors import ConanException, ConanInvalidConfiguration, ConanMigrationError
+from conan.errors import ConanException, ConanInvalidConfiguration, ConanMigrationError
 from conans.util.files import exception_message_safe
 
 

--- a/conan/cli/command.py
+++ b/conan/cli/command.py
@@ -1,7 +1,7 @@
 import argparse
 import textwrap
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 class OnceArgument(argparse.Action):

--- a/conan/cli/commands/build.py
+++ b/conan/cli/commands/build.py
@@ -4,10 +4,8 @@ from conan.api.output import ConanOutput
 from conan.cli.command import conan_command
 from conan.cli import make_abs_path
 from conan.cli.args import add_lockfile_args, add_common_install_arguments, add_reference_args
-from conan.internal.conan_app import ConanApp
 from conan.cli.printers import print_profiles
 from conan.cli.printers.graph import print_graph_packages, print_graph_basic
-from conans.client.conanfile.build import run_build_method
 
 
 @conan_command(group='Creator')
@@ -59,11 +57,9 @@ def build(conan_api, parser, *args):
     conan_api.install.install_consumer(deps_graph=deps_graph, source_folder=source_folder,
                                        output_folder=output_folder)
 
-    # TODO: Decide API to put this
-    app = ConanApp(conan_api.cache_folder)
+    out.title("Calling build()")
     conanfile = deps_graph.root.conanfile
-    conanfile.folders.set_base_package(conanfile.folders.base_build)
-    run_build_method(conanfile, app.hook_manager)
+    conan_api.local.build(conanfile)
 
     lockfile = conan_api.lockfile.update_lockfile(lockfile, deps_graph, args.lockfile_packages,
                                                   clean=args.lockfile_clean)

--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -2,7 +2,7 @@ from conan.api.conan_api import ConanAPI
 from conan.api.model import ListPattern
 from conan.api.output import cli_out_write
 from conan.cli.command import conan_command, conan_subcommand, OnceArgument
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
 

--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -7,11 +7,9 @@ from conan.cli.command import conan_command, OnceArgument
 from conan.cli.commands.export import common_args_export
 from conan.cli.args import add_lockfile_args, add_common_install_arguments
 from conan.cli.printers import print_profiles
-from conan.internal.conan_app import ConanApp
 from conan.cli.printers.graph import print_graph_packages, print_graph_basic
-from conans.client.conanfile.build import run_build_method
-from conans.errors import ConanException, conanfile_exception_formatter
-from conans.util.files import chdir, mkdir
+from conan.errors import ConanException
+from conans.util.files import mkdir
 
 
 def json_create(deps_graph):
@@ -135,15 +133,11 @@ def test_package(conan_api, deps_graph, test_conanfile_path, tested_python_requi
                                        source_folder=conanfile_folder)
 
     out.title("Testing the package: Building")
-    app = ConanApp(conan_api.cache_folder)
-    conanfile.folders.set_base_package(conanfile.folders.base_build)
-    run_build_method(conanfile, app.hook_manager)
+    conan_api.local.build(conanfile)
 
     out.title("Testing the package: Executing test")
     conanfile.output.highlight("Running test()")
-    with conanfile_exception_formatter(conanfile, "test"):
-        with chdir(conanfile.build_folder):
-            conanfile.test()
+    conan_api.local.test(conanfile)
 
 
 def _get_test_conanfile_path(tf, conanfile_path):

--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -10,7 +10,7 @@ from conan.cli.formatters.graph.graph_info_text import format_graph_info
 from conan.cli.printers.graph import print_graph_packages, print_graph_basic
 from conan.internal.deploy import do_deploys
 from conans.client.graph.install_graph import InstallGraph
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 @conan_command(group="Consumer")

--- a/conan/cli/commands/install.py
+++ b/conan/cli/commands/install.py
@@ -7,7 +7,7 @@ from conan.cli.command import conan_command
 from conan.cli import make_abs_path
 from conan.cli.printers import print_profiles
 from conan.cli.printers.graph import print_graph_packages, print_graph_basic
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 def json_install(info):

--- a/conan/cli/commands/new.py
+++ b/conan/cli/commands/new.py
@@ -5,7 +5,7 @@ from jinja2 import Environment, meta, exceptions
 
 from conan.api.output import ConanOutput
 from conan.cli.command import conan_command
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.util.files import save
 
 

--- a/conan/cli/commands/profile.py
+++ b/conan/cli/commands/profile.py
@@ -4,7 +4,7 @@ from conan.api.output import ConanOutput, cli_out_write
 from conan.cli.command import conan_command, conan_subcommand
 from conan.cli.formatters import default_json_formatter
 from conan.cli.args import add_profiles_args
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.util.files import save
 
 

--- a/conan/cli/commands/remote.py
+++ b/conan/cli/commands/remote.py
@@ -8,7 +8,7 @@ from conan.cli.command import conan_command, conan_subcommand, OnceArgument
 from conan.cli.commands.list import remote_color, error_color, recipe_color, \
     reference_color
 from conans.client.userio import UserInput
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 def formatter_remote_list_json(remotes):

--- a/conan/cli/commands/search.py
+++ b/conan/cli/commands/search.py
@@ -4,7 +4,7 @@ from conan.api.conan_api import ConanAPI
 from conan.api.model import ListPattern
 from conan.cli.command import conan_command
 from conan.cli.commands.list import print_list_text, print_list_json
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 # FIXME: "conan search" == "conan list (*) -r="*"" --> implement @conan_alias_command??

--- a/conan/cli/commands/source.py
+++ b/conan/cli/commands/source.py
@@ -2,11 +2,6 @@ import os
 
 from conan.cli.command import conan_command
 from conan.cli.args import add_reference_args
-from conan.internal.conan_app import ConanApp
-from conans.client.graph.graph import CONTEXT_HOST
-from conans.client.graph.profile_node_definer import initialize_conanfile_profile
-from conans.client.source import run_source_method
-from conans.errors import conanfile_exception_formatter
 
 
 @conan_command(group="Creator")
@@ -14,35 +9,12 @@ def source(conan_api, parser, *args):
     """
     Call the source() method.
     """
-    parser.add_argument("path", nargs="?",
-                        help="Path to a folder containing a recipe (conanfile.py "
-                             "or conanfile.txt) or to a recipe file. e.g., "
-                             "./my_project/conanfile.txt.")
+    parser.add_argument("path", help="Path to a folder containing a conanfile.py")
     add_reference_args(parser)
     args = parser.parse_args(*args)
 
     cwd = os.getcwd()
     path = conan_api.local.get_conanfile_path(args.path, cwd, py=True)
-    folder = os.path.dirname(path)
-
-    # TODO: Decide API to put this
-    app = ConanApp(conan_api.cache_folder)
-    # This profile is empty, but with the conf from global.conf
-    profile = conan_api.profiles.get_profile([])
-    conanfile = app.loader.load_consumer(path,
-                                         name=args.name, version=args.version,
-                                         user=args.user, channel=args.channel,
-                                         graph_lock=None)
-
-    initialize_conanfile_profile(conanfile, profile, profile, CONTEXT_HOST, False)
-    # This is important, otherwise the ``conan source`` doesn't define layout and fails
-    if hasattr(conanfile, "layout"):
-        with conanfile_exception_formatter(conanfile, "layout"):
-            conanfile.layout()
-
-    conanfile.folders.set_base_source(folder)
-    conanfile.folders.set_base_export_sources(folder)
-    conanfile.folders.set_base_build(None)
-    conanfile.folders.set_base_package(None)
-
-    run_source_method(conanfile, app.hook_manager)
+    # TODO: Missing lockfile for python_requires
+    conan_api.local.source(path, name=args.name, version=args.version, user=args.user,
+                           channel=args.channel)

--- a/conan/cli/commands/upload.py
+++ b/conan/cli/commands/upload.py
@@ -2,7 +2,7 @@ from conan.api.conan_api import ConanAPI
 from conan.api.model import ListPattern
 from conan.cli.command import conan_command, OnceArgument
 from conans.client.userio import UserInput
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 @conan_command(group="Creator")

--- a/conan/errors.py
+++ b/conan/errors.py
@@ -1,2 +1,3 @@
 from conans.errors import ConanException
 from conans.errors import ConanInvalidConfiguration
+from conans.errors import ConanMigrationError


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Internal pure refactor: the Command layer is still using many ``internal`` and ``from conans.`` details, which is bad, must be cleaned, otherwise users doing custom commands might start copying & pasting internal details