### PR TITLE
Add  `core.version_ranges:resolve_prereleases` conf

### DIFF
--- a/conan/api/subapi/graph.py
+++ b/conan/api/subapi/graph.py
@@ -167,7 +167,7 @@ class GraphAPI:
         assert profile_build is not None
 
         remotes = remotes or []
-        builder = DepsGraphBuilder(app.proxy, app.loader, app.range_resolver, remotes,
+        builder = DepsGraphBuilder(app.proxy, app.loader, app.range_resolver, app.cache, remotes,
                                    update, check_update)
         deps_graph = builder.load_graph(root_node, profile_host, profile_build, lockfile)
         return deps_graph

--- a/conans/client/conf/required_version.py
+++ b/conans/client/conf/required_version.py
@@ -10,7 +10,9 @@ def validate_conan_version(required_range):
     version_range = VersionRange(required_range)
     for conditions in version_range.condition_sets:
         conditions.prerelease = True
-    if not version_range.contains(clientver):
+    # TODO: Think what's the better approach for resolving prereleases.
+    # Listening to the global conf does not sound useful here
+    if not version_range.contains(clientver, resolve_prerelease=None):
         raise ConanException("Current Conan version ({}) does not satisfy "
                              "the defined one ({}).".format(clientver, required_range))
 

--- a/conans/client/conf/required_version.py
+++ b/conans/client/conf/required_version.py
@@ -10,7 +10,7 @@ def validate_conan_version(required_range):
     version_range = VersionRange(required_range)
     for conditions in version_range.condition_sets:
         conditions.prerelease = True
-    if clientver not in version_range:
+    if not version_range.contains(clientver):
         raise ConanException("Current Conan version ({}) does not satisfy "
                              "the defined one ({}).".format(clientver, required_range))
 

--- a/conans/client/conf/required_version.py
+++ b/conans/client/conf/required_version.py
@@ -10,8 +10,6 @@ def validate_conan_version(required_range):
     version_range = VersionRange(required_range)
     for conditions in version_range.condition_sets:
         conditions.prerelease = True
-    # TODO: Think what's the better approach for resolving prereleases.
-    # Listening to the global conf does not sound useful here
     if not version_range.contains(clientver, resolve_prerelease=None):
         raise ConanException("Current Conan version ({}) does not satisfy "
                              "the defined one ({}).".format(clientver, required_range))

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -118,7 +118,7 @@ class DepsGraphBuilder(object):
 
         elif prev_version_range is not None:
             # TODO: Check user/channel conflicts first
-            if not prev_version_range.contains(require.ref.version):
+            if not prev_version_range.contains(require.ref.version, resolve_prereleases):
                 raise GraphError.conflict(node, require, prev_node, prev_require, base_previous)
         else:
             def _conflicting_refs(ref1, ref2):

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -39,7 +39,7 @@ class DepsGraphBuilder(object):
         root_node.conanfile.settings_target = None
 
         self._prepare_node(root_node, profile_host, profile_build, Options())
-        resolve_prereleases = self._cache.new_config.get('core.ranges_resolve_prereleases',
+        resolve_prereleases = self._cache.new_config.get('core.version_ranges:resolve_prereleases',
                                                          default=None, check_type=bool)
         self._initialize_requires(root_node, dep_graph, graph_lock, resolve_prereleases)
         dep_graph.add_node(root_node)

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -116,8 +116,8 @@ class DepsGraphBuilder(object):
                     raise GraphError.conflict(node, require, prev_node, prev_require, base_previous)
 
         elif prev_version_range is not None:
-            # TODO: CHeck user/channel conflicts first
-            if require.ref.version not in prev_version_range:
+            # TODO: Check user/channel conflicts first
+            if not prev_version_range.contains(require.ref.version):
                 raise GraphError.conflict(node, require, prev_node, prev_require, base_previous)
         else:
             def _conflicting_refs(ref1, ref2):

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -25,9 +25,7 @@ class DepsGraphBuilder(object):
         self._remotes = remotes  # TODO: pass as arg to load_graph()
         self._update = update
         self._check_update = check_update
-        self._resolve_prereleases = self._cache.new_config.get('core.version_ranges:'
-                                                                'resolve_prereleases',
-                                                                default=None, check_type=bool)
+        self._resolve_prereleases = self._cache.new_config.get('core.version_ranges:resolve_prereleases')
 
     def load_graph(self, root_node, profile_host, profile_build, graph_lock=None):
         assert profile_host is not None

--- a/conans/client/graph/python_requires.py
+++ b/conans/client/graph/python_requires.py
@@ -83,7 +83,7 @@ class PyRequireLoader(object):
         for py_requires_ref in py_requires_refs:
             py_requires_ref = RecipeReference.loads(py_requires_ref)
             requirement = Requirement(py_requires_ref)
-            resolved_ref = self._resolve_ref(requirement, graph_lock, remotes, update)
+            resolved_ref = self._resolve_ref(requirement, graph_lock, remotes, update, resolve_prereleases)
             try:
                 py_require = self._cached_py_requires[resolved_ref]
             except KeyError:

--- a/conans/client/graph/python_requires.py
+++ b/conans/client/graph/python_requires.py
@@ -66,7 +66,7 @@ class PyRequireLoader(object):
             py_requires_refs = [py_requires_refs, ]
 
         py_requires = self._resolve_py_requires(py_requires_refs, graph_lock, loader, remotes,
-                                                update, check_update)
+                                                update, check_update, None)
         if hasattr(conanfile, "python_requires_extend"):
             py_requires_extend = conanfile.python_requires_extend
             if isinstance(py_requires_extend, str):
@@ -78,7 +78,7 @@ class PyRequireLoader(object):
         conanfile.python_requires = py_requires
 
     def _resolve_py_requires(self, py_requires_refs, graph_lock, loader, remotes, update,
-                             check_update):
+                             check_update, resolve_prereleases):
         result = PyRequires()
         for py_requires_ref in py_requires_refs:
             py_requires_ref = RecipeReference.loads(py_requires_ref)

--- a/conans/client/graph/python_requires.py
+++ b/conans/client/graph/python_requires.py
@@ -66,7 +66,7 @@ class PyRequireLoader(object):
             py_requires_refs = [py_requires_refs, ]
 
         py_requires = self._resolve_py_requires(py_requires_refs, graph_lock, loader, remotes,
-                                                update, check_update, None)
+                                                update, check_update)
         if hasattr(conanfile, "python_requires_extend"):
             py_requires_extend = conanfile.python_requires_extend
             if isinstance(py_requires_extend, str):
@@ -78,12 +78,12 @@ class PyRequireLoader(object):
         conanfile.python_requires = py_requires
 
     def _resolve_py_requires(self, py_requires_refs, graph_lock, loader, remotes, update,
-                             check_update, resolve_prereleases):
+                             check_update):
         result = PyRequires()
         for py_requires_ref in py_requires_refs:
             py_requires_ref = RecipeReference.loads(py_requires_ref)
             requirement = Requirement(py_requires_ref)
-            resolved_ref = self._resolve_ref(requirement, graph_lock, remotes, update, resolve_prereleases)
+            resolved_ref = self._resolve_ref(requirement, graph_lock, remotes, update)
             try:
                 py_require = self._cached_py_requires[resolved_ref]
             except KeyError:

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -12,6 +12,9 @@ class RangeResolver:
         self._cached_cache = {}  # Cache caching of search result, so invariant wrt installations
         self._cached_remote_found = {}  # dict {ref (pkg/*): {remote_name: results (pkg/1, pkg/2)}}
         self.resolved_ranges = {}
+        self._resolve_prereleases = self._cache.new_config.get('core.version_ranges'
+                                                               ':resolve_prereleases',
+                                                               default=None, check_type=bool)
 
     def resolve(self, require, base_conanref, remotes, update):
         version_range = require.version_range
@@ -25,16 +28,12 @@ class RangeResolver:
             require.ref = previous_ref
             return
 
-        # If the conf is None, do whatever the range specifies
-        # True: Force prerelease resolving, False: Force no prerelease resolving
-        resolve_prereleases = self._cache.new_config.get('core.version_ranges:resolve_prereleases', default=None, check_type=bool)
-
         ref = require.ref
         search_ref = RecipeReference(ref.name, "*", ref.user, ref.channel)
 
-        resolved_ref = self._resolve_local(search_ref, version_range, resolve_prereleases)
+        resolved_ref = self._resolve_local(search_ref, version_range)
         if resolved_ref is None or update:
-            remote_resolved_ref = self._resolve_remote(search_ref, version_range, remotes, update, resolve_prereleases)
+            remote_resolved_ref = self._resolve_remote(search_ref, version_range, remotes, update)
             if resolved_ref is None or (remote_resolved_ref is not None and
                                         resolved_ref.version < remote_resolved_ref.version):
                 resolved_ref = remote_resolved_ref
@@ -48,7 +47,7 @@ class RangeResolver:
         self.resolved_ranges[require.ref] = resolved_ref
         require.ref = resolved_ref
 
-    def _resolve_local(self, search_ref, version_range, resolve_prereleases):
+    def _resolve_local(self, search_ref, version_range):
         pattern = str(search_ref)
         local_found = self._cached_cache.get(pattern)
         if local_found is None:
@@ -59,7 +58,7 @@ class RangeResolver:
                            and ref.channel == search_ref.channel]
             self._cached_cache[pattern] = local_found
         if local_found:
-            return self._resolve_version(version_range, local_found, resolve_prereleases)
+            return self._resolve_version(version_range, local_found, self._resolve_prereleases)
 
     def _search_remote_recipes(self, remote, search_ref):
         pattern = str(search_ref)
@@ -73,18 +72,20 @@ class RangeResolver:
             pattern_cached.update({remote.name: results})
         return results
 
-    def _resolve_remote(self, search_ref, version_range, remotes, update, resolve_prereleases):
+    def _resolve_remote(self, search_ref, version_range, remotes, update):
         update_candidates = []
         for remote in remotes:
             remote_results = self._search_remote_recipes(remote, search_ref)
-            resolved_version = self._resolve_version(version_range, remote_results, resolve_prereleases)
+            resolved_version = self._resolve_version(version_range, remote_results,
+                                                     self._resolve_prereleases)
             if resolved_version:
                 if not update:
                     return resolved_version  # Return first valid occurrence in first remote
                 else:
                     update_candidates.append(resolved_version)
         if len(update_candidates) > 0:  # pick latest from already resolved candidates
-            resolved_version = self._resolve_version(version_range, update_candidates, resolve_prereleases)
+            resolved_version = self._resolve_version(version_range, update_candidates,
+                                                     self._resolve_prereleases)
             return resolved_version
 
     @staticmethod

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -27,7 +27,7 @@ class RangeResolver:
 
         # If the conf is None, do whatever the range specifies
         # True: Force prerelease resolving, False: Force no prerelease resolving
-        resolve_prereleases = self._cache.new_confg.get('core.ranges_resolve_prereleases', default=None, check_type=bool)
+        resolve_prereleases = self._cache.new_config.get('core.ranges_resolve_prereleases', default=None, check_type=bool)
 
         ref = require.ref
         search_ref = RecipeReference(ref.name, "*", ref.user, ref.channel)

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -12,9 +12,7 @@ class RangeResolver:
         self._cached_cache = {}  # Cache caching of search result, so invariant wrt installations
         self._cached_remote_found = {}  # dict {ref (pkg/*): {remote_name: results (pkg/1, pkg/2)}}
         self.resolved_ranges = {}
-        self._resolve_prereleases = self._cache.new_config.get('core.version_ranges'
-                                                               ':resolve_prereleases',
-                                                               default=None, check_type=bool)
+        self._resolve_prereleases = self._cache.new_config.get('core.version_ranges:resolve_prereleases')
 
     def resolve(self, require, base_conanref, remotes, update):
         version_range = require.version_range

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -27,7 +27,7 @@ class RangeResolver:
 
         # If the conf is None, do whatever the range specifies
         # True: Force prerelease resolving, False: Force no prerelease resolving
-        resolve_prereleases = self._cache.new_config.get('core.ranges_resolve_prereleases', default=None, check_type=bool)
+        resolve_prereleases = self._cache.new_config.get('core.version_ranges:resolve_prereleases', default=None, check_type=bool)
 
         ref = require.ref
         search_ref = RecipeReference(ref.name, "*", ref.user, ref.channel)

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -13,7 +13,7 @@ BUILT_IN_CONFS = {
     "core:default_profile": "Defines the default host profile ('default' by default)",
     "core:default_build_profile": "Defines the default build profile (None by default)",
     "core:allow_uppercase_pkg_names": "Temporarily (will be removed in 2.X) allow uppercase names",
-    "core.ranges_resolve_prereleases": "Whether version ranges can resolve to pre-releases or not",
+    "core.version_ranges:resolve_prereleases": "Whether version ranges can resolve to pre-releases or not",
     "core.upload:retry": "Number of retries in case of failure when uploading to Conan server",
     "core.upload:retry_wait": "Seconds to wait between upload attempts to Conan server",
     "core.download:parallel": "Number of concurrent threads to download packages",

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -13,6 +13,7 @@ BUILT_IN_CONFS = {
     "core:default_profile": "Defines the default host profile ('default' by default)",
     "core:default_build_profile": "Defines the default build profile (None by default)",
     "core:allow_uppercase_pkg_names": "Temporarily (will be removed in 2.X) allow uppercase names",
+    "core.ranges_resolve_prereleases": "Whether version ranges can resolve to pre-releases or not",
     "core.upload:retry": "Number of retries in case of failure when uploading to Conan server",
     "core.upload:retry_wait": "Seconds to wait between upload attempts to Conan server",
     "core.download:parallel": "Number of concurrent threads to download packages",

--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -201,7 +201,7 @@ class Lockfile(object):
             result["alias"] = {repr(k): repr(v) for k, v in self._alias.items()}
         return result
 
-    def resolve_locked(self, node, require, resolve_prereleases=None):
+    def resolve_locked(self, node, require, resolve_prereleases):
         if require.build or node.context == CONTEXT_BUILD:
             locked_refs = self._build_requires.refs()
         else:

--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -201,7 +201,7 @@ class Lockfile(object):
             result["alias"] = {repr(k): repr(v) for k, v in self._alias.items()}
         return result
 
-    def resolve_locked(self, node, require, resolve_prereleases):
+    def resolve_locked(self, node, require, resolve_prereleases=None):
         if require.build or node.context == CONTEXT_BUILD:
             locked_refs = self._build_requires.refs()
         else:

--- a/conans/model/version_range.py
+++ b/conans/model/version_range.py
@@ -56,9 +56,14 @@ class _ConditionSet:
         else:
             return [_Condition(operator, Version(version))]
 
-    def valid(self, version):
+    def valid(self, version, conf_resolve_prepreleases=None):
         if version.pre:
-            if not self.prerelease:
+            # Follow the expression desires only if core.ranges_resolve_prereleases is None,
+            # else force to the conf's value
+            if conf_resolve_prepreleases is None:
+                if not self.prerelease:
+                    return False
+            elif conf_resolve_prepreleases is False:
                 return False
         for condition in self.conditions:
             if condition.operator == ">":
@@ -83,7 +88,7 @@ class VersionRange:
     def __init__(self, expression):
         self._expression = expression
         tokens = expression.split(",")
-        prereleases = None
+        prereleases = False
         for t in tokens[1:]:
             if "include_prerelease" in t:
                 prereleases = True
@@ -96,9 +101,10 @@ class VersionRange:
     def __str__(self):
         return self._expression
 
-    def __contains__(self, version):
+    def contains(self, version, conf_resolve_prerelease=None):
         assert isinstance(version, Version), type(version)
         for condition_set in self.condition_sets:
-            if condition_set.valid(version):
+            if condition_set.valid(version, conf_resolve_prerelease):
                 return True
         return False
+

--- a/conans/model/version_range.py
+++ b/conans/model/version_range.py
@@ -101,7 +101,16 @@ class VersionRange:
     def __str__(self):
         return self._expression
 
-    def contains(self, version, resolve_prerelease=None):
+    def contains(self, version: Version, resolve_prerelease: bool | None):
+        """
+        Whether <version> is inside the version range
+
+        :param version: Version to check against
+        :param resolve_prerelease: If ``True``, ensure prereleases can be resolved in this range
+        If ``False``, prerelases can NOT be resolved in this range
+        If ``None``, prereleases are resolved only if this version range expression says so
+        :return: Whether the version is inside the range
+        """
         assert isinstance(version, Version), type(version)
         for condition_set in self.condition_sets:
             if condition_set._valid(version, resolve_prerelease):

--- a/conans/model/version_range.py
+++ b/conans/model/version_range.py
@@ -56,7 +56,7 @@ class _ConditionSet:
         else:
             return [_Condition(operator, Version(version))]
 
-    def valid(self, version, conf_resolve_prepreleases=None):
+    def _valid(self, version, conf_resolve_prepreleases):
         if version.pre:
             # Follow the expression desires only if core.version_ranges:resolve_prereleases is None,
             # else force to the conf's value
@@ -101,10 +101,10 @@ class VersionRange:
     def __str__(self):
         return self._expression
 
-    def contains(self, version, conf_resolve_prerelease=None):
+    def contains(self, version, resolve_prerelease=None):
         assert isinstance(version, Version), type(version)
         for condition_set in self.condition_sets:
-            if condition_set.valid(version, conf_resolve_prerelease):
+            if condition_set._valid(version, resolve_prerelease):
                 return True
         return False
 

--- a/conans/model/version_range.py
+++ b/conans/model/version_range.py
@@ -58,7 +58,7 @@ class _ConditionSet:
 
     def valid(self, version, conf_resolve_prepreleases=None):
         if version.pre:
-            # Follow the expression desires only if core.ranges_resolve_prereleases is None,
+            # Follow the expression desires only if core.version_ranges:resolve_prereleases is None,
             # else force to the conf's value
             if conf_resolve_prepreleases is None:
                 if not self.prerelease:

--- a/conans/model/version_range.py
+++ b/conans/model/version_range.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from typing import Optional
 
 from conans.errors import ConanException
 from conans.model.recipe_ref import Version
@@ -101,7 +102,7 @@ class VersionRange:
     def __str__(self):
         return self._expression
 
-    def contains(self, version: Version, resolve_prerelease: bool | None):
+    def contains(self, version: Version, resolve_prerelease: Optional[bool]):
         """
         Whether <version> is inside the version range
 

--- a/conans/test/integration/graph/version_ranges/version_range_conf.py
+++ b/conans/test/integration/graph/version_ranges/version_range_conf.py
@@ -1,0 +1,108 @@
+from utils.tools import TestClient
+import textwrap
+
+
+def test_version_range_conf_nonexplicit_expression():
+    tc = TestClient()
+
+    base = textwrap.dedent("""
+    from conan import ConanFile
+
+    class Base(ConanFile):
+        name = "base"
+    """)
+
+    tc.save({"base/conanfile.py": base})
+    tc.run("create base/conanfile.py --version=1.5.1")
+    tc.run("create base/conanfile.py --version=2.5.0-pre")
+
+    conanfilev1 = textwrap.dedent("""
+    from conan import ConanFile
+
+    class Package(ConanFile):
+        name = "pkg"
+        version = "1.0"
+        requires = "base/[>1 <2]"
+    """)
+
+    conanfilev2 = textwrap.dedent("""
+        from conan import ConanFile
+
+        class Package(ConanFile):
+            name = "pkg"
+            version = "2.0"
+            requires = "base/[>2 <3]"
+        """)
+
+    tc.save({"v1/conanfile.py": conanfilev1, "v2/conanfile.py": conanfilev2})
+
+    tc.save({"global.conf": "core.ranges_resolve_prereleases=False"}, path=tc.cache.cache_folder)
+    tc.run("create v1/conanfile.py")
+    assert "base/[>1 <2]: base/1.5.1" in tc.out
+    tc.run("create v2/conanfile.py", assert_error=True)
+    assert "Package 'base/[>2 <3]' not resolved" in tc.out
+
+    tc.save({"global.conf": "core.ranges_resolve_prereleases=True"}, path=tc.cache.cache_folder)
+    tc.run("create v1/conanfile.py")
+    assert "base/[>1 <2]: base/1.5.1" in tc.out
+    tc.run("create v2/conanfile.py")
+    assert "base/[>2 <3]: base/2.5.0-pre" in tc.out
+
+    tc.save({"global.conf": "core.ranges_resolve_prereleases=None"}, path=tc.cache.cache_folder)
+    tc.run("create v1/conanfile.py")
+    assert "base/[>1 <2]: base/1.5.1" in tc.out
+    tc.run("create v2/conanfile.py")
+    assert "Package 'base/[>2 <3]' not resolved" in tc.out
+
+
+def test_version_range_conf_explicit_expression():
+    tc = TestClient()
+
+    base = textwrap.dedent("""
+    from conan import ConanFile
+
+    class Base(ConanFile):
+        name = "base"
+    """)
+
+    tc.save({"base/conanfile.py": base})
+    tc.run("create base/conanfile.py --version=1.5.1")
+    tc.run("create base/conanfile.py --version=2.5.0-pre")
+
+    conanfilev1 = textwrap.dedent("""
+    from conan import ConanFile
+
+    class Package(ConanFile):
+        name = "pkg"
+        version = "1.0"
+        requires = "base/[>1- <2]"
+    """)
+
+    conanfilev2 = textwrap.dedent("""
+        from conan import ConanFile
+
+        class Package(ConanFile):
+            name = "pkg"
+            version = "2.0"
+            requires = "base/[>2- <3]"
+        """)
+
+    tc.save({"v1/conanfile.py": conanfilev1, "v2/conanfile.py": conanfilev2})
+
+    tc.save({"global.conf": "core.ranges_resolve_prereleases=False"}, path=tc.cache.cache_folder)
+    tc.run("create v1/conanfile.py")
+    assert "base/[>1- <2]: base/1.5.1" in tc.out
+    tc.run("create v2/conanfile.py", assert_error=True)
+    assert "Package 'base/[>2- <3]' not resolved" in tc.out
+
+    tc.save({"global.conf": "core.ranges_resolve_prereleases=True"}, path=tc.cache.cache_folder)
+    tc.run("create v1/conanfile.py")
+    assert "base/[>1- <2]: base/1.5.1" in tc.out
+    tc.run("create v2/conanfile.py")
+    assert "base/[>2- <3]: base/2.5.0-pre" in tc.out
+
+    tc.save({"global.conf": "core.ranges_resolve_prereleases=None"}, path=tc.cache.cache_folder)
+    tc.run("create v1/conanfile.py")
+    assert "base/[>1- <2]: base/1.5.1" in tc.out
+    tc.run("create v2/conanfile.py")
+    assert "base/[>2- <3]: base/2.5.0-pre" in tc.out

--- a/conans/test/integration/graph/version_ranges/version_range_conf.py
+++ b/conans/test/integration/graph/version_ranges/version_range_conf.py
@@ -1,3 +1,4 @@
+from conans.test.assets.genconanfile import GenConanfile
 from utils.tools import TestClient
 import textwrap
 
@@ -69,25 +70,8 @@ def test_version_range_conf_explicit_expression():
     tc.run("create base/conanfile.py --version=1.5.1")
     tc.run("create base/conanfile.py --version=2.5.0-pre")
 
-    conanfilev1 = textwrap.dedent("""
-    from conan import ConanFile
-
-    class Package(ConanFile):
-        name = "pkg"
-        version = "1.0"
-        requires = "base/[>1- <2]"
-    """)
-
-    conanfilev2 = textwrap.dedent("""
-        from conan import ConanFile
-
-        class Package(ConanFile):
-            name = "pkg"
-            version = "2.0"
-            requires = "base/[>2- <3]"
-        """)
-
-    tc.save({"v1/conanfile.py": conanfilev1, "v2/conanfile.py": conanfilev2})
+    tc.save({"v1/conanfile.py": GenConanfile("pkg", "1.0").with_requires("base/[>1- <2]"),
+             "v2/conanfile.py": GenConanfile("pkg", "2.0").with_requires("base/[>2- <3]")})
 
     tc.save({"global.conf": "core.version_ranges:resolve_prereleases=False"}, path=tc.cache.cache_folder)
     tc.run("create v1/conanfile.py")

--- a/conans/test/integration/graph/version_ranges/version_range_conf.py
+++ b/conans/test/integration/graph/version_ranges/version_range_conf.py
@@ -36,19 +36,19 @@ def test_version_range_conf_nonexplicit_expression():
 
     tc.save({"v1/conanfile.py": conanfilev1, "v2/conanfile.py": conanfilev2})
 
-    tc.save({"global.conf": "core.ranges_resolve_prereleases=False"}, path=tc.cache.cache_folder)
+    tc.save({"global.conf": "core.version_ranges:resolve_prereleases=False"}, path=tc.cache.cache_folder)
     tc.run("create v1/conanfile.py")
     assert "base/[>1 <2]: base/1.5.1" in tc.out
     tc.run("create v2/conanfile.py", assert_error=True)
     assert "Package 'base/[>2 <3]' not resolved" in tc.out
 
-    tc.save({"global.conf": "core.ranges_resolve_prereleases=True"}, path=tc.cache.cache_folder)
+    tc.save({"global.conf": "core.version_ranges:resolve_prereleases=True"}, path=tc.cache.cache_folder)
     tc.run("create v1/conanfile.py")
     assert "base/[>1 <2]: base/1.5.1" in tc.out
     tc.run("create v2/conanfile.py")
     assert "base/[>2 <3]: base/2.5.0-pre" in tc.out
 
-    tc.save({"global.conf": "core.ranges_resolve_prereleases=None"}, path=tc.cache.cache_folder)
+    tc.save({"global.conf": "core.version_ranges:resolve_prereleases=None"}, path=tc.cache.cache_folder)
     tc.run("create v1/conanfile.py")
     assert "base/[>1 <2]: base/1.5.1" in tc.out
     tc.run("create v2/conanfile.py")
@@ -89,19 +89,19 @@ def test_version_range_conf_explicit_expression():
 
     tc.save({"v1/conanfile.py": conanfilev1, "v2/conanfile.py": conanfilev2})
 
-    tc.save({"global.conf": "core.ranges_resolve_prereleases=False"}, path=tc.cache.cache_folder)
+    tc.save({"global.conf": "core.version_ranges:resolve_prereleases=False"}, path=tc.cache.cache_folder)
     tc.run("create v1/conanfile.py")
     assert "base/[>1- <2]: base/1.5.1" in tc.out
     tc.run("create v2/conanfile.py", assert_error=True)
     assert "Package 'base/[>2- <3]' not resolved" in tc.out
 
-    tc.save({"global.conf": "core.ranges_resolve_prereleases=True"}, path=tc.cache.cache_folder)
+    tc.save({"global.conf": "core.version_ranges:resolve_prereleases=True"}, path=tc.cache.cache_folder)
     tc.run("create v1/conanfile.py")
     assert "base/[>1- <2]: base/1.5.1" in tc.out
     tc.run("create v2/conanfile.py")
     assert "base/[>2- <3]: base/2.5.0-pre" in tc.out
 
-    tc.save({"global.conf": "core.ranges_resolve_prereleases=None"}, path=tc.cache.cache_folder)
+    tc.save({"global.conf": "core.version_ranges:resolve_prereleases=None"}, path=tc.cache.cache_folder)
     tc.run("create v1/conanfile.py")
     assert "base/[>1- <2]: base/1.5.1" in tc.out
     tc.run("create v2/conanfile.py")

--- a/conans/test/integration/graph/version_ranges/version_range_conf.py
+++ b/conans/test/integration/graph/version_ranges/version_range_conf.py
@@ -17,25 +17,8 @@ def test_version_range_conf_nonexplicit_expression():
     tc.run("create base/conanfile.py --version=1.5.1")
     tc.run("create base/conanfile.py --version=2.5.0-pre")
 
-    conanfilev1 = textwrap.dedent("""
-    from conan import ConanFile
-
-    class Package(ConanFile):
-        name = "pkg"
-        version = "1.0"
-        requires = "base/[>1 <2]"
-    """)
-
-    conanfilev2 = textwrap.dedent("""
-        from conan import ConanFile
-
-        class Package(ConanFile):
-            name = "pkg"
-            version = "2.0"
-            requires = "base/[>2 <3]"
-        """)
-
-    tc.save({"v1/conanfile.py": conanfilev1, "v2/conanfile.py": conanfilev2})
+    tc.save({"v1/conanfile.py": GenConanfile("pkg", "1.0").with_requires("base/[>1 <2]"),
+             "v2/conanfile.py": GenConanfile("pkg", "2.0").with_requires("base/[>2 <3]")})
 
     tc.save({"global.conf": "core.version_ranges:resolve_prereleases=False"}, path=tc.cache.cache_folder)
     tc.run("create v1/conanfile.py")
@@ -52,7 +35,8 @@ def test_version_range_conf_nonexplicit_expression():
     tc.save({"global.conf": "core.version_ranges:resolve_prereleases=None"}, path=tc.cache.cache_folder)
     tc.run("create v1/conanfile.py")
     assert "base/[>1 <2]: base/1.5.1" in tc.out
-    tc.run("create v2/conanfile.py")
+
+    tc.run("create v2/conanfile.py", assert_error=True)
     assert "Package 'base/[>2 <3]' not resolved" in tc.out
 
 

--- a/conans/test/unittests/model/version/test_version_range.py
+++ b/conans/test/unittests/model/version/test_version_range.py
@@ -47,10 +47,45 @@ def test_range(version_range, conditions, versions_in, versions_out):
             assert condition.version == expected_condition[1]
 
     for v in versions_in:
-        assert Version(v) in r
+        assert r.contains(Version(v))
 
     for v in versions_out:
-        assert Version(v) not in r
+        assert not r.contains(Version(v))
+
+
+@pytest.mark.parametrize("version_range, resolve_prereleases, versions_in, versions_out", [
+    ['*', True, ["1.5.1", "1.5.1-pre1", "2.1-pre1"], []],
+    ['*', False, ["1.5.1"], ["1.5.1-pre1", "2.1-pre1"]],
+    ['*', None, ["1.5.1"], ["1.5.1-pre1", "2.1-pre1"]],
+
+    ['*-', True, ["1.5.1", "1.5.1-pre1", "2.1-pre1"], []],
+    ['*-', False, ["1.5.1"], ["1.5.1-pre1", "2.1-pre1"]],
+    ['*-', None, ["1.5.1", "1.5.1-pre1", "2.1-pre1"], []],
+
+    ['*, include_prerelease', True, ["1.5.1", "1.5.1-pre1", "2.1-pre1"], []],
+    ['*, include_prerelease', False, ["1.5.1"], ["1.5.1-pre1", "2.1-pre1"]],
+    ['*, include_prerelease', None, ["1.5.1", "1.5.1-pre1", "2.1-pre1"], []],
+
+    ['>1 <2.0', True, ["1.5.1", "1.5.1-pre1"], ["2.1-pre1"]],
+    ['>1 <2.0', False, ["1.5.1"], ["1.5.1-pre1", "2.1-pre1"]],
+    ['>1 <2.0', None, ["1.5.1"], ["1.5.1-pre1", "2.1-pre1"]],
+
+    ['>1- <2.0', True, ["1.5.1", "1.5.1-pre1"], ["2.1-pre1"]],
+    ['>1- <2.0', False, ["1.5.1"], ["1.5.1-pre1", "2.1-pre1"]],
+    ['>1- <2.0', None, ["1.5.1", "1.5.1-pre1"], ["2.1-pre1"]],
+
+    ['>1 <2.0, include_prerelease', True, ["1.5.1", "1.5.1-pre1"], ["2.1-pre1"]],
+    ['>1 <2.0, include_prerelease', False, ["1.5.1"], ["1.5.1-pre1", "2.1-pre1"]],
+    ['>1 <2.0, include_prerelease', None, ["1.5.1", "1.5.1-pre1"], ["2.1-pre1"]],
+])
+def test_range_prereleases_conf(version_range, resolve_prereleases, versions_in, versions_out):
+    r = VersionRange(version_range)
+
+    for v in versions_in:
+        assert r.contains(Version(v), resolve_prereleases), f"Expected '{version_range}' to contain '{v}' (conf.ranges_resolve_prereleases={resolve_prereleases})"
+
+    for v in versions_out:
+        assert not r.contains(Version(v), resolve_prereleases), f"Expected '{version_range}' NOT to contain '{v}' (conf.ranges_resolve_prereleases={resolve_prereleases})"
 
 
 def test_wrong_range_syntax():

--- a/conans/test/unittests/model/version/test_version_range.py
+++ b/conans/test/unittests/model/version/test_version_range.py
@@ -47,10 +47,10 @@ def test_range(version_range, conditions, versions_in, versions_out):
             assert condition.version == expected_condition[1]
 
     for v in versions_in:
-        assert r.contains(Version(v))
+        assert r.contains(Version(v), None)
 
     for v in versions_out:
-        assert not r.contains(Version(v))
+        assert not r.contains(Version(v), None)
 
 
 @pytest.mark.parametrize("version_range, resolve_prereleases, versions_in, versions_out", [


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Future changelog: Feature: Add `core.version_ranges:resolve_prereleases` conf to control whether version ranges can resolve to prerelease versions

I still have some questions regarding the implementation of the feature itself,
but this is now at a point where it makes sense to open the PR,
even though there are still places that need updating (And so tests are failing)

Specially I'd need to discuss if changing the VersionRange api is ok,
as this removes the `__contains__` function in favour of a `contains` method,
to be able to pass it extra arguments, which can't be done with the `in` operator.

The logic for the conf is:
 - `True`: Always allows to resolve prerelease versions, whatever the expression says
 - `False`: Never allows prerelease versions to be resolved
 - `None`: Listens to whatever the the range expression says

The open questions are:
 - Is `None` the best default for an unspecified conf? My guess it that yes, but I better make sure
 - Is the current implementation even ok? I had a good look into how this could be done, and this seemed to me like the only viable alternative, but happy to hear otherwise.
 - Is there a better name for the conf?: A: Yes. `core.version_ranges:resolve_prereleases` (Was  `core.ranges_resolve_prereleases`)