### PR TITLE
export-pkg remote improvements

### DIFF
--- a/conan/cli/commands/export_pkg.py
+++ b/conan/cli/commands/export_pkg.py
@@ -27,6 +27,13 @@ def export_pkg(conan_api, parser, *args):
     parser.add_argument("-tf", "--test-folder", action=OnceArgument,
                         help='Alternative test folder name. By default it is "test_package". '
                              'Use "" to skip the test stage')
+    parser.add_argument("-sb", "--skip-binaries", action="store_true",
+                        help="Skip installing dependencies binaries")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("-r", "--remote", action="append", default=None,
+                       help='Look in the specified remote or remotes server')
+    group.add_argument("-nr", "--no-remote", action="store_true",
+                       help='Do not use remote, resolve exclusively in the cache')
 
     add_reference_args(parser)
     add_lockfile_args(parser)
@@ -39,6 +46,7 @@ def export_pkg(conan_api, parser, *args):
     lockfile = conan_api.lockfile.get_lockfile(lockfile=args.lockfile, conanfile_path=path,
                                                cwd=cwd, partial=args.lockfile_partial)
     profile_host, profile_build = conan_api.profiles.get_profiles_from_args(args)
+    remotes = conan_api.remotes.list(args.remote) if not args.no_remote else []
 
     ref, conanfile = conan_api.export.export(path=path, name=args.name, version=args.version,
                                              user=args.user, channel=args.channel, lockfile=lockfile)
@@ -52,12 +60,13 @@ def export_pkg(conan_api, parser, *args):
                                                      ref.name, ref.version, ref.user, ref.channel,
                                                      profile_host=profile_host,
                                                      profile_build=profile_build,
-                                                     lockfile=lockfile, remotes=None, update=None,
+                                                     lockfile=lockfile, remotes=remotes, update=None,
                                                      is_build_require=args.build_require)
 
     print_graph_basic(deps_graph)
     deps_graph.report_graph_error()
-    conan_api.graph.analyze_binaries(deps_graph, build_mode=[ref.name], lockfile=lockfile)
+    conan_api.graph.analyze_binaries(deps_graph, build_mode=[ref.name], lockfile=lockfile,
+                                     remotes=remotes)
     deps_graph.report_graph_error()
 
     root_node = deps_graph.root
@@ -65,7 +74,8 @@ def export_pkg(conan_api, parser, *args):
 
     # It is necessary to install binaries, in case there are build_requires necessary to export
     # But they should be local, if this was built here
-    conan_api.install.install_binaries(deps_graph=deps_graph, remotes=None)
+    if not args.skip_binaries:
+        conan_api.install.install_binaries(deps_graph=deps_graph, remotes=remotes)
     source_folder = os.path.dirname(path)
     output_folder = make_abs_path(args.output_folder, cwd) if args.output_folder else None
     conan_api.install.install_consumer(deps_graph=deps_graph, source_folder=source_folder,

--- a/conan/cli/commands/export_pkg.py
+++ b/conan/cli/commands/export_pkg.py
@@ -72,9 +72,12 @@ def export_pkg(conan_api, parser, *args):
     root_node = deps_graph.root
     root_node.ref = ref
 
-    # It is necessary to install binaries, in case there are build_requires necessary to export
-    # But they should be local, if this was built here
     if not args.skip_binaries:
+        # unless the user explicitly opts-out with --skip-binaries, it is necessary to install
+        # binaries, in case there are build_requires necessary to export, like tool-requires=cmake
+        # and package() method doing ``cmake.install()``
+        # for most cases, deps would be in local cache already because of a previous "conan install"
+        # but if it is not the case, the binaries from remotes will be downloaded
         conan_api.install.install_binaries(deps_graph=deps_graph, remotes=remotes)
     source_folder = os.path.dirname(path)
     output_folder = make_abs_path(args.output_folder, cwd) if args.output_folder else None

--- a/conan/cli/commands/install.py
+++ b/conan/cli/commands/install.py
@@ -7,7 +7,6 @@ from conan.cli.command import conan_command
 from conan.cli import make_abs_path
 from conan.cli.printers import print_profiles
 from conan.cli.printers.graph import print_graph_packages, print_graph_basic
-from conan.errors import ConanException
 
 
 def json_install(info):


### PR DESCRIPTION
Changelog: Feature: Add ``conan export-pkg --skip-binaries`` to allow exporting without binaries of dependencies.
Changelog: Fix: Allow ``conan export-pkg`` to use remotes to install missing dependencies not in the cache.
Docs: https://github.com/conan-io/docs/pull/3106

Close https://github.com/conan-io/conan/issues/13320