### PR TITLE
adds qcc cppstd compatibility info

### DIFF
--- a/conan/tools/build/cppstd.py
+++ b/conan/tools/build/cppstd.py
@@ -112,7 +112,9 @@ def supported_cppstd(conanfile, compiler=None, compiler_version=None):
             "gcc": _gcc_supported_cppstd,
             "msvc": _msvc_supported_cppstd,
             "clang": _clang_supported_cppstd,
-            "mcst-lcc": _mcst_lcc_supported_cppstd}.get(compiler)
+            "mcst-lcc": _mcst_lcc_supported_cppstd,
+            "qcc": _qcc_supported_cppstd,
+            }.get(compiler)
     if func:
         return func(Version(compiler_version))
     return None
@@ -254,3 +256,13 @@ def _mcst_lcc_supported_cppstd(version):
     # FIXME: When cppstd 23 was introduced????
 
     return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17", "20", "gnu20"]
+
+def _qcc_supported_cppstd(version):
+    """
+    [98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17]
+    """
+
+    if version < "5":
+        return ["98", "gnu98"]
+    else:
+        return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"]

--- a/conans/test/unittests/tools/build/test_cppstd.py
+++ b/conans/test/unittests/tools/build/test_cppstd.py
@@ -104,6 +104,16 @@ def test_supported_cppstd_mcst(compiler, compiler_version, values):
     sot = supported_cppstd(conanfile)
     assert sot == values
 
+@pytest.mark.parametrize("compiler,compiler_version,values", [
+    ("qcc", "4.4", ['98', 'gnu98']),
+    ("qcc", "5.4", ['98', 'gnu98', '11', 'gnu11', "14", "gnu14", "17", "gnu17"]),
+    ("qcc", "8.3", ['98', 'gnu98', '11', 'gnu11', "14", "gnu14", "17", "gnu17"]),
+])
+def test_supported_cppstd_qcc(compiler, compiler_version, values):
+    settings = MockSettings({"compiler": compiler, "compiler.version": compiler_version})
+    conanfile = MockConanfile(settings)
+    sot = supported_cppstd(conanfile)
+    assert sot == values
 
 @pytest.mark.parametrize("compiler,compiler_version,result", [
     ("gcc", "5", 'gnu98'),


### PR DESCRIPTION
Changelog: Bugfix: adds qcc cppstd compatibility info to allow dep graph to be calculated.
Docs: Omit

Close #13325

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
