### PR TITLE
allow global.conf jinja include

### DIFF
--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -3,8 +3,7 @@ import platform
 from typing import List
 
 import yaml
-from jinja2 import Template
-
+from jinja2 import FileSystemLoader, Environment
 
 from conan.internal.cache.cache import DataCache, RecipeLayout, PackageLayout
 from conans.client.cache.editable import EditablePackages
@@ -152,7 +151,9 @@ class ClientCache(object):
                 distro = None
                 if platform.system() in ["Linux", "FreeBSD"]:
                     import distro
-                content = Template(text).render({"platform": platform, "os": os, "distro": distro})
+                base_path = os.path.dirname(self.new_config_path)
+                template = Environment(loader=FileSystemLoader(base_path)).from_string(text)
+                content = template.render({"platform": platform, "os": os, "distro": distro})
                 self._new_config.loads(content)
         return self._new_config
 

--- a/conans/test/integration/configuration/conf/test_conf.py
+++ b/conans/test/integration/configuration/conf/test_conf.py
@@ -188,6 +188,23 @@ def test_jinja_global_conf(client):
         assert "user.mycompany:dist=42" in client.out
 
 
+def test_jinja_global_conf_include(client):
+    global_conf = textwrap.dedent("""\
+        {% include "user_global.conf" %}
+        {% import "user_global.conf" as vars %}
+        user.mycompany:dist = {{vars.myvar*2}}
+        """)
+    user_global_conf = textwrap.dedent("""\
+        {% set myvar = 42 %}
+        user.mycompany:parallel = {{myvar}}
+        """)
+    save(client.cache.new_config_path, global_conf)
+    save(os.path.join(client.cache_folder, "user_global.conf"), user_global_conf)
+    client.run("install .")
+    assert "user.mycompany:parallel=42" in client.out
+    assert "user.mycompany:dist=84" in client.out
+
+
 def test_empty_conf_valid():
     tc = TestClient()
     profile = textwrap.dedent(r"""

--- a/conans/test/integration/configuration/test_profile_jinja.py
+++ b/conans/test/integration/configuration/test_profile_jinja.py
@@ -36,7 +36,7 @@ def test_profile_template_variables():
     assert "os=FreeBSD" in client.out
 
 
-def test_profile_template_inclusion():
+def test_profile_template_import():
     client = TestClient()
     tpl1 = textwrap.dedent("""
         {% import "profile_vars" as vars %}
@@ -45,6 +45,23 @@ def test_profile_template_inclusion():
         """)
     tpl2 = textwrap.dedent("""
         {% set a = "FreeBSD" %}
+        """)
+    client.save({"conanfile.py": GenConanfile(),
+                 "profile1": tpl1,
+                 "profile_vars": tpl2})
+    client.run("install . -pr=profile1")
+    assert "os=FreeBSD" in client.out
+
+
+def test_profile_template_include():
+    client = TestClient()
+    tpl1 = textwrap.dedent("""
+        {% include "profile_vars" %}
+        """)
+    tpl2 = textwrap.dedent("""
+        {% set a = "FreeBSD" %}
+        [settings]
+        os = {{ a }}
         """)
     client.save({"conanfile.py": GenConanfile(),
                  "profile1": tpl1,


### PR DESCRIPTION
Changelog: Feature: Allow ``global.conf`` jinja2 inclusion of other files.
Docs: Omit

Close https://github.com/conan-io/conan/issues/13334

Not explicit documentation, as this would likely be the expected behavior of the jinja rendering.
