### PR TITLE
fix download sets for future metadata readiness

### DIFF
--- a/conans/client/rest/rest_client_v1.py
+++ b/conans/client/rest/rest_client_v1.py
@@ -210,6 +210,8 @@ class RestV1Methods(RestCommonMethods):
     def get_recipe(self, ref, dest_folder):
         urls = self._get_recipe_urls(ref)
         urls.pop(EXPORT_SOURCES_TGZ_NAME, None)
+        accepted_files = ["conanfile.py", "conan_export.tgz", "conanmanifest.txt"]
+        urls = {f: url for f, url in urls.items() if any(f.startswith(m) for m in accepted_files)}
         check_compressed_files(EXPORT_TGZ_NAME, urls)
         md5s = self.get_recipe_snapshot(ref) if self._config.download_cache else None
         zipped_files = self._download_files_to_folder(urls, dest_folder, md5s)
@@ -234,6 +236,8 @@ class RestV1Methods(RestCommonMethods):
 
     def get_package(self, pref, dest_folder):
         urls = self._get_package_urls(pref)
+        accepted_files = ["conaninfo.txt", "conan_package.tgz", "conanmanifest.txt"]
+        urls = {f: url for f, url in urls.items() if any(f.startswith(m) for m in accepted_files)}
         check_compressed_files(PACKAGE_TGZ_NAME, urls)
         md5s = self.get_package_snapshot(pref) if self._config.download_cache else None
         zipped_files = self._download_files_to_folder(urls, dest_folder, md5s)

--- a/conans/client/rest/rest_client_v2.py
+++ b/conans/client/rest/rest_client_v2.py
@@ -89,8 +89,8 @@ class RestV2Methods(RestCommonMethods):
         data = self._get_file_list_json(url)
         files = data["files"]
         check_compressed_files(EXPORT_TGZ_NAME, files)
-        if EXPORT_SOURCES_TGZ_NAME in files:
-            files.remove(EXPORT_SOURCES_TGZ_NAME)
+        accepted_files = ["conanfile.py", "conan_export.tgz", "conanmanifest.txt"]
+        files = [f for f in files if any(f.startswith(m) for m in accepted_files)]
 
         # If we didn't indicated reference, server got the latest, use absolute now, it's safer
         urls = {fn: self.router.recipe_file(ref, fn) for fn in files}
@@ -122,6 +122,8 @@ class RestV2Methods(RestCommonMethods):
         url = self.router.package_snapshot(pref)
         data = self._get_file_list_json(url)
         files = data["files"]
+        accepted_files = ["conaninfo.txt", "conan_package.tgz", "conanmanifest.txt"]
+        files = [f for f in files if any(f.startswith(m) for m in accepted_files)]
         check_compressed_files(PACKAGE_TGZ_NAME, files)
         # If we didn't indicated reference, server got the latest, use absolute now, it's safer
         urls = {fn: self.router.package_file(pref, fn) for fn in files}

--- a/conans/test/integration/export_sources_test.py
+++ b/conans/test/integration/export_sources_test.py
@@ -143,7 +143,7 @@ class ExportsSourcesTest(unittest.TestCase):
         self.assertEqual(scan_folder(export_src_folder or self.export_sources_folder),
                          sorted(expected_src_exports))
 
-    def _check_export_installed_folder(self, mode, updated=False):
+    def _check_export_installed_folder(self, mode):
         """ Just installed, no EXPORT_SOURCES_DIR is present
         """
         if mode == "exports_sources":
@@ -156,8 +156,6 @@ class ExportsSourcesTest(unittest.TestCase):
             expected_exports = ['conanfile.py', 'conanmanifest.txt', "src/data.txt"]
         if mode == "overlap":
             expected_exports = ['conanfile.py', 'conanmanifest.txt', "src/data.txt", "src/hello.h"]
-        if updated:
-            expected_exports.append("license.txt")
 
         self.assertEqual(scan_folder(self.export_folder), sorted(expected_exports))
         self.assertFalse(os.path.exists(self.export_sources_folder))
@@ -376,15 +374,3 @@ class ExportsSourcesTest(unittest.TestCase):
         self.client.run("install Hello/0.1@lasote/testing --update")
         self.assertIn("Hello/0.1@lasote/testing: Already installed!", self.client.out)
         self._check_export_installed_folder(mode)
-
-        rev = self.server.server_store.get_last_revision(self.ref)
-        ref = self.ref.copy_with_rev(rev.revision)
-        server_path = self.server.server_store.export(ref)
-        save(os.path.join(server_path, "license.txt"), "mylicense")
-        manifest = FileTreeManifest.load(server_path)
-        manifest.time += 1
-        manifest.file_sums["license.txt"] = md5sum(os.path.join(server_path, "license.txt"))
-        manifest.save(server_path)
-
-        self.client.run("install Hello/0.1@lasote/testing --update")
-        self._check_export_installed_folder(mode, updated=True)

--- a/conans/test/integration/remote/rest_api_test.py
+++ b/conans/test/integration/remote/rest_api_test.py
@@ -135,7 +135,7 @@ class RestApiTest(unittest.TestCase):
         # Get the package
         tmp_dir = temp_folder()
         self.api.get_package(pref, tmp_dir)
-        self.assertIn("hello.cpp", os.listdir(tmp_dir))
+        self.assertNotIn("hello.cpp", os.listdir(tmp_dir))
 
     def test_get_package_info(self):
         # Upload a conans

--- a/conans/test/unittests/util/xz_test.py
+++ b/conans/test/unittests/util/xz_test.py
@@ -36,51 +36,6 @@ class XZTest(TestCase):
         self.assertIn("ERROR: This Conan version is not prepared to handle "
                       "'conan_export.txz' file format", client.out)
 
-    def test_error_sources_xz(self):
-        server = TestServer()
-        ref = ConanFileReference.loads("Pkg/0.1@user/channel")
-        ref = ref.copy_with_rev(DEFAULT_REVISION_V1)
-        client = TestClient(servers={"default": server},
-                            users={"default": [("lasote", "mypass")]})
-        server.server_store.update_last_revision(ref)
-        export = server.server_store.export(ref)
-        conanfile = """from conans import ConanFile
-class Pkg(ConanFile):
-    exports_sources = "*"
-"""
-        save_files(export, {"conanfile.py": conanfile,
-                            "conanmanifest.txt": "1",
-                            "conan_sources.txz": "#"})
-        client.run("install Pkg/0.1@user/channel --build", assert_error=True)
-        self.assertIn("ERROR: This Conan version is not prepared to handle "
-                      "'conan_sources.txz' file format", client.out)
-
-    def test_error_package_xz(self):
-        server = TestServer()
-        ref = ConanFileReference.loads("Pkg/0.1@user/channel")
-        ref = ref.copy_with_rev(DEFAULT_REVISION_V1)
-        client = TestClient(servers={"default": server},
-                            users={"default": [("lasote", "mypass")]})
-        server.server_store.update_last_revision(ref)
-        export = server.server_store.export(ref)  # *1 the path can't be known before upload a revision
-        conanfile = """from conans import ConanFile
-class Pkg(ConanFile):
-    exports_sources = "*"
-"""
-        save_files(export, {"conanfile.py": conanfile,
-                            "conanmanifest.txt": "1"})
-        pref = PackageReference(ref, NO_SETTINGS_PACKAGE_ID, DEFAULT_REVISION_V1)
-        server.server_store.update_last_package_revision(pref.copy_with_revs(DEFAULT_REVISION_V1,
-                                                                             DEFAULT_REVISION_V1))
-
-        package = server.server_store.package(pref)
-        save_files(package, {"conaninfo.txt": "#",
-                             "conanmanifest.txt": "1",
-                             "conan_package.txz": "#"})
-        client.run("install Pkg/0.1@user/channel", assert_error=True)
-        self.assertIn("ERROR: This Conan version is not prepared to handle "
-                      "'conan_package.txz' file format", client.out)
-
     @pytest.mark.skipif(not six.PY3, reason="only Py3")
     def test(self):
         tmp_dir = temp_folder()

--- a/conans/test/unittests/util/xz_test.py
+++ b/conans/test/unittests/util/xz_test.py
@@ -21,21 +21,6 @@ from conans.util.files import load, save_files
 class XZTest(TestCase):
     output = TestBufferConanOutput()
 
-    def test_error_xz(self):
-        server = TestServer()
-        ref = ConanFileReference.loads("Pkg/0.1@user/channel")
-        ref = ref.copy_with_rev(DEFAULT_REVISION_V1)
-        export = server.server_store.export(ref)
-        server.server_store.update_last_revision(ref)
-        save_files(export, {"conanfile.py": "#",
-                            "conanmanifest.txt": "#",
-                            "conan_export.txz": "#"})
-        client = TestClient(servers={"default": server},
-                            users={"default": [("lasote", "mypass")]})
-        client.run("install Pkg/0.1@user/channel", assert_error=True)
-        self.assertIn("ERROR: This Conan version is not prepared to handle "
-                      "'conan_export.txz' file format", client.out)
-
     @pytest.mark.skipif(not six.PY3, reason="only Py3")
     def test(self):
         tmp_dir = temp_folder()


### PR DESCRIPTION
Changelog: Fix: Prepare Conan 1.60 to not break if Conan 2.X starts adding metadata files to packages.
Docs: Omit

Backport of https://github.com/conan-io/conan/pull/13349, so future >=1.60 versions do not break if Conan 2.X starts to add metadata