### PR TITLE
Add `conan config show <conf>` command

### DIFF
--- a/conan/api/subapi/config.py
+++ b/conan/api/subapi/config.py
@@ -21,3 +21,7 @@ class ConfigAPI:
     def get(self, name, default=None, check_type=None):
         app = ConanApp(self.conan_api.cache_folder)
         return app.cache.new_config.get(name, default=default, check_type=check_type)
+
+    def show(self, pattern):
+        app = ConanApp(self.conan_api.cache_folder)
+        return app.cache.new_config.show(pattern)

--- a/conan/cli/commands/config.py
+++ b/conan/cli/commands/config.py
@@ -66,3 +66,13 @@ def config_list(conan_api, parser, subparser, *args):
     """
     parser.parse_args(*args)
     return BUILT_IN_CONFS
+
+
+@conan_subcommand(formatters={"text": list_text_formatter, "json": default_json_formatter})
+def config_get(conan_api, parser, subparser, *args):
+    """
+    Get the value of the specified conf
+    """
+    subparser.add_argument('conf', help='Conf item for which to query its value')
+    args = parser.parse_args(*args)
+    return {args.conf: conan_api.config.get(args.conf)}

--- a/conan/cli/commands/config.py
+++ b/conan/cli/commands/config.py
@@ -69,10 +69,11 @@ def config_list(conan_api, parser, subparser, *args):
 
 
 @conan_subcommand(formatters={"text": list_text_formatter, "json": default_json_formatter})
-def config_get(conan_api, parser, subparser, *args):
+def config_show(conan_api, parser, subparser, *args):
     """
     Get the value of the specified conf
     """
-    subparser.add_argument('conf', help='Conf item for which to query its value')
+    subparser.add_argument('pattern', help='Conf item(s) pattern for which to query their value')
     args = parser.parse_args(*args)
-    return {args.conf: conan_api.config.get(args.conf)}
+
+    return conan_api.config.show(args.pattern)

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -307,8 +307,10 @@ class Conf:
         self._values.pop(conf_name, None)
         return value
 
-    def show(self, pattern):
-        return {key: self.get(key) for key in self._values.keys()if fnmatch.fnmatch(key, pattern)}
+    def show(self, fnpattern, pattern=""):
+        return {key: self.get(key)
+                for key in self._values.keys()
+                if fnmatch.fnmatch(pattern + key, fnpattern)}
 
     def copy(self):
         c = Conf()
@@ -485,11 +487,21 @@ class ConfDefinition:
         return self._pattern_confs.get(pattern, Conf()).get(name, default=default,
                                                             check_type=check_type)
 
-    def show(self, pattern):
+    def show(self, fnpattern):
+        """
+        Get the value of the confs that match the requested pattern
+        """
         result = {}
 
-        for p in self._pattern_confs.values():
-            result.update(p.show(pattern))
+        for patter_key, patter_conf in self._pattern_confs.items():
+            if patter_key is None:
+                patter_key = ""
+            else:
+                patter_key += ":"
+
+            pattern_values = patter_conf.show(fnpattern, patter_key)
+            result.update({patter_key + pattern_subkey: pattern_subvalue
+                           for pattern_subkey, pattern_subvalue in pattern_values.items()})
 
         return result
 

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -475,7 +475,7 @@ class ConfDefinition:
 
     def get(self, conf_name, default=None, check_type=None):
         """
-        Get the value of the  conf name requested and convert it to the [type]-like passed.
+        Get the value of the conf name requested and convert it to the [type]-like passed.
         """
         pattern, name = self._split_pattern_name(conf_name)
         return self._pattern_confs.get(pattern, Conf()).get(name, default=default,

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -1,5 +1,6 @@
 import re
 import os
+import fnmatch
 
 from collections import OrderedDict
 
@@ -306,6 +307,9 @@ class Conf:
         self._values.pop(conf_name, None)
         return value
 
+    def show(self, pattern):
+        return {key: self.get(key) for key in self._values.keys()if fnmatch.fnmatch(key, pattern)}
+
     def copy(self):
         c = Conf()
         c._values = self._values.copy()
@@ -480,6 +484,14 @@ class ConfDefinition:
         pattern, name = self._split_pattern_name(conf_name)
         return self._pattern_confs.get(pattern, Conf()).get(name, default=default,
                                                             check_type=check_type)
+
+    def show(self, pattern):
+        result = {}
+
+        for p in self._pattern_confs.values():
+            result.update(p.show(pattern))
+
+        return result
 
     def pop(self, conf_name, default=None):
         """

--- a/conans/test/integration/command/config_test.py
+++ b/conans/test/integration/command/config_test.py
@@ -117,6 +117,9 @@ def test_config_show():
     tools.files.download:retry=7
     core.net.http:timeout=30
     core.net.http:max_retries=5
+    zlib/*:user.mycategory:retry=True
+    zlib/*:user.mycategory:foo=0
+    zlib/*:user.myothercategory:foo=0
     """)
     tc = TestClient()
     tc.save_home({"global.conf": globalconf})
@@ -133,3 +136,18 @@ def test_config_show():
     assert "tools.files.download:retry_wait" in tc.out
     assert "tools.files.download:retry" in tc.out
     assert "core.net.http:max_retries" in tc.out
+    assert "zlib/*:user.mycategory:retry" in tc.out
+
+    tc.run("config show zlib*")
+    assert "zlib/*:user.mycategory:retry" in tc.out
+    assert "zlib/*:user.mycategory:foo" in tc.out
+    assert "zlib/*:user.myothercategory:foo" in tc.out
+
+    tc.run("config show zlib/*")
+    assert "zlib/*:user.mycategory:retry" in tc.out
+    assert "zlib/*:user.mycategory:foo" in tc.out
+    assert "zlib/*:user.myothercategory:foo" in tc.out
+
+    tc.run("config show zlib/*:foo")
+    assert "zlib/*:user.mycategory:foo" in tc.out
+    assert "zlib/*:user.myothercategory:foo" in tc.out

--- a/conans/test/integration/command/config_test.py
+++ b/conans/test/integration/command/config_test.py
@@ -108,3 +108,13 @@ def test_config_install_conanignore():
     _assert_config_exists("foo")
 
     os.listdir(tc.current_folder)
+
+
+def test_config_get():
+    globalconf = textwrap.dedent("""
+    tools.build:jobs=42
+    """)
+    tc = TestClient()
+    tc.save_home({"global.conf": globalconf})
+    tc.run("config get tools.build:jobs")
+    assert "42" in tc.out

--- a/conans/test/integration/command/config_test.py
+++ b/conans/test/integration/command/config_test.py
@@ -110,11 +110,26 @@ def test_config_install_conanignore():
     os.listdir(tc.current_folder)
 
 
-def test_config_get():
+def test_config_show():
     globalconf = textwrap.dedent("""
     tools.build:jobs=42
+    tools.files.download:retry_wait=10
+    tools.files.download:retry=7
+    core.net.http:timeout=30
+    core.net.http:max_retries=5
     """)
     tc = TestClient()
     tc.save_home({"global.conf": globalconf})
-    tc.run("config get tools.build:jobs")
+    tc.run("config show tools.build:jobs")
     assert "42" in tc.out
+
+    tc.run("config show core*")
+    assert "core.net.http:timeout" in tc.out
+    assert "30" in tc.out
+    assert "core.net.http:max_retries" in tc.out
+    assert "5" in tc.out
+
+    tc.run("config show *retr*")
+    assert "tools.files.download:retry_wait" in tc.out
+    assert "tools.files.download:retry" in tc.out
+    assert "core.net.http:max_retries" in tc.out


### PR DESCRIPTION
Changelog: Feature: Add `conan config show <conf>` command.
Docs: https://github.com/conan-io/docs/pull/3091

Let's you get the value for any given configuration. This is the simplest implementation, which does not allow you to input additional profiles nor conf values in the cli, so for now just works from the global.conf, but can be extended in the future:

 - Allow to take into account profiles and conf values supplied by the CLI
 - Pass a pattern to match the confs against and show the values of every matching ones
