### PR TITLE
allow vswhere prereleases

### DIFF
--- a/conans/client/conf/detect_vs.py
+++ b/conans/client/conf/detect_vs.py
@@ -84,7 +84,7 @@ def vs_installation_path(version):
     return result_vs_installation_path
 
 
-def vswhere(all_=False, prerelease=False, products=None, requires=None, version="", latest=False,
+def vswhere(all_=False, prerelease=True, products=None, requires=None, version="", latest=False,
             legacy=False, property_="", nologo=True):
 
     # 'version' option only works if Visual Studio 2017 is installed:


### PR DESCRIPTION
Changelog: Fix: Allow internal ``vswhere`` calls to detect and use VS pre-releases too.
Docs: Omit

Close https://github.com/conan-io/conan/issues/13345