### PR TITLE
copy conanfile.py before calling `export()` and `export_sources()`

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -129,10 +129,10 @@ def cmd_export(app, conanfile_path, name, version, user, channel, keep_source,
         export_src_folder = package_layout.export_sources()
         mkdir(export_folder)
         mkdir(export_src_folder)
+        shutil.copy2(conanfile_path, package_layout.conanfile())
         origin_folder = os.path.dirname(conanfile_path)
         export_recipe(conanfile, origin_folder, export_folder)
         export_source(conanfile, origin_folder, export_src_folder)
-        shutil.copy2(conanfile_path, package_layout.conanfile())
 
         # Calculate the "auto" values and replace in conanfile.py
         scm_data, local_src_folder = _capture_scm_auto_fields(conanfile,


### PR DESCRIPTION
Ref: #13362
Changelog: (Feature): copy conanfile.py before calling export() and export_sources()

Docs: https://github.com/conan-io/docs/pull/XXXX

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
