### PR TITLE
Avoid raising fatal exception if custom command under a folder breaks

### DIFF
--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -61,8 +61,12 @@ class Cli:
             for module in pkgutil.iter_modules([layer_folder]):
                 module_name = module[1]
                 if module_name.startswith("cmd_"):
-                    self._add_command(f"{folder}.{module_name}", module_name.replace("cmd_", ""),
-                                      package=folder)
+                    module_path = f"{folder}.{module_name}"
+                    try:
+                        self._add_command(module_path, module_name.replace("cmd_", ""),
+                                          package=folder)
+                    except Exception as e:
+                        ConanOutput().error(f"Error loading custom command {module_path}: {e}")
 
     def _add_command(self, import_path, method_name, package=None):
         try:

--- a/conans/test/integration/command_v2/custom_commands_test.py
+++ b/conans/test/integration/command_v2/custom_commands_test.py
@@ -19,6 +19,28 @@ class TestCustomCommands:
         client.run("list *")
         assert "ERROR: Error loading custom command 'cmd_mycommand.py': " \
                "No module named 'this_doesnt_exist'" in client.out
+        # But it won't break the whole conan and you can still use the rest of it
+        client.run("config home")
+        assert client.cache_folder in client.out
+
+    def test_import_error_custom_command_subfolder(self):
+        """
+        used to break, this is handled differently in conan
+        """
+        mycommand = textwrap.dedent("""
+            import this_doesnt_exist
+            """)
+
+        client = TestClient()
+        command_file_path = os.path.join(client.cache_folder, 'extensions',
+                                         'commands', 'mycompany', 'cmd_mycommand.py')
+        client.save({f"{command_file_path}": mycommand})
+        # Call to any other command, it will fail loading the custom command,
+        client.run("list *")
+        assert "ERROR: Error loading custom command mycompany.cmd_mycommand" in client.out
+        # But it won't break the whole conan and you can still use the rest of it
+        client.run("config home")
+        assert client.cache_folder in client.out
 
     def test_simple_custom_command(self):
         mycommand = textwrap.dedent("""


### PR DESCRIPTION
Changelog: Bugfix: Avoid raising fatal exceptions for malformed custom commands.
Docs: Omit

Commands under a prefix were not being guarded against fatal exceptions, so an error in those meant you needed to remove the file manually to be able to work with Conan again