### PR TITLE
Create summary of cached content

### DIFF
--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -218,7 +218,8 @@ def download(conanfile, url, filename, verify=True, retry=None, retry_wait=None,
             os.makedirs(os.path.dirname(filename), exist_ok=True)  # filename in subfolder must exist
             downloader.download(url=file_url, file_path=filename, auth=auth, overwrite=overwrite,
                                 verify_ssl=verify, retry=retry, retry_wait=retry_wait,
-                                headers=headers, md5=md5, sha1=sha1, sha256=sha256)
+                                headers=headers, md5=md5, sha1=sha1, sha256=sha256,
+                                conanfile=conanfile)
         out.writeln("")
 
     if not isinstance(url, (list, tuple)):

--- a/conans/client/downloaders/caching_file_downloader.py
+++ b/conans/client/downloaders/caching_file_downloader.py
@@ -55,7 +55,8 @@ class CachingFileDownloader:
                 h = sha256
                 sources_cache = True
             else:
-                ConanOutput().warning("Use sha256 as file checksums for downloaded sources")
+                ConanOutput()\
+                    .warning("Expected sha256 to be used as file checksums for downloaded sources")
         if h is None:
             h = self._get_hash(url, md5, sha1, sha256)
 

--- a/conans/client/downloaders/caching_file_downloader.py
+++ b/conans/client/downloaders/caching_file_downloader.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 from contextlib import contextmanager
@@ -5,7 +6,8 @@ from threading import Lock
 
 from conan.api.output import ConanOutput
 from conans.client.downloaders.file_downloader import FileDownloader
-from conans.util.files import mkdir, set_dirty_context_manager, remove_if_dirty
+from conans.model.conan_file import ConanFile
+from conans.util.files import mkdir, set_dirty_context_manager, remove_if_dirty, load, save
 from conans.util.locks import SimpleLock
 from conans.util.sha import sha256 as compute_sha256
 
@@ -18,11 +20,13 @@ class CachingFileDownloader:
         self._file_downloader = FileDownloader(requester)
 
     def download(self, url, file_path, retry=2, retry_wait=0, verify_ssl=True, auth=None,
-                 overwrite=False, headers=None, md5=None, sha1=None, sha256=None):
+                 overwrite=False, headers=None, md5=None, sha1=None, sha256=None,
+                 conanfile=None):
         if self._download_cache:
             self._caching_download(url, file_path, retry=retry, retry_wait=retry_wait,
                                    verify_ssl=verify_ssl, auth=auth, overwrite=overwrite,
-                                   headers=headers, md5=md5, sha1=sha1, sha256=sha256)
+                                   headers=headers, md5=md5, sha1=sha1, sha256=sha256,
+                                   conanfile=conanfile)
         else:
             self._file_downloader.download(url, file_path, retry=retry, retry_wait=retry_wait,
                                            verify_ssl=verify_ssl, auth=auth, overwrite=overwrite,
@@ -43,17 +47,45 @@ class CachingFileDownloader:
             finally:
                 thread_lock.release()
 
-    def _caching_download(self, url, file_path, md5, sha1, sha256, **kwargs):
-        h = self._get_hash(url, md5, sha1, sha256)
+    def _caching_download(self, url, file_path, md5, sha1, sha256, conanfile: ConanFile, **kwargs):
+        sources_cache = False
+        h = None
+        if conanfile is not None:
+            if sha256:
+                h = sha256
+                sources_cache = True
+            else:
+                ConanOutput().warning("sha256 expected")
+        if h is None:
+            h = self._get_hash(url, md5, sha1, sha256)
+
         with self._lock(h):
-            cached_path = os.path.join(self._download_cache, h)
+            if sources_cache:
+                cached_path = os.path.join(self._download_cache, 's', h)
+            else:
+                cached_path = os.path.join(self._download_cache, 'c', h)
             remove_if_dirty(cached_path)
 
             if not os.path.exists(cached_path):
                 with set_dirty_context_manager(cached_path):
-                    self._file_downloader.download(url=url, file_path=cached_path, md5=md5,
+                    self._file_downloader.download(url, cached_path, md5=md5,
                                                    sha1=sha1, sha256=sha256, **kwargs)
+            if sources_cache:
+                summary_path = cached_path + ".json"
+                if os.path.exists(summary_path):
+                    summary = json.loads(load(summary_path))
+                else:
+                    summary = {}
 
+                try:
+                    summary_key = conanfile.ref.repr_notime()
+                except AttributeError:
+                    summary_key = "unknown"
+
+                urls = summary.setdefault(summary_key, [])
+                if url not in urls:
+                    urls.append(url)
+                save(summary_path, json.dumps(summary))
             # Everything good, file in the cache, just copy it to final destination
             file_path = os.path.abspath(file_path)
             mkdir(os.path.dirname(file_path))

--- a/conans/client/downloaders/caching_file_downloader.py
+++ b/conans/client/downloaders/caching_file_downloader.py
@@ -55,7 +55,7 @@ class CachingFileDownloader:
                 h = sha256
                 sources_cache = True
             else:
-                ConanOutput().warning("sha256 expected")
+                ConanOutput().warning("Use sha256 as file checksums for downloaded sources")
         if h is None:
             h = self._get_hash(url, md5, sha1, sha256)
 

--- a/conans/client/downloaders/caching_file_downloader.py
+++ b/conans/client/downloaders/caching_file_downloader.py
@@ -80,7 +80,10 @@ class CachingFileDownloader:
                 try:
                     summary_key = conanfile.ref.repr_notime()
                 except AttributeError:
-                    summary_key = "unknown"
+                    if conanfile.recipe_folder is not None:
+                        summary_key = conanfile.recipe_folder
+                    else:
+                        summary_key = "unknown"
 
                 urls = summary.setdefault(summary_key, [])
                 if url not in urls:

--- a/conans/client/downloaders/caching_file_downloader.py
+++ b/conans/client/downloaders/caching_file_downloader.py
@@ -6,7 +6,6 @@ from threading import Lock
 
 from conan.api.output import ConanOutput
 from conans.client.downloaders.file_downloader import FileDownloader
-from conans.model.conan_file import ConanFile
 from conans.util.files import mkdir, set_dirty_context_manager, remove_if_dirty, load, save
 from conans.util.locks import SimpleLock
 from conans.util.sha import sha256 as compute_sha256
@@ -47,7 +46,7 @@ class CachingFileDownloader:
             finally:
                 thread_lock.release()
 
-    def _caching_download(self, url, file_path, md5, sha1, sha256, conanfile: ConanFile, **kwargs):
+    def _caching_download(self, url, file_path, md5, sha1, sha256, conanfile, **kwargs):
         sources_cache = False
         h = None
         if conanfile is not None:
@@ -81,10 +80,9 @@ class CachingFileDownloader:
                 try:
                     summary_key = conanfile.ref.repr_notime()
                 except AttributeError:
-                    if conanfile.recipe_folder is not None:
-                        summary_key = conanfile.recipe_folder
-                    else:
-                        summary_key = "unknown"
+                    # The recipe path would be different between machines
+                    # So best we can do is to set this as unknown
+                    summary_key = "unknown"
 
                 urls = summary.setdefault(summary_key, [])
                 if url not in urls:

--- a/conans/test/integration/cache/download_cache_test.py
+++ b/conans/test/integration/cache/download_cache_test.py
@@ -192,8 +192,8 @@ class TestDownloadCache:
 
             assert 2 == len(os.listdir(os.path.join(tmp_folder, "s")))
             content = json.loads(load(os.path.join(tmp_folder, "s", sha256 + ".json")))
-            assert "http://localhost:5000/myfile.txt" in content[client.current_folder]
-            assert len(content[client.current_folder]) == 1
+            assert "http://localhost:5000/myfile.txt" in content["unknown"]
+            assert len(content["unknown"]) == 1
 
             conanfile = textwrap.dedent(f"""
                 from conan import ConanFile
@@ -210,10 +210,15 @@ class TestDownloadCache:
 
             assert 2 == len(os.listdir(os.path.join(tmp_folder, "s")))
             content = json.loads(load(os.path.join(tmp_folder, "s", sha256 + ".json")))
-            assert "http://localhost.mirror:5000/myfile.txt" in content[client.current_folder]
-            assert "http://localhost:5000/myfile.txt" in content[client.current_folder]
-            assert len(content[client.current_folder]) == 2
+            assert "http://localhost.mirror:5000/myfile.txt" in content["unknown"]
+            assert "http://localhost:5000/myfile.txt" in content["unknown"]
+            assert len(content["unknown"]) == 2
 
             # Ensure the cache is working and we didn't break anything by modifying the summary
             client.run("source .")
             assert "Downloading file" not in client.out
+
+            client.run("create . --format=json")
+            content = json.loads(load(os.path.join(tmp_folder, "s", sha256 + ".json")))
+            out = json.loads(client.stdout)
+            assert content[out["graph"]["nodes"][1]["ref"]] == ["http://localhost.mirror:5000/myfile.txt"]

--- a/conans/test/integration/cache/download_cache_test.py
+++ b/conans/test/integration/cache/download_cache_test.py
@@ -1,12 +1,14 @@
+import json
 import os
 import textwrap
+from unittest import mock
 
 from bottle import static_file, request
 
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient, StoppableThreadBottle
-from conans.util.files import save, set_dirty
+from conans.util.files import save, set_dirty, load
 
 
 class TestDownloadCache:
@@ -129,7 +131,8 @@ class TestDownloadCache:
 
         # 2 files cached, plus "locks" folder = 3
         # "locks" folder + 2 files cached + .dirty file from previous failure
-        assert 4 == len(os.listdir(tmp_folder))
+        assert 2 == len(os.listdir(tmp_folder))
+        assert 3 == len(os.listdir(os.path.join(tmp_folder, "c")))
 
         # remove remote file
         os.remove(file_path)
@@ -164,3 +167,49 @@ class TestDownloadCache:
                path=c.cache.cache_folder)
         c.run("install --requires=mypkg/0.1@user/testing", assert_error=True)
         assert 'core.download:download_cache must be an absolute path' in c.out
+
+    def test_users_download_cache_(self):
+        nonce = ""
+        def custom_download(this, url, filepath, **kwargs):
+            save(filepath, f"Hello, world!{nonce}")
+
+        with mock.patch("conans.client.downloaders.file_downloader.FileDownloader.download", custom_download):
+            client = TestClient()
+            tmp_folder = temp_folder()
+            client.save({"global.conf": f"tools.files.download:download_cache={tmp_folder}"},
+                        path=client.cache.cache_folder)
+            sha256 = "d9014c4624844aa5bac314773d6b689ad467fa4e1d1a50a1b8a99d5a95f72ff5"
+            conanfile = textwrap.dedent(f"""
+                from conan import ConanFile
+                from conan.tools.files import download
+                class Pkg(ConanFile):
+                   def source(self):
+                       download(self, "http://localhost:5000/myfile.txt", "myfile.txt",
+                                sha256="{sha256}")
+                """)
+            client.save({"conanfile.py": conanfile})
+            client.run("source .")
+
+            assert 2 == len(os.listdir(os.path.join(tmp_folder, "s")))
+            content = json.loads(load(os.path.join(tmp_folder, "s", sha256 + ".json")))
+            assert "http://localhost:5000/myfile.txt" in content["unknown"]
+            assert len(content["unknown"]) == 1
+
+            conanfile = textwrap.dedent(f"""
+                from conan import ConanFile
+                from conan.tools.files import download
+                class Pkg2(ConanFile):
+                    name = "pkg"
+                    version = "1.0"
+                    def source(self):
+                        download(self, "http://localhost.mirror:5000/myfile.txt", "myfile.txt",
+                                 sha256="{sha256}")
+                """)
+            client.save({"conanfile.py": conanfile})
+            client.run("source .")
+
+            assert 2 == len(os.listdir(os.path.join(tmp_folder, "s")))
+            content = json.loads(load(os.path.join(tmp_folder, "s", sha256 + ".json")))
+            assert "http://localhost.mirror:5000/myfile.txt" in content["unknown"]
+            assert "http://localhost:5000/myfile.txt" in content["unknown"]
+            assert len(content["unknown"]) == 2

--- a/conans/test/integration/cache/download_cache_test.py
+++ b/conans/test/integration/cache/download_cache_test.py
@@ -220,5 +220,4 @@ class TestDownloadCache:
 
             client.run("create . --format=json")
             content = json.loads(load(os.path.join(tmp_folder, "s", sha256 + ".json")))
-            out = json.loads(client.stdout)
-            assert content[out["graph"]["nodes"][1]["ref"]] == ["http://localhost.mirror:5000/myfile.txt"]
+            assert content["pkg/1.0#" + client.exported_recipe_revision()] == ["http://localhost.mirror:5000/myfile.txt"]

--- a/conans/test/integration/cache/download_cache_test.py
+++ b/conans/test/integration/cache/download_cache_test.py
@@ -168,10 +168,9 @@ class TestDownloadCache:
         c.run("install --requires=mypkg/0.1@user/testing", assert_error=True)
         assert 'core.download:download_cache must be an absolute path' in c.out
 
-    def test_users_download_cache_(self):
-        nonce = ""
+    def test_users_download_cache_summary(self):
         def custom_download(this, url, filepath, **kwargs):
-            save(filepath, f"Hello, world!{nonce}")
+            save(filepath, f"Hello, world!")
 
         with mock.patch("conans.client.downloaders.file_downloader.FileDownloader.download", custom_download):
             client = TestClient()
@@ -192,8 +191,8 @@ class TestDownloadCache:
 
             assert 2 == len(os.listdir(os.path.join(tmp_folder, "s")))
             content = json.loads(load(os.path.join(tmp_folder, "s", sha256 + ".json")))
-            assert "http://localhost:5000/myfile.txt" in content["unknown"]
-            assert len(content["unknown"]) == 1
+            assert "http://localhost:5000/myfile.txt" in content[client.current_folder]
+            assert len(content[client.current_folder]) == 1
 
             conanfile = textwrap.dedent(f"""
                 from conan import ConanFile
@@ -210,6 +209,6 @@ class TestDownloadCache:
 
             assert 2 == len(os.listdir(os.path.join(tmp_folder, "s")))
             content = json.loads(load(os.path.join(tmp_folder, "s", sha256 + ".json")))
-            assert "http://localhost.mirror:5000/myfile.txt" in content["unknown"]
-            assert "http://localhost:5000/myfile.txt" in content["unknown"]
-            assert len(content["unknown"]) == 2
+            assert "http://localhost.mirror:5000/myfile.txt" in content[client.current_folder]
+            assert "http://localhost:5000/myfile.txt" in content[client.current_folder]
+            assert len(content[client.current_folder]) == 2

--- a/conans/test/integration/cache/download_cache_test.py
+++ b/conans/test/integration/cache/download_cache_test.py
@@ -170,6 +170,7 @@ class TestDownloadCache:
 
     def test_users_download_cache_summary(self):
         def custom_download(this, url, filepath, **kwargs):
+            print("Downloading file")
             save(filepath, f"Hello, world!")
 
         with mock.patch("conans.client.downloaders.file_downloader.FileDownloader.download", custom_download):
@@ -212,3 +213,7 @@ class TestDownloadCache:
             assert "http://localhost.mirror:5000/myfile.txt" in content[client.current_folder]
             assert "http://localhost:5000/myfile.txt" in content[client.current_folder]
             assert len(content[client.current_folder]) == 2
+
+            # Ensure the cache is working and we didn't break anything by modifying the summary
+            client.run("source .")
+            assert "Downloading file" not in client.out


### PR DESCRIPTION
Changelog: Feature: Create summary of cached content.
Docs: Omit

Co-Authored-By: @memsharded 

Initial work towards the sources backup feature, this PR aims to implement a simple "summary.json" for sources downloaded by a conanfile, which stores info about which reference downloaded which URL, relying in the sha256 checksum as the key.

It also changes the cache layout a bit by moving the mentioned downloaded files by the conanfile to their own `s/` subfolder, and the rest to `c/`

Omitted docs because it only makes sense to document this once the whole feature lands
