### PR TITLE
Add output to `conan remote enable/disable`

### DIFF
--- a/conan/api/subapi/remotes.py
+++ b/conan/api/subapi/remotes.py
@@ -49,12 +49,14 @@ class RemotesAPI:
         for r in remotes:
             r.disabled = True
             self.update(r)
+        return remotes
 
     def enable(self, pattern):
         remotes = self.list(pattern, only_enabled=False)
         for r in remotes:
             r.disabled = False
             self.update(r)
+        return remotes
 
     def get(self, remote_name):
         app = ConanApp(self.conan_api.cache_folder)

--- a/conan/cli/commands/remote.py
+++ b/conan/cli/commands/remote.py
@@ -130,7 +130,7 @@ def remote_rename(conan_api, parser, subparser, *args):
     conan_api.remotes.rename(r, args.new_name)
 
 
-@conan_subcommand()
+@conan_subcommand(formatters={"text": print_remote_list, "json": formatter_remote_list_json})
 def remote_enable(conan_api, parser, subparser, *args):
     """
     Enable all the remotes matching a pattern.
@@ -138,10 +138,10 @@ def remote_enable(conan_api, parser, subparser, *args):
     subparser.add_argument("remote", help="Pattern of the remote/s to enable. "
                                           "The pattern uses 'fnmatch' style wildcards.")
     args = parser.parse_args(*args)
-    conan_api.remotes.enable(args.remote)
+    return conan_api.remotes.enable(args.remote)
 
 
-@conan_subcommand()
+@conan_subcommand(formatters={"text": print_remote_list, "json": formatter_remote_list_json})
 def remote_disable(conan_api, parser, subparser, *args):
     """
     Disable all the remotes matching a pattern.
@@ -149,7 +149,7 @@ def remote_disable(conan_api, parser, subparser, *args):
     subparser.add_argument("remote", help="Pattern of the remote/s to disable. "
                                           "The pattern uses 'fnmatch' style wildcards.")
     args = parser.parse_args(*args)
-    conan_api.remotes.disable(args.remote)
+    return conan_api.remotes.disable(args.remote)
 
 
 # ### User related commands

--- a/conans/test/integration/command/remote_test.py
+++ b/conans/test/integration/command/remote_test.py
@@ -199,6 +199,12 @@ class RemoteTest(unittest.TestCase):
         assert "my-remote3: http://someurl3 [Verify SSL: True, Enabled: False]" in client.out
 
         client.run("remote disable * --format=json")
+
+        registry = load(client.cache.remotes_path)
+        data = json.loads(registry)
+        for remote in data["remotes"]:
+            self.assertEqual(remote["disabled"], True)
+
         data = json.loads(client.out)
         for remote in data:
             assert remote["enabled"] is False

--- a/conans/test/integration/command/remote_test.py
+++ b/conans/test/integration/command/remote_test.py
@@ -179,7 +179,11 @@ class RemoteTest(unittest.TestCase):
         client.run("remote add my-remote2 http://someurl2")
         client.run("remote add my-remote3 http://someurl3")
         client.run("remote disable my-remote0")
+        assert "my-remote0" in client.out
+        assert "Enabled: False" in client.out
         client.run("remote disable my-remote3")
+        assert "my-remote3" in client.out
+        assert "Enabled: False" in client.out
         registry = load(client.cache.remotes_path)
         data = json.loads(registry)
         self.assertEqual(data["remotes"][0]["name"], "my-remote0")
@@ -194,17 +198,21 @@ class RemoteTest(unittest.TestCase):
         assert "my-remote0: http://someurl0 [Verify SSL: True, Enabled: False]" in client.out
         assert "my-remote3: http://someurl3 [Verify SSL: True, Enabled: False]" in client.out
 
-        client.run("remote disable *")
-        registry = load(client.cache.remotes_path)
-        data = json.loads(registry)
-        for remote in data["remotes"]:
-            self.assertEqual(remote["disabled"], True)
+        client.run("remote disable * --format=json")
+        data = json.loads(client.out)
+        for remote in data:
+            assert remote["enabled"] is False
 
         client.run("remote enable *")
         registry = load(client.cache.remotes_path)
         data = json.loads(registry)
         for remote in data["remotes"]:
             self.assertNotIn("disabled", remote)
+        assert "my-remote0" in client.out
+        assert "my-remote1" in client.out
+        assert "my-remote2" in client.out
+        assert "my-remote3" in client.out
+        assert "Enabled: False" not in client.out
 
     def test_invalid_remote_disable(self):
         client = TestClient()


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Add output to `conan remote enable/disable <pattern>`, as it didn't tell you what remotes were affected by your operation