### PR TITLE
Feature/premakedeps

### DIFF
--- a/conan/tools/premake/premakedeps.py
+++ b/conan/tools/premake/premakedeps.py
@@ -271,8 +271,9 @@ class PremakeDeps(object):
                 fallback_configuration = configurations[-1]
             
             # Emit package premake file
-            pkg_files.append(PREMAKE_PKG_FILE.format(pkgname=dep_name))
-            self._output_lua_file(pkg_files[-1], [
+            pkg_filename = PREMAKE_PKG_FILE.format(pkgname=dep_name)
+            pkg_files.append(pkg_filename)
+            self._output_lua_file(pkg_filename, [
                 # Includes
                 *['include "{}"'.format(profile[0]) for profile in profiles],
                 # Functions

--- a/conan/tools/premake/premakedeps.py
+++ b/conan/tools/premake/premakedeps.py
@@ -235,8 +235,11 @@ class PremakeDeps(object):
 
             # Create list of all available profiles by searching on disk
             file_pattern = PREMAKE_VAR_FILE.format(pkgname=dep_name, config="_*")
-            file_regex = PREMAKE_VAR_FILE.format(pkgname=dep_name, config="_(([^_]*)_(.*))")
+            file_regex = PREMAKE_VAR_FILE.format(pkgname=re.escape(dep_name), config="_(([^_]*)_(.*))")
             available_files = glob.glob(file_pattern)
+            # Add filename of current generations var file if not already present
+            if var_filename not in available_files:
+                available_files.append(var_filename)
             profiles = [
                 (regex_res[0], regex_res.group(1), regex_res.group(2), regex_res.group(3)) for regex_res in [
                     re.search(file_regex, file_name) for file_name in available_files
@@ -246,9 +249,9 @@ class PremakeDeps(object):
             architectures = list(dict.fromkeys([profile[3] for profile in profiles]))
 
             # Fallback configuration (when user defined config is unknown -> prefer release or last)
-            fallback_configuration = configurations[-1]
-            if "release" in configurations: 
-                fallback_configuration = "release"
+            fallback_configuration = "release"
+            if "release" not in configurations and len(configurations) > 0: 
+                fallback_configuration = configurations[-1]
             
             # Emit package premake file
             pkg_files.append(PREMAKE_PKG_FILE.format(pkgname=dep_name))

--- a/conan/tools/premake/premakedeps.py
+++ b/conan/tools/premake/premakedeps.py
@@ -1,10 +1,10 @@
-from conan.internal import check_duplicated_generator
-from conans.model.build_info import CppInfo
-from conans.util.files import save
-
 import itertools 
 import glob
 import re
+
+from conan.internal import check_duplicated_generator
+from conans.model.build_info import CppInfo
+from conans.util.files import save
 
 # Filename format strings
 PREMAKE_VAR_FILE = "conan_{pkgname}_vars{config}.premake5.lua"
@@ -106,10 +106,17 @@ class _PremakeTemplate(object):
         self.sysroot = "%s" % deps_cpp_info.sysroot.replace("\\",
                                                             "/") if deps_cpp_info.sysroot else ""
 
-# Main premake5 dependency generator
 class PremakeDeps(object):
+    """
+    PremakeDeps class generator
+    conandeps.premake5.lua: unconditional import of all *direct* dependencies only
+    """
 
     def __init__(self, conanfile):
+        """
+        :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
+        """
+
         self._conanfile = conanfile
 
         # Tab configuration
@@ -122,6 +129,11 @@ class PremakeDeps(object):
         self.architecture = conanfile.settings.arch
 
     def generate(self):
+        """
+        Generates ``conan_<pkg>_vars_<config>.premake5.lua``, ``conan_<pkg>_<config>.premake5.lua``,
+        and ``conan_<pkg>.premake5.lua`` files into the ``conanfile.generators_folder``.
+        """
+
         check_duplicated_generator(self, self._conanfile)
         # Current directory is the generators_folder
         generator_files = self.content
@@ -152,7 +164,7 @@ class PremakeDeps(object):
         ]
     
     def _premake_filtered_fallback(self, content, configurations, architecture, indent=1):
-        fallback_filter = ", ".join([f'"configuration:not {configuration}"' for configuration in configurations])
+        fallback_filter = ", ".join([f'"configurations:not {configuration}"' for configuration in configurations])
         lines = list(itertools.chain.from_iterable([cnt.splitlines() for cnt in content]))
         return [
             # Set new filter

--- a/conans/test/integration/toolchains/premake/test_premakedeps.py
+++ b/conans/test/integration/toolchains/premake/test_premakedeps.py
@@ -1,16 +1,70 @@
 import textwrap
+import os
 
 from conans.test.utils.tools import TestClient
 
+def assert_configuration_file(client, configuration):
+    contents = client.load(f"conan_pkg.name-more+_{configuration}_x86_64.premake5.lua")
+    assert f'include "conan_pkg.name-more+_vars_{configuration}_x86_64.premake5.lua"' in contents
+    assert f'function conan_setup_build_pkg.name-more+_{configuration}_x86_64()' in contents
+    assert f'function conan_setup_link_pkg.name-more+_{configuration}_x86_64()' in contents
+    assert f'function conan_setup_pkg.name-more+_{configuration}_x86_64()' in contents
+
+def assert_vars_file(client, configuration):
+    contents = client.load(f"conan_pkg.name-more+_vars_{configuration}_x86_64.premake5.lua")
+    assert f'conan_includedirs_pkg.name-more+_{configuration}_x86_64' in contents
+    assert f'conan_libdirs_pkg.name-more+_{configuration}_x86_64' in contents
+    assert f'conan_bindirs_pkg.name-more+_{configuration}_x86_64' in contents
+    assert f'conan_libs_pkg.name-more+_{configuration}_x86_64' in contents
+    assert f'conan_system_libs_pkg.name-more+_{configuration}_x86_64' in contents
+    assert f'conan_defines_pkg.name-more+_{configuration}_x86_64' in contents
+    assert f'conan_cxxflags_pkg.name-more+_{configuration}_x86_64' in contents
+    assert f'conan_cflags_pkg.name-more+_{configuration}_x86_64' in contents
+    assert f'conan_sharedlinkflags_pkg.name-more+_{configuration}_x86_64' in contents
+    assert f'conan_exelinkflags_pkg.name-more+_{configuration}_x86_64' in contents
+    assert f'conan_frameworks_pkg.name-more+_{configuration}_x86_64' in contents
 
 def test_premakedeps():
-    conanfile = textwrap.dedent("""
-        [generators]
-        PremakeDeps
-        """)
+    # Create package
     client = TestClient()
-    client.save({"conanfile.txt": conanfile}, clean_first=True)
-    client.run("install .")
+    print(client.current_folder)
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        class Pkg(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+            name = "pkg.name-more+"
+            version = "1.0"
 
-    contents = client.load("conandeps.premake.lua")
-    assert 'function conan_basic_setup()' in contents
+            def package_info(self):
+                self.cpp_info.components["libmpdecimal++"].libs = ["libmp++"]
+                self.cpp_info.components["mycomp.some-comp+"].libs = ["mylib"]
+                self.cpp_info.components["libmpdecimal++"].requires = ["mycomp.some-comp+"]
+        """)
+    client.save({"conanfile.py": conanfile}, clean_first=True)
+    client.run("create . -s arch=x86_64 -s build_type=Debug")
+    client.run("create . -s arch=x86_64 -s build_type=Release")
+
+    # Run conan
+    client.run("install --require=pkg.name-more+/1.0@ -g PremakeDeps -s arch=x86_64 -s build_type=Debug")
+    client.run("install --require=pkg.name-more+/1.0@ -g PremakeDeps -s arch=x86_64 -s build_type=Release")
+
+    # Assert root lua file
+    contents = client.load("conandeps.premake5.lua")
+    assert 'include "conan_pkg.name-more+.premake5.lua"' in contents
+    assert 'function conan_setup_build()' in contents
+    assert 'function conan_setup_link()' in contents
+    assert 'function conan_setup()' in contents
+
+    # Assert package root file
+    contents = client.load("conan_pkg.name-more+.premake5.lua")
+    assert 'include "conan_pkg.name-more+_vars_debug_x86_64.premake5.lua"' in contents
+    assert 'include "conan_pkg.name-more+_vars_release_x86_64.premake5.lua"' in contents
+    assert 'function conan_setup_build_pkg.name-more+()' in contents
+    assert 'function conan_setup_link_pkg.name-more+()' in contents
+    assert 'function conan_setup_pkg.name-more+()' in contents
+
+    # Assert package per configuration files
+    assert_configuration_file(client, 'debug')
+    assert_vars_file(client, 'debug')
+    assert_configuration_file(client, 'release')
+    assert_vars_file(client, 'release')

--- a/conans/test/integration/toolchains/premake/test_premakedeps.py
+++ b/conans/test/integration/toolchains/premake/test_premakedeps.py
@@ -1,28 +1,26 @@
 import textwrap
-import os
 
 from conans.test.utils.tools import TestClient
 
-def assert_configuration_file(client, configuration):
-    contents = client.load(f"conan_pkg.name-more+_{configuration}_x86_64.premake5.lua")
-    assert f'include "conan_pkg.name-more+_vars_{configuration}_x86_64.premake5.lua"' in contents
-    assert f'function conan_setup_build_pkg.name-more+_{configuration}_x86_64()' in contents
-    assert f'function conan_setup_link_pkg.name-more+_{configuration}_x86_64()' in contents
-    assert f'function conan_setup_pkg.name-more+_{configuration}_x86_64()' in contents
-
 def assert_vars_file(client, configuration):
     contents = client.load(f"conan_pkg.name-more+_vars_{configuration}_x86_64.premake5.lua")
-    assert f'conan_includedirs_pkg.name-more+_{configuration}_x86_64' in contents
-    assert f'conan_libdirs_pkg.name-more+_{configuration}_x86_64' in contents
-    assert f'conan_bindirs_pkg.name-more+_{configuration}_x86_64' in contents
-    assert f'conan_libs_pkg.name-more+_{configuration}_x86_64' in contents
-    assert f'conan_system_libs_pkg.name-more+_{configuration}_x86_64' in contents
-    assert f'conan_defines_pkg.name-more+_{configuration}_x86_64' in contents
-    assert f'conan_cxxflags_pkg.name-more+_{configuration}_x86_64' in contents
-    assert f'conan_cflags_pkg.name-more+_{configuration}_x86_64' in contents
-    assert f'conan_sharedlinkflags_pkg.name-more+_{configuration}_x86_64' in contents
-    assert f'conan_exelinkflags_pkg.name-more+_{configuration}_x86_64' in contents
-    assert f'conan_frameworks_pkg.name-more+_{configuration}_x86_64' in contents
+    assert f'include "conanutils.premake5.lua"' in contents
+    assert f't_conandeps = {{}}' in contents
+    assert f't_conandeps["{configuration}_x86_64"] = {{}}' in contents
+    assert f't_conandeps["{configuration}_x86_64"]["pkg.name-more+"] = {{}}' in contents
+    assert f't_conandeps["{configuration}_x86_64"]["pkg.name-more+"]["includedirs"]' in contents
+    assert f't_conandeps["{configuration}_x86_64"]["pkg.name-more+"]["libdirs"]' in contents
+    assert f't_conandeps["{configuration}_x86_64"]["pkg.name-more+"]["bindirs"]' in contents
+    assert f't_conandeps["{configuration}_x86_64"]["pkg.name-more+"]["libs"]' in contents
+    assert f't_conandeps["{configuration}_x86_64"]["pkg.name-more+"]["system_libs"]' in contents
+    assert f't_conandeps["{configuration}_x86_64"]["pkg.name-more+"]["defines"]' in contents
+    assert f't_conandeps["{configuration}_x86_64"]["pkg.name-more+"]["cxxflags"]' in contents
+    assert f't_conandeps["{configuration}_x86_64"]["pkg.name-more+"]["cflags"]' in contents
+    assert f't_conandeps["{configuration}_x86_64"]["pkg.name-more+"]["sharedlinkflags"]' in contents
+    assert f't_conandeps["{configuration}_x86_64"]["pkg.name-more+"]["exelinkflags"]' in contents
+    assert f't_conandeps["{configuration}_x86_64"]["pkg.name-more+"]["frameworks"]' in contents
+    assert f'if conandeps == nil then conandeps = {{}} end' in contents
+    assert f'conan_premake_tmerge(conandeps, t_conandeps)' in contents
 
 def test_premakedeps():
     # Create package
@@ -51,20 +49,15 @@ def test_premakedeps():
     # Assert root lua file
     contents = client.load("conandeps.premake5.lua")
     assert 'include "conan_pkg.name-more+.premake5.lua"' in contents
-    assert 'function conan_setup_build()' in contents
-    assert 'function conan_setup_link()' in contents
-    assert 'function conan_setup()' in contents
+    assert 'function conan_setup_build(conf, pkg)' in contents
+    assert 'function conan_setup_link(conf, pkg)' in contents
+    assert 'function conan_setup(conf, pkg)' in contents
 
     # Assert package root file
     contents = client.load("conan_pkg.name-more+.premake5.lua")
     assert 'include "conan_pkg.name-more+_vars_debug_x86_64.premake5.lua"' in contents
     assert 'include "conan_pkg.name-more+_vars_release_x86_64.premake5.lua"' in contents
-    assert 'function conan_setup_build_pkg.name-more+()' in contents
-    assert 'function conan_setup_link_pkg.name-more+()' in contents
-    assert 'function conan_setup_pkg.name-more+()' in contents
 
     # Assert package per configuration files
-    assert_configuration_file(client, 'debug')
     assert_vars_file(client, 'debug')
-    assert_configuration_file(client, 'release')
     assert_vars_file(client, 'release')


### PR DESCRIPTION
Changelog: Feature: Adding preliminary (non documented, dev-only) support for premake5 deps (PremakeDeps).
Docs: Omit

Fixes #13275 (Based on PR #13350)

**Features**
- Implements lua file generation for premake consumption (New feature for 2.0)
- Supports multi build with changing architecture and configuration (New for the premake tool)
- Generates a lua file with variables (includedirs, libdirs, ...) per configuration (Based on existing implementation, adapted for multi build and new architecture)
- Generates a lua file with functions (Just build/compiler setup, linker setup and both) for automatic premake project setup per package and profile/config (Breaks compatibility with conan1 but is way more flexible)
- Generates a lua file with functions (see previous) for automatic premake project setup per package
- Generates a global `conandeps.premake5.lua` file with functions (see previous) for automatic premake project setup. 
- Has fallback capabilities to `release` when no fitting conan configuration is available

**Status**
WIP-Status: Code works and has been covered with a basic unit test. Documentation is still required.

**Checklist**
- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] ~~I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.~~ Delayed until full premake5 support is implemented.

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
