### PR TITLE
Restore 2.0.1 version in release/2.0 branch

### DIFF
--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -2,4 +2,4 @@ CHECKSUM_DEPLOY = "checksum_deploy"  # Only when v2
 REVISIONS = "revisions"  # Only when enabled in config, not by default look at server_launcher.py
 OAUTH_TOKEN = "oauth_token"
 
-__version__ = '2.1.0-dev'
+__version__ = '2.0.1'


### PR DESCRIPTION
Changelog: omit
Docs: omit

Somehow the -dev version finished in the release branch. Normally the version in release branch is updated right before releasing, so the next change in this branch should be to 2.0.2 before release. We could also use 2.0.2-dev from the moment we know that there could be a 2.0.2.