### PR TITLE
allow relative paths to cache in global.conf

### DIFF
--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -152,10 +152,10 @@ class ClientCache(object):
                 distro = None
                 if platform.system() in ["Linux", "FreeBSD"]:
                     import distro
-                base_path = os.path.dirname(self.new_config_path)
-                template = Environment(loader=FileSystemLoader(base_path)).from_string(text)
+                template = Environment(loader=FileSystemLoader(self.cache_folder)).from_string(text)
                 content = template.render({"platform": platform, "os": os, "distro": distro,
-                                           "conan_version": conan_version})
+                                           "conan_version": conan_version,
+                                           "conan_home_folder": self.cache_folder})
 
                 self._new_config.loads(content)
         return self._new_config

--- a/conans/test/integration/configuration/conf/test_conf.py
+++ b/conans/test/integration/configuration/conf/test_conf.py
@@ -208,6 +208,14 @@ def test_jinja_global_conf_include(client):
     assert "user.mycompany:dist=84" in client.out
 
 
+def test_jinja_global_conf_paths():
+    c = TestClient()
+    global_conf = 'user.mycompany:myfile = {{os.path.join(conan_home_folder, "myfile")}}'
+    save(c.cache.new_config_path, global_conf)
+    c.run("config show *")
+    assert f"user.mycompany:myfile: {os.path.join(c.cache_folder, 'myfile')}" in c.out
+
+
 def test_empty_conf_valid():
     tc = TestClient()
     profile = textwrap.dedent(r"""


### PR DESCRIPTION
Changelog: Feature: Allow relative paths to the Conan home folder in the ``global.conf``.
Docs: https://github.com/conan-io/docs/pull/3087

Close https://github.com/conan-io/conan/issues/13413