### PR TITLE
Remove profile arguments from conan profile path

### DIFF
--- a/conan/cli/commands/profile.py
+++ b/conan/cli/commands/profile.py
@@ -43,7 +43,6 @@ def profile_path(conan_api, parser, subparser, *args):
     """
     Show profile path location.
     """
-    add_profiles_args(subparser)
     subparser.add_argument("name", help="Profile name")
     args = parser.parse_args(*args)
     return conan_api.profiles.get_path(args.name)


### PR DESCRIPTION
Changelog: Fix: Remove profile arguments from `conan profile path`.
Docs: https://github.com/conan-io/docs/pull/3090

Conan profile path was showing arguments not related with that command:

```
$ conan profile path -h
usage: conan profile path [-h] [-v [V]] [-o OPTIONS_HOST]
                          [-o:b OPTIONS_BUILD] [-o:h OPTIONS_HOST]
                          [-pr PROFILE_HOST] [-pr:b PROFILE_BUILD]
                          [-pr:h PROFILE_HOST] [-s SETTINGS_HOST]
                          [-s:b SETTINGS_BUILD] [-s:h SETTINGS_HOST]
                          [-c CONF_HOST] [-c:b CONF_BUILD] [-c:h CONF_HOST]
                          name

Show profile path location.

positional arguments:
  name                  Profile name

optional arguments:
  -h, --help            show this help message and exit
  -v [V]                Level of detail of the output. Valid options from less
                        verbose to more verbose: -vquiet, -verror, -vwarning,
                        -vnotice, -vstatus, -v or -vverbose, -vv or -vdebug,
                        -vvv or -vtrace
  -o OPTIONS_HOST, --options OPTIONS_HOST
                        Define options values (host machine), e.g.: -o
                        Pkg:with_qt=true
  -o:b OPTIONS_BUILD, --options:build OPTIONS_BUILD
                        Define options values (build machine), e.g.: -o:b
                        Pkg:with_qt=true
  -o:h OPTIONS_HOST, --options:host OPTIONS_HOST
                        Define options values (host machine), e.g.: -o:h
                        Pkg:with_qt=true
  -pr PROFILE_HOST, --profile PROFILE_HOST
                        Apply the specified profile to the host machine
  -pr:b PROFILE_BUILD, --profile:build PROFILE_BUILD
                        Apply the specified profile to the build machine
  -pr:h PROFILE_HOST, --profile:host PROFILE_HOST
                        Apply the specified profile to the host machine
  -s SETTINGS_HOST, --settings SETTINGS_HOST
                        Settings to build the package, overwriting the
                        defaults (host machine). e.g.: -s compiler=gcc
  -s:b SETTINGS_BUILD, --settings:build SETTINGS_BUILD
                        Settings to build the package, overwriting the
                        defaults (build machine). e.g.: -s:b compiler=gcc
  -s:h SETTINGS_HOST, --settings:host SETTINGS_HOST
                        Settings to build the package, overwriting the
                        defaults (host machine). e.g.: -s:h compiler=gcc
  -c CONF_HOST, --conf CONF_HOST
                        Configuration to build the package, overwriting the
                        defaults (host machine). e.g.: -c
                        tools.cmake.cmaketoolchain:generator=Xcode
  -c:b CONF_BUILD, --conf:build CONF_BUILD
                        Configuration to build the package, overwriting the
                        defaults (build machine). e.g.: -c:b
                        tools.cmake.cmaketoolchain:generator=Xcode
  -c:h CONF_HOST, --conf:host CONF_HOST
                        Configuration to build the package, overwriting the
                        defaults (host machine). e.g.: -c:h
                        tools.cmake.cmaketoolchain:generator=Xcode
```