### PR TITLE
fix build-scripts creation

### DIFF
--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -61,7 +61,11 @@ def create(conan_api, parser, *args):
         # TODO: This section might be overlapping with ``graph_compute()``
         requires = [ref] if not args.build_require else None
         tool_requires = [ref] if args.build_require else None
-
+        # FIXME: Dirty: package type still raw, not processed yet
+        # TODO: Why not for package_type = "application" like cmake to be used as build-require?
+        if conanfile.package_type == "build-scripts" and not args.build_require:
+            # swap them
+            requires, tool_requires = tool_requires, requires
         deps_graph = conan_api.graph.load_graph_requires(requires, tool_requires,
                                                          profile_host=profile_host,
                                                          profile_build=profile_build,

--- a/conans/test/integration/graph/test_skip_binaries.py
+++ b/conans/test/integration/graph/test_skip_binaries.py
@@ -1,5 +1,3 @@
-import re
-
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient, NO_SETTINGS_PACKAGE_ID
 
@@ -82,3 +80,15 @@ def test_test_requires():
     client.save({"conanfile.py": GenConanfile().with_requires("pkg/1.0")})
     client.run("create . --name=app --version=1.0")
     client.assert_listed_binary({"gtest/1.0": (package_id, "Skip")}, test=True)
+
+
+def test_build_scripts_no_skip():
+    c = TestClient()
+    c.save({"scripts/conanfile.py": GenConanfile("script", "0.1").with_package_type("build-scripts"),
+            "app/conanfile.py": GenConanfile().with_tool_requires("script/0.1")})
+    c.run("create scripts")
+    c.assert_listed_binary({"script/0.1": ("da39a3ee5e6b4b0d3255bfef95601890afd80709", "Build")},
+                           build=True)
+    c.run("install app")
+    c.assert_listed_binary({"script/0.1": ("da39a3ee5e6b4b0d3255bfef95601890afd80709", "Cache")},
+                           build=True)


### PR DESCRIPTION
Changelog: Fix: Allow automatic processing of ``package_type = "build-scripts"`` in ``conan create`` as ``--build-require``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/13431

This is not super clean, but it should also be very low-risk, and it would unblock some conan-center recipes.
We will create a ticket for 2.0.3 to discuss a bit further about the ``--build-require`` case.


