### PR TITLE
fix profile path <nonexisting>

### DIFF
--- a/conan/api/subapi/profiles.py
+++ b/conan/api/subapi/profiles.py
@@ -55,6 +55,7 @@ class ProfilesAPI:
             or local, depending on the "cwd"
         """
         loader = ProfileLoader(self._cache)
+        cwd = cwd or os.getcwd()
         profile_path = loader.get_profile_path(profile, cwd, exists=exists)
         return profile_path
 

--- a/conans/test/integration/command/test_profile.py
+++ b/conans/test/integration/command/test_profile.py
@@ -1,4 +1,4 @@
-import os 
+import os
 
 from conans.test.utils.tools import TestClient
 
@@ -7,6 +7,12 @@ def test_profile_path():
     c = TestClient()
     c.run("profile path default")
     assert "default" in c.out
+
+
+def test_profile_path_missing():
+    c = TestClient()
+    c.run("profile path notexisting", assert_error=True)
+    assert "ERROR: Profile not found: notexisting" in c.out
 
 
 def test_ignore_paths_when_listing_profiles():


### PR DESCRIPTION
Changelog: Bugfix: Solve bug in ``conan profile path <nonexisting>`` that was crashing.
Docs: Omit
