### PR TITLE
fix meson cpp_std for VS2019 and 2022 c++20.

### DIFF
--- a/conan/tools/build/flags.py
+++ b/conan/tools/build/flags.py
@@ -185,7 +185,7 @@ def cppstd_flag(settings):
     return flag
 
 
-def _cppstd_msvc(visual_version, cppstd):
+def cppstd_msvc_flag(visual_version, cppstd):
     # https://docs.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version
     v14 = None
     v17 = None
@@ -198,11 +198,15 @@ def _cppstd_msvc(visual_version, cppstd):
     if visual_version >= "191":
         v17 = "c++17"
         v20 = "c++latest"
-    if visual_version >= "193":
+    if visual_version >= "192":
         v20 = "c++20"
+    if visual_version >= "193":
         v23 = "c++latest"
 
-    flag = {"14": v14, "17": v17, "20": v20, "23": v23}.get(str(cppstd), None)
+    return {"14": v14, "17": v17, "20": v20, "23": v23}.get(str(cppstd), None)
+
+def _cppstd_msvc(visual_version, cppstd):
+    flag = cppstd_msvc_flag(visual_version, cppstd)
     return "/std:%s" % flag if flag else None
 
 

--- a/conan/tools/meson/helpers.py
+++ b/conan/tools/meson/helpers.py
@@ -1,3 +1,5 @@
+from conan.tools.build.flags import cppstd_msvc_flag
+
 __all__ = ["to_meson_machine", "to_meson_value", "to_cppstd_flag"]
 
 # https://mesonbuild.com/Reference-tables.html#operating-system-names
@@ -47,11 +49,6 @@ _meson_cpu_family_map = {
     'x86_64': ('x86_64', 'x86_64', 'little')
 }
 
-_vs_cppstd_map = {
-    '14': "vc++14",
-    '17': "vc++17",
-    '20': "vc++latest"
-}
 
 # Meson valid values
 # "none", "c++98", "c++03", "c++11", "c++14", "c++17", "c++1z", "c++2a", "c++20",
@@ -102,14 +99,19 @@ def to_meson_value(value):
 
 
 # FIXME: Move to another more common module
-def to_cppstd_flag(compiler, cppstd):
+def to_cppstd_flag(compiler, compiler_version, cppstd):
     """Gets a valid cppstd flag.
 
     :param compiler: ``str`` compiler name.
+    :param compiler_version: ``str`` compiler version.
     :param cppstd: ``str`` cppstd version.
     :return: ``str`` cppstd flag.
     """
     if compiler == "msvc":
-        return _vs_cppstd_map.get(cppstd)
+        # Meson's logic with 'vc++X' vs 'c++X' is possibly a little outdated.
+        # Presumably the intent is 'vc++X' is permissive and 'c++X' is not,
+        # but '/permissive-' is the default since 16.8.
+        flag = cppstd_msvc_flag(compiler_version, cppstd)
+        return 'v%s' % flag if flag else None
     else:
         return _cppstd_map.get(cppstd)

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -122,8 +122,12 @@ class MesonToolchain(object):
         compiler = self._conanfile.settings.get_safe("compiler")
         if compiler is None:
             raise ConanException("MesonToolchain needs 'settings.compiler', but it is not defined")
+        compiler_version = self._conanfile.settings.get_safe("compiler.version")
+        if compiler_version is None:
+            raise ConanException("MesonToolchain needs 'settings.compiler.version', but it is not defined")
+
         cppstd = self._conanfile.settings.get_safe("compiler.cppstd")
-        self._cpp_std = to_cppstd_flag(compiler, cppstd)
+        self._cpp_std = to_cppstd_flag(compiler, compiler_version, cppstd)
 
         if compiler == "msvc":
             vscrt = msvc_runtime_flag(self._conanfile)

--- a/conans/test/unittests/client/build/cpp_std_flags_test.py
+++ b/conans/test/unittests/client/build/cpp_std_flags_test.py
@@ -235,6 +235,7 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(_make_cppstd_flag("msvc", "170", "17"), None)
 
         self.assertEqual(_make_cppstd_flag("msvc", "180", "11"), None)
+
         self.assertEqual(_make_cppstd_flag("msvc", "190", "14"), '/std:c++14')
         self.assertEqual(_make_cppstd_flag("msvc", "190", "17"), '/std:c++latest')
 
@@ -244,7 +245,7 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(_make_cppstd_flag("msvc", "191", "20"), '/std:c++latest')
 
         self.assertEqual(_make_cppstd_flag("msvc", "192", "17"), '/std:c++17')
-        self.assertEqual(_make_cppstd_flag("msvc", "192", "20"), '/std:c++latest')
+        self.assertEqual(_make_cppstd_flag("msvc", "192", "20"), '/std:c++20')
 
         self.assertEqual(_make_cppstd_flag("msvc", "193", "20"), '/std:c++20')
         self.assertEqual(_make_cppstd_flag("msvc", "193", "23"), '/std:c++latest')


### PR DESCRIPTION
Changelog: Fix: Generate `cpp_std=vc++20` for c++20 with meson with VS2019 and VS2022, rather than `vc++latest`.
Docs: Omit

Fixes #13424

Note meson 1.0.1 is required for it (meson) to accept `vc++20` with clang-cl.

Given the comment about `_msvc_supported_cppstd` in the issue, I've made a slight change from the version there. It looks like `_msvc_supported_cppstd` reports VS2019 as only supporting up to c++20, so I've kept c++23 as VS2022 only in this version.

Thanks