### PR TITLE
default tools.files.download:download_cache to core.xxx equivalent

### DIFF
--- a/conan/internal/conan_app.py
+++ b/conan/internal/conan_app.py
@@ -28,9 +28,10 @@ class CmdWrapper:
 
 
 class ConanFileHelpers:
-    def __init__(self, requester, cmd_wrapper):
+    def __init__(self, requester, cmd_wrapper, global_conf):
         self.requester = requester
         self.cmd_wrapper = cmd_wrapper
+        self.global_conf = global_conf
 
 
 class ConanApp(object):
@@ -41,9 +42,10 @@ class ConanApp(object):
 
         self.hook_manager = HookManager(self.cache.hooks_path)
         # Wraps an http_requester to inject proxies, certs, etc
-        self.requester = ConanRequester(self.cache.new_config, cache_folder)
+        global_conf = self.cache.new_config
+        self.requester = ConanRequester(global_conf, cache_folder)
         # To handle remote connections
-        rest_client_factory = RestApiClientFactory(self.requester, self.cache.new_config)
+        rest_client_factory = RestApiClientFactory(self.requester, global_conf)
         # Wraps RestApiClient to add authentication support (same interface)
         auth_manager = ConanApiAuthManager(rest_client_factory, self.cache)
         # Handle remote connections
@@ -54,5 +56,5 @@ class ConanApp(object):
 
         self.pyreq_loader = PyRequireLoader(self.proxy, self.range_resolver)
         cmd_wrap = CmdWrapper(self.cache)
-        conanfile_helpers = ConanFileHelpers(self.requester, cmd_wrap)
+        conanfile_helpers = ConanFileHelpers(self.requester, cmd_wrap, global_conf)
         self.loader = ConanFileLoader(self.pyreq_loader, conanfile_helpers)

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -191,6 +191,7 @@ def download(conanfile, url, filename, verify=True, retry=None, retry_wait=None,
     """
     # TODO: Add all parameters to the new conf
     requester = conanfile._conan_helpers.requester
+    global_conf = conanfile._conan_helpers.global_conf
     config = conanfile.conf
     out = ConanOutput()
     overwrite = True
@@ -200,11 +201,12 @@ def download(conanfile, url, filename, verify=True, retry=None, retry_wait=None,
     retry_wait = retry_wait if retry_wait is not None else 5
     retry_wait = config.get("tools.files.download:retry_wait", check_type=int, default=retry_wait)
 
-    # Conan 2.0: Removed "tools.files.download:download_cache" from configuration
-    checksum = md5 or sha1 or sha256
-    download_cache = config.get("tools.files.download:download_cache") if checksum else None
-    if download_cache and not os.path.isabs(download_cache):
-        raise ConanException("core.download:download_cache must be an absolute path")
+    download_cache = None
+    if md5 or sha1 or sha256:  # If there is no checksum, no cache is used
+        download_cache = config.get("tools.files.download:download_cache")
+        download_cache = download_cache or global_conf.get("core.download:download_cache")
+        if download_cache and not os.path.isabs(download_cache):
+            raise ConanException("core.download:download_cache must be an absolute path")
 
     filename = os.path.abspath(filename)
 

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -57,7 +57,7 @@ BUILT_IN_CONFS = {
     "tools.cmake.cmaketoolchain:system_processor": "Define CMAKE_SYSTEM_PROCESSOR in CMakeToolchain",
     "tools.cmake.cmaketoolchain:toolset_arch": "Toolset architecture to be used as part of CMAKE_GENERATOR_TOOLSET in CMakeToolchain",
     "tools.cmake.cmake_layout:build_folder_vars": "Settings and Options that will produce a different build folder and different CMake presets names",
-    "tools.files.download:download_cache": "Define the cache folder to store downloads from files.download()/get()",
+    "tools.files.download:download_cache": "Define the cache folder to store downloads from files.download()/get() (defaults to core.download:download_cache)",
     "tools.files.download:retry": "Number of retries in case of failure when downloading",
     "tools.files.download:retry_wait": "Seconds to wait between download attempts",
     "tools.gnu:make_program": "Indicate path to make program",

--- a/conans/test/unittests/tools/files/test_downloads.py
+++ b/conans/test/unittests/tools/files/test_downloads.py
@@ -165,9 +165,8 @@ class TestDownload:
 
     def test_download_localfile(self):
         conanfile = ConanFileMock()
-        conanfile._conan_requester = requests
 
-        file_location =  os.path.join(temp_folder(), "file.txt")
+        file_location = os.path.join(temp_folder(), "file.txt")
         save(file_location, "this is some content")
 
         file_url = f"file:///{file_location}"
@@ -180,7 +179,6 @@ class TestDownload:
 
     def test_download_localfile_notfound(self):
         conanfile = ConanFileMock()
-        conanfile._conan_requester = requests
 
         file_url = "file:///path/to/missing/file.txt"
         dest = os.path.join(temp_folder(), "file.txt")
@@ -189,6 +187,7 @@ class TestDownload:
             download(conanfile, file_url, dest)
 
         assert "No such file" in str(exc.value)
+
 
 @pytest.fixture()
 def bottle_server_zip():

--- a/conans/test/utils/mocks.py
+++ b/conans/test/utils/mocks.py
@@ -129,7 +129,7 @@ class ConanFileMock(ConanFile):
         self.system_requires = {}
         self.win_bash = None
         self.conf = ConfDefinition().get_conanfile_conf(None)
-        self._conan_helpers = ConanFileHelpers(None, None)
+        self._conan_helpers = ConanFileHelpers(None, None, {})
         self.cpp = Infos()
 
     def run(self, command, win_bash=False, subsystem=None, env=None, ignore_errors=False):


### PR DESCRIPTION
Changelog: Feature: Default ``tools.files.download:download_cache`` to ``core.download:download_cache``, so it is only necessary to define one.
Docs: Omit
