### PR TITLE
Add basic package filter for conan list html output

### DIFF
--- a/conan/cli/command.py
+++ b/conan/cli/command.py
@@ -93,9 +93,6 @@ class BaseConanCommand:
             raise ConanException("{} is not a known format. Supported formatters are: {}".format(
                 formatarg, ", ".join(self._help_formatters)))
 
-        if type(info) is dict:
-            info["cli_args"] = " ".join([f"{arg}={getattr(parser_args, arg)}" for arg in vars(parser_args) if getattr(parser_args, arg)])
-
         formatter(info)
 
 

--- a/conan/cli/command.py
+++ b/conan/cli/command.py
@@ -93,8 +93,9 @@ class BaseConanCommand:
             raise ConanException("{} is not a known format. Supported formatters are: {}".format(
                 formatarg, ", ".join(self._help_formatters)))
 
-        if info is not None:
+        if type(info) is dict:
             info["cli_args"] = " ".join([f"{arg}={getattr(parser_args, arg)}" for arg in vars(parser_args) if getattr(parser_args, arg)])
+
         formatter(info)
 
 

--- a/conan/cli/command.py
+++ b/conan/cli/command.py
@@ -93,6 +93,7 @@ class BaseConanCommand:
             raise ConanException("{} is not a known format. Supported formatters are: {}".format(
                 formatarg, ", ".join(self._help_formatters)))
 
+        info["cli_args"] = " ".join([f"{arg}={getattr(parser_args, arg)}" for arg in vars(parser_args) if getattr(parser_args, arg)])
         formatter(info)
 
 

--- a/conan/cli/command.py
+++ b/conan/cli/command.py
@@ -93,7 +93,8 @@ class BaseConanCommand:
             raise ConanException("{} is not a known format. Supported formatters are: {}".format(
                 formatarg, ", ".join(self._help_formatters)))
 
-        info["cli_args"] = " ".join([f"{arg}={getattr(parser_args, arg)}" for arg in vars(parser_args) if getattr(parser_args, arg)])
+        if info is not None:
+            info["cli_args"] = " ".join([f"{arg}={getattr(parser_args, arg)}" for arg in vars(parser_args) if getattr(parser_args, arg)])
         formatter(info)
 
 

--- a/conan/cli/commands/list.py
+++ b/conan/cli/commands/list.py
@@ -120,7 +120,9 @@ def list(conan_api: ConanAPI, parser, *args):
             results[name] = {"error": str(e)}
         else:
             results[name] = list_bundle.serialize()
+
     return {
         "results": results,
-        "conan_api": conan_api
+        "conan_api": conan_api,
+        "cli_args": " ".join([f"{arg}={getattr(args, arg)}" for arg in vars(args) if getattr(args, arg)])
     }

--- a/conan/cli/formatters/list/list.py
+++ b/conan/cli/formatters/list/list.py
@@ -11,11 +11,12 @@ from conans import __version__ as client_version
 
 def list_packages_html(result):
     results = result["results"]
+    cli_args = result["cli_args"]
     conan_api = result["conan_api"]
     template_folder = os.path.join(conan_api.cache_folder, "templates")
     user_template = os.path.join(template_folder, "list_packages.html")
     template = load(user_template) if os.path.isfile(user_template) else list_packages_html_template
     template = Template(template, autoescape=select_autoescape(['html', 'xml']))
     content = template.render(results=json.dumps(results), base_template_path=template_folder,
-                              version=client_version)
+                              version=client_version, cli_args=cli_args)
     cli_out_write(content)

--- a/conan/cli/formatters/list/search_table_html.py
+++ b/conan/cli/formatters/list/search_table_html.py
@@ -100,11 +100,16 @@ list_packages_html_template = r"""
             let options = new Set();
             let settings = new Set();
             for (const [package, packageInfo] of Object.entries(revInfo["packages"])) {
-                for (const [key, value] of Object.entries(packageInfo["info"]["options"])) {
-                    options.add(`${key}=${value}`)
+                let info = packageInfo["info"];
+                if ("options" in info) {
+                    for (const [key, value] of Object.entries(info["options"])) {
+                        options.add(`${key}=${value}`)
+                    }
                 }
-                for (const [key, value] of Object.entries(packageInfo["info"]["settings"])) {
-                    settings.add(`${key}=${value}`)
+                if ("settings" in info) {
+                    for (const [key, value] of Object.entries(info["settings"])) {
+                        settings.add(`${key}=${value}`)
+                    }
                 }
             }
             return [options, settings]
@@ -153,7 +158,6 @@ list_packages_html_template = r"""
                     filters.push(checkbox.value)
                 }
             })
-            console.log(filters);
 
             activeRevInfo = revInfo;
             let packageList = ``;

--- a/conan/cli/formatters/list/search_table_html.py
+++ b/conan/cli/formatters/list/search_table_html.py
@@ -281,7 +281,7 @@ list_packages_html_template = r"""
 <body>
     <nav class="navbar navbar-expand-lg bg-light">
         <div class="container-fluid">
-            <a class="navbar-brand">conan list results</a>
+            <a class="navbar-brand">conan list: {{ cli_args }}</a>
         </div>
     </nav>
 

--- a/conan/cli/formatters/list/search_table_html.py
+++ b/conan/cli/formatters/list/search_table_html.py
@@ -294,7 +294,7 @@ list_packages_html_template = r"""
 
 <footer>
     <div class="text-center p-2" style="background-color: rgba(0, 0, 0, 0.05);">
-        Conan <b>2.0.2</b>
+        Conan <b>{{ version }}</b>
         <script>
             document.write(new Date().getFullYear());
         </script>


### PR DESCRIPTION
Changelog: Feature: Add filtering for options and settings in conan list html output.
Docs: omit

This is also passing the arguments from the cli to show the input in the top navbar in the html

![image](https://user-images.githubusercontent.com/5045666/225901759-514caf02-4cac-4882-9c72-167e0bd82225.png)


