### PR TITLE
fix python-requires in remote for export-pkg

### DIFF
--- a/conan/cli/commands/export_pkg.py
+++ b/conan/cli/commands/export_pkg.py
@@ -49,7 +49,8 @@ def export_pkg(conan_api, parser, *args):
     remotes = conan_api.remotes.list(args.remote) if not args.no_remote else []
 
     ref, conanfile = conan_api.export.export(path=path, name=args.name, version=args.version,
-                                             user=args.user, channel=args.channel, lockfile=lockfile)
+                                             user=args.user, channel=args.channel, lockfile=lockfile,
+                                             remotes=remotes)
     # The package_type is not fully processed at export
     assert conanfile.package_type != "python-require", "A python-require cannot be export-pkg"
     lockfile = conan_api.lockfile.update_lockfile_export(lockfile, conanfile, ref,

--- a/conans/test/integration/command/export_pkg_test.py
+++ b/conans/test/integration/command/export_pkg_test.py
@@ -594,3 +594,17 @@ def test_export_pkg_test_package_build_require():
     assert "RUN TEST PACKAGE!!!!" in c.out
     lock = json.loads(c.load("conan.lock"))
     assert "pkg/1.0" in lock["build_requires"][0]
+
+
+def test_export_pkg_remote_python_requires():
+    """ Test that remote python-requires can be resolved
+    """
+    c = TestClient(default_server_user=True)
+    c.save({"tool/conanfile.py": GenConanfile("tool", "1.0"),
+            "pkg/conanfile.py": GenConanfile("pkg", "1.0").with_python_requires("tool/1.0")})
+
+    c.run("create tool")
+    c.run("upload tool* -r=default -c")
+    c.run("remove * -c")
+    c.run("export-pkg pkg")
+    assert "conanfile.py (pkg/1.0): Exported package binary" in c.out


### PR DESCRIPTION
Changelog: Bugfix: Fix ``python-requires`` in remotes when running ``conan export-pkg``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/13495