### PR TITLE
feature conan cache check-integrity

### DIFF
--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -84,7 +84,7 @@ def cache_check_integrity(conan_api: ConanAPI, parser, subparser, *args):
     """
     Check the integrity of the local cache for the given references
     """
-    subparser.add_argument("pattern", help="Selection pattern for references to clean")
+    subparser.add_argument("pattern", help="Selection pattern for references to check integrity for")
     subparser.add_argument('-p', '--package-query', action=OnceArgument,
                            help="Only the packages matching a specific query, e.g., "
                                 "os=Windows AND (arch=x86 OR compiler=gcc)")

--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -77,3 +77,19 @@ def cache_clean(conan_api: ConanAPI, parser, subparser, *args):
     package_list = conan_api.list.select(ref_pattern, package_query=args.package_query)
     conan_api.cache.clean(package_list, source=args.source, build=args.build,
                           download=args.download)
+
+
+@conan_subcommand(formatters={"text": cli_out_write})
+def cache_check_integrity(conan_api: ConanAPI, parser, subparser, *args):
+    """
+    Show the path to the Conan cache for a given reference.
+    """
+    subparser.add_argument("pattern", help="Selection pattern for references to clean")
+    subparser.add_argument('-p', '--package-query', action=OnceArgument,
+                           help="Only the packages matching a specific query, e.g., "
+                                "os=Windows AND (arch=x86 OR compiler=gcc)")
+    args = parser.parse_args(*args)
+
+    ref_pattern = ListPattern(args.pattern, rrev="*", package_id="*", prev="*")
+    package_list = conan_api.list.select(ref_pattern, package_query=args.package_query)
+    conan_api.cache.check_integrity(package_list)

--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -82,7 +82,7 @@ def cache_clean(conan_api: ConanAPI, parser, subparser, *args):
 @conan_subcommand(formatters={"text": cli_out_write})
 def cache_check_integrity(conan_api: ConanAPI, parser, subparser, *args):
     """
-    Show the path to the Conan cache for a given reference.
+    Check the integrity of the local cache for the given references
     """
     subparser.add_argument("pattern", help="Selection pattern for references to clean")
     subparser.add_argument('-p', '--package-query', action=OnceArgument,

--- a/conans/search/search.py
+++ b/conans/search/search.py
@@ -4,7 +4,6 @@ from collections import OrderedDict
 from fnmatch import translate
 from typing import Dict
 
-from conan.api.output import ConanOutput
 from conans.errors import ConanException
 from conans.model.info import load_binary_info
 from conans.model.package_ref import PkgReference
@@ -115,8 +114,8 @@ def get_cache_packages_binary_info(cache, prefs) -> Dict[PkgReference, dict]:
         # Read conaninfo
         info_path = os.path.join(pkg_layout.package(), CONANINFO)
         if not os.path.exists(info_path):
-            ConanOutput().error("There is no conaninfo.txt: %s" % str(info_path))
-            continue
+            raise ConanException(f"Corrupted package '{pkg_layout.reference}' "
+                                 f"without conaninfo.txt in: {info_path}")
         conan_info_content = load(info_path)
 
         info = load_binary_info(conan_info_content)

--- a/conans/test/integration/command_v2/test_cache_integrity.py
+++ b/conans/test/integration/command_v2/test_cache_integrity.py
@@ -1,0 +1,28 @@
+import os
+
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.tools import TestClient
+from conans.util.files import save
+
+
+def test_cache_integrity():
+    t = TestClient()
+    t.save({"conanfile.py": GenConanfile()})
+    t.run("create . --name pkg1 --version 1.0")
+    t.run("create . --name pkg2 --version=2.0")
+    pref = t.created_package_reference("pkg2/2.0")
+    layout = t.get_latest_pkg_layout(pref)
+    conaninfo = os.path.join(layout.package(), "conaninfo.txt")
+    save(conaninfo, "[settings]")
+    t.run("create . --name pkg3 --version=3.0")
+    pref = t.created_package_reference("pkg3/3.0")
+    layout = t.get_latest_pkg_layout(pref)
+    conaninfo = os.path.join(layout.package(), "conaninfo.txt")
+    save(conaninfo, "[settings]")
+
+    t.run("cache check-integrity *", assert_error=True)
+    assert "pkg1/1.0: Integrity checked: ok" in t.out
+    assert "pkg1/1.0:da39a3ee5e6b4b0d3255bfef95601890afd80709: Integrity checked: ok" in t.out
+    assert "ERROR: pkg2/2.0:da39a3ee5e6b4b0d3255bfef95601890afd80709: Manifest mismatch" in t.out
+    assert "ERROR: pkg3/3.0:da39a3ee5e6b4b0d3255bfef95601890afd80709: Manifest mismatch" in t.out
+    


### PR DESCRIPTION
Changelog: Feature: New ``conan cache check-integrity`` command to replace 1.X legacy ``conan upload --skip-upload --check``.
Docs: https://github.com/conan-io/docs/pull/3147


Close https://github.com/conan-io/conan/issues/13499
