### PR TITLE
Tests/remove

### DIFF
--- a/conan/api/model.py
+++ b/conan/api/model.py
@@ -132,6 +132,8 @@ class ListPattern:
             raise ConanException(f"Recipe '{self.ref}' not found")
 
     def filter_rrevs(self, rrevs):
+        if self.rrev == "!latest":
+            return rrevs[1:]
         rrevs = [r for r in rrevs if fnmatch.fnmatch(r.revision, self.rrev)]
         if not rrevs:
             refs_str = f'{self.ref}#{self.rrev}'
@@ -148,6 +150,8 @@ class ListPattern:
         return prefs
 
     def filter_prevs(self, prevs):
+        if self.prev == "!latest":
+            return prevs[1:]
         prevs = [p for p in prevs if fnmatch.fnmatch(p.revision, self.prev)]
         if not prevs:
             refs_str = f'{self.ref}#{self.rrev}:{self.package_id}#{self.prev}'


### PR DESCRIPTION
Changelog: Feature: Introduce the ``conan remove *#!latest`` (also for package-revisions), to remove all revisions except the latest one.
Docs: https://github.com/conan-io/docs/pull/3144

Close https://github.com/conan-io/conan/issues/13475

Also some minor refactors to a test, removing unnecessary ``with populated_client.mocked_servers():``