### PR TITLE
Fix subcommands from commands with underscores

### DIFF
--- a/conan/cli/command.py
+++ b/conan/cli/command.py
@@ -149,6 +149,7 @@ class ConanCommand(BaseConanCommand):
             self._subcommand_parser = self._parser.add_subparsers(dest='subcommand',
                                                                   help='sub-command help')
             self._subcommand_parser.required = True
+        subcommand.set_name(self.name)
         subcommand.set_parser(self._parser, self._subcommand_parser)
         self._subcommands[subcommand.name] = subcommand
 
@@ -174,12 +175,15 @@ class ConanSubCommand(BaseConanCommand):
         super().__init__(method, formatters=formatters)
         self._parent_parser = None
         self._parser = None
-        self._name = "-".join(method.__name__.split("_")[1:])
+        self._subcommand_name = method.__name__.replace('_', '-')
 
     def run(self, conan_api, *args):
         info = self._method(conan_api, self._parent_parser, self._parser, *args)
         # It is necessary to do it after calling the "method" otherwise parser not complete
         self._format(self._parent_parser, info, *args)
+
+    def set_name(self, parent_name):
+        self._name = self._subcommand_name.replace(f'{parent_name}-', '', 1)
 
     def set_parser(self, parent_parser, subcommand_parser):
         self._parser = subcommand_parser.add_parser(self._name, help=self._doc)

--- a/conans/test/integration/command_v2/custom_commands_test.py
+++ b/conans/test/integration/command_v2/custom_commands_test.py
@@ -161,6 +161,36 @@ class TestCustomCommands:
         client.run("complex sub1 myargument -f json")
         assert f'{{"argument1": "myargument"}}' in client.out
 
+    def test_custom_command_with_subcommands_with_underscore(self):
+        complex_command = textwrap.dedent("""
+            import json
+
+            from conan.cli.command import conan_command, conan_subcommand
+            from conan.api.output import cli_out_write
+
+            @conan_command()
+            def command_with_underscores(conan_api, parser, *args, **kwargs):
+                \"""
+                this is a command with subcommands
+                \"""
+
+            @conan_subcommand()
+            def command_with_underscores_subcommand_with_underscores_too(conan_api, parser, subparser, *args):
+                \"""
+                sub1 subcommand
+                \"""
+                subparser.add_argument("argument1", help="This is argument number 1")
+                args = parser.parse_args(*args)
+                cli_out_write(args.argument1)
+            """)
+
+        client = TestClient()
+        command_file_path = os.path.join(client.cache_folder, 'extensions',
+                                         'commands', 'cmd_command_with_underscores.py')
+        client.save({f"{command_file_path}": complex_command})
+        client.run("command-with-underscores subcommand-with-underscores-too myargument")
+        assert "myargument" in client.out
+
     def test_overwrite_builtin_command(self):
         complex_command = textwrap.dedent("""
             import json


### PR DESCRIPTION
Changelog: Bugfix: Fix subcommands names when the parent command has underscores.
Docs: omit

When implementing a custom command that has something like:

```
@conan_command(group="Custom commands")
def build_info(conan_api: ConanAPI, parser, *args):
...

@conan_subcommand()
def build_info_create(conan_api: ConanAPI, parser, subparser, *args):
...
```
I noticed that the subcommand name was not properly formed, it appeared as `info-create` instead of `create`.

Maybe we want to get rid of the restriction of being the main command the start of the subcommand names and just use:

```
@conan_command(group="Custom commands")
def build_info(conan_api: ConanAPI, parser, *args):
...

@conan_subcommand()
def create(conan_api: ConanAPI, parser, subparser, *args):
...
```
