### PR TITLE
relocatable full_deploy CMake

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -47,7 +47,16 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
         dependency_filenames = self._get_dependency_filenames()
         # Get the nodes that have the property cmake_find_mode=None (no files to generate)
         dependency_find_modes = self._get_dependencies_find_modes()
-        root_folder = self._root_folder.replace('\\', '/').replace('$', '\\$').replace('"', '\\"')
+
+        # Make the root_folder relative to the generated xxx-data.cmake file
+        root_folder = self._root_folder
+        generators_folder = self.cmakedeps._conanfile.generators_folder
+        if os.path.commonpath([root_folder, generators_folder]) == generators_folder:
+            rel_path = os.path.relpath(root_folder, generators_folder)
+            rel_path = rel_path.replace('\\', '/').replace('$', '\\$').replace('"', '\\"')
+            root_folder = f"${{CMAKE_CURRENT_LIST_DIR}}/{rel_path}"
+        else:
+            root_folder = root_folder.replace('\\', '/').replace('$', '\\$').replace('"', '\\"')
 
         return {"global_cpp": global_cpp,
                 "has_components": self.conanfile.cpp_info.has_components,

--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -414,8 +414,11 @@ class EnvVars:
             {deactivate}
             """).format(deactivate=deactivate if generate_deactivate else "")
         result = [capture]
+        location = os.path.dirname(file_location)
         for varname, varvalues in self._values.items():
             value = varvalues.get_str("%{name}%", subsystem=self._subsystem, pathsep=self._pathsep)
+            # To make the script relocatable
+            value = value.replace(location, "%~dp0")
             result.append('set "{}={}"'.format(varname, value))
 
         content = "\n".join(result)

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -447,28 +447,30 @@ class CppInfo(object):
                 origin = getattr(component, varname)
                 if origin is not None:
                     origin[:] = [os.path.join(folder, el) for el in origin]
-            if component._generator_properties is not None:
-                updates = {}
-                for prop_name, value in component._generator_properties.items():
-                    if prop_name == "cmake_build_modules":
-                        if isinstance(value, list):
-                            updates[prop_name] = [os.path.join(folder, v) for v in value]
-                        else:
-                            updates[prop_name] = os.path.join(folder, value)
-                component._generator_properties.update(updates)
+            properties = component._generator_properties
+            if properties is not None:
+                modules = properties.get("cmake_build_modules")  # Only this prop at this moment
+                if modules is not None:
+                    assert isinstance(modules, list), "cmake_build_modules must be a list"
+                    properties["cmake_build_modules"] = [os.path.join(folder, v) for v in modules]
 
     def deploy_base_folder(self, package_folder, deploy_folder):
         """Prepend the folder to all the directories"""
+        def relocate(el):
+            rel_path = os.path.relpath(el, package_folder)
+            return os.path.join(deploy_folder, rel_path)
+
         for component in self.components.values():
             for varname in _DIRS_VAR_NAMES:
                 origin = getattr(component, varname)
                 if origin is not None:
-                    new_ = []
-                    for el in origin:
-                        rel_path = os.path.relpath(el, package_folder)
-                        new_.append(os.path.join(deploy_folder, rel_path))
-                    origin[:] = new_
-                # TODO: Missing properties
+                    origin[:] = [relocate(f) for f in origin]
+            properties = component._generator_properties
+            if properties is not None:
+                modules = properties.get("cmake_build_modules")  # Only this prop at this moment
+                if modules is not None:
+                    assert isinstance(modules, list), "cmake_build_modules must be a list"
+                    properties["cmake_build_modules"] = [relocate(f) for f in modules]
 
     def _raise_circle_components_requires_error(self):
         """

--- a/conans/test/functional/command/test_install_deploy.py
+++ b/conans/test/functional/command/test_install_deploy.py
@@ -1,4 +1,6 @@
 import os
+import platform
+import shutil
 import textwrap
 
 import pytest
@@ -15,8 +17,30 @@ from conans.util.files import save
 def test_install_deploy():
     c = TestClient()
     c.run("new cmake_lib -d name=hello -d version=0.1")
+    c.run("create . -o *:shared=True -tf=")
+    conanfile = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+        from conan.tools.files import save
+        class Tool(ConanFile):
+            name = "tool"
+            version = "1.0"
+            def package(self):
+                save(self, os.path.join(self.package_folder, "build", "my_tools.cmake"),
+                     'set(MY_TOOL_VARIABLE "Hello world!")')
+
+            def package_info(self):
+                self.cpp_info.includedirs = []
+                self.cpp_info.libdirs = []
+                self.cpp_info.bindirs = []
+                path_build_modules = os.path.join("build", "my_tools.cmake")
+                self.cpp_info.set_property("cmake_build_modules", [path_build_modules])
+            """)
+    c.save({"conanfile.py": conanfile}, clean_first=True)
     c.run("create .")
-    cmake = gen_cmakelists(appname="my_app", appsources=["main.cpp"], find_package=["hello"])
+    custom_content = 'message(STATUS "MY_TOOL_VARIABLE=${MY_TOOL_VARIABLE}!")'
+    cmake = gen_cmakelists(appname="my_app", appsources=["main.cpp"], find_package=["hello", "tool"],
+                           custom_content=custom_content)
     deploy = textwrap.dedent("""
         import os, shutil
 
@@ -28,23 +52,36 @@ def test_install_deploy():
                 shutil.copytree(d.package_folder, new_folder)
                 d.set_deploy_folder(new_folder)
         """)
-    c.save({"conanfile.txt": "[requires]\nhello/0.1",
+    c.save({"conanfile.txt": "[requires]\nhello/0.1\ntool/1.0",
             "deploy.py": deploy,
             "CMakeLists.txt": cmake,
             "main.cpp": gen_function_cpp(name="main", includes=["hello"], calls=["hello"])},
            clean_first=True)
-    c.run("install . --deploy=deploy.py -of=mydeploy -g CMakeToolchain -g CMakeDeps")
+    c.run("install . -o *:shared=True "
+          "--deploy=deploy.py -of=mydeploy -g CMakeToolchain -g CMakeDeps")
+    print(c.out)
     c.run("remove * -c")  # Make sure the cache is clean, no deps there
-    cwd = c.current_folder.replace("\\", "/")
     arch = c.get_default_host_profile().settings['arch']
     deps = c.load(f"mydeploy/hello-release-{arch}-data.cmake")
-    assert f'set(hello_PACKAGE_FOLDER_RELEASE "{cwd}/mydeploy/hello")' in deps
+    assert 'set(hello_PACKAGE_FOLDER_RELEASE "${CMAKE_CURRENT_LIST_DIR}/hello")' in deps
     assert 'set(hello_INCLUDE_DIRS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/include")' in deps
     assert 'set(hello_LIB_DIRS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/lib")' in deps
 
+    # We can fully move it to another folder, and still works
+    tmp = os.path.join(temp_folder(), "relocated")
+    shutil.copytree(c.current_folder, tmp)
+    shutil.rmtree(c.current_folder)
+    c2 = TestClient(current_folder=tmp)
     # I can totally build without errors with deployed
-    c.run_command("cmake . -DCMAKE_TOOLCHAIN_FILE=mydeploy/conan_toolchain.cmake -DCMAKE_BUILD_TYPE=Release")
-    c.run_command("cmake --build . --config Release")
+    c2.run_command("cmake . -DCMAKE_TOOLCHAIN_FILE=mydeploy/conan_toolchain.cmake "
+                   "-DCMAKE_BUILD_TYPE=Release")
+    assert "MY_TOOL_VARIABLE=Hello world!!" in c2.out
+    c2.run_command("cmake --build . --config Release")
+    if platform.system() == "Windows":  # Only the .bat env-generators are relocatable
+        cmd = r"mydeploy\conanrun.bat && Release\my_app.exe"
+        # For Lunux: cmd = ". mydeploy/conanrun.sh && ./my_app"
+        c2.run_command(cmd)
+        assert "hello/0.1: Hello World Release!" in c2.out
 
 
 def test_copy_files_deploy():
@@ -108,7 +145,7 @@ def test_multi_deploy():
     assert "conanfile.txt: deploy cache!!" in c.out
 
 
-def test_builtin_deploy():
+def test_builtin_full_deploy():
     """ check the built-in full_deploy
     """
     c = TestClient()
@@ -121,6 +158,10 @@ def test_builtin_deploy():
             def package(self):
                 content = f"{self.settings.build_type}-{self.settings.arch}"
                 save(self, os.path.join(self.package_folder, "include/hello.h"), content)
+
+            def package_info(self):
+                path_build_modules = os.path.join("build", "my_tools_{}.cmake".format(self.context))
+                self.cpp_info.set_property("cmake_build_modules", [path_build_modules])
             """)
     c.save({"conanfile.py": conanfile})
     c.run("create . --name=dep --version=0.1")
@@ -138,10 +179,14 @@ def test_builtin_deploy():
     assert "Debug-x86" in debug
     cmake_release = c.load(f"output/dep-release-{host_arch}-data.cmake")
     assert 'set(dep_INCLUDE_DIRS_RELEASE "${dep_PACKAGE_FOLDER_RELEASE}/include")' in cmake_release
-    assert f"output/host/dep/0.1/Release/{host_arch}" in cmake_release
+    assert f"${{CMAKE_CURRENT_LIST_DIR}}/host/dep/0.1/Release/{host_arch}" in cmake_release
+    assert 'set(dep_BUILD_MODULES_PATHS_RELEASE ' \
+           '"${dep_PACKAGE_FOLDER_RELEASE}/build/my_tools_host.cmake")' in cmake_release
     cmake_debug = c.load("output/dep-debug-x86-data.cmake")
     assert 'set(dep_INCLUDE_DIRS_DEBUG "${dep_PACKAGE_FOLDER_DEBUG}/include")' in cmake_debug
-    assert "output/host/dep/0.1/Debug/x86" in cmake_debug
+    assert "${CMAKE_CURRENT_LIST_DIR}/host/dep/0.1/Debug/x86" in cmake_debug
+    assert 'set(dep_BUILD_MODULES_PATHS_DEBUG ' \
+           '"${dep_PACKAGE_FOLDER_DEBUG}/build/my_tools_host.cmake")' in cmake_debug
 
 
 def test_deploy_reference():

--- a/conans/test/unittests/tools/cmake/test_cmakedeps.py
+++ b/conans/test/unittests/tools/cmake/test_cmakedeps.py
@@ -22,6 +22,7 @@ def test_cpp_info_name_cmakedeps():
                                    "arch": ["x86"]})
     conanfile.settings.build_type = "Release"
     conanfile.settings.arch = "x86"
+    conanfile.folders.set_base_generators("/")
 
     cpp_info = CppInfo(set_defaults=True)
     cpp_info.set_property("cmake_target_name", "MySuperPkg1::MySuperPkg1")
@@ -62,6 +63,7 @@ def test_cpp_info_name_cmakedeps_components():
                                    "arch": ["x86", "x64"]})
     conanfile.settings.build_type = "Debug"
     conanfile.settings.arch = "x64"
+    conanfile.folders.set_base_generators("/")
 
     cpp_info = CppInfo()
     cpp_info.set_property("cmake_file_name", "ComplexFileName1")
@@ -111,6 +113,7 @@ def test_cmake_deps_links_flags():
                                    "arch": ["x86"]})
     conanfile.settings.build_type = "Release"
     conanfile.settings.arch = "x86"
+    conanfile.folders.set_base_generators("/")
 
     cpp_info = CppInfo()
     # https://github.com/conan-io/conan/issues/8811 regression, fix with explicit - instead of /
@@ -158,6 +161,7 @@ def test_component_name_same_package():
                                    "arch": ["x86"]})
     conanfile.settings.build_type = "Release"
     conanfile.settings.arch = "x86"
+    conanfile.folders.set_base_generators("/")
 
     cpp_info = CppInfo(set_defaults=True)
 


### PR DESCRIPTION
Changelog: Feature: The ``full_deploy`` deployer together with ``CMakeDeps`` generator learned to create relative paths deploys, so they are relocatable.
Docs: Omit

Close https://github.com/conan-io/conan/issues/13511
