### PR TITLE
CMakeDeps: do not print warnings when alias targets already defined

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/targets.py
+++ b/conan/tools/cmake/cmakedeps/templates/targets.py
@@ -80,8 +80,6 @@ class TargetsTemplate(CMakeDepsFileTemplate):
         if(NOT TARGET {{alias}})
             add_library({{alias}} INTERFACE IMPORTED)
             set_property(TARGET {{ alias }} PROPERTY INTERFACE_LINK_LIBRARIES {{target}})
-        else()
-            message(WARNING "Target name '{{alias}}' already exists.")
         endif()
 
         {%- endfor %}
@@ -93,8 +91,6 @@ class TargetsTemplate(CMakeDepsFileTemplate):
         if(NOT TARGET {{alias}})
             add_library({{alias}} INTERFACE IMPORTED)
             set_property(TARGET {{ alias }} PROPERTY INTERFACE_LINK_LIBRARIES {{target}})
-        else()
-            message(WARNING "Target name '{{alias}}' already exists.")
         endif()
 
             {%- endfor %}


### PR DESCRIPTION
Changelog: Bugfix: Remove warnings from defined alias targets in CMakeDeps in case the generated files are processed twice
Docs: Omit

When targets are created with `add_library` during the workflow of `find_package` (either when processing a `XXX-config.cmake` file or `FindXXX.cmake` one), it is entirely possible (and valid) that the file is processed twice - so it is customary to guard the call to `add_library` with `if (NOT TARGET...)`.
What's unusual is to print a warning if the target was already defined - especially a regular warning that the consumers cannot do anything about. 


This PR aligns these calls with _every other_ invocation of `add_library` within the `CMakeDeps` generator - none of the others have a warning in this instance.
