### PR TITLE
do not skip requirements of editable packages

### DIFF
--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -336,7 +336,8 @@ class GraphBinariesAnalyzer(object):
         required_nodes = set()
         required_nodes.add(graph.root)
         for node in graph.nodes:
-            if node.binary != BINARY_BUILD and node is not graph.root:
+            if node.binary not in (BINARY_BUILD, BINARY_EDITABLE_BUILD, BINARY_EDITABLE) \
+                    and node is not graph.root:
                 continue
             for req, dep in node.transitive_deps.items():
                 dep_node = dep.node

--- a/conans/test/integration/editable/transitive_editable_test.py
+++ b/conans/test/integration/editable/transitive_editable_test.py
@@ -1,45 +1,31 @@
-import os
 import textwrap
-import unittest
 
-import pytest
-
-from conans.model.recipe_ref import RecipeReference
 from conans.test.utils.tools import TestClient, GenConanfile
-from conans.util.files import mkdir
 
 
-class TransitiveEditableTest(unittest.TestCase):
-
-    @pytest.mark.xfail(reason="Editables not taken into account for cache2.0 yet."
-                              "TODO: cache2.0 fix with editables")
-    def test_transitive_editables(self):
-        # https://github.com/conan-io/conan/issues/4445
-        libc_ref = RecipeReference.loads("LibC/0.1@user/testing")
-        libb_ref = RecipeReference.loads("LibB/0.1@user/testing")
-
-        client = TestClient()
-        conanfileC = GenConanfile()
-        client.save({"conanfile.py": str(conanfileC)})
-        client.run("editable add . LibC/0.1@user/testing")
-
-        client2 = TestClient(client.cache_folder)
-        conanfileB = GenConanfile().with_name("LibB").with_version("0.1").with_require(libc_ref)
-
-        client2.save({"conanfile.py": str(conanfileB)})
-        client2.run("create . --user=user --channel=testing")
-
-        conanfileA = GenConanfile().with_name("LibA").with_version("0.1")\
-                                   .with_require(libb_ref)\
-                                   .with_require(libc_ref)
-        client2.save({"conanfile.py": str(conanfileA)})
-        client2.run("install .")
-        client2.current_folder = os.path.join(client2.current_folder, "build")
-        mkdir(client2.current_folder)
-        client2.run("install ..")
+def test_transitive_editables_half_diamond():
+    # https://github.com/conan-io/conan/issues/4445
+    client = TestClient()
+    client.save({"libc/conanfile.py": GenConanfile("libc", "0.1"),
+                 "libb/conanfile.py": GenConanfile("libb", "0.1").with_require("libc/0.1"),
+                 "liba/conanfile.py": GenConanfile("liba", "0.1").with_requires("libb/0.1",
+                                                                                "libc/0.1")})
+    client.run("editable add libc")
+    client.run("create libb")
+    client.run("install liba")
+    assert "libc/0.1 - Editable" in client.out
+    with client.chdir("liba/build"):
+        client.run("install ..")
+        assert "libc/0.1 - Editable" in client.out
 
 
-def test_transitive_test_requires():
+def test_transitive_editable_test_requires():
+    """
+    This test was crashing because editable packages was "SKIP"ing some dependencies as
+    "test_requires", but editables need the dependencies to generate() and to build()
+
+    https://github.com/conan-io/conan/issues/13543
+    """
     c = TestClient()
     pkga = textwrap.dedent("""
         from conan import ConanFile
@@ -85,4 +71,6 @@ def test_transitive_test_requires():
     c.run("create gtest")
     c.run("build pkga")
     c.run("editable add pkga")
+    # This used to crash, due to paths in test_requires not being processed (package_info() not
+    # being called
     c.run("build pkgb")


### PR DESCRIPTION
Changelog: Bugfix: Avoid generators errors because dependencies binaries of editable packages were "skip".
Docs: Omit

Close https://github.com/conan-io/conan/issues/13543
