### PR TITLE
do not add same remote multiple times

### DIFF
--- a/conans/client/cache/remote_registry.py
+++ b/conans/client/cache/remote_registry.py
@@ -45,12 +45,21 @@ class _Remotes(object):
     def add(self, new_remote: Remote, index=None, force=False):
         assert isinstance(new_remote, Remote)
         current = self.get_by_name(new_remote.name)
-        if current:
-            if force:
-                ConanOutput().warning(f"Remote '{new_remote.name}' already exists in remotes")
-            else:
+        if current:  # same name remote existing!
+            if not force:
                 raise ConanException(f"Remote '{new_remote.name}' already exists in remotes "
                                      "(use --force to continue)")
+
+            ConanOutput().warning(f"Remote '{new_remote.name}' already exists in remotes")
+            if current.url != new_remote.url:
+                ConanOutput().warning("Updating existing remote with new url")
+            current_index = self._remotes.index(current)
+            self._remotes.remove(current)
+            index = index or current_index
+            self._remotes.insert(index, new_remote)
+            return
+
+        # The remote name doesn't exist
         for r in self._remotes:
             if r.url == new_remote.url:
                 msg = f"Remote url already existing in remote '{r.name}'. " \

--- a/conans/test/integration/command/remote_test.py
+++ b/conans/test/integration/command/remote_test.py
@@ -308,3 +308,21 @@ def test_add_duplicated_url():
     c.run("remote list")
     assert "remote1" in c.out
     assert "remote2" in c.out
+    # make sure we can remove both
+    # https://github.com/conan-io/conan/issues/13569
+    c.run("remote remove *")
+    c.run("remote list")
+    assert "remote1" not in c.out
+    assert "remote2" not in c.out
+
+
+def test_add_duplicated_name_url():
+    """ do not add extra remote with same name and same url
+        # https://github.com/conan-io/conan/issues/13569
+    """
+    c = TestClient()
+    c.run("remote add remote1 http://url")
+    c.run("remote add remote1 http://url --force")
+    assert "WARN: Remote 'remote1' already exists in remotes" in c.out
+    c.run("remote list")
+    assert 1 == str(c.out).count("remote1")


### PR DESCRIPTION
Changelog: Bugfix: Do not allow adding more than 1 remote with the same remote name.
Docs: Omit

Close https://github.com/conan-io/conan/issues/13569
