### PR TITLE
clean temp folders in cache

### DIFF
--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -1,3 +1,5 @@
+import shutil
+
 from conan.internal.conan_app import ConanApp
 from conan.internal.integrity_check import IntegrityChecker
 from conans.errors import ConanException
@@ -47,17 +49,21 @@ class CacheAPI:
         checker = IntegrityChecker(app)
         checker.check(package_list)
 
-    def clean(self, package_list, source=None, build=None, download=None):
+    def clean(self, package_list, source=True, build=True, download=True, temp=True):
         """
         Remove non critical folders from the cache, like source, build and download (.tgz store)
         folders.
         :param package_list: the package lists that should be cleaned
         :param source: boolean, remove the "source" folder if True
         :param build: boolean, remove the "build" folder if True
-        :param download: boolena, remove the "download (.tgz)" folder if True
+        :param download: boolen, remove the "download (.tgz)" folder if True
+        :param temp: boolean, remove the temporary folders
         :return:
         """
+
         app = ConanApp(self.conan_api.cache_folder)
+        if temp:
+            shutil.rmtree(app.cache.temp_folder)
         for ref, ref_bundle in package_list.refs():
             ref_layout = app.cache.ref_layout(ref)
             if source:

--- a/conan/api/subapi/profiles.py
+++ b/conan/api/subapi/profiles.py
@@ -8,14 +8,15 @@ from conans.model.profile import Profile
 class ProfilesAPI:
 
     def __init__(self, conan_api):
-        self._cache = ClientCache(conan_api.cache_folder)
+        self._conan_api = conan_api
 
     def get_default_host(self):
         """
         :return: the path to the default "host" profile, either in the cache or as defined
             by the user in configuration
         """
-        loader = ProfileLoader(self._cache)
+        cache = ClientCache(self._conan_api.cache_folder)
+        loader = ProfileLoader(cache)
         return loader.get_default_host()
 
     def get_default_build(self):
@@ -23,7 +24,8 @@ class ProfilesAPI:
         :return: the path to the default "build" profile, either in the cache or as
             defined by the user in configuration
         """
-        loader = ProfileLoader(self._cache)
+        cache = ClientCache(self._conan_api.cache_folder)
+        loader = ProfileLoader(cache)
         return loader.get_default_build()
 
     def get_profiles_from_args(self, args):
@@ -41,12 +43,13 @@ class ProfilesAPI:
         finally adding the individual settings, options (priority over the profiles)
         """
         assert isinstance(profiles, list), "Please provide a list of profiles"
-        loader = ProfileLoader(self._cache)
+        cache = ClientCache(self._conan_api.cache_folder)
+        loader = ProfileLoader(cache)
         profile = loader.from_cli_args(profiles, settings, options, conf, cwd)
         profile.conf.validate()
-        self._cache.new_config.validate()
+        cache.new_config.validate()
         # Apply the new_config to the profiles the global one, so recipes get it too
-        profile.conf.rebase_conf_definition(self._cache.new_config)
+        profile.conf.rebase_conf_definition(cache.new_config)
         return profile
 
     def get_path(self, profile, cwd=None, exists=True):
@@ -54,7 +57,8 @@ class ProfilesAPI:
         :return: the resolved path of the given profile name, that could be in the cache,
             or local, depending on the "cwd"
         """
-        loader = ProfileLoader(self._cache)
+        cache = ClientCache(self._conan_api.cache_folder)
+        loader = ProfileLoader(cache)
         cwd = cwd or os.getcwd()
         profile_path = loader.get_profile_path(profile, cwd, exists=exists)
         return profile_path
@@ -68,7 +72,8 @@ class ProfilesAPI:
         paths_to_ignore = ['.DS_Store']
 
         profiles = []
-        profiles_path = self._cache.profiles_path
+        cache = ClientCache(self._conan_api.cache_folder)
+        profiles_path = cache.profiles_path
         if os.path.exists(profiles_path):
             for current_directory, _, files in os.walk(profiles_path, followlinks=True):
                 files = filter(lambda file: os.path.relpath(

--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -59,24 +59,29 @@ def cache_clean(conan_api: ConanAPI, parser, subparser, *args):
     (.tgz store) ones.
     """
     subparser.add_argument("pattern", help="Selection pattern for references to clean")
+    subparser.add_argument("-a", "--all", action='store_true', default=False,
+                           help="Clean everything (source, build, download, temps")
     subparser.add_argument("-s", "--source", action='store_true', default=False,
                            help="Clean source folders")
     subparser.add_argument("-b", "--build", action='store_true', default=False,
                            help="Clean build folders")
     subparser.add_argument("-d", "--download", action='store_true', default=False,
                            help="Clean download folders")
+    subparser.add_argument("-t", "--temp", action='store_true', default=False,
+                           help="Clean temporary folders")
     subparser.add_argument('-p', '--package-query', action=OnceArgument,
                            help="Remove only the packages matching a specific query, e.g., "
                                 "os=Windows AND (arch=x86 OR compiler=gcc)")
     args = parser.parse_args(*args)
 
-    if not args.source and not args.build and not args.download:
-        raise ConanException("Define at least one argument among [--source, --build, --download]")
+    if not args.all and not args.source and not args.build and not args.download and not args.temp:
+        raise ConanException("Define at least one argument among "
+                             "[--all, --source, --build, --download, --temp]")
 
     ref_pattern = ListPattern(args.pattern, rrev="*", package_id="*", prev="*")
     package_list = conan_api.list.select(ref_pattern, package_query=args.package_query)
-    conan_api.cache.clean(package_list, source=args.source, build=args.build,
-                          download=args.download)
+    conan_api.cache.clean(package_list, source=args.source or args.all, build=args.build or args.all,
+                          download=args.download or args.all, temp=args.temp or args.all)
 
 
 @conan_subcommand(formatters={"text": cli_out_write})

--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -58,9 +58,7 @@ def cache_clean(conan_api: ConanAPI, parser, subparser, *args):
     Remove non-critical folders from the cache, like source, build and/or download
     (.tgz store) ones.
     """
-    subparser.add_argument("pattern", help="Selection pattern for references to clean")
-    subparser.add_argument("-a", "--all", action='store_true', default=False,
-                           help="Clean everything (source, build, download, temps")
+    subparser.add_argument("pattern", nargs="?", help="Selection pattern for references to clean")
     subparser.add_argument("-s", "--source", action='store_true', default=False,
                            help="Clean source folders")
     subparser.add_argument("-b", "--build", action='store_true', default=False,
@@ -74,14 +72,13 @@ def cache_clean(conan_api: ConanAPI, parser, subparser, *args):
                                 "os=Windows AND (arch=x86 OR compiler=gcc)")
     args = parser.parse_args(*args)
 
-    if not args.all and not args.source and not args.build and not args.download and not args.temp:
-        raise ConanException("Define at least one argument among "
-                             "[--all, --source, --build, --download, --temp]")
-
-    ref_pattern = ListPattern(args.pattern, rrev="*", package_id="*", prev="*")
+    ref_pattern = ListPattern(args.pattern or "*", rrev="*", package_id="*", prev="*")
     package_list = conan_api.list.select(ref_pattern, package_query=args.package_query)
-    conan_api.cache.clean(package_list, source=args.source or args.all, build=args.build or args.all,
-                          download=args.download or args.all, temp=args.temp or args.all)
+    if args.build or args.source or args.download or args.temp:
+        conan_api.cache.clean(package_list, source=args.source, build=args.build,
+                              download=args.download, temp=args.temp)
+    else:
+        conan_api.cache.clean(package_list)
 
 
 @conan_subcommand(formatters={"text": cli_out_write})

--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -51,6 +51,13 @@ class ClientCache(object):
         db_filename = os.path.join(self._store_folder, 'cache.sqlite3')
         self._data_cache = DataCache(self._store_folder, db_filename)
 
+    @property
+    def temp_folder(self):
+        """ temporary folder where Conan puts exports and packages before the final revision
+        is computed"""
+        # TODO: Improve the path definitions, this is very hardcoded
+        return os.path.join(self.cache_folder, "p", "t")
+
     def create_export_recipe_layout(self, ref: RecipeReference):
         return self._data_cache.create_export_recipe_layout(ref)
 

--- a/conans/test/integration/command_v2/test_cache_clean.py
+++ b/conans/test/integration/command_v2/test_cache_clean.py
@@ -32,4 +32,14 @@ def test_cache_clean():
 def test_cache_clean_noargs_error():
     c = TestClient()
     c.run('cache clean "*"', assert_error=True)
-    assert "Define at least one argument among [--source, --build, --download]" in c.out
+    assert "Define at least one argument among [" in c.out
+
+
+def test_cache_clean_all():
+    c = TestClient()
+    c.save({"conanfile.py": GenConanfile("pkg", "0.1").with_package("error")})
+    c.run("create .", assert_error=True)
+    folder = os.path.join(c.cache_folder, "p", "t")
+    assert len(os.listdir(folder)) == 1
+    c.run('cache clean "*" -a')
+    assert not os.path.exists(folder)

--- a/conans/test/integration/command_v2/test_cache_clean.py
+++ b/conans/test/integration/command_v2/test_cache_clean.py
@@ -24,22 +24,25 @@ def test_cache_clean():
     assert os.path.exists(ref_layout.download_export())
     assert os.path.exists(pkg_layout.download_package())
 
-    c.run('cache clean "*" -d')
+    c.run('cache clean -d')
     assert not os.path.exists(ref_layout.download_export())
     assert not os.path.exists(pkg_layout.download_package())
 
 
-def test_cache_clean_noargs_error():
-    c = TestClient()
-    c.run('cache clean "*"', assert_error=True)
-    assert "Define at least one argument among [" in c.out
-
-
 def test_cache_clean_all():
     c = TestClient()
-    c.save({"conanfile.py": GenConanfile("pkg", "0.1").with_package("error")})
-    c.run("create .", assert_error=True)
+    c.save({"pkg1/conanfile.py": GenConanfile("pkg", "0.1").with_package("error"),
+            "pkg2/conanfile.py": GenConanfile("pkg", "0.2")})
+    c.run("create pkg1", assert_error=True)
+    c.run("create pkg2")
+    pref = c.created_package_reference("pkg/0.2")
     folder = os.path.join(c.cache_folder, "p", "t")
     assert len(os.listdir(folder)) == 1
-    c.run('cache clean "*" -a')
+    c.run('cache clean')
     assert not os.path.exists(folder)
+    ref_layout = c.get_latest_ref_layout(pref.ref)
+    pkg_layout = c.get_latest_pkg_layout(pref)
+    assert not os.path.exists(ref_layout.source())
+    assert not os.path.exists(ref_layout.download_export())
+    assert not os.path.exists(pkg_layout.build())
+    assert not os.path.exists(pkg_layout.download_package())


### PR DESCRIPTION
Changelog: Feature: ``conan cache clean`` learned the ``--all`` and ``--temp`` to clean everything (sources, builds) and also the temporary folders.
Docs: https://github.com/conan-io/docs/pull/3145

Close https://github.com/conan-io/conan/issues/13576

- Minor refactor to improve ProfilesAPI interface, avoiding possible caching bugs