### PR TITLE
Fix double delete error in conan cache clean

### DIFF
--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -63,7 +63,7 @@ class CacheAPI:
 
         app = ConanApp(self.conan_api.cache_folder)
         if temp:
-            shutil.rmtree(app.cache.temp_folder)
+            rmdir(app.cache.temp_folder)
         for ref, ref_bundle in package_list.refs():
             ref_layout = app.cache.ref_layout(ref)
             if source:

--- a/conans/test/integration/command_v2/test_cache_clean.py
+++ b/conans/test/integration/command_v2/test_cache_clean.py
@@ -46,3 +46,8 @@ def test_cache_clean_all():
     assert not os.path.exists(ref_layout.download_export())
     assert not os.path.exists(pkg_layout.build())
     assert not os.path.exists(pkg_layout.download_package())
+
+    # A second clean like this used to crash
+    # as it tried to delete a folder that was not there and tripped shutils up
+    c.run('cache clean')
+    assert not os.path.exists(folder)


### PR DESCRIPTION
Changelog: Bugfix: Fix double delete error in `conan cache clean`.
Docs: Omit

`shutils.rmtree` raises when the folder does not exist. Calling `conan cache clean` more than once (For different references, for example), crashed. Use `rmdir` instead to avoid this behaviour
