### PR TITLE
Fix html output when pattern does not list package revisions

### DIFF
--- a/conan/cli/formatters/list/search_table_html.py
+++ b/conan/cli/formatters/list/search_table_html.py
@@ -168,12 +168,15 @@ list_packages_html_template = r"""
                     packageList += `<h6 class="mb-1">${package}</h6>`;
                     packageList += `${getInfoFieldsBadges(packageInfo["info"])}`;
 
-                    packageList += `<br><br><b>Package revisions:</>`;
-                    packageList += `<ul>`;
-                    for (const [packageRev, packageRevInfo] of Object.entries(packageInfo["revisions"])) {
-                        packageList += `<li>${packageRev}&nbsp(${formatDate(packageRevInfo["timestamp"])})</li>`;
+                    packageList += `<br><br>`;
+                    if ("revisions" in packageInfo) {
+                        packageList += `<br><br><b>Package revisions:</>`;
+                        packageList += `<ul>`;
+                        for (const [packageRev, packageRevInfo] of Object.entries(packageInfo["revisions"])) {
+                            packageList += `<li>${packageRev}&nbsp(${formatDate(packageRevInfo["timestamp"])})</li>`;
+                        }
+                        packageList += `</ul>`;
                     }
-                    packageList += `</ul>`;
                     packageList += `</div>`;
                     packageList += `<br>`;
                 }


### PR DESCRIPTION
Changelog: Fix: Fix html output when pattern does not list package revisions, like: ``conan list "*#*:*"``. 
Docs: Omit

When using patterns that contained package id's but did not contain package revisions like ``*#*:*``, the Javascript broke, but it was ok for the rest of the cases. Now it works fine again:

![image](https://user-images.githubusercontent.com/5045666/229696935-0a1ece2c-2228-45b8-8ba8-62e83c7c30c4.png)
