### PR TITLE
Feature/relativize generators

### DIFF
--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -9,6 +9,7 @@ from conan.tools.cmake.cmakedeps.templates.macros import MacrosTemplate
 from conan.tools.cmake.cmakedeps.templates.target_configuration import TargetConfigurationTemplate
 from conan.tools.cmake.cmakedeps.templates.target_data import ConfigDataTemplate
 from conan.tools.cmake.cmakedeps.templates.targets import TargetsTemplate
+from conans.client.generators import relativize_generated_file
 from conans.errors import ConanException
 from conans.util.files import save
 
@@ -94,7 +95,9 @@ class CMakeDeps(object):
             ret[config_version.filename] = config_version.render()
 
         data_target = ConfigDataTemplate(self, require, dep, find_module_mode)
-        ret[data_target.filename] = data_target.render()
+        data_content = relativize_generated_file(data_target.render(), self._conanfile,
+                                                 "${CMAKE_CURRENT_LIST_DIR}")
+        ret[data_target.filename] = data_content
 
         target_configuration = TargetConfigurationTemplate(self, require, dep, find_module_mode)
         ret[target_configuration.filename] = target_configuration.render()

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -4,6 +4,7 @@ import textwrap
 from conan.tools.cmake.cmakedeps import FIND_MODE_NONE, FIND_MODE_CONFIG, FIND_MODE_MODULE, \
     FIND_MODE_BOTH
 from conan.tools.cmake.cmakedeps.templates import CMakeDepsFileTemplate
+from conan.tools.cmake.utils import relativize_cmake_path
 from conans.errors import ConanException
 from conans.model.dependencies import get_transitive_requires
 
@@ -50,13 +51,7 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
 
         # Make the root_folder relative to the generated xxx-data.cmake file
         root_folder = self._root_folder
-        generators_folder = self.cmakedeps._conanfile.generators_folder
-        if os.path.commonpath([root_folder, generators_folder]) == generators_folder:
-            rel_path = os.path.relpath(root_folder, generators_folder)
-            rel_path = rel_path.replace('\\', '/').replace('$', '\\$').replace('"', '\\"')
-            root_folder = f"${{CMAKE_CURRENT_LIST_DIR}}/{rel_path}"
-        else:
-            root_folder = root_folder.replace('\\', '/').replace('$', '\\$').replace('"', '\\"')
+        root_folder = relativize_cmake_path(root_folder, self.cmakedeps._conanfile)
 
         return {"global_cpp": global_cpp,
                 "has_components": self.conanfile.cpp_info.has_components,

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -4,7 +4,6 @@ import textwrap
 from conan.tools.cmake.cmakedeps import FIND_MODE_NONE, FIND_MODE_CONFIG, FIND_MODE_MODULE, \
     FIND_MODE_BOTH
 from conan.tools.cmake.cmakedeps.templates import CMakeDepsFileTemplate
-from conan.tools.cmake.utils import relativize_cmake_path
 from conans.errors import ConanException
 from conans.model.dependencies import get_transitive_requires
 
@@ -51,7 +50,7 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
 
         # Make the root_folder relative to the generated xxx-data.cmake file
         root_folder = self._root_folder
-        root_folder = relativize_cmake_path(root_folder, self.cmakedeps._conanfile)
+        root_folder = root_folder.replace('\\', '/').replace('$', '\\$').replace('"', '\\"')
 
         return {"global_cpp": global_cpp,
                 "has_components": self.conanfile.cpp_info.has_components,

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -12,7 +12,6 @@ from conan.tools.build import build_jobs
 from conan.tools.build.flags import architecture_flag, libcxx_flags
 from conan.tools.build.cross_building import cross_building
 from conan.tools.cmake.toolchain import CONAN_TOOLCHAIN_FILENAME
-from conan.tools.cmake.utils import relativize_cmake_path
 from conan.tools.intel import IntelCC
 from conan.tools.microsoft.visual import msvc_version_to_toolset_version
 from conans.client.subsystems import deduce_subsystem, WINDOWS
@@ -450,8 +449,11 @@ class FindFiles(Block):
         {% endif %}
     """)
 
-    def _join_paths(self, paths):
-        return " ".join(['"{}"'.format(relativize_cmake_path(p, self._conanfile)) for p in paths])
+    @staticmethod
+    def _join_paths(paths):
+        return " ".join(['"{}"'.format(p.replace('\\', '/')
+                                        .replace('$', '\\$')
+                                        .replace('"', '\\"')) for p in paths])
 
     def context(self):
         # To find the generated cmake_find_package finders

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -12,6 +12,7 @@ from conan.tools.build import build_jobs
 from conan.tools.build.flags import architecture_flag, libcxx_flags
 from conan.tools.build.cross_building import cross_building
 from conan.tools.cmake.toolchain import CONAN_TOOLCHAIN_FILENAME
+from conan.tools.cmake.utils import relativize_cmake_path
 from conan.tools.intel import IntelCC
 from conan.tools.microsoft.visual import msvc_version_to_toolset_version
 from conans.client.subsystems import deduce_subsystem, WINDOWS
@@ -449,11 +450,8 @@ class FindFiles(Block):
         {% endif %}
     """)
 
-    @staticmethod
-    def _join_paths(paths):
-        return " ".join(['"{}"'.format(p.replace('\\', '/')
-                                        .replace('$', '\\$')
-                                        .replace('"', '\\"')) for p in paths])
+    def _join_paths(self, paths):
+        return " ".join(['"{}"'.format(relativize_cmake_path(p, self._conanfile)) for p in paths])
 
     def context(self):
         # To find the generated cmake_find_package finders
@@ -520,12 +518,9 @@ class PkgConfigBlock(Block):
         pkg_config = self._conanfile.conf.get("tools.gnu:pkg_config", check_type=str)
         if pkg_config:
             pkg_config = pkg_config.replace("\\", "/")
-        pkg_config_path = self._conanfile.generators_folder
-        if pkg_config_path:
-            # hardcoding scope as "build"
-            subsystem = deduce_subsystem(self._conanfile, "build")
-            pathsep = ":" if subsystem != WINDOWS else ";"
-            pkg_config_path = pkg_config_path.replace("\\", "/") + pathsep
+        subsystem = deduce_subsystem(self._conanfile, "build")
+        pathsep = ":" if subsystem != WINDOWS else ";"
+        pkg_config_path = "${CMAKE_CURRENT_LIST_DIR}" + pathsep
         return {"pkg_config": pkg_config,
                 "pkg_config_path": pkg_config_path}
 

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -16,6 +16,7 @@ from conan.tools.cmake.toolchain.blocks import ToolchainBlocks, UserToolchain, G
 from conan.tools.intel import IntelCC
 from conan.tools.microsoft import VCVars
 from conan.tools.microsoft.visual import vs_ide_version
+from conans.client.generators import relativize_generated_file
 from conans.errors import ConanException
 from conans.model.options import _PackageOption
 from conans.util.files import save
@@ -171,6 +172,7 @@ class CMakeToolchain(object):
     def content(self):
         context = self._context()
         content = Template(self._template, trim_blocks=True, lstrip_blocks=True).render(**context)
+        content = relativize_generated_file(content, self._conanfile, "${CMAKE_CURRENT_LIST_DIR}")
         return content
 
     def generate(self):

--- a/conan/tools/cmake/utils.py
+++ b/conan/tools/cmake/utils.py
@@ -5,15 +5,3 @@ def is_multi_configuration(generator):
     if not generator:
         return False
     return "Visual" in generator or "Xcode" in generator or "Multi-Config" in generator
-
-
-def relativize_cmake_path(folder, conanfile):
-    generators_folder = conanfile.generators_folder
-    base_folder = conanfile.folders._base_generators
-    if os.path.commonpath([folder, base_folder]) == base_folder:
-        rel_path = os.path.relpath(folder, generators_folder)
-        rel_path = rel_path.replace('\\', '/').replace('$', '\\$').replace('"', '\\"')
-        root_folder = f"${{CMAKE_CURRENT_LIST_DIR}}/{rel_path}"
-    else:
-        root_folder = folder.replace('\\', '/').replace('$', '\\$').replace('"', '\\"')
-    return root_folder

--- a/conan/tools/cmake/utils.py
+++ b/conan/tools/cmake/utils.py
@@ -1,5 +1,19 @@
+import os
+
 
 def is_multi_configuration(generator):
     if not generator:
         return False
     return "Visual" in generator or "Xcode" in generator or "Multi-Config" in generator
+
+
+def relativize_cmake_path(folder, conanfile):
+    generators_folder = conanfile.generators_folder
+    base_folder = conanfile.folders._base_generators
+    if os.path.commonpath([folder, base_folder]) == base_folder:
+        rel_path = os.path.relpath(folder, generators_folder)
+        rel_path = rel_path.replace('\\', '/').replace('$', '\\$').replace('"', '\\"')
+        root_folder = f"${{CMAKE_CURRENT_LIST_DIR}}/{rel_path}"
+    else:
+        root_folder = folder.replace('\\', '/').replace('$', '\\$').replace('"', '\\"')
+    return root_folder

--- a/conan/tools/cmake/utils.py
+++ b/conan/tools/cmake/utils.py
@@ -1,5 +1,3 @@
-import os
-
 
 def is_multi_configuration(generator):
     if not generator:

--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -3,6 +3,7 @@ import textwrap
 from collections import OrderedDict
 from contextlib import contextmanager
 
+from conans.client.generators import relativize_generated_file
 from conans.client.subsystems import deduce_subsystem, WINDOWS, subsystem_path
 from conans.errors import ConanException
 from conans.model.recipe_ref import ref_matches
@@ -414,14 +415,13 @@ class EnvVars:
             {deactivate}
             """).format(deactivate=deactivate if generate_deactivate else "")
         result = [capture]
-        location = os.path.abspath(os.path.dirname(file_location))
         for varname, varvalues in self._values.items():
             value = varvalues.get_str("%{name}%", subsystem=self._subsystem, pathsep=self._pathsep)
             # To make the script relocatable
-            value = value.replace(location, "%~dp0")
             result.append('set "{}={}"'.format(varname, value))
 
         content = "\n".join(result)
+        content = relativize_generated_file(content, self._conanfile, "%~dp0")
         # It is very important to save it correctly with utf-8, the Conan util save() is broken
         os.makedirs(os.path.dirname(os.path.abspath(file_location)), exist_ok=True)
         open(file_location, "w", encoding="utf-8").write(content)

--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -177,7 +177,7 @@ def relativize_generated_file(content, conanfile, placeholder):
     generators_folder = conanfile.generators_folder
     abs_base_path = conanfile.folders._base_generators
     rel_path = os.path.relpath(abs_base_path, generators_folder)
-    new_path = os.path.normpath(os.path.join(placeholder, rel_path))
-    content = content.replace(generators_folder, new_path)
-    content = content.replace(generators_folder.replace("\\", "/"), new_path.replace("\\", "/"))
+    new_path = placeholder if rel_path == "." else os.path.join(placeholder, rel_path)
+    content = content.replace(abs_base_path, new_path)
+    content = content.replace(abs_base_path.replace("\\", "/"), new_path.replace("\\", "/"))
     return content

--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -174,8 +174,10 @@ def _generate_aggregated_env(conanfile):
 
 
 def relativize_generated_file(content, conanfile, placeholder):
-    generators_folder = conanfile.generators_folder
     abs_base_path = conanfile.folders._base_generators
+    if not abs_base_path or not os.path.isabs(abs_base_path):
+        return content
+    generators_folder = conanfile.generators_folder
     rel_path = os.path.relpath(abs_base_path, generators_folder)
     new_path = placeholder if rel_path == "." else os.path.join(placeholder, rel_path)
     content = content.replace(abs_base_path, new_path)

--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -177,6 +177,7 @@ def relativize_generated_file(content, conanfile, placeholder):
     generators_folder = conanfile.generators_folder
     abs_base_path = conanfile.folders._base_generators
     rel_path = os.path.relpath(abs_base_path, generators_folder)
-    new_path = placeholder + rel_path
+    new_path = os.path.normpath(os.path.join(placeholder, rel_path))
     content = content.replace(generators_folder, new_path)
+    content = content.replace(generators_folder.replace("\\", "/"), new_path.replace("\\", "/"))
     return content

--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -171,3 +171,12 @@ def _generate_aggregated_env(conanfile):
     if generated:
         conanfile.output.highlight("Generating aggregated env files")
         conanfile.output.info(f"Generated aggregated env files: {generated}")
+
+
+def relativize_generated_file(content, conanfile, placeholder):
+    generators_folder = conanfile.generators_folder
+    abs_base_path = conanfile.folders._base_generators
+    rel_path = os.path.relpath(abs_base_path, generators_folder)
+    new_path = placeholder + rel_path
+    content = content.replace(generators_folder, new_path)
+    return content

--- a/conans/test/functional/command/test_install_deploy.py
+++ b/conans/test/functional/command/test_install_deploy.py
@@ -85,7 +85,6 @@ def test_install_deploy(client):
 
     # We can fully move it to another folder, and still works
     tmp = os.path.join(temp_folder(), "relocated")
-    print(tmp)
     shutil.copytree(c.current_folder, tmp)
     shutil.rmtree(c.current_folder)
     c2 = TestClient(current_folder=tmp)
@@ -132,7 +131,6 @@ def test_install_full_deploy_layout(client):
 
     # We can fully move it to another folder, and still works
     tmp = os.path.join(temp_folder(), "relocated")
-    print(tmp)
     shutil.copytree(c.current_folder, tmp)
     shutil.rmtree(c.current_folder)
     c2 = TestClient(current_folder=tmp)

--- a/conans/test/functional/command/test_install_deploy.py
+++ b/conans/test/functional/command/test_install_deploy.py
@@ -75,6 +75,7 @@ def test_install_deploy(client):
            clean_first=True)
     c.run("install . -o *:shared=True "
           "--deploy=deploy.py -of=mydeploy -g CMakeToolchain -g CMakeDeps")
+    print(c.current_folder)
     c.run("remove * -c")  # Make sure the cache is clean, no deps there
     arch = c.get_default_host_profile().settings['arch']
     deps = c.load(f"mydeploy/hello-release-{arch}-data.cmake")

--- a/conans/test/functional/command/test_install_deploy.py
+++ b/conans/test/functional/command/test_install_deploy.py
@@ -13,31 +13,47 @@ from conans.test.utils.tools import TestClient
 from conans.util.files import save
 
 
-@pytest.mark.tool("cmake")
-def test_install_deploy():
+@pytest.fixture(scope="module")
+def _client():
     c = TestClient()
     c.run("new cmake_lib -d name=hello -d version=0.1")
     c.run("create . -o *:shared=True -tf=")
     conanfile = textwrap.dedent("""
-        import os
-        from conan import ConanFile
-        from conan.tools.files import save
-        class Tool(ConanFile):
-            name = "tool"
-            version = "1.0"
-            def package(self):
-                save(self, os.path.join(self.package_folder, "build", "my_tools.cmake"),
-                     'set(MY_TOOL_VARIABLE "Hello world!")')
+           import os
+           from conan import ConanFile
+           from conan.tools.files import save
+           class Tool(ConanFile):
+               name = "tool"
+               version = "1.0"
+               def package(self):
+                   save(self, os.path.join(self.package_folder, "build", "my_tools.cmake"),
+                        'set(MY_TOOL_VARIABLE "Hello world!")')
 
-            def package_info(self):
-                self.cpp_info.includedirs = []
-                self.cpp_info.libdirs = []
-                self.cpp_info.bindirs = []
-                path_build_modules = os.path.join("build", "my_tools.cmake")
-                self.cpp_info.set_property("cmake_build_modules", [path_build_modules])
-            """)
+               def package_info(self):
+                   self.cpp_info.includedirs = []
+                   self.cpp_info.libdirs = []
+                   self.cpp_info.bindirs = []
+                   path_build_modules = os.path.join("build", "my_tools.cmake")
+                   self.cpp_info.set_property("cmake_build_modules", [path_build_modules])
+               """)
     c.save({"conanfile.py": conanfile}, clean_first=True)
     c.run("create .")
+    return c
+
+
+@pytest.fixture()
+def client(_client):
+    """ this is much faster than creating and uploading everythin
+    """
+    client = TestClient(default_server_user=True)
+    shutil.rmtree(client.cache_folder)
+    shutil.copytree(_client.cache_folder, client.cache_folder)
+    return client
+
+
+@pytest.mark.tool("cmake")
+def test_install_deploy(client):
+    c = client
     custom_content = 'message(STATUS "MY_TOOL_VARIABLE=${MY_TOOL_VARIABLE}!")'
     cmake = gen_cmakelists(appname="my_app", appsources=["main.cpp"], find_package=["hello", "tool"],
                            custom_content=custom_content)
@@ -59,7 +75,6 @@ def test_install_deploy():
            clean_first=True)
     c.run("install . -o *:shared=True "
           "--deploy=deploy.py -of=mydeploy -g CMakeToolchain -g CMakeDeps")
-    print(c.out)
     c.run("remove * -c")  # Make sure the cache is clean, no deps there
     arch = c.get_default_host_profile().settings['arch']
     deps = c.load(f"mydeploy/hello-release-{arch}-data.cmake")
@@ -69,6 +84,7 @@ def test_install_deploy():
 
     # We can fully move it to another folder, and still works
     tmp = os.path.join(temp_folder(), "relocated")
+    print(tmp)
     shutil.copytree(c.current_folder, tmp)
     shutil.rmtree(c.current_folder)
     c2 = TestClient(current_folder=tmp)
@@ -82,6 +98,54 @@ def test_install_deploy():
         # For Lunux: cmd = ". mydeploy/conanrun.sh && ./my_app"
         c2.run_command(cmd)
         assert "hello/0.1: Hello World Release!" in c2.out
+
+
+@pytest.mark.tool("cmake")
+def test_install_full_deploy_layout(client):
+    c = client
+    custom_content = 'message(STATUS "MY_TOOL_VARIABLE=${MY_TOOL_VARIABLE}!")'
+    cmake = gen_cmakelists(appname="my_app", appsources=["main.cpp"], find_package=["hello", "tool"],
+                           custom_content=custom_content)
+    conanfile = textwrap.dedent("""
+        [requires]
+        hello/0.1
+        tool/1.0
+        [generators]
+        CMakeDeps
+        CMakeToolchain
+        [layout]
+        cmake_layout
+        """)
+    c.save({"conanfile.txt": conanfile,
+            "CMakeLists.txt": cmake,
+            "main.cpp": gen_function_cpp(name="main", includes=["hello"], calls=["hello"])},
+           clean_first=True)
+    c.run("install . -o *:shared=True --deploy=full_deploy.py")
+    c.run("remove * -c")  # Make sure the cache is clean, no deps there
+    arch = c.get_default_host_profile().settings['arch']
+    deps = c.load(f"build/generators/hello-release-{arch}-data.cmake")
+    assert 'set(hello_PACKAGE_FOLDER_RELEASE "${CMAKE_CURRENT_LIST_DIR}/' \
+           '../../host/hello/0.1/Release/x86_64")' in deps
+    assert 'set(hello_INCLUDE_DIRS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/include")' in deps
+    assert 'set(hello_LIB_DIRS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/lib")' in deps
+
+    # We can fully move it to another folder, and still works
+    tmp = os.path.join(temp_folder(), "relocated")
+    print(tmp)
+    shutil.copytree(c.current_folder, tmp)
+    shutil.rmtree(c.current_folder)
+    c2 = TestClient(current_folder=tmp)
+    with c2.chdir("build"):
+        # I can totally build without errors with deployed
+        c2.run_command("cmake .. -DCMAKE_TOOLCHAIN_FILE=generators/conan_toolchain.cmake "
+                       "-DCMAKE_BUILD_TYPE=Release")
+        assert "MY_TOOL_VARIABLE=Hello world!!" in c2.out
+        c2.run_command("cmake --build . --config Release")
+        if platform.system() == "Windows":  # Only the .bat env-generators are relocatable
+            cmd = r"generators\conanrun.bat && Release\my_app.exe"
+            # For Lunux: cmd = ". mydeploy/conanrun.sh && ./my_app"
+            c2.run_command(cmd)
+            assert "hello/0.1: Hello World Release!" in c2.out
 
 
 def test_copy_files_deploy():

--- a/conans/test/functional/command/test_install_deploy.py
+++ b/conans/test/functional/command/test_install_deploy.py
@@ -126,7 +126,7 @@ def test_install_full_deploy_layout(client):
     rel_path = "../../" if platform.system() == "Windows" else "../../../"
     deps = c.load(f"build{folder}/generators/hello-release-{arch}-data.cmake")
     assert 'set(hello_PACKAGE_FOLDER_RELEASE "${CMAKE_CURRENT_LIST_DIR}/' \
-           f'{rel_path}host/hello/0.1/Release/{arch}")' in deps
+           f'{rel_path}full_deploy/host/hello/0.1/Release/{arch}")' in deps
     assert 'set(hello_INCLUDE_DIRS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/include")' in deps
     assert 'set(hello_LIB_DIRS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/lib")' in deps
 

--- a/conans/test/functional/command/test_install_deploy.py
+++ b/conans/test/functional/command/test_install_deploy.py
@@ -126,7 +126,7 @@ def test_install_full_deploy_layout(client):
     rel_path = "../../" if platform.system() == "Windows" else "../../../"
     deps = c.load(f"build{folder}/generators/hello-release-{arch}-data.cmake")
     assert 'set(hello_PACKAGE_FOLDER_RELEASE "${CMAKE_CURRENT_LIST_DIR}/' \
-           f'{rel_path}host/hello/0.1/Release/x86_64")' in deps
+           f'{rel_path}host/hello/0.1/Release/{arch}")' in deps
     assert 'set(hello_INCLUDE_DIRS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/include")' in deps
     assert 'set(hello_LIB_DIRS_RELEASE "${hello_PACKAGE_FOLDER_RELEASE}/lib")' in deps
 

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -727,7 +727,7 @@ def test_pkg_config_block():
     assert 'set(PKG_CONFIG_EXECUTABLE /usr/local/bin/pkg-config CACHE FILEPATH ' in toolchain
     pathsep = ":" if os_ != "Windows" else ";"
     pkg_config_path_set = 'set(ENV{PKG_CONFIG_PATH} "%s$ENV{PKG_CONFIG_PATH}")' % \
-                          (client.current_folder.replace("\\", "/") + pathsep)
+                          ("${CMAKE_CURRENT_LIST_DIR}" + pathsep)
     assert pkg_config_path_set in toolchain
 
 

--- a/conans/test/unittests/tools/cmake/test_cmakedeps.py
+++ b/conans/test/unittests/tools/cmake/test_cmakedeps.py
@@ -22,7 +22,7 @@ def test_cpp_info_name_cmakedeps():
                                    "arch": ["x86"]})
     conanfile.settings.build_type = "Release"
     conanfile.settings.arch = "x86"
-    conanfile.folders.set_base_generators("/")
+    conanfile.folders.set_base_generators("/some/abs/path")  # non-existing to not relativize
 
     cpp_info = CppInfo(set_defaults=True)
     cpp_info.set_property("cmake_target_name", "MySuperPkg1::MySuperPkg1")
@@ -63,7 +63,7 @@ def test_cpp_info_name_cmakedeps_components():
                                    "arch": ["x86", "x64"]})
     conanfile.settings.build_type = "Debug"
     conanfile.settings.arch = "x64"
-    conanfile.folders.set_base_generators("/")
+    conanfile.folders.set_base_generators("/some/abs/path")  # non-existing to not relativize
 
     cpp_info = CppInfo()
     cpp_info.set_property("cmake_file_name", "ComplexFileName1")
@@ -113,7 +113,7 @@ def test_cmake_deps_links_flags():
                                    "arch": ["x86"]})
     conanfile.settings.build_type = "Release"
     conanfile.settings.arch = "x86"
-    conanfile.folders.set_base_generators("/")
+    conanfile.folders.set_base_generators("/some/abs/path")  # non-existing to not relativize
 
     cpp_info = CppInfo()
     # https://github.com/conan-io/conan/issues/8811 regression, fix with explicit - instead of /
@@ -161,7 +161,7 @@ def test_component_name_same_package():
                                    "arch": ["x86"]})
     conanfile.settings.build_type = "Release"
     conanfile.settings.arch = "x86"
-    conanfile.folders.set_base_generators("/")
+    conanfile.folders.set_base_generators("/some/abs/path")  # non-existing to not relativize
 
     cpp_info = CppInfo(set_defaults=True)
 

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -32,7 +32,7 @@ def conanfile():
     c.settings.os = "Windows"
     c.conf = Conf()
     c.conf.define("tools.cmake.cmaketoolchain:system_name", "potato")
-    c.folders.set_base_generators(".")
+    c.folders.set_base_generators("/some/abs/path")  # non-existing to not relativize
     c._conan_node = Mock()
     c._conan_node.transitive_deps = {}
     return c
@@ -146,7 +146,7 @@ def conanfile_apple():
     c.settings.os.version = "10.15"
     c.settings_build = c.settings
     c.conf = Conf()
-    c.folders.set_base_generators(".")
+    c.folders.set_base_generators("/some/abs/path")  # non-existing to not relativize
     c._conan_node = Mock()
     c._conan_node.dependencies = []
     c._conan_node.transitive_deps = {}


### PR DESCRIPTION
Changelog: Feature: Make CMakeDeps, CMakeToolchain and Environment (.bat, Windows only) generated files have relative paths.
Docs: Omit

Continuation of https://github.com/conan-io/conan/pull/13526, some missing gaps

Close https://github.com/conan-io/conan/issues/13606
Close https://github.com/conan-io/conan/issues/13644
