### PR TITLE
Make STATUS the default log level

### DIFF
--- a/conan/cli/command.py
+++ b/conan/cli/command.py
@@ -117,8 +117,8 @@ class ConanArgumentParser(argparse.ArgumentParser):
                   "warning": LEVEL_WARNING,  # -vwaring 60
                   "notice": LEVEL_NOTICE,  # -vnotice 50
                   "status": LEVEL_STATUS,  # -vstatus 40
+                  None: LEVEL_STATUS,  # -v 40
                   "verbose": LEVEL_VERBOSE,  # -vverbose 30
-                  None: LEVEL_VERBOSE,  # -v 30
                   "debug": LEVEL_DEBUG,  # -vdebug 20
                   "v": LEVEL_DEBUG,  # -vv 20
                   "trace": LEVEL_TRACE,  # -vtrace 10

--- a/conans/test/integration/command_v2/test_output_level.py
+++ b/conans/test/integration/command_v2/test_output_level.py
@@ -41,7 +41,7 @@ def test_output_level():
     t.run("create . --name foo --version 1.0 -v")
     assert "This is a trace" not in t.out
     assert "This is a debug" not in t.out
-    assert "This is a verbose" in t.out
+    assert "This is a verbose" not in t.out
     assert "This is a info" in t.out
     assert "This is a highlight" in t.out
     assert "This is a success" in t.out


### PR DESCRIPTION
Changelog: Bugfix: Make `STATUS` the default log level.
Docs: Omit

This gets Conan in line with other systems using the same log level convention where STATUS is the default level (See CMake as an example).
We're lucky because we don't have a single `verbose` nor `status` call in the codebase, so this change is not reflected in any of the outputs that Conan currently emits.

Closes #13444