### PR TITLE
fix full_deploy build folder collision

### DIFF
--- a/conan/internal/deploy.py
+++ b/conan/internal/deploy.py
@@ -80,6 +80,7 @@ def direct_deploy(graph, output_folder):
     import os
     import shutil
 
+    output_folder = os.path.join(output_folder, "direct_deploy")
     conanfile = graph.root.conanfile
     conanfile.output.info(f"Conan built-in pkg deployer to {output_folder}")
     # If the argument is --requires, the current conanfile is a virtual one with 1 single

--- a/conan/internal/deploy.py
+++ b/conan/internal/deploy.py
@@ -58,7 +58,7 @@ def full_deploy(graph, output_folder):
     for dep in conanfile.dependencies.values():
         if dep.package_folder is None:
             continue
-        folder_name = os.path.join(dep.context, dep.ref.name, str(dep.ref.version))
+        folder_name = os.path.join("full_deploy", dep.context, dep.ref.name, str(dep.ref.version))
         build_type = dep.info.settings.get_safe("build_type")
         arch = dep.info.settings.get_safe("arch")
         if build_type:

--- a/conans/test/functional/command/test_install_deploy.py
+++ b/conans/test/functional/command/test_install_deploy.py
@@ -246,7 +246,7 @@ def test_deploy_editable():
 
 
 def test_deploy_single_package():
-    """ Lets try a deploy that executes on a single package reference
+    """ Let's try a deploy that executes on a single package reference
     """
     c = TestClient()
     c.save({"conanfile.py": GenConanfile("pkg", "1.0").with_package_file("include/hi.h", "hi"),
@@ -255,10 +255,10 @@ def test_deploy_single_package():
 
     # if we deploy one --requires, we get that package
     c.run("install  --requires=pkg/1.0 --deploy=direct_deploy --output-folder=output")
-    header = c.load("output/pkg/include/hi.h")
+    header = c.load("output/direct_deploy/pkg/include/hi.h")
     assert "hi" in header
 
     # If we deploy a local conanfile.txt, we get deployed its direct dependencies
     c.run("install consumer/conanfile.txt --deploy=direct_deploy --output-folder=output2")
-    header = c.load("output2/pkg/include/hi.h")
+    header = c.load("output2/direct_deploy/pkg/include/hi.h")
     assert "hi" in header

--- a/conans/test/functional/command/test_install_deploy.py
+++ b/conans/test/functional/command/test_install_deploy.py
@@ -173,18 +173,18 @@ def test_builtin_full_deploy():
           "-s build_type=Debug -s arch=x86")
 
     host_arch = c.get_default_host_profile().settings['arch']
-    release = c.load(f"output/host/dep/0.1/Release/{host_arch}/include/hello.h")
+    release = c.load(f"output/full_deploy/host/dep/0.1/Release/{host_arch}/include/hello.h")
     assert f"Release-{host_arch}" in release
-    debug = c.load("output/host/dep/0.1/Debug/x86/include/hello.h")
+    debug = c.load("output/full_deploy/host/dep/0.1/Debug/x86/include/hello.h")
     assert "Debug-x86" in debug
     cmake_release = c.load(f"output/dep-release-{host_arch}-data.cmake")
     assert 'set(dep_INCLUDE_DIRS_RELEASE "${dep_PACKAGE_FOLDER_RELEASE}/include")' in cmake_release
-    assert f"${{CMAKE_CURRENT_LIST_DIR}}/host/dep/0.1/Release/{host_arch}" in cmake_release
+    assert f"${{CMAKE_CURRENT_LIST_DIR}}/full_deploy/host/dep/0.1/Release/{host_arch}" in cmake_release
     assert 'set(dep_BUILD_MODULES_PATHS_RELEASE ' \
            '"${dep_PACKAGE_FOLDER_RELEASE}/build/my_tools_host.cmake")' in cmake_release
     cmake_debug = c.load("output/dep-debug-x86-data.cmake")
     assert 'set(dep_INCLUDE_DIRS_DEBUG "${dep_PACKAGE_FOLDER_DEBUG}/include")' in cmake_debug
-    assert "${CMAKE_CURRENT_LIST_DIR}/host/dep/0.1/Debug/x86" in cmake_debug
+    assert "${CMAKE_CURRENT_LIST_DIR}/full_deploy/host/dep/0.1/Debug/x86" in cmake_debug
     assert 'set(dep_BUILD_MODULES_PATHS_DEBUG ' \
            '"${dep_PACKAGE_FOLDER_DEBUG}/build/my_tools_host.cmake")' in cmake_debug
 
@@ -198,14 +198,14 @@ def test_deploy_reference():
 
     c.run("install  --requires=pkg/1.0 --deploy=full_deploy --output-folder=output")
     # NOTE: Full deployer always use build_type/arch, even if None/None in the path, same structure
-    header = c.load("output/host/pkg/1.0/include/hi.h")
+    header = c.load("output/full_deploy/host/pkg/1.0/include/hi.h")
     assert "hi" in header
 
     # Testing that we can deploy to the current folder too
     c.save({}, clean_first=True)
     c.run("install  --requires=pkg/1.0 --deploy=full_deploy")
     # NOTE: Full deployer always use build_type/arch, even if None/None in the path, same structure
-    header = c.load("host/pkg/1.0/include/hi.h")
+    header = c.load("full_deploy/host/pkg/1.0/include/hi.h")
     assert "hi" in header
 
 
@@ -217,14 +217,14 @@ def test_deploy_overwrite():
     c.run("create .")
 
     c.run("install  --requires=pkg/1.0 --deploy=full_deploy --output-folder=output")
-    header = c.load("output/host/pkg/1.0/include/hi.h")
+    header = c.load("output/full_deploy/host/pkg/1.0/include/hi.h")
     assert "hi" in header
 
     # modify the package
     c.save({"conanfile.py": GenConanfile("pkg", "1.0").with_package_file("include/hi.h", "bye")})
     c.run("create .")
     c.run("install  --requires=pkg/1.0 --deploy=full_deploy --output-folder=output")
-    header = c.load("output/host/pkg/1.0/include/hi.h")
+    header = c.load("output/full_deploy/host/pkg/1.0/include/hi.h")
     assert "bye" in header
 
 
@@ -241,7 +241,7 @@ def test_deploy_editable():
     # If we don't change to another folder, the full_deploy will be recursive and fail
     with c.chdir(temp_folder()):
         c.run("install  --requires=pkg/1.0 --deploy=full_deploy --output-folder=output")
-        header = c.load("output/host/pkg/1.0/src/include/hi.h")
+        header = c.load("output/full_deploy/host/pkg/1.0/src/include/hi.h")
         assert "hi" in header
 
 

--- a/conans/test/functional/toolchains/cmake/test_ninja.py
+++ b/conans/test/functional/toolchains/cmake/test_ninja.py
@@ -79,7 +79,7 @@ def test_locally_build_linux(build_type, shared, client):
     assert 'cmake -G "Ninja"' in client.out
     assert "main: {}!".format(build_type) in client.out
     client.run(f"install --requires=hello/1.0@ --deploy=full_deploy -of=mydeploy {settings}")
-    deploy_path = os.path.join(client.current_folder, "mydeploy", "host", "hello", "1.0",
+    deploy_path = os.path.join(client.current_folder, "mydeploy", "full_deploy", "host", "hello", "1.0",
                                build_type, "x86_64")
     client.run_command(f"LD_LIBRARY_PATH='{deploy_path}/lib' {deploy_path}/bin/myapp")
     check_exe_run(client.out, ["main", "hello"], "gcc", None, build_type, "x86_64", cppstd=None)
@@ -113,7 +113,7 @@ def test_locally_build_msvc(build_type, shared, client):
     assert 'cmake -G "Ninja"' in client.out
     assert "main: {}!".format(build_type) in client.out
     client.run(f"install --requires=hello/1.0@ --deploy=full_deploy -of=mydeploy {settings}")
-    client.run_command(fr"mydeploy\host\hello\1.0\{build_type}\x86_64\bin\myapp.exe")
+    client.run_command(fr"full_deploy\mydeploy\host\hello\1.0\{build_type}\x86_64\bin\myapp.exe")
     check_exe_run(client.out, ["main", "hello"], "msvc", "19", build_type, "x86_64", cppstd="14")
 
 

--- a/conans/test/functional/toolchains/cmake/test_ninja.py
+++ b/conans/test/functional/toolchains/cmake/test_ninja.py
@@ -5,7 +5,6 @@ import pytest
 
 from conan.tools.cmake import CMakeToolchain
 from conan.tools.cmake.presets import load_cmake_presets
-from conan.tools.build import load_toolchain_args
 from conans.test.assets.cmake import gen_cmakelists
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.assets.sources import gen_function_h, gen_function_cpp
@@ -113,7 +112,7 @@ def test_locally_build_msvc(build_type, shared, client):
     assert 'cmake -G "Ninja"' in client.out
     assert "main: {}!".format(build_type) in client.out
     client.run(f"install --requires=hello/1.0@ --deploy=full_deploy -of=mydeploy {settings}")
-    client.run_command(fr"full_deploy\mydeploy\host\hello\1.0\{build_type}\x86_64\bin\myapp.exe")
+    client.run_command(fr"mydeploy\full_deploy\host\hello\1.0\{build_type}\x86_64\bin\myapp.exe")
     check_exe_run(client.out, ["main", "hello"], "msvc", "19", build_type, "x86_64", cppstd="14")
 
 

--- a/conans/test/integration/symlinks/symlinks_test.py
+++ b/conans/test/integration/symlinks/symlinks_test.py
@@ -58,7 +58,7 @@ def test_complete_round_trip():
     c.run("remove * -c")
     c.save({}, clean_first=True)
     c.run("install --requires=hello/0.1 --deploy=full_deploy")
-    checker(os.path.join(c.current_folder, "host", "hello", "0.1"))
+    checker(os.path.join(c.current_folder, "full_deploy", "host", "hello", "0.1"))
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="Requires Symlinks")
@@ -90,7 +90,7 @@ def test_complete_round_trip_broken_link():
     c.run("remove * -c")
     c.save({}, clean_first=True)
     c.run("install --requires=hello/0.1 --deploy=full_deploy")
-    checker(os.path.join(c.current_folder, "host", "hello", "0.1"))
+    checker(os.path.join(c.current_folder, "full_deploy", "host", "hello", "0.1"))
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="Requires Symlinks")
@@ -127,7 +127,7 @@ def test_complete_round_trip_external_link():
     c.run("remove * -c")
     c.save({}, clean_first=True)
     c.run("install --requires=hello/0.1 --deploy=full_deploy")
-    checker(os.path.join(c.current_folder, "host", "hello", "0.1"))
+    checker(os.path.join(c.current_folder, "full_deploy", "host", "hello", "0.1"))
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="Requires Symlinks")
@@ -172,7 +172,7 @@ def test_complete_round_trip_folders():
     c.run("remove * -c")
     c.save({}, clean_first=True)
     c.run("install --requires=hello/0.1 --deploy=full_deploy")
-    checker(os.path.join(c.current_folder, "host", "hello", "0.1"))
+    checker(os.path.join(c.current_folder, "full_deploy", "host", "hello", "0.1"))
 
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="Only linux")
@@ -232,7 +232,7 @@ def test_package_with_symlinks(package_files):
     # Check package files are there
     package_folder = client2.get_latest_pkg_layout(pref).package()
     assert_folder_symlinks(package_folder)
-    assert_folder_symlinks(os.path.join(client2.current_folder, "host", "hello", "0.1"))
+    assert_folder_symlinks(os.path.join(client2.current_folder, "full_deploy", "host", "hello", "0.1"))
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="Symlinks not in Windows")


### PR DESCRIPTION
Changelog: Bugfix: Add ``full_deploy`` subfolder for the ``full_deploy`` deployer to avoid collision with "build" folder.
Changelog: Fix: Add ``direct_deploy`` subfolder for the ``direct_deploy`` deployer.
Docs: https://github.com/conan-io/docs/pull/3155

