### PR TITLE
Add `-gc` to pass global confs in CLI

### DIFF
--- a/conan/api/subapi/profiles.py
+++ b/conan/api/subapi/profiles.py
@@ -32,14 +32,14 @@ class ProfilesAPI:
         build = [self.get_default_build()] if not args.profile_build else args.profile_build
         host = [self.get_default_host()] if not args.profile_host else args.profile_host
         profile_build = self.get_profile(profiles=build, settings=args.settings_build,
-                                         options=args.options_build, globalconf=args.global_conf,
+                                         options=args.options_build, global_conf=args.global_conf,
                                          conf=args.conf_build)
         profile_host = self.get_profile(profiles=host, settings=args.settings_host,
-                                        options=args.options_host, globalconf=args.global_conf,
+                                        options=args.options_host, global_conf=args.global_conf,
                                         conf=args.conf_host)
         return profile_host, profile_build
 
-    def get_profile(self, profiles, settings=None, options=None, globalconf=None, conf=None, cwd=None):
+    def get_profile(self, profiles, settings=None, options=None, global_conf=None, conf=None, cwd=None):
         """ Computes a Profile as the result of aggregating all the user arguments, first it
         loads the "profiles", composing them in order (last profile has priority), and
         finally adding the individual settings, options (priority over the profiles)
@@ -47,7 +47,7 @@ class ProfilesAPI:
         assert isinstance(profiles, list), "Please provide a list of profiles"
         cache = ClientCache(self._conan_api.cache_folder)
         loader = ProfileLoader(cache)
-        profile = loader.from_cli_args(profiles, settings, options, globalconf, conf, cwd)
+        profile = loader.from_cli_args(profiles, settings, options, global_conf, conf, cwd)
         profile.conf.validate()
         cache.new_config.validate()
         # Apply the new_config to the profiles the global one, so recipes get it too

--- a/conan/api/subapi/profiles.py
+++ b/conan/api/subapi/profiles.py
@@ -32,12 +32,14 @@ class ProfilesAPI:
         build = [self.get_default_build()] if not args.profile_build else args.profile_build
         host = [self.get_default_host()] if not args.profile_host else args.profile_host
         profile_build = self.get_profile(profiles=build, settings=args.settings_build,
-                                         options=args.options_build, conf=args.conf_build)
+                                         options=args.options_build, globalconf=args.global_conf,
+                                         conf=args.conf_build)
         profile_host = self.get_profile(profiles=host, settings=args.settings_host,
-                                        options=args.options_host, conf=args.conf_host)
+                                        options=args.options_host, globalconf=args.global_conf,
+                                        conf=args.conf_host)
         return profile_host, profile_build
 
-    def get_profile(self, profiles, settings=None, options=None, conf=None, cwd=None):
+    def get_profile(self, profiles, settings=None, options=None, globalconf=None, conf=None, cwd=None):
         """ Computes a Profile as the result of aggregating all the user arguments, first it
         loads the "profiles", composing them in order (last profile has priority), and
         finally adding the individual settings, options (priority over the profiles)
@@ -45,7 +47,7 @@ class ProfilesAPI:
         assert isinstance(profiles, list), "Please provide a list of profiles"
         cache = ClientCache(self._conan_api.cache_folder)
         loader = ProfileLoader(cache)
-        profile = loader.from_cli_args(profiles, settings, options, conf, cwd)
+        profile = loader.from_cli_args(profiles, settings, options, globalconf, conf, cwd)
         profile.conf.validate()
         cache.new_config.validate()
         # Apply the new_config to the profiles the global one, so recipes get it too

--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -88,11 +88,20 @@ def add_profiles_args(parser):
                                  'tools.cmake.cmaketoolchain:generator=Xcode'.format(machine,
                                                                                      short_suffix))
 
+    def global_conf_args():
+        parser.add_argument("-gc",
+                            "--global-conf",
+                            action="append",
+                            dest="global_conf",
+                            help="Global configuration for Conan")
+
     for item_fn in [options_args, profile_args, settings_args, conf_args]:
         item_fn("host", "",
                 "")  # By default it is the HOST, the one we are building binaries for
         item_fn("build", ":b", ":build")
         item_fn("host", ":h", ":host")
+
+    global_conf_args()
 
 
 def add_reference_args(parser):

--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -97,7 +97,7 @@ def add_profiles_args(parser):
 
     for item_fn in [options_args, profile_args, settings_args, conf_args]:
         item_fn("host", "",
-                "")  # By default it is the HOST, the one we are building binaries for
+                "")  # By default, it is the HOST, the one we are building binaries for
         item_fn("build", ":b", ":build")
         item_fn("host", ":h", ":host")
 

--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -116,13 +116,10 @@ class ProfileLoader:
         if hasattr(mod, "profile_plugin"):
             return mod.profile_plugin
 
-    def from_cli_args(self, profiles, settings, options, globalconf, conf, cwd):
+    def from_cli_args(self, profiles, settings, options, global_conf, conf, cwd):
         """ Return a Profile object, as the result of merging a potentially existing Profile
         file and the args command-line arguments
         """
-        if globalconf and any(not CORE_CONF_PATTERN.match(c) for c in globalconf):
-            raise ConanException("[global conf] configurations should be of the form 'core.*'")
-
         if conf and any(CORE_CONF_PATTERN.match(c) for c in conf):
             raise ConanException("[conf] 'core.*' configurations are not allowed in profiles.")
 
@@ -131,7 +128,7 @@ class ProfileLoader:
             tmp = self.load_profile(p, cwd)
             result.compose_profile(tmp)
 
-        args_profile = _profile_parse_args(settings, options, globalconf, conf)
+        args_profile = _profile_parse_args(settings, options, global_conf, conf)
         result.compose_profile(args_profile)
         # Only after everything has been aggregated, try to complete missing settings
         profile_plugin = self._load_profile_plugin()
@@ -393,7 +390,7 @@ def _profile_parse_args(settings, options, globalconf, conf):
     if conf:
         confs = ConfDefinition()
         confs.loads("\n".join(conf))
-        result.conf.rebase_conf_definition(confs)
+        result.conf.update_conf_definition(confs)
 
     for pkg, values in package_settings.items():
         result.package_settings[pkg] = OrderedDict(values)

--- a/conans/test/integration/command/test_profile.py
+++ b/conans/test/integration/command/test_profile.py
@@ -28,3 +28,39 @@ def test_ignore_paths_when_listing_profiles():
     c.run("profile list")
 
     assert ignore_path not in c.out
+
+
+def test_conf_global_cli():
+    tc = TestClient()
+
+    tc.run("profile show -c user.myconf:key=value -gc core.download:retry=10")
+
+    assert "core.download:retry=10" in tc.out
+    assert tc.out.count("core.download:retry=10") == 2
+    assert "user.myconf:key=value" in tc.out
+    assert tc.out.count("user.myconf:key=value") == 1
+
+
+def test_conf_global_cli_rebase():
+    tc = TestClient()
+
+    # Ensure -c wins over -gc
+    tc.run("profile show -c tools.build:jobs=9 -gc tools.build:jobs=42")
+    assert "tools.build:jobs=9" in tc.out
+    assert "tools.build:jobs=42" in tc.out
+
+    # Also ensure -c:b & -c:h wins over -gc just in case
+    tc.run("profile show -c:b tools.build:jobs=9 -c:h tools.build:jobs=17 -gc tools.build:jobs=42")
+    assert "tools.build:jobs=9" in tc.out
+    assert "tools.build:jobs=17" in tc.out
+    assert "tools.build:jobs=42" not in tc.out
+
+
+def test_conf_global_cli_file():
+    # Ensure CLI has priority over global.conf
+    tc = TestClient()
+    tc.save_home({"global.conf": "core.download:retry=9"})
+
+    tc.run("profile show -gc core.download:retry=13")
+    assert "core.download:retry=13" in tc.out
+    assert "core.download:retry=9" not in tc.out

--- a/conans/test/unittests/client/profile_loader/compiler_cppstd_test.py
+++ b/conans/test/unittests/client/profile_loader/compiler_cppstd_test.py
@@ -52,12 +52,12 @@ class SettingsCppStdTests(unittest.TestCase):
         profile_loader = ProfileLoader(self.cache)
         with self.assertRaisesRegex(ConanException,
                                     "'settings.compiler.cppstd' doesn't exist for 'apple-clang'"):
-            profile_loader.from_cli_args(["default"], None, None, None, None)
+            profile_loader.from_cli_args(["default"], None, None, None, None, None)
 
     def test_no_value(self):
         self._save_profile()
         profile_loader = ProfileLoader(self.cache)
-        r = profile_loader.from_cli_args(["default"], None, None, None, None)
+        r = profile_loader.from_cli_args(["default"], None, None, None, None, None)
         self.assertNotIn("compiler.cppstd", r.settings)
 
     def test_value_none(self):
@@ -65,12 +65,12 @@ class SettingsCppStdTests(unittest.TestCase):
         profile_loader = ProfileLoader(self.cache)
         # It is incorrect to assign compiler.cppstd=None in the profile
         with self.assertRaisesRegex(ConanException, "Invalid setting"):
-            r = profile_loader.from_cli_args(["default"], None, None, None, None)
+            r = profile_loader.from_cli_args(["default"], None, None, None, None, None)
 
     def test_value_valid(self):
         self._save_profile(compiler_cppstd="11")
         profile_loader = ProfileLoader(self.cache)
-        r = profile_loader.from_cli_args(["default"], None, None, None, None)
+        r = profile_loader.from_cli_args(["default"], None, None, None, None, None)
         self.assertEqual(r.settings["compiler.cppstd"], "11")
         self.assertNotIn("cppstd", r.settings)
 
@@ -79,4 +79,4 @@ class SettingsCppStdTests(unittest.TestCase):
         profile_loader = ProfileLoader(self.cache)
         with self.assertRaisesRegex(ConanException, "Invalid setting '13' is not a valid "
                                                     "'settings.compiler.cppstd' value"):
-            r = profile_loader.from_cli_args(["default"], None, None, None, None)
+            r = profile_loader.from_cli_args(["default"], None, None, None, None, None)

--- a/conans/test/unittests/client/profile_loader/profile_loader_test.py
+++ b/conans/test/unittests/client/profile_loader/profile_loader_test.py
@@ -250,5 +250,5 @@ def test_profile_core_confs_error(conf_name):
     profile_loader = ProfileLoader(cache=None)  # If not used cache, will not error
 
     with pytest.raises(ConanException) as exc:
-        profile_loader.from_cli_args([], [], [], [conf_name], None)
+        profile_loader.from_cli_args([], [], [], None, [conf_name], None)
     assert "[conf] 'core.*' configurations are not allowed in profiles" in str(exc.value)


### PR DESCRIPTION
Changelog: Feature: Add `--global-conf` flag to pass global confs in CLI
Docs: 

In progress. I just realized that we don't only want `-gc` where passing profiles is allowed, but everywhere. Still need to do that, but for now passing `-gc` will allow you to override global.conf's contents

Closes #13410