### PR TITLE
fix package-query patterns for options

### DIFF
--- a/conans/search/search.py
+++ b/conans/search/search.py
@@ -61,6 +61,7 @@ def _evaluate(prop_name, prop_value, binary_info):
     if not prop_name.startswith("options."):
         return compatible_prop(info_settings.get(prop_name, None), prop_value)
     else:
+        prop_name = prop_name[len("options."):]
         return compatible_prop(info_options.get(prop_name, None), prop_value)
 
 

--- a/conans/test/integration/command_v2/list_test.py
+++ b/conans/test/integration/command_v2/list_test.py
@@ -584,6 +584,37 @@ def test_list_prefs_query_custom_settings():
     assert "newsetting.subsetting: 2" not in c.out
 
 
+def test_list_query_options():
+    """
+    Make sure query works for custom settings
+    https://github.com/conan-io/conan/issues/13617
+    """
+    c = TestClient(default_server_user=True)
+    c.save({"conanfile.py": GenConanfile("pkg", "1.0").with_option("myoption", [1, 2, 3])})
+    c.run("create . -o myoption=1")
+    c.run("create . -o myoption=2")
+    c.run("create . -o myoption=3")
+
+    c.run("list pkg/1.0:* -p options.myoption=1")
+    assert "myoption: 1" in c.out
+    assert "myoption: 2" not in c.out
+    assert "myoption: 3" not in c.out
+    c.run("list pkg/1.0:* -p options.myoption=2")
+    assert "myoption: 1" not in c.out
+    assert "myoption: 2" in c.out
+    assert "myoption: 3" not in c.out
+
+    c.run("upload * -r=default -c")
+    c.run("list pkg/1.0:* -p options.myoption=1 -r=default")
+    assert "myoption: 1" in c.out
+    assert "myoption: 2" not in c.out
+    assert "myoption: 3" not in c.out
+    c.run("list pkg/1.0:* -p options.myoption=2 -r=default")
+    assert "myoption: 1" not in c.out
+    assert "myoption: 2" in c.out
+    assert "myoption: 3" not in c.out
+
+
 class TestListNoUserChannel:
     def test_no_user_channel(self):
         c = TestClient(default_server_user=True)


### PR DESCRIPTION
Changelog: Bugfix: Fix the ``--package-query`` argument for ``options``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/13617