### PR TITLE
Add error in conan remove when using -p without a pattern that matches packages

### DIFF
--- a/conan/cli/commands/remove.py
+++ b/conan/cli/commands/remove.py
@@ -2,6 +2,7 @@ from conan.api.conan_api import ConanAPI
 from conan.api.model import ListPattern
 from conan.cli.command import conan_command, OnceArgument
 from conans.client.userio import UserInput
+from conans.errors import ConanException
 
 
 @conan_command(group="Consumer")
@@ -36,6 +37,8 @@ def remove(conan_api: ConanAPI, parser, *args):
     select_bundle = conan_api.list.select(ref_pattern, args.package_query, remote)
 
     if ref_pattern.package_id is None:
+        if args.package_query is not None:
+            raise ConanException('--package-query supplied but the pattern does not match packages')
         for ref, _ in select_bundle.refs():
             if confirmation("Remove the recipe and all the packages of '{}'?"
                             "".format(ref.repr_notime())):

--- a/conans/test/integration/command/remove_test.py
+++ b/conans/test/integration/command/remove_test.py
@@ -331,6 +331,7 @@ def test_new_remove_package_revisions_expressions(populated_client, with_remote,
 
 def test_package_query_no_package_ref(populated_client):
     populated_client.run("remove * -p 'compiler=clang'", assert_error=True)
+    assert "--package-query supplied but the pattern does not match packages" in populated_client.out
 
 
 def _get_all_recipes(client, with_remote):

--- a/conans/test/integration/command/remove_test.py
+++ b/conans/test/integration/command/remove_test.py
@@ -329,6 +329,10 @@ def test_new_remove_package_revisions_expressions(populated_client, with_remote,
         assert data.get("error_msg") in populated_client.out
 
 
+def test_package_query_no_package_ref(populated_client):
+    populated_client.run("remove * -p 'compiler=clang'", assert_error=True)
+
+
 def _get_all_recipes(client, with_remote):
     api = ConanAPI(client.cache_folder)
     remote = api.remotes.get("default") if with_remote else None

--- a/conans/test/integration/settings/settings_override_test.py
+++ b/conans/test/integration/settings/settings_override_test.py
@@ -81,7 +81,7 @@ def test_exclude_patterns_settings():
     client.run("create zlib --name zlib --version 1.0")
     client.run("create openssl --name openssl --version 1.0")
 
-    # We miss openss and zlib debug packages
+    # We miss openssl and zlib debug packages
     client.run("install consumer -s build_type=Debug", assert_error=True)
     assert "ERROR: Missing prebuilt package for 'openssl/1.0', 'zlib/1.0'" in client.out
 
@@ -100,7 +100,7 @@ def test_exclude_patterns_settings():
     client.run("install --requires consumer/1.0 -s consumer/*:build_type=Debug")
 
     # Priority between package scoped settings
-    client.run('remove consumer/*#* -p="build_type=Debug" -c')
+    client.run('remove consumer/*#* -c')
     client.run("install --reference consumer/1.0 -s build_type=Debug", assert_error=True)
     # Pre-check, there is no Debug package for any of them
     assert "ERROR: Missing prebuilt package for 'consumer/1.0', 'openssl/1.0', 'zlib/1.0'"


### PR DESCRIPTION
Changelog: Fix: Add error in `conan remove` when using `--package-query` without providing a pattern that matches packages.
Docs: Omit

Not sure about the readability of the error message, would appreciate suggestions to improve it

Closes #13595
(For real this time)