### PR TITLE
[PkgConfigDeps] Added `bindir` to generated `.pc` files

### DIFF
--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -133,7 +133,7 @@ class _PCContentGenerator:
         {{ "includedir%d=%s" % (loop.index, path) }}
         {% endfor %}
         {% for path in bindirs %}
-        {{ f"bindir{loop.index}={path}" }}
+        {{ "bindir{}={}".format(loop.index, path) }}
         {% endfor %}
         {% if pkg_config_custom_content %}
         # Custom PC content

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -97,7 +97,7 @@ class _PCContentGenerator:
     template = textwrap.dedent("""\
         {%- macro get_libs(libdirs, cpp_info, gnudeps_flags) -%}
         {%- for _ in libdirs -%}
-        {{ '-L"${libdir%s}"' % loop.index + " " }}
+        {{ '-L"${libdir%s}"' % (loop.index0 or "") + " " }}
         {%- endfor -%}
         {%- for sys_lib in (cpp_info.libs + cpp_info.system_libs) -%}
         {{ "-l%s" % sys_lib + " " }}
@@ -112,7 +112,7 @@ class _PCContentGenerator:
 
         {%- macro get_cflags(includedirs, cxxflags, cflags, defines) -%}
         {%- for _ in includedirs -%}
-        {{ '-I"${includedir%s}"' % loop.index + " " }}
+        {{ '-I"${includedir%s}"' % (loop.index0 or "") + " " }}
         {%- endfor -%}
         {%- for cxxflag in cxxflags -%}
         {{ cxxflag + " " }}
@@ -127,13 +127,13 @@ class _PCContentGenerator:
 
         prefix={{ prefix_path }}
         {% for path in libdirs %}
-        {{ "libdir{}={}".format(loop.index, path) }}
+        {{ "libdir{}={}".format((loop.index0 or ""), path) }}
         {% endfor %}
         {% for path in includedirs %}
-        {{ "includedir%d=%s" % (loop.index, path) }}
+        {{ "includedir%s=%s" % ((loop.index0 or ""), path) }}
         {% endfor %}
         {% for path in bindirs %}
-        {{ "bindir{}={}".format(loop.index, path) }}
+        {{ "bindir{}={}".format((loop.index0 or ""), path) }}
         {% endfor %}
         {% if pkg_config_custom_content %}
         # Custom PC content

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -132,6 +132,9 @@ class _PCContentGenerator:
         {% for path in includedirs %}
         {{ "includedir%d=%s" % (loop.index, path) }}
         {% endfor %}
+        {% for path in bindirs %}
+        {{ f"bindir{loop.index}={path}" }}
+        {% endfor %}
         {% if pkg_config_custom_content %}
         # Custom PC content
         {{ pkg_config_custom_content }}
@@ -171,12 +174,14 @@ class _PCContentGenerator:
         prefix_path = root_folder.replace("\\", "/")
         libdirs = _get_formatted_dirs(info.cpp_info.libdirs, prefix_path)
         includedirs = _get_formatted_dirs(info.cpp_info.includedirs, prefix_path)
+        bindirs = _get_formatted_dirs(info.cpp_info.bindirs, prefix_path)
         custom_content = info.cpp_info.get_property("pkg_config_custom_content")
 
         context = {
             "prefix_path": prefix_path,
             "libdirs": libdirs,
             "includedirs": includedirs,
+            "bindirs": bindirs,
             "pkg_config_custom_content": custom_content,
             "name": info.name,
             "description": info.description,
@@ -308,7 +313,7 @@ class _PCGenerator:
         Get all the PC files and contents for any dependency:
 
         * If the given dependency does not have components:
-            The PC file will be the depency one.
+            The PC file will be the dependency one.
 
         * If the given dependency has components:
             The PC files will be saved in this order:

--- a/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
@@ -8,7 +8,7 @@ from conans.test.utils.tools import TestClient
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="Needs pkg-config")
 @pytest.mark.tool("pkg_config")
-def test_pkg_configdeps_definitions_escape():
+def test_pkgconfigdeps_definitions_escape():
     client = TestClient(path_with_spaces=False)
     conanfile = textwrap.dedent(r'''
         from conan import ConanFile
@@ -54,3 +54,64 @@ def test_pkgconfigdeps_with_test_requires():
     client.run("install . -g PkgConfigDeps")
     assert "Description: Conan package: test" in client.load("test.pc")
     assert "Description: Conan package: app" in client.load("app.pc")
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="It makes sense only for Windows")
+@pytest.mark.tool("meson")  # https://github.com/mesonbuild/meson/pull/11649 is part of Meson 1.1.0
+@pytest.mark.tool("pkg_config")
+def test_pkgconfigdeps_bindir_and_meson():
+    """
+    This test checks that the field bindir introduced by PkgConfigDeps is useful for Windows
+    OS and shared=True where all the DLL's files are located by default there.
+
+    Basically, Meson (version >= 1.1.0) reads from the *.pc files the bindir variable if exists, and
+    uses that variable to link with if SHARED libraries.
+
+    Issue: https://github.com/conan-io/conan/issues/13532
+    """
+    client = TestClient()
+    client.run("new meson_lib -d name=hello -d version=1.0")
+    client.run("create . -tf \"\" -o *:shared=True")
+    test_meson_build = textwrap.dedent("""
+    project('Testhello', 'cpp')
+    hello = dependency('hello', version : '>=1.0')
+    example = executable('example', 'src/example.cpp', dependencies: hello)
+    test('./src/example', example)
+    """)
+    test_conanfile = textwrap.dedent("""
+    import os
+    from conan import ConanFile
+    from conan.tools.build import can_run
+    from conan.tools.meson import Meson
+    from conan.tools.layout import basic_layout
+
+    class helloTestConan(ConanFile):
+        settings = "os", "compiler", "build_type", "arch"
+        generators = "PkgConfigDeps", "MesonToolchain"
+        options = {"shared": [True, False], "fPIC": [True, False]}
+        default_options = {"shared": True, "fPIC": True}
+
+        def requirements(self):
+            self.requires("hello/1.0")
+
+        def build(self):
+            meson = Meson(self)
+            meson.configure()
+            meson.build()
+
+        def layout(self):
+            basic_layout(self)
+
+        def test(self):
+            if can_run(self):
+                cmd = os.path.join(self.cpp.build.bindir, "example")
+                self.run(cmd, env="conanrun")
+    """)
+    client.save({
+        "test_package/conanfile.py": test_conanfile,
+        "test_package/meson.build": test_meson_build
+    })
+    client.run("build test_package/conanfile.py -o *:shared=True")
+    # Important: Only Meson >= 1.1.0 brings this capability
+    # Executing directly "meson test" fails if the bindir field does not exist
+    client.run_command("meson test -C test_package/build-release")
+    assert "1/1 ./src/example OK"

--- a/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
@@ -1,4 +1,5 @@
 import platform
+import sys
 import textwrap
 
 import pytest
@@ -55,6 +56,8 @@ def test_pkgconfigdeps_with_test_requires():
     assert "Description: Conan package: test" in client.load("test.pc")
     assert "Description: Conan package: app" in client.load("app.pc")
 
+
+@pytest.mark.skipif(sys.version_info.minor < 7, reason="Meson 1.1.x version needs Python >= 3.7")
 @pytest.mark.skipif(platform.system() != "Windows", reason="It makes sense only for Windows")
 @pytest.mark.tool("meson")  # https://github.com/mesonbuild/meson/pull/11649 is part of Meson 1.1.0
 @pytest.mark.tool("pkg_config")

--- a/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/functional/toolchains/gnu/test_pkgconfigdeps.py
@@ -100,11 +100,6 @@ def test_pkgconfigdeps_bindir_and_meson():
 
         def layout(self):
             basic_layout(self)
-
-        def test(self):
-            if can_run(self):
-                cmd = os.path.join(self.cpp.build.bindir, "example")
-                self.run(cmd, env="conanrun")
     """)
     client.save({
         "test_package/conanfile.py": test_conanfile,

--- a/conans/test/integration/layout/test_layout_paths.py
+++ b/conans/test/integration/layout/test_layout_paths.py
@@ -34,7 +34,7 @@ def test_editable_layout_paths():
 
     assert 'set(dep_INCLUDE_DIRS_RELEASE "${dep_PACKAGE_FOLDER_RELEASE}/include")' in data
     pc = c.load("pkg/dep.pc")
-    assert "includedir1=${prefix}/include" in pc
+    assert "includedir=${prefix}/include" in pc
     xcode = c.load("pkg/conan_dep_dep_release_x86_64.xcconfig")
     dep_path = os.path.join(c.current_folder, "dep")
     assert f"PACKAGE_ROOT_dep[config=Release][arch=x86_64][sdk=*] = {dep_path}" in xcode

--- a/conans/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -31,9 +31,9 @@ def test_pkg_config_dirs():
                 fake_dir = os.path.join("/", "my_absoulte_path", "fake")
                 include_dir = os.path.join(fake_dir, libname, "include")
                 lib_dir = os.path.join(fake_dir, libname, "lib")
-                lib_dir2 = os.path.join(self.package_folder, "lib2")
+                lib_dir1 = os.path.join(self.package_folder, "lib2")
                 self.cpp_info.includedirs = [include_dir]
-                self.cpp_info.libdirs = [lib_dir, lib_dir2]
+                self.cpp_info.libdirs = [lib_dir, lib_dir1]
         """)
     client = TestClient()
     client.save({"conanfile.py": conanfile})
@@ -46,20 +46,20 @@ def test_pkg_config_dirs():
     assert 'Name: mylib' in pc_content
     assert 'Description: Conan package: mylib' in pc_content
     assert 'Version: 0.1' in pc_content
-    assert 'Libs: -L"${libdir1}" -L"${libdir2}"' in pc_content
-    assert 'Cflags: -I"${includedir1}"' in pc_content
+    assert 'Libs: -L"${libdir}" -L"${libdir}"' in pc_content
+    assert 'Cflags: -I"${includedir}"' in pc_content
 
     def assert_is_abs(path):
         assert os.path.isabs(path) is True
 
     for line in pc_content.splitlines():
-        if line.startswith("includedir1="):
-            assert_is_abs(line[len("includedir1="):])
+        if line.startswith("includedir="):
+            assert_is_abs(line[len("includedir="):])
             assert line.endswith("include")
-        elif line.startswith("libdir1="):
-            assert_is_abs(line[len("libdir1="):])
+        elif line.startswith("libdir="):
+            assert_is_abs(line[len("libdir="):])
             assert line.endswith("lib")
-        elif line.startswith("libdir2="):
+        elif line.startswith("libdir1="):
             assert "${prefix}/lib2" in line
 
 
@@ -120,7 +120,7 @@ def test_system_libs():
     client.run("install --requires=mylib/0.1@ -g PkgConfigDeps")
 
     pc_content = client.load("mylib.pc")
-    assert 'Libs: -L"${libdir1}" -lmylib1 -lmylib2 -lsystem_lib1 -lsystem_lib2' in pc_content
+    assert 'Libs: -L"${libdir}" -lmylib1 -lmylib2 -lsystem_lib1 -lsystem_lib2' in pc_content
 
 
 def test_multiple_include():
@@ -145,13 +145,13 @@ def test_multiple_include():
     client.run("install --requires=pkg/0.1@ -g PkgConfigDeps")
 
     pc_content = client.load("pkg.pc")
-    assert "includedir1=${prefix}/inc1" in pc_content
-    assert "includedir2=${prefix}/inc2" in pc_content
-    assert "includedir3=${prefix}/inc3/foo" in pc_content
-    assert "libdir1=${prefix}/lib1" in pc_content
-    assert "libdir2=${prefix}/lib2" in pc_content
-    assert 'Libs: -L"${libdir1}" -L"${libdir2}"' in pc_content
-    assert 'Cflags: -I"${includedir1}" -I"${includedir2}" -I"${includedir3}"' in pc_content
+    assert "includedir=${prefix}/inc1" in pc_content
+    assert "includedir1=${prefix}/inc2" in pc_content
+    assert "includedir2=${prefix}/inc3/foo" in pc_content
+    assert "libdir=${prefix}/lib1" in pc_content
+    assert "libdir1=${prefix}/lib2" in pc_content
+    assert 'Libs: -L"${libdir}" -L"${libdir1}"' in pc_content
+    assert 'Cflags: -I"${includedir}" -I"${includedir1}" -I"${includedir2}"' in pc_content
 
 
 def test_custom_content():
@@ -184,7 +184,7 @@ def test_custom_content():
     client.run("install --requires=pkg/0.1@ -g PkgConfigDeps")
 
     pc_content = client.load("pkg.pc")
-    assert "libdir1=${prefix}/lib" in pc_content
+    assert "libdir=${prefix}/lib" in pc_content
     assert "datadir=${prefix}/share" in pc_content
     assert "schemasdir=${datadir}/mylib/schemas" in pc_content
     assert "bindir=${prefix}/bin" in pc_content
@@ -568,9 +568,9 @@ def test_with_editable_layout():
     with client.chdir("pkg"):
         client.run("install . -g PkgConfigDeps")
         pc = client.load("dep.pc")
-        assert 'Libs: -L"${libdir1}" -lmylib' in pc
-        assert 'includedir1=' in pc
-        assert 'Cflags: -I"${includedir1}"' in pc
+        assert 'Libs: -L"${libdir}" -lmylib' in pc
+        assert 'includedir=' in pc
+        assert 'Cflags: -I"${includedir}"' in pc
 
 
 def test_tool_requires():

--- a/conans/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -34,6 +34,7 @@ def test_pkg_config_dirs():
                 lib_dir1 = os.path.join(self.package_folder, "lib2")
                 self.cpp_info.includedirs = [include_dir]
                 self.cpp_info.libdirs = [lib_dir, lib_dir1]
+                self.cpp_info.bindirs = ["mybin"]
         """)
     client = TestClient()
     client.save({"conanfile.py": conanfile})
@@ -46,8 +47,10 @@ def test_pkg_config_dirs():
     assert 'Name: mylib' in pc_content
     assert 'Description: Conan package: mylib' in pc_content
     assert 'Version: 0.1' in pc_content
-    assert 'Libs: -L"${libdir}" -L"${libdir}"' in pc_content
+    assert 'Libs: -L"${libdir}" -L"${libdir1}"' in pc_content
     assert 'Cflags: -I"${includedir}"' in pc_content
+    # https://github.com/conan-io/conan/pull/13623
+    assert 'bindir=${prefix}/mybin' in pc_content
 
     def assert_is_abs(path):
         assert os.path.isabs(path) is True


### PR DESCRIPTION
Changelog: Feature: Added `bindir` to generated `.pc` file in `PkgConfigDeps`.
Changelog: Bugfix: Removed `libdir1` and `includedir1` as the default index. Now, `PkgConfigDeps` creates the `libdir` and `includedir` variables by default in `.pc` files.
Docs: https://github.com/conan-io/docs/pull/3269

After asking @bruchar1, this seems to be the mvp for the asked feature :)

Closes #13532

UPDATED:

In a nutshell:

* I think this `bindir` is harmless.
* Honoring `libdir`, `includedir` and `bindir` as default variables created (if several ones have to be created, then, they'll be `libdir`, `libdir1`, `libdir2`, and so on). After running a grep in CCI, these libraries could be affected by this change (they'd need a migration if they use this latest feature):
```shell
$ ag "dir1"
gdk-pixbuf/all/conanfile.py
202:            "gdk_pixbuf_binarydir": "${libdir1}/gdk-pixbuf-2.0/2.10",

glib/all/conanfile.py
263:            # Can't use libdir here as it is libdir1 when using the PkgConfigDeps generator.

gstreamer/all/conanfile.py
122:            # PkgConfigDep uses libdir1 instead of libdir, so the path is spelled out explicitly here.
```
So `gdk-pixbuf`, `glib` and `gstreamer` should be fixed a priori.
* We have functional tests running the meson templates (lib and exe) in all platforms, so I think it's enough to see those tests passing without any errors.