### PR TITLE
fix cache files and DB after forbidden downloads

### DIFF
--- a/conan/internal/cache/cache.py
+++ b/conan/internal/cache/cache.py
@@ -170,6 +170,7 @@ class DataCache:
 
     def remove_recipe(self, layout: RecipeLayout):
         layout.remove()
+        # FIXME: This is clearing package binaries from DB, but not from disk/layout
         self._db.remove_recipe(layout.reference)
 
     def remove_package(self, layout: RecipeLayout):

--- a/conans/client/rest/auth_manager.py
+++ b/conans/client/rest/auth_manager.py
@@ -40,8 +40,8 @@ class ConanApiAuthManager(object):
         try:
             ret = getattr(rest_client, method_name)(*args, **kwargs)
             return ret
-        except ForbiddenException:
-            raise ForbiddenException("Permission denied for user: '%s'" % user)
+        except ForbiddenException as e:
+            raise ForbiddenException(f"Permission denied for user: '{user}': {e}")
         except AuthenticationException:
             # User valid but not enough permissions
             if user is None or token is None:

--- a/conans/client/rest/rest_client_v2.py
+++ b/conans/client/rest/rest_client_v2.py
@@ -161,6 +161,8 @@ class RestV2Methods(RestCommonMethods):
                                     verify_ssl=self.verify_ssl, retry=retry, retry_wait=retry_wait)
         for t in threads:
             t.join()
+        for t in threads:  # Need to join all before raising errors
+            t.raise_errors()
 
     def remove_all_packages(self, ref):
         """ Remove all packages from the specified reference"""

--- a/conans/util/thread.py
+++ b/conans/util/thread.py
@@ -11,5 +11,7 @@ class ExceptionThread(Thread):
 
     def join(self, timeout=None):
         super().join(timeout=timeout)
+
+    def raise_errors(self):
         if self._exc:
             raise self._exc


### PR DESCRIPTION
Changelog: Fix: When server responds Forbidden to the download of 1 file in a recipe/package, make sure other files and DB are cleaned.
Docs: Omit


The symptom before is that even if the error was correctly reported, some files might be left trailing, and some commands could still report the recipe/package is there, even if it is incomplete