### PR TITLE
fix issue when overrides happen in diamonds

### DIFF
--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -79,6 +79,8 @@ class Node(object):
         # List to avoid mutating the dict
         for transitive in list(prev_node.transitive_deps.values()):
             # TODO: possibly optimize in a bulk propagate
+            if transitive.require.override:
+                continue
             prev_node.propagate_downstream(transitive.require, transitive.node, self)
 
     def propagate_downstream(self, require, node, src_node=None):


### PR DESCRIPTION
Changelog: Bugfix: Fix crash when ``override`` is used in a node of the graph that is also the closing node of a diamond.
Docs: Omit

Close https://github.com/conan-io/conan/issues/13630