### PR TITLE
Improve provide conflict error message

### DIFF
--- a/conans/client/graph/graph_error.py
+++ b/conans/client/graph/graph_error.py
@@ -2,73 +2,66 @@ from conans.errors import ConanException
 
 
 class GraphError(ConanException):
-    # TODO: refactor into multiple classes, do not do type by attribute "kind"
-    LOOP = "graph loop"
-    VERSION_CONFLICT = "version conflict"
-    PROVIDE_CONFLICT = "provide conflict"
-    MISSING_RECIPE = "missing recipe"
-    RUNTIME = "runtime"
+    pass
 
-    def __init__(self, kind):
-        self.kind = kind
+
+class GraphConflictError(GraphError):
+
+    def __init__(self, node, require, prev_node, prev_require, base_previous):
+        self.node = node
+        self.require = require
+        self.prev_node = prev_node
+        self.prev_require = prev_require
+        self.base_previous = base_previous
 
     def __str__(self):
-        # TODO: Nicer error reporting
-        if self.kind == GraphError.MISSING_RECIPE:
-            return f"Package '{self.require.ref}' not resolved: {self.missing_error}"
-        elif self.kind == GraphError.VERSION_CONFLICT:
-            return f"Version conflict: {self.node.ref}->{self.require.ref}, "\
-                   f"{self.base_previous.ref}->{self.prev_require.ref}."
-        elif self.kind == GraphError.LOOP:
-            return "There is a cycle/loop in the graph:\n"\
-                   f"    Initial ancestor: {self.ancestor}\n" \
-                   f"    Require: {self.require.ref}\n" \
-                   f"    Dependency: {self.node}"
-        return self.kind
+        return f"Version conflict: {self.node.ref}->{self.require.ref}, "\
+               f"{self.base_previous.ref}->{self.prev_require.ref}."
 
-    @staticmethod
-    def loop(node, require, ancestor):
-        result = GraphError(GraphError.LOOP)
-        result.node = node
-        result.require = require
-        result.ancestor = ancestor
-        node.error = ancestor.error = result
-        return result
 
-    @staticmethod
-    def runtime(node, conflicting_node):
-        result = GraphError(GraphError.RUNTIME)
-        result.node = node
-        result.conflicting_node = conflicting_node
-        node.error = conflicting_node.error = result
-        return result
+class GraphLoopError(GraphError):
 
-    @staticmethod
-    def provides(node, conflicting_node):
-        result = GraphError(GraphError.PROVIDE_CONFLICT)
-        result.node = node
-        result.conflicting_node = conflicting_node
-        node.error = conflicting_node.error = result
-        return result
+    def __init__(self, node, require, ancestor):
+        self.node = node
+        self.require = require
+        self.ancestor = ancestor
 
-    @staticmethod
-    def missing(node, require, missing_error):
-        result = GraphError(GraphError.MISSING_RECIPE)
-        result.node = node
-        result.require = require
-        result.missing_error = missing_error
-        node.error = result
-        return result
+    def __str__(self):
+        return "There is a cycle/loop in the graph:\n"\
+               f"    Initial ancestor: {self.ancestor}\n" \
+               f"    Require: {self.require.ref}\n" \
+               f"    Dependency: {self.node}"
 
-    @staticmethod
-    def conflict(node, require, prev_node, prev_require, base_previous):
-        result = GraphError(GraphError.VERSION_CONFLICT)
-        result.node = node
-        result.require = require
-        result.prev_node = prev_node
-        result.prev_require = prev_require
-        result.base_previous = base_previous
-        node.error = base_previous.error = result
-        if prev_node:
-            prev_node.error = result
-        return result
+
+class GraphMissingError(GraphError):
+
+    def __init__(self, node, require, missing_error):
+        self.node = node
+        self.require = require
+        self.missing_error = missing_error
+
+    def __str__(self):
+        return f"Package '{self.require.ref}' not resolved: {self.missing_error}."
+
+
+class GraphProvidesError(ConanException):
+
+    def __init__(self, node, conflicting_node):
+        self.node = node
+        self.conflicting_node = conflicting_node
+        node.error = conflicting_node.error
+
+    def __str__(self):
+        return f"Provide Conflict: Both '{self.node.ref}' and '{self.conflicting_node.ref}' " \
+               f"provide '{self.node.conanfile.provides}'."
+
+
+class GraphRuntimeError(ConanException):
+
+    def __init__(self, node, conflicting_node):
+        self.node = node
+        self.conflicting_node = conflicting_node
+
+    def __str__(self):
+        return f"Runtime Error: Could not process '{self.node.ref}' with " \
+               f"'{self.conflicting_node.ref}'."

--- a/conans/client/graph/graph_error.py
+++ b/conans/client/graph/graph_error.py
@@ -44,7 +44,7 @@ class GraphMissingError(GraphError):
         return f"Package '{self.require.ref}' not resolved: {self.missing_error}."
 
 
-class GraphProvidesError(ConanException):
+class GraphProvidesError(GraphError):
 
     def __init__(self, node, conflicting_node):
         self.node = node
@@ -56,7 +56,7 @@ class GraphProvidesError(ConanException):
                f"provide '{self.node.conanfile.provides}'."
 
 
-class GraphRuntimeError(ConanException):
+class GraphRuntimeError(GraphError):
 
     def __init__(self, node, conflicting_node):
         self.node = node

--- a/conans/client/graph/provides.py
+++ b/conans/client/graph/provides.py
@@ -1,4 +1,4 @@
-from conans.client.graph.graph_error import GraphError
+from conans.client.graph.graph_error import GraphProvidesError
 from conans.model.recipe_ref import RecipeReference
 
 
@@ -18,7 +18,7 @@ def check_graph_provides(dep_graph):
             for provide in dep_provides:
                 # First check if collides with current node
                 if current_provides is not None and provide in current_provides:
-                    raise GraphError.provides(node, dep_node)
+                    raise GraphProvidesError(node, dep_node)
 
                 # Then, check if collides with other requirements
                 new_req = dep_require.copy_requirement()
@@ -26,10 +26,10 @@ def check_graph_provides(dep_graph):
                                               new_req.ref.channel)
                 existing = node.transitive_deps.get(new_req)
                 if existing is not None:
-                    raise GraphError.provides(existing.node, dep_node)
+                    raise GraphProvidesError(existing.node, dep_node)
                 else:
                     existing_provide = provides.get(new_req)
                     if existing_provide is not None:
-                        raise GraphError.provides(existing_provide, dep_node)
+                        raise GraphProvidesError(existing_provide, dep_node)
                     else:
                         provides[new_req] = dep_node

--- a/conans/test/integration/graph/core/graph_manager_test.py
+++ b/conans/test/integration/graph/core/graph_manager_test.py
@@ -1,7 +1,7 @@
 import pytest
 from parameterized import parameterized
 
-from conans.client.graph.graph_error import GraphError
+from conans.client.graph.graph_error import GraphMissingError, GraphLoopError, GraphConflictError
 from conans.errors import ConanException
 from conans.test.integration.graph.core.graph_manager_base import GraphManagerTest
 from conans.test.utils.tools import GenConanfile
@@ -56,7 +56,7 @@ class TestLinear(GraphManagerTest):
         deps_graph = self.build_consumer(consumer, install=False)
 
         # TODO: Better error handling
-        assert deps_graph.error.kind == GraphError.MISSING_RECIPE
+        assert type(deps_graph.error) == GraphMissingError
 
         self.assertEqual(1, len(deps_graph.nodes))
         app = deps_graph.root
@@ -1402,7 +1402,7 @@ class TestDiamond(GraphManagerTest):
         consumer = self.recipe_consumer("app/0.1", ["libb/0.1", "libc/0.1"])
         deps_graph = self.build_consumer(consumer, install=False)
 
-        assert deps_graph.error.kind == GraphError.VERSION_CONFLICT
+        assert type(deps_graph.error) == GraphConflictError
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
@@ -1426,7 +1426,7 @@ class TestDiamond(GraphManagerTest):
 
         deps_graph = self.build_consumer(consumer, install=False)
 
-        assert deps_graph.error.kind == GraphError.VERSION_CONFLICT
+        assert type(deps_graph.error) == GraphConflictError
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
@@ -1455,7 +1455,7 @@ class TestDiamond(GraphManagerTest):
 
         deps_graph = self.build_consumer(consumer, install=False)
 
-        assert deps_graph.error.kind == GraphError.VERSION_CONFLICT
+        assert type(deps_graph.error) == GraphConflictError
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
@@ -1636,7 +1636,7 @@ class TestDiamondMultiple(GraphManagerTest):
 
         deps_graph = self.build_consumer(consumer, install=False)
         # TODO: Better error modeling
-        assert deps_graph.error.kind == GraphError.LOOP
+        assert type(deps_graph.error) == GraphLoopError
 
         self.assertEqual(4, len(deps_graph.nodes))
 
@@ -1686,7 +1686,7 @@ class TransitiveOverridesGraphTest(GraphManagerTest):
 
         deps_graph = self.build_consumer(consumer, install=False)
         assert deps_graph.error is not False
-        assert deps_graph.error.kind == GraphError.VERSION_CONFLICT
+        assert type(deps_graph.error) == GraphConflictError
 
         self.assertEqual(2, len(deps_graph.nodes))
         app = deps_graph.root
@@ -1757,7 +1757,7 @@ class TransitiveOverridesGraphTest(GraphManagerTest):
         consumer = self.recipe_consumer("app/0.1", ["dep1/2.0", "dep2/1.0"])
         deps_graph = self.build_consumer(consumer, install=False)
 
-        assert deps_graph.error.kind == GraphError.VERSION_CONFLICT
+        assert type(deps_graph.error) == GraphConflictError
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
@@ -1991,7 +1991,7 @@ class TestProjectApp(GraphManagerTest):
                                                         build=False, run=True),
                                       install=False)
 
-        assert deps_graph.error.kind == GraphError.VERSION_CONFLICT
+        assert type(deps_graph.error) == GraphConflictError
 
     def test_project_require_apps_transitive(self):
         # project -> app1 (app type) -> lib
@@ -2040,7 +2040,7 @@ class TestProjectApp(GraphManagerTest):
                                                                                    "app2/0.1"),
                                       install=False)
 
-        assert deps_graph.error.kind == GraphError.VERSION_CONFLICT
+        assert type(deps_graph.error) == GraphConflictError
 
     def test_project_require_private(self):
         # project -(!visible)-> app1 -> lib1

--- a/conans/test/integration/graph/core/test_build_requires.py
+++ b/conans/test/integration/graph/core/test_build_requires.py
@@ -4,7 +4,7 @@ import pytest
 
 from parameterized import parameterized
 
-from conans.client.graph.graph_error import GraphError
+from conans.client.graph.graph_error import GraphConflictError, GraphLoopError, GraphRuntimeError
 from conans.model.recipe_ref import RecipeReference
 from conans.test.integration.graph.core.graph_manager_base import GraphManagerTest
 from conans.test.utils.tools import GenConanfile, NO_SETTINGS_PACKAGE_ID, TestClient
@@ -203,7 +203,7 @@ class TestBuildRequiresTransitivityDiamond(GraphManagerTest):
         deps_graph = self.build_graph(GenConanfile("app", "0.1").with_require("lib/0.1"),
                                       install=False)
 
-        assert deps_graph.error.kind == GraphError.RUNTIME
+        assert type(deps_graph.error) == GraphRuntimeError
 
         self.assertEqual(6, len(deps_graph.nodes))
         app = deps_graph.root
@@ -508,7 +508,7 @@ class PublicBuildRequiresTest(GraphManagerTest):
                                                                                "libc/0.1"),
                                       install=False)
 
-        assert deps_graph.error.kind == GraphError.VERSION_CONFLICT
+        assert type(deps_graph.error) == GraphConflictError
 
         # Build requires always apply to the consumer
         self.assertEqual(4, len(deps_graph.nodes))
@@ -617,7 +617,7 @@ class TestLoops(GraphManagerTest):
         deps_graph = self.build_graph(GenConanfile("app", "0.1").with_build_requires("cmake/0.1"),
                                       install=False)
 
-        assert deps_graph.error.kind == GraphError.LOOP
+        assert type(deps_graph.error) == GraphLoopError
 
         # Build requires always apply to the consumer
         self.assertEqual(2, len(deps_graph.nodes))
@@ -636,7 +636,7 @@ class TestLoops(GraphManagerTest):
         deps_graph = self.build_graph(GenConanfile().with_build_requires("cmake/0.1"),
                                       install=False)
 
-        assert deps_graph.error.kind == GraphError.LOOP
+        assert type(deps_graph.error) == GraphLoopError
 
         # Build requires always apply to the consumer
         self.assertEqual(4, len(deps_graph.nodes))

--- a/conans/test/integration/graph/core/test_options.py
+++ b/conans/test/integration/graph/core/test_options.py
@@ -1,4 +1,3 @@
-from conans.client.graph.graph_error import GraphError
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.integration.graph.core.graph_manager_base import GraphManagerTest
 from conans.test.integration.graph.core.graph_manager_test import _check_transitive

--- a/conans/test/integration/graph/core/test_provides.py
+++ b/conans/test/integration/graph/core/test_provides.py
@@ -2,7 +2,7 @@ import textwrap
 
 from parameterized import parameterized
 
-from conans.client.graph.graph_error import GraphError
+from conans.client.graph.graph_error import GraphProvidesError
 from conans.test.integration.graph.core.graph_manager_base import GraphManagerTest
 from conans.test.integration.graph.core.graph_manager_test import _check_transitive
 from conans.test.utils.tools import GenConanfile, TestClient
@@ -17,7 +17,7 @@ class TestProvidesTest(GraphManagerTest):
                                            with_requires("libb/0.1"))
         deps_graph = self.build_consumer(consumer, install=False)
 
-        assert deps_graph.error.kind == GraphError.PROVIDE_CONFLICT
+        assert type(deps_graph.error) == GraphProvidesError
 
         self.assertEqual(2, len(deps_graph.nodes))
         app = deps_graph.root
@@ -34,7 +34,7 @@ class TestProvidesTest(GraphManagerTest):
                                            with_requires("libb/0.1"))
         deps_graph = self.build_consumer(consumer, install=False)
 
-        assert deps_graph.error.kind == GraphError.PROVIDE_CONFLICT
+        assert type(deps_graph.error) == GraphProvidesError
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
@@ -60,7 +60,7 @@ class TestProvidesTest(GraphManagerTest):
                                                with_requires("libb/0.1", "libc/0.1"))
         deps_graph = self.build_consumer(consumer, install=False)
 
-        assert deps_graph.error.kind == GraphError.PROVIDE_CONFLICT
+        assert type(deps_graph.error) == GraphProvidesError
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
@@ -105,7 +105,7 @@ class TestProvidesTest(GraphManagerTest):
         consumer = self.recipe_consumer("app/0.1", ["libb/0.1", "libc/0.1"])
         deps_graph = self.build_consumer(consumer, install=False)
 
-        assert deps_graph.error.kind == GraphError.PROVIDE_CONFLICT
+        assert type(deps_graph.error) == GraphProvidesError
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
@@ -131,7 +131,7 @@ class TestProvidesTest(GraphManagerTest):
         consumer = self.recipe_consumer("app/0.1", ["libc/0.1"])
 
         deps_graph = self.build_consumer(consumer, install=False)
-        assert deps_graph.error.kind == GraphError.PROVIDE_CONFLICT
+        assert type(deps_graph.error) == GraphProvidesError
 
         self.assertEqual(4, len(deps_graph.nodes))
 
@@ -200,7 +200,7 @@ class ProvidesBuildRequireTest(GraphManagerTest):
 
         deps_graph = self.build_consumer(path, install=False)
 
-        assert deps_graph.error.kind == GraphError.PROVIDE_CONFLICT
+        assert type(deps_graph.error) == GraphProvidesError
 
         self.assertEqual(3, len(deps_graph.nodes))
 
@@ -221,7 +221,7 @@ class ProvidesBuildRequireTest(GraphManagerTest):
                                        .with_tool_requires("br1/0.1", "br2/0.1"))
         deps_graph = self.build_consumer(path, install=False)
 
-        assert deps_graph.error.kind == GraphError.PROVIDE_CONFLICT
+        assert type(deps_graph.error) == GraphProvidesError
 
         self.assertEqual(3, len(deps_graph.nodes))
 
@@ -256,5 +256,4 @@ def test_conditional():
     t.run("create requires.py")
     t.run("install app.py --name=app --version=version")
     t.run("install app.py --name=app --version=version -o app/*:conflict=True", assert_error=True)
-    # TODO: Improve the error diagnostics
-    assert "ERROR: provide conflict" in t.out
+    assert "ERROR: Provide Conflict: Both 'app/version' and 'req/v1' provide 'libjpeg'" in t.out

--- a/conans/test/integration/graph/core/test_version_ranges.py
+++ b/conans/test/integration/graph/core/test_version_ranges.py
@@ -3,7 +3,7 @@ from collections import OrderedDict
 import pytest
 
 from conan.api.model import Remote
-from conans.client.graph.graph_error import GraphError
+from conans.client.graph.graph_error import GraphConflictError, GraphMissingError
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.integration.graph.core.graph_manager_base import GraphManagerTest
 from conans.test.utils.tools import TestClient, TestServer, NO_SETTINGS_PACKAGE_ID
@@ -55,7 +55,7 @@ class TestVersionRanges(GraphManagerTest):
 
         deps_graph = self.build_consumer(consumer, install=False)
 
-        assert deps_graph.error.kind == GraphError.MISSING_RECIPE
+        assert type(deps_graph.error) == GraphMissingError
 
         self.assertEqual(1, len(deps_graph.nodes))
         app = deps_graph.root
@@ -68,7 +68,7 @@ class TestVersionRanges(GraphManagerTest):
 
         deps_graph = self.build_consumer(consumer, install=False)
 
-        assert deps_graph.error.kind == GraphError.MISSING_RECIPE
+        assert type(deps_graph.error) == GraphMissingError
 
         self.assertEqual(1, len(deps_graph.nodes))
         app = deps_graph.root
@@ -82,7 +82,7 @@ class TestVersionRanges(GraphManagerTest):
 
         deps_graph = self.build_consumer(consumer, install=False)
 
-        assert deps_graph.error.kind == GraphError.MISSING_RECIPE
+        assert type(deps_graph.error) == GraphMissingError
 
         self.assertEqual(1, len(deps_graph.nodes))
         app = deps_graph.root
@@ -96,7 +96,7 @@ class TestVersionRanges(GraphManagerTest):
 
         deps_graph = self.build_consumer(consumer, install=False)
 
-        assert deps_graph.error.kind == GraphError.MISSING_RECIPE
+        assert type(deps_graph.error) == GraphMissingError
 
         self.assertEqual(1, len(deps_graph.nodes))
         app = deps_graph.root
@@ -178,7 +178,7 @@ class TestVersionRangesDiamond(GraphManagerTest):
         consumer = self.recipe_consumer("app/0.1", ["libb/0.1", "libc/0.1"])
         deps_graph = self.build_consumer(consumer, install=False)
 
-        assert deps_graph.error.kind == GraphError.VERSION_CONFLICT
+        assert type(deps_graph.error) == GraphConflictError
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
@@ -201,7 +201,7 @@ class TestVersionRangesDiamond(GraphManagerTest):
         consumer = self.recipe_consumer("app/0.1", ["libb/0.1", "libc/0.1"])
         deps_graph = self.build_consumer(consumer, install=False)
 
-        assert deps_graph.error.kind == GraphError.VERSION_CONFLICT
+        assert type(deps_graph.error) == GraphConflictError
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
@@ -279,7 +279,7 @@ class TestVersionRangesOverridesDiamond(GraphManagerTest):
         consumer = self.recipe_consumer("app/0.1", ["libb/0.1", "liba/[>1.0]"])
         deps_graph = self.build_consumer(consumer, install=False)
 
-        assert deps_graph.error.kind == GraphError.VERSION_CONFLICT
+        assert type(deps_graph.error) == GraphConflictError
 
         self.assertEqual(2, len(deps_graph.nodes))
         app = deps_graph.root
@@ -335,7 +335,7 @@ class TestVersionRangesOverridesDiamond(GraphManagerTest):
                                            .with_requirement("liba/[<0.3]"))
         deps_graph = self.build_consumer(consumer, install=False)
 
-        assert deps_graph.error.kind == GraphError.VERSION_CONFLICT
+        assert type(deps_graph.error) == GraphConflictError
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root


### PR DESCRIPTION
Changelog: Fix: Improve `provides` conflict message error.
Docs: Omit

- Split up old `GraphError` generic class to specialized classes 
- No more consult `.kind` attribute, each class has its own information
- Update tests which depends on graph error
- Improve graph error messages.

fixes #13548

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
