### PR TITLE
fix conan list for packages with no settings or options

### DIFF
--- a/conans/search/search.py
+++ b/conans/search/search.py
@@ -55,14 +55,14 @@ def _evaluate(prop_name, prop_value, binary_info):
         return (_prop_value == setting_value) or (_prop_value == "None" and setting_value is None)
 
     # TODO: Necessary to generalize this query evaluation to include all possible fields
-    info_settings = binary_info.get("settings")
-    info_options = binary_info.get("options")
+    info_settings = binary_info.get("settings", {})
+    info_options = binary_info.get("options", {})
 
     if not prop_name.startswith("options."):
-        return compatible_prop(info_settings.get(prop_name, None), prop_value)
+        return compatible_prop(info_settings.get(prop_name), prop_value)
     else:
         prop_name = prop_name[len("options."):]
-        return compatible_prop(info_options.get(prop_name, None), prop_value)
+        return compatible_prop(info_options.get(prop_name), prop_value)
 
 
 def search_recipes(cache, pattern=None, ignorecase=True):


### PR DESCRIPTION
Changelog: Bugfix: ``conan list -p <package-query>`` failed when a package had no settings or options.
Docs: Omit
