### PR TITLE
extend --build-require to more commands and cases

### DIFF
--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -118,6 +118,8 @@ def graph_info(conan_api, parser, subparser, *args):
                            help='Print information only for packages that match the patterns')
     subparser.add_argument("--deploy", action="append",
                            help='Deploy using the provided deployer to the output folder')
+    subparser.add_argument("--build-require", action='store_true', default=False,
+                           help='Whether the provided reference is a build-require')
     args = parser.parse_args(*args)
 
     # parameter validation
@@ -141,7 +143,8 @@ def graph_info(conan_api, parser, subparser, *args):
                                                          args.user, args.channel,
                                                          profile_host, profile_build, lockfile,
                                                          remotes, args.update,
-                                                         check_updates=args.check_updates)
+                                                         check_updates=args.check_updates,
+                                                         is_build_require=args.build_require)
     else:
         deps_graph = conan_api.graph.load_graph_requires(args.requires, args.tool_requires,
                                                          profile_host, profile_build, lockfile,

--- a/conan/cli/commands/install.py
+++ b/conan/cli/commands/install.py
@@ -36,6 +36,8 @@ def install(conan_api, parser, *args):
                         help='The root output folder for generated and build files')
     parser.add_argument("--deploy", action="append",
                         help='Deploy using the provided deployer to the output folder')
+    parser.add_argument("--build-require", action='store_true', default=False,
+                        help='Whether the provided reference is a build-require')
     args = parser.parse_args(*args)
 
     validate_common_graph_args(args)
@@ -64,7 +66,8 @@ def install(conan_api, parser, *args):
         deps_graph = conan_api.graph.load_graph_consumer(path, args.name, args.version,
                                                          args.user, args.channel,
                                                          profile_host, profile_build, lockfile,
-                                                         remotes, args.update)
+                                                         remotes, args.update,
+                                                         is_build_require=args.build_require)
     else:
         deps_graph = conan_api.graph.load_graph_requires(args.requires, args.tool_requires,
                                                          profile_host, profile_build, lockfile,

--- a/conan/cli/commands/lock.py
+++ b/conan/cli/commands/lock.py
@@ -23,6 +23,8 @@ def lock_create(conan_api, parser, subparser, *args):
     Create a lockfile from a conanfile or a reference.
     """
     common_graph_args(subparser)
+    subparser.add_argument("--build-require", action='store_true', default=False,
+                           help='Whether the provided reference is a build-require')
     args = parser.parse_args(*args)
 
     # parameter validation
@@ -39,7 +41,8 @@ def lock_create(conan_api, parser, subparser, *args):
         graph = conan_api.graph.load_graph_consumer(path, args.name, args.version,
                                                     args.user, args.channel,
                                                     profile_host, profile_build, lockfile,
-                                                    remotes, args.build, args.update)
+                                                    remotes, args.build, args.update,
+                                                    is_build_require=args.build_require)
     else:
         graph = conan_api.graph.load_graph_requires(args.requires, args.tool_requires,
                                                     profile_host, profile_build, lockfile,

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -36,10 +36,6 @@ class DepsGraphBuilder(object):
         # print("Loading graph")
         dep_graph = DepsGraph()
 
-        # TODO: Why assign here the settings_build and settings_target?
-        root_node.conanfile.settings_build = profile_build.processed_settings.copy()
-        root_node.conanfile.settings_target = None
-
         self._prepare_node(root_node, profile_host, profile_build, Options())
         self._initialize_requires(root_node, dep_graph, graph_lock)
         dep_graph.add_node(root_node)

--- a/conans/test/integration/lockfile/test_lock_build_requires.py
+++ b/conans/test/integration/lockfile/test_lock_build_requires.py
@@ -1,4 +1,5 @@
 import json
+import textwrap
 
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
@@ -52,3 +53,67 @@ def test_lock_buildrequires_create_transitive():
     lock = json.loads(c.load("conan.lock"))
     assert "tool/0.1#e4f0da4d9097c4da0725ea25b8bf83c8" in lock["build_requires"][0]
     assert "dep/0.1#f8c2264d0b32a4c33f251fe2944bb642" in lock["build_requires"][1]
+
+
+def test_lock_create_build_require_transitive():
+    """ cross compiling from Windows to Linux
+    """
+    c = TestClient()
+    dep = textwrap.dedent("""
+        from conan import ConanFile
+        class Dep(ConanFile):
+            name = "dep"
+            settings = "os"
+            def package_id(self):
+                self.output.info(f"MYOS:{self.info.settings.os}!!")
+                self.output.info(f"TARGET:{self.settings_target.os}!!")
+            """)
+    tool = textwrap.dedent("""
+        from conan import ConanFile
+        class Tool(ConanFile):
+           name = "tool"
+           version = "0.1"
+           requires = "dep/[*]"
+           settings = "os"
+           def generate(self):
+               self.output.info(f"MYOS-GEN:{self.info.settings.os}!!")
+               self.output.info(f"TARGET-GEN:{self.settings_target.os}!!")
+           def package_id(self):
+               self.output.info(f"MYOS:{self.info.settings.os}!!")
+               self.output.info(f"TARGET:{self.settings_target.os}!!")
+           """)
+    c.save({"dep/conanfile.py": dep,
+            "tool/conanfile.py": tool})
+    c.run("create dep --build-require --version=0.1 -s:b os=Windows -s:h os=Linux")
+    assert "dep/0.1: MYOS:Windows!!" in c.out
+    assert "dep/0.1: TARGET:Linux!!" in c.out
+
+    # The lockfile should contain dep in build-requires
+    c.run("lock create tool --build-require -s:b os=Windows -s:h os=Linux")
+    assert "dep/0.1: MYOS:Windows!!" in c.out
+    assert "dep/0.1: TARGET:Linux!!" in c.out
+    lock = json.loads(c.load("tool/conan.lock"))
+    assert "dep/0.1" in lock["build_requires"][0]
+
+    # Now try to apply it in  graph info, even if a new 0.2 verion si there
+    c.run("create dep --build-require --version=0.2 -s:b os=Windows -s:h os=Linux")
+    assert "dep/0.2: MYOS:Windows!!" in c.out
+    assert "dep/0.2: TARGET:Linux!!" in c.out
+
+    c.run("graph info tool --build-require -s:b os=Windows -s:h os=Linux")
+    c.assert_listed_require({"dep/0.1": "Cache"}, build=True)
+    assert "dep/0.1: MYOS:Windows!!" in c.out
+    assert "dep/0.1: TARGET:Linux!!" in c.out
+    assert "conanfile.py (tool/0.1): MYOS:Windows!!" in c.out
+    assert "conanfile.py (tool/0.1): TARGET:Linux!!" in c.out
+    assert "context: build" in c.out
+    assert "context: host" not in c.out
+
+    c.run("install tool --build-require -s:b os=Windows -s:h os=Linux")
+    c.assert_listed_require({"dep/0.1": "Cache"}, build=True)
+    assert "dep/0.1: MYOS:Windows!!" in c.out
+    assert "dep/0.1: TARGET:Linux!!" in c.out
+    assert "conanfile.py (tool/0.1): MYOS:Windows!!" in c.out
+    assert "conanfile.py (tool/0.1): TARGET:Linux!!" in c.out
+    assert "conanfile.py (tool/0.1): MYOS-GEN:Windows!!" in c.out
+    assert "conanfile.py (tool/0.1): TARGET-GEN:Linux!!" in c.out


### PR DESCRIPTION
Changelog: Feature: extend ``--build-require`` to more commands (``graph info``, ``lock create``, ``install``) and cases.
Docs: https://github.com/conan-io/docs/pull/3166

