### PR TITLE
Add info_invalid to graph node serialization

### DIFF
--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -219,6 +219,7 @@ class Node(object):
         result["binary"] = self.binary
         # TODO: This doesn't match the model, check it
         result["invalid_build"] = self.cant_build
+        result["info_invalid"] = self.conanfile.info.invalid if self.conanfile.info is not None and self.conanfile.info.invalid is not None else False
         # Adding the conanfile information: settings, options, etc
         result.update(self.conanfile.serialize())
         result["context"] = self.context

--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -219,7 +219,7 @@ class Node(object):
         result["binary"] = self.binary
         # TODO: This doesn't match the model, check it
         result["invalid_build"] = self.cant_build
-        result["info_invalid"] = self.conanfile.info.invalid if self.conanfile.info is not None and self.conanfile.info.invalid is not None else False
+        result["info_invalid"] = getattr(getattr(self.conanfile, "info", None), "invalid", None)
         # Adding the conanfile information: settings, options, etc
         result.update(self.conanfile.serialize())
         result["context"] = self.context

--- a/conans/test/integration/command/info/info_test.py
+++ b/conans/test/integration/command/info/info_test.py
@@ -374,25 +374,6 @@ class TestErrorsInGraph:
         tc.run("graph info . -o 'pkg/1.0:myoption=True'")
         assert "info_invalid: pkg/1.0 does not support myoption=True" in tc.out
 
-    def test_invalid_bad_settings(self):
-        tc = TestClient()
-        conanfile = textwrap.dedent("""
-        from conan import ConanFile
-        from conan.errors import ConanInvalidConfiguration
-        class Pkg(ConanFile):
-            name = "pkg"
-            version = "1.0"
-            options = {"myoption": [True, False]}
-            default_options = {"myoption": False}
-
-            def package_id(self):
-                del self.info.options.myoption""")
-
-        tc.save({"conanfile.py": conanfile})
-        tc.run("graph info .")
-        assert "info_invalid: False" in tc.out
-        tc.run("graph info . -o 'pkg/1.0:myoption=True'")
-        assert "info_invalid: pkg/1.0 does not support myoption=True" in tc.out
 
 class TestInfoUpdate:
 

--- a/conans/test/integration/command/info/info_test.py
+++ b/conans/test/integration/command/info/info_test.py
@@ -97,8 +97,6 @@ class TestBasicCliOutput:
         assert recipe["provides"] == ["bar"]
 
 
-
-
 class TestConanfilePath:
     def test_cwd(self):
         # Check the first positional argument is a relative path
@@ -356,6 +354,45 @@ class TestErrorsInGraph:
         assert "ERROR: Package 'dep/0.1' not resolved: dep/0.1: Cannot load" in c.out
         assert exit_code == ERROR_GENERAL
 
+    def test_invalid_config_validate(self):
+        tc = TestClient()
+        conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.errors import ConanInvalidConfiguration
+        class Pkg(ConanFile):
+            name = "pkg"
+            version = "1.0"
+            options = {"myoption": [True, False]}
+            default_options = {"myoption": False}
+            def validate(self):
+                if self.options.myoption:
+                    raise ConanInvalidConfiguration(f"{self.ref} does not support myoption=True")""")
+
+        tc.save({"conanfile.py": conanfile})
+        tc.run("graph info .")
+        assert "info_invalid: False" in tc.out
+        tc.run("graph info . -o 'pkg/1.0:myoption=True'")
+        assert "info_invalid: pkg/1.0 does not support myoption=True" in tc.out
+
+    def test_invalid_bad_settings(self):
+        tc = TestClient()
+        conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.errors import ConanInvalidConfiguration
+        class Pkg(ConanFile):
+            name = "pkg"
+            version = "1.0"
+            options = {"myoption": [True, False]}
+            default_options = {"myoption": False}
+
+            def package_id(self):
+                del self.info.options.myoption""")
+
+        tc.save({"conanfile.py": conanfile})
+        tc.run("graph info .")
+        assert "info_invalid: False" in tc.out
+        tc.run("graph info . -o 'pkg/1.0:myoption=True'")
+        assert "info_invalid: pkg/1.0 does not support myoption=True" in tc.out
 
 class TestInfoUpdate:
 

--- a/conans/test/integration/command/info/info_test.py
+++ b/conans/test/integration/command/info/info_test.py
@@ -354,26 +354,6 @@ class TestErrorsInGraph:
         assert "ERROR: Package 'dep/0.1' not resolved: dep/0.1: Cannot load" in c.out
         assert exit_code == ERROR_GENERAL
 
-    def test_invalid_config_validate(self):
-        tc = TestClient()
-        conanfile = textwrap.dedent("""
-        from conan import ConanFile
-        from conan.errors import ConanInvalidConfiguration
-        class Pkg(ConanFile):
-            name = "pkg"
-            version = "1.0"
-            options = {"myoption": [True, False]}
-            default_options = {"myoption": False}
-            def validate(self):
-                if self.options.myoption:
-                    raise ConanInvalidConfiguration(f"{self.ref} does not support myoption=True")""")
-
-        tc.save({"conanfile.py": conanfile})
-        tc.run("graph info .")
-        assert "info_invalid: False" in tc.out
-        tc.run("graph info . -o 'pkg/1.0:myoption=True'")
-        assert "info_invalid: pkg/1.0 does not support myoption=True" in tc.out
-
 
 class TestInfoUpdate:
 

--- a/conans/test/integration/package_id/test_validate.py
+++ b/conans/test/integration/package_id/test_validate.py
@@ -40,10 +40,12 @@ class TestValidate(unittest.TestCase):
 
         client.run("graph info --require pkg/0.1 -s os=Windows")
         self.assertIn("binary: Invalid", client.out)
+        assert "info_invalid: Windows not supported" in client.out
 
         client.run("graph info --require pkg/0.1 -s os=Windows --format json")
         myjson = json.loads(client.stdout)
         self.assertEqual(myjson["nodes"][1]["binary"], BINARY_INVALID)
+        assert myjson["nodes"][1]["info_invalid"] == "Windows not supported" in client.out
 
     def test_validate_header_only(self):
         client = TestClient()


### PR DESCRIPTION
Changelog: Feature: Add info_invalid to graph node serialization
Docs: Omit

This would have been useful while debugging the cppstd issue in c3i, so I'm adding it to help the next person who find themselves wanting to know why InvalidConfiguration was raised. This might also help in other ways for `validate_build` in c3i :)

