### PR TITLE
add: hint that sha256 sum triggers download cache

### DIFF
--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -185,7 +185,7 @@ def download(conanfile, url, filename, verify=True, retry=None, retry_wait=None,
     :param headers: A dictionary with additional headers
     :param md5: MD5 hash code to check the downloaded file
     :param sha1: SHA-1 hash code to check the downloaded file
-    :param sha256: SHA-256 hash code to check the downloaded file
+    :param sha256: SHA-256 hash code to check the downloaded file. If set, the download is cached.
     """
     config = conanfile.conf
 


### PR DESCRIPTION
see https://github.com/conan-io/docs/issues/3505
and https://github.com/conan-io/conan/blob/release/2.0/conans/client/downloaders/caching_file_downloader.py#L30

Changelog: (Feature | Fix | Bugfix): Added doc line that sha256sum caches downloads
Docs: https://github.com/conan-io/docs/pull/XXXX

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
