### PR TITLE
Update CONTRIBUTING.md Pull Request Guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -25,7 +25,7 @@ To contribute follow the next steps:
 3. Fork the [Conan main repository](https://github.com/conan-io/conan) and create a `feature/xxx` branch from the `develop` branch and develop
    your fix/feature as discussed in previous step.
 4. Try to keep your branch updated with the `develop` branch to avoid conflicts.
-5. Open a pull request, and select `develop` as the base branch. Never open a pull request to ``release/xxx`` branches.
+5. Open a pull request, and select `develop` as the base branch. Never open a pull request to ``release/xxx`` branches, unless the branch is to be part of the next 2.0.X patch. In that case, the PR should be targeted to release/2.0.
 6. Add the text (besides other comments): "fixes #IssueNumber" in the body of the PR, referring to the issue of step 1.
 7. Submit a PR to the Conan documentation about the changes done providing examples if needed.
 


### PR DESCRIPTION
Changelog: omit
Docs: omit

In the comments of issue 8563, it appears that the contributing docs are outdated in regards to making a pull request to the Conan 2.0 branch 'release/2.0'. (See conversation below):
<img width="702" alt="image" src="https://user-images.githubusercontent.com/55863770/232358919-214d5cd9-08de-47c9-99cd-b0b41d113ef7.png">

I changed the text in bullet point 5 from the section "Dev-flow & Pull Requests" from "Never open a pull request to release/xxx branches." to "Never open a pull request to release/xxx branches, unless the branch is to be part of the next 2.0.X patch. In that case, the PR should be targeted to release/2.0."

I believe this is more accurate as @memsharded told me to make a pull request to 'release/2.0'