### PR TITLE
custom global generators in cache extensions/generators folder

### DIFF
--- a/conan/api/subapi/install.py
+++ b/conan/api/subapi/install.py
@@ -69,4 +69,4 @@ class InstallAPI:
 
         conanfile.generators = list(set(conanfile.generators).union(generators or []))
         app = ConanApp(self.conan_api.cache_folder)
-        write_generators(conanfile, app.hook_manager)
+        write_generators(conanfile, app)

--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -189,6 +189,10 @@ class ClientCache(object):
         return os.path.join(self.cache_folder, EXTENSIONS_FOLDER, CUSTOM_COMMANDS_FOLDER)
 
     @property
+    def custom_generators_path(self):
+        return os.path.join(self.cache_folder, EXTENSIONS_FOLDER, "generators")
+
+    @property
     def plugins_path(self):
         return os.path.join(self.cache_folder, EXTENSIONS_FOLDER, PLUGINS_FOLDER)
 

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -88,7 +88,7 @@ class _PackageBuilder(object):
                 raise ConanException("%s\nError copying sources to build folder" % msg)
 
     def _build(self, conanfile, pref):
-        write_generators(conanfile, self._hook_manager)
+        write_generators(conanfile, self._app)
 
         try:
             run_build_method(conanfile, self._hook_manager)
@@ -351,7 +351,7 @@ class BinaryInstaller:
         output = conanfile.output
         output.info("Rewriting files of editable package "
                     "'{}' at '{}'".format(conanfile.name, conanfile.generators_folder))
-        write_generators(conanfile, self._hook_manager)
+        write_generators(conanfile, self._app)
 
         if node.binary == BINARY_EDITABLE_BUILD:
             run_build_method(conanfile, self._hook_manager)

--- a/conans/test/integration/generators/test_custom_global_generators.py
+++ b/conans/test/integration/generators/test_custom_global_generators.py
@@ -1,0 +1,69 @@
+import os
+import textwrap
+
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.tools import TestClient
+from conans.util.files import save
+
+
+def test_custom_global_generator():
+    c = TestClient()
+    generator = textwrap.dedent("""
+        class MyCustomGenerator:
+            def __init__(self, conanfile):
+                self._conanfile = conanfile
+            def generate(self):
+                pkg = self._conanfile.dependencies["pkg"].ref
+                self._conanfile.output.info(f"DEP: {pkg}!!")
+        """)
+    save(os.path.join(c.cache.custom_generators_path, "mygen.py"), generator)
+    conanfile = textwrap.dedent("""
+        [requires]
+        pkg/0.1
+
+        [generators]
+        MyCustomGenerator
+        """)
+    c.save({"pkg/conanfile.py": GenConanfile("pkg", "0.1"),
+            "conanfile.txt": conanfile})
+    c.run("create pkg")
+    c.run("install .")
+    assert "conanfile.txt: Generator 'MyCustomGenerator' calling 'generate()'" in c.out
+    assert "conanfile.txt: DEP: pkg/0.1!!" in c.out
+
+    # By CLI also works
+    conanfile = textwrap.dedent("""
+        [requires]
+        pkg/0.1
+        """)
+    c.save({"conanfile.txt": conanfile})
+    c.run("install . -g MyCustomGenerator")
+    assert "conanfile.txt: Generator 'MyCustomGenerator' calling 'generate()'" in c.out
+    assert "conanfile.txt: DEP: pkg/0.1!!" in c.out
+
+
+def test_custom_global_generator_imports():
+    """
+    our custom generator can use python imports
+    """
+    c = TestClient()
+    generator = textwrap.dedent("""
+        from _myfunc import mygenerate
+
+        class MyCustomGenerator:
+            def __init__(self, conanfile):
+                self._conanfile = conanfile
+            def generate(self):
+                mygenerate(self._conanfile)
+        """)
+    myaux = textwrap.dedent("""
+        def mygenerate(conanfile):
+            conanfile.output.info("MYGENERATE WORKS!!")
+        """)
+    save(os.path.join(c.cache.custom_generators_path, "mygen.py"), generator)
+    save(os.path.join(c.cache.custom_generators_path, "_myfunc.py"), myaux)
+
+    c.save({"conanfile.txt": ""})
+    c.run("install . -g MyCustomGenerator")
+    assert "conanfile.txt: Generator 'MyCustomGenerator' calling 'generate()'" in c.out
+    assert "conanfile.txt: MYGENERATE WORKS!!" in c.out

--- a/conans/test/integration/generators/test_custom_global_generators.py
+++ b/conans/test/integration/generators/test_custom_global_generators.py
@@ -41,6 +41,18 @@ def test_custom_global_generator():
     assert "conanfile.txt: Generator 'MyCustomGenerator' calling 'generate()'" in c.out
     assert "conanfile.txt: DEP: pkg/0.1!!" in c.out
 
+    # In conanfile.py also works
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        class MyPkg(ConanFile):
+            requires = "pkg/0.1"
+            generators = "MyCustomGenerator"
+            """)
+    c.save({"conanfile.py": conanfile}, clean_first=True)
+    c.run("install . ")
+    assert "conanfile.py: Generator 'MyCustomGenerator' calling 'generate()'" in c.out
+    assert "conanfile.py: DEP: pkg/0.1!!" in c.out
+
 
 def test_custom_global_generator_imports():
     """


### PR DESCRIPTION
Changelog: Feature: New global custom generators in cache "extensions/generators" that can be used by name.
Docs: https://github.com/conan-io/docs/pull/3213

Close https://github.com/conan-io/conan/issues/13709
