### PR TITLE
Render profile name when using Jinja2

### DIFF
--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -158,9 +158,11 @@ class ProfileLoader:
 
         # All profiles will be now rendered with jinja2 as first pass
         base_path = os.path.dirname(profile_path)
+        file_path = os.path.basename(profile_path)
         context = {"platform": platform,
                    "os": os,
                    "profile_dir": base_path,
+                   "profile_name": file_path,
                    "conan_version": conan_version}
         rtemplate = Environment(loader=FileSystemLoader(base_path)).from_string(text)
         text = rtemplate.render(context)

--- a/conans/test/integration/configuration/test_profile_jinja.py
+++ b/conans/test/integration/configuration/test_profile_jinja.py
@@ -6,7 +6,6 @@ from conan import conan_version
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
 from conans.util.env import environment_update
-from conan.tools.files import save
 
 
 def test_profile_template():
@@ -125,7 +124,6 @@ def test_profile_template_profile_name():
         """)
     default = textwrap.dedent("""
         [settings]
-        os=Windows
         [conf]
         user.profile:name = {{ profile_name }}
         """)

--- a/conans/test/integration/configuration/test_profile_jinja.py
+++ b/conans/test/integration/configuration/test_profile_jinja.py
@@ -124,6 +124,7 @@ def test_profile_template_profile_name():
         """)
     default = textwrap.dedent("""
         [settings]
+        os=Windows
         [conf]
         user.profile:name = {{ profile_name }}
         """)


### PR DESCRIPTION
Parse the profile file name (including its extension) as profile_name for Jinja2 context.

Changelog: Feature: Render the profile file name as profile_name
Docs: https://github.com/conan-io/docs/pull/3180

closes #13698

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
