### PR TITLE
Split build & compilation verbosity control into two confs

### DIFF
--- a/conan/tools/apple/xcodebuild.py
+++ b/conan/tools/apple/xcodebuild.py
@@ -12,26 +12,25 @@ class XcodeBuild(object):
 
     @property
     def _verbosity(self):
-        verbosity = self._conanfile.conf.get("tools.build:verbosity")
+        verbosity = self._conanfile.conf.get("tools.build:verbosity", choices=("quiet", "error",
+                                                                               "warning", "notice",
+                                                                               "status", "normal",
+                                                                               "verbose", "debug",
+                                                                               "v", "trace", "vv"))
         if verbosity:
-            if verbosity not in ("quiet", "error", "warning", "notice", "status", "verbose",
-                                 "normal", "debug", "v", "trace", "vv"):
-                raise ConanException(f"Value '{verbosity}' for 'tools.build:verbosity' is not valid")
-            else:
-                # quiet, nothing, verbose
-                verbosity = {"quiet": "quiet",
-                             "error": "quiet",
-                             "warning": "quiet",
-                             "notice": "quiet",
-                             "status": None,
-                             "verbose": None,
-                             "normal": None,
-                             "debug": "verbose",
-                             "v": "verbose",
-                             "trace": "verbose",
-                             "vv": "verbose"}.get(verbosity)
-                if verbosity is not None:
-                    return "-{}".format(verbosity)
+            verbosity = {"quiet": "quiet",
+                         "error": "quiet",
+                         "warning": "quiet",
+                         "notice": "quiet",
+                         "status": None,
+                         "normal": None,
+                         "verbose": None,
+                         "debug": "verbose",
+                         "v": "verbose",
+                         "trace": "verbose",
+                         "vv": "verbose"}.get(verbosity)
+            if verbosity is not None:
+                return "-{}".format(verbosity)
         return ""
 
     @property

--- a/conan/tools/apple/xcodebuild.py
+++ b/conan/tools/apple/xcodebuild.py
@@ -12,26 +12,10 @@ class XcodeBuild(object):
 
     @property
     def _verbosity(self):
-        verbosity = self._conanfile.conf.get("tools.build:verbosity", choices=("quiet", "error",
-                                                                               "warning", "notice",
-                                                                               "status", "normal",
-                                                                               "verbose", "debug",
-                                                                               "v", "trace", "vv"))
-        if verbosity:
-            verbosity = {"quiet": "quiet",
-                         "error": "quiet",
-                         "warning": "quiet",
-                         "notice": "quiet",
-                         "status": None,
-                         "normal": None,
-                         "verbose": None,
-                         "debug": "verbose",
-                         "v": "verbose",
-                         "trace": "verbose",
-                         "vv": "verbose"}.get(verbosity)
-            if verbosity is not None:
-                return "-{}".format(verbosity)
-        return ""
+        verbosity = self._conanfile.conf.get("tools.build:verbosity", choices=("quiet", "verbose")) \
+                    or self._conanfile.conf.get("tools.compilation:verbosity",
+                                                choices=("quiet", "verbose"))
+        return "-" + verbosity if verbosity is not None else ""
 
     @property
     def _sdkroot(self):

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -106,7 +106,7 @@ class CMake(object):
 
         verbosity = self._verbosity
         if verbosity is not None:
-            arg_list.append(f'--log-level="{verbosity}"')
+            arg_list.append(f'--loglevel={verbosity}')
 
         if cli_args:
             arg_list.extend(cli_args)

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -106,7 +106,7 @@ class CMake(object):
 
         verbosity = self._verbosity
         if verbosity is not None:
-            arg_list.append(f"--log-level={verbosity}")
+            arg_list.append(f'--log-level="{verbosity}"')
 
         if cli_args:
             arg_list.extend(cli_args)

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -104,6 +104,10 @@ class CMake(object):
         arg_list.extend(['-D{}="{}"'.format(k, v) for k, v in self._cache_variables.items()])
         arg_list.append('"{}"'.format(cmakelist_folder))
 
+        verbosity = self._verbosity
+        if verbosity is not None:
+            arg_list.append(f"--log-level={verbosity}")
+
         if cli_args:
             arg_list.extend(cli_args)
 
@@ -209,3 +213,19 @@ class CMake(object):
         env = ["conanbuild", "conanrun"] if env == "" else env
         self._build(build_type=build_type, target=target, cli_args=cli_args,
                     build_tool_args=build_tool_args, env=env)
+
+    @property
+    def _verbosity(self):
+        verbosity = self._conanfile.conf.get("tools.build:verbosity")
+        if verbosity:
+            # ERROR, WARNING, NOTICE, STATUS (default), VERBOSE, DEBUG, or TRACE
+            verbosities = {
+
+            }
+            if verbosity not in ("quiet", "error", "warning", "notice", "status", "normal",
+                                 "verbose", "debug", "v", "trace", "vv"):
+                raise ConanException(f"Unknown value '{verbosity}' for 'tools.build:verbosity'")
+            else:
+                # We map 1:1 to CMake's log levels
+                return verbosity
+        return None

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -134,10 +134,11 @@ class CMake(object):
         cmd_line_args = _cmake_cmd_line_args(self._conanfile, self._generator)
         if build_tool_args:
             cmd_line_args.extend(build_tool_args)
-        if cmd_line_args:
-            args += ['--'] + cmd_line_args
 
         args.extend(self._compilation_verbosity_arg)
+
+        if cmd_line_args:
+            args += ['--'] + cmd_line_args
 
         arg_list = ['"{}"'.format(bf), build_config, cmd_args_to_string(args)]
         arg_list = " ".join(filter(None, arg_list))

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -216,16 +216,15 @@ class CMake(object):
 
     @property
     def _verbosity(self):
-        verbosity = self._conanfile.conf.get("tools.build:verbosity")
+        verbosity = self._conanfile.conf.get("tools.build:verbosity", choices=("quiet", "error",
+                                                                               "warning", "notice",
+                                                                               "status", "normal",
+                                                                               "verbose", "debug",
+                                                                               "v", "trace", "vv"))
         if verbosity:
-            # ERROR, WARNING, NOTICE, STATUS (default), VERBOSE, DEBUG, or TRACE
-            verbosities = {
-
-            }
-            if verbosity not in ("quiet", "error", "warning", "notice", "status", "normal",
-                                 "verbose", "debug", "v", "trace", "vv"):
-                raise ConanException(f"Unknown value '{verbosity}' for 'tools.build:verbosity'")
-            else:
-                # We map 1:1 to CMake's log levels
-                return verbosity
+            # Our verbosity maps to CMake's in most except for these 4
+            return {"quiet": "ERROR",
+                    "normal": "STATUS",
+                    "v": "DEBUG",
+                    "vv": "TRACE"}.get(verbosity, verbosity).upper()
         return None

--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -104,25 +104,13 @@ class Meson(object):
         # verbosity of build tools. This passes -v to ninja, for example.
         # See https://github.com/mesonbuild/meson/blob/master/mesonbuild/mcompile.py#L156
         verbosity = self._conanfile.conf.get("tools.compilation:verbosity",
-                                             choices=("quiet", "error",
-                                                      "warning", "notice",
-                                                      "status", "normal",
-                                                      "verbose", "debug",
-                                                      "v", "trace", "vv"))
-        if verbosity in ("verbose", "debug", "v", "trace", "vv"):
-            return "--verbose"
-        return ""
+                                             choices=("quiet", "verbose"))
+        return "--verbose" if verbosity == "verbose" else ""
 
     @property
     def _install_verbosity(self):
         # https://github.com/mesonbuild/meson/blob/master/mesonbuild/minstall.py#L81
         # Errors are always logged, and status about installed files is controlled by this flag,
         # so it's a bit backwards
-        verbosity = self._conanfile.conf.get("tools.build:verbosity", choices=("quiet", "error",
-                                                                               "warning", "notice",
-                                                                               "status", "normal",
-                                                                               "verbose", "debug",
-                                                                               "v", "trace", "vv"))
-        if verbosity == "quiet":
-            return "--quiet"
-        return ""
+        verbosity = self._conanfile.conf.get("tools.build:verbosity", choices=("quiet", "verbose"))
+        return "--quiet" if verbosity else ""

--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -2,6 +2,7 @@ import os
 
 from conan.tools.build import build_jobs
 from conan.tools.meson.toolchain import MesonToolchain
+from conans.errors import ConanException
 
 
 class Meson(object):
@@ -67,6 +68,9 @@ class Meson(object):
             cmd += " -j{}".format(njobs)
         if target:
             cmd += " {}".format(target)
+        verbosity = self._build_verbosity
+        if verbosity:
+            cmd += " " + verbosity
         self._conanfile.output.info("Meson build cmd: {}".format(cmd))
         self._conanfile.run(cmd)
 
@@ -78,6 +82,9 @@ class Meson(object):
         self.configure(reconfigure=True)  # To re-do the destination package-folder
         meson_build_folder = self._conanfile.build_folder
         cmd = 'meson install -C "{}"'.format(meson_build_folder)
+        verbosity = self._install_verbosity
+        if verbosity:
+            cmd += " " + verbosity
         self._conanfile.run(cmd)
 
     def test(self):
@@ -91,3 +98,28 @@ class Meson(object):
         # TODO: Do we need vcvars for test?
         # TODO: This should use conanrunenv, but what if meson itself is a build-require?
         self._conanfile.run(cmd)
+
+    @property
+    def _build_verbosity(self):
+        verbosity = self._conanfile.conf.get("tools.build:verbosity")
+        if verbosity:
+            if verbosity not in ("quiet", "error", "warning", "notice", "status", "normal",
+                                 "verbose", "debug", "v", "trace", "vv"):
+                raise ConanException(f"Unknown value '{verbosity}' for 'tools.build:verbosity'")
+            elif verbosity in ("verbose", "debug", "v", "trace", "vv"):
+                return "--verbose"
+        return ""
+
+    @property
+    def _install_verbosity(self):
+        verbosity = self._conanfile.conf.get("tools.build:verbosity")
+        if verbosity:
+            if verbosity not in ("quiet", "error", "warning", "notice", "status", "normal",
+                                 "verbose", "debug", "v", "trace", "vv"):
+                raise ConanException(f"Unknown value '{verbosity}' for 'tools.build:verbosity'")
+            elif verbosity == "quiet":
+                # https://github.com/mesonbuild/meson/blob/master/mesonbuild/minstall.py
+                # Errors are always logged, and status about installed files is controlled by this flag,
+                # so it's a bit backwards
+                return "--quiet"
+        return ""

--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -101,25 +101,25 @@ class Meson(object):
 
     @property
     def _build_verbosity(self):
-        verbosity = self._conanfile.conf.get("tools.build:verbosity")
-        if verbosity:
-            if verbosity not in ("quiet", "error", "warning", "notice", "status", "normal",
-                                 "verbose", "debug", "v", "trace", "vv"):
-                raise ConanException(f"Unknown value '{verbosity}' for 'tools.build:verbosity'")
-            elif verbosity in ("verbose", "debug", "v", "trace", "vv"):
-                return "--verbose"
+        verbosity = self._conanfile.conf.get("tools.build:verbosity", choices=("quiet", "error",
+                                                                               "warning", "notice",
+                                                                               "status", "normal",
+                                                                               "verbose", "debug",
+                                                                               "v", "trace", "vv"))
+        if verbosity in ("verbose", "debug", "v", "trace", "vv"):
+            return "--verbose"
         return ""
 
     @property
     def _install_verbosity(self):
-        verbosity = self._conanfile.conf.get("tools.build:verbosity")
-        if verbosity:
-            if verbosity not in ("quiet", "error", "warning", "notice", "status", "normal",
-                                 "verbose", "debug", "v", "trace", "vv"):
-                raise ConanException(f"Unknown value '{verbosity}' for 'tools.build:verbosity'")
-            elif verbosity == "quiet":
-                # https://github.com/mesonbuild/meson/blob/master/mesonbuild/minstall.py
-                # Errors are always logged, and status about installed files is controlled by this flag,
-                # so it's a bit backwards
-                return "--quiet"
+        verbosity = self._conanfile.conf.get("tools.build:verbosity", choices=("quiet", "error",
+                                                                               "warning", "notice",
+                                                                               "status", "normal",
+                                                                               "verbose", "debug",
+                                                                               "v", "trace", "vv"))
+        if verbosity == "quiet":
+            # https://github.com/mesonbuild/meson/blob/master/mesonbuild/minstall.py
+            # Errors are always logged, and status about installed files is controlled by this flag,
+            # so it's a bit backwards
+            return "--quiet"
         return ""

--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -101,25 +101,28 @@ class Meson(object):
 
     @property
     def _build_verbosity(self):
-        verbosity = self._conanfile.conf.get("tools.build:verbosity", choices=("quiet", "error",
-                                                                               "warning", "notice",
-                                                                               "status", "normal",
-                                                                               "verbose", "debug",
-                                                                               "v", "trace", "vv"))
+        # verbosity of build tools. This passes -v to ninja, for example.
+        # See https://github.com/mesonbuild/meson/blob/master/mesonbuild/mcompile.py#L156
+        verbosity = self._conanfile.conf.get("tools.compilation:verbosity",
+                                             choices=("quiet", "error",
+                                                      "warning", "notice",
+                                                      "status", "normal",
+                                                      "verbose", "debug",
+                                                      "v", "trace", "vv"))
         if verbosity in ("verbose", "debug", "v", "trace", "vv"):
             return "--verbose"
         return ""
 
     @property
     def _install_verbosity(self):
+        # https://github.com/mesonbuild/meson/blob/master/mesonbuild/minstall.py#L81
+        # Errors are always logged, and status about installed files is controlled by this flag,
+        # so it's a bit backwards
         verbosity = self._conanfile.conf.get("tools.build:verbosity", choices=("quiet", "error",
                                                                                "warning", "notice",
                                                                                "status", "normal",
                                                                                "verbose", "debug",
                                                                                "v", "trace", "vv"))
         if verbosity == "quiet":
-            # https://github.com/mesonbuild/meson/blob/master/mesonbuild/minstall.py
-            # Errors are always logged, and status about installed files is controlled by this flag,
-            # so it's a bit backwards
             return "--quiet"
         return ""

--- a/conan/tools/microsoft/msbuild.py
+++ b/conan/tools/microsoft/msbuild.py
@@ -2,24 +2,16 @@ from conans.errors import ConanException
 
 
 def msbuild_verbosity_cmd_line_arg(conanfile):
-    verbosity = conanfile.conf.get("tools.build:verbosity", choices=("quiet", "error",
-                                                                     "warning", "notice",
-                                                                     "status", "normal",
-                                                                     "verbose", "debug",
-                                                                     "v", "trace", "vv"))
+    """
+    Controls msbuild verbosity.
+    See https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-command-line-reference
+    :return:
+    """
+    verbosity = conanfile.conf.get("tools.build:verbosity", choices=("quiet", "verbose"))
     if verbosity is not None:
         verbosity = {
             "quiet": "Quiet",
-            "error": "Minimal",
-            "warning": "Minimal",
-            "notice": "Minimal",
-            "status": "Normal",
-            "verbose": "Normal",
-            "normal": "Normal",
-            "debug": "Detailed",
-            "v": "Detailed",
-            "trace": "Diagnostic",
-            "vv": "Diagnostic"
+            "verbose": "Detailed",
         }.get(verbosity)
         return f'/verbosity:{verbosity}'
     return ""

--- a/conan/tools/microsoft/msbuild.py
+++ b/conan/tools/microsoft/msbuild.py
@@ -2,27 +2,25 @@ from conans.errors import ConanException
 
 
 def msbuild_verbosity_cmd_line_arg(conanfile):
-    verbosity = conanfile.conf.get("tools.build:verbosity")
-    if verbosity:
-        if verbosity not in ("quiet", "error", "warning", "notice", "status", "verbose",
-                             "normal", "debug", "v", "trace", "vv"):
-            raise ConanException(f"Unknown value '{verbosity}' for 'tools.build:verbosity'")
-        else:
-            # "Quiet", "Minimal", "Normal", "Detailed", "Diagnostic"
-            verbosity = {
-                "quiet": "Quiet",
-                "error": "Minimal",
-                "warning": "Minimal",
-                "notice": "Minimal",
-                "status": "Normal",
-                "verbose": "Normal",
-                "normal": "Normal",
-                "debug": "Detailed",
-                "v": "Detailed",
-                "trace": "Diagnostic",
-                "vv": "Diagnostic"
-            }.get(verbosity)
-            return '/verbosity:{}'.format(verbosity)
+    verbosity = conanfile.conf.get("tools.build:verbosity", choices=("quiet", "error",
+                                                                     "warning", "notice",
+                                                                     "status", "normal",
+                                                                     "verbose", "debug",
+                                                                     "v", "trace", "vv"))
+    verbosity = {
+        "quiet": "Quiet",
+        "error": "Minimal",
+        "warning": "Minimal",
+        "notice": "Minimal",
+        "status": "Normal",
+        "verbose": "Normal",
+        "normal": "Normal",
+        "debug": "Detailed",
+        "v": "Detailed",
+        "trace": "Diagnostic",
+        "vv": "Diagnostic"
+    }.get(verbosity)
+    return f'/verbosity:{verbosity}'
 
 
 def msbuild_arch(arch):

--- a/conan/tools/microsoft/msbuild.py
+++ b/conan/tools/microsoft/msbuild.py
@@ -7,20 +7,22 @@ def msbuild_verbosity_cmd_line_arg(conanfile):
                                                                      "status", "normal",
                                                                      "verbose", "debug",
                                                                      "v", "trace", "vv"))
-    verbosity = {
-        "quiet": "Quiet",
-        "error": "Minimal",
-        "warning": "Minimal",
-        "notice": "Minimal",
-        "status": "Normal",
-        "verbose": "Normal",
-        "normal": "Normal",
-        "debug": "Detailed",
-        "v": "Detailed",
-        "trace": "Diagnostic",
-        "vv": "Diagnostic"
-    }.get(verbosity)
-    return f'/verbosity:{verbosity}'
+    if verbosity is not None:
+        verbosity = {
+            "quiet": "Quiet",
+            "error": "Minimal",
+            "warning": "Minimal",
+            "notice": "Minimal",
+            "status": "Normal",
+            "verbose": "Normal",
+            "normal": "Normal",
+            "debug": "Detailed",
+            "v": "Detailed",
+            "trace": "Diagnostic",
+            "vv": "Diagnostic"
+        }.get(verbosity)
+        return f'/verbosity:{verbosity}'
+    return ""
 
 
 def msbuild_arch(arch):

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -51,10 +51,8 @@ BUILT_IN_CONFS = {
     "tools.build:sysroot": "Pass the --sysroot=<tools.build:sysroot> flag if available. (None by default)",
     "tools.build.cross_building:can_run": "Bool value that indicates whether is possible to run a non-native "
                                           "app on the same architecture. It's used by 'can_run' tool",
-    "tools.build:verbosity": "Verbosity of build systems. "
-                             "Possible values are 'quiet', 'error', 'warning', 'notice', 'status', 'verbose', 'normal', 'debug', 'v', 'trace' and 'vv'",
-    "tools.compilation:verbosity": "Verbosity of compilation tools. "
-                                   "Possible values are 'quiet', 'error', 'warning', 'notice', 'status', 'verbose', 'normal', 'debug', 'v', 'trace' and 'vv'",
+    "tools.build:verbosity": "Verbosity of build systems if set. Possible values are 'quiet' and 'verbose'",
+    "tools.compilation:verbosity": "Verbosity of compilation tools if set. Possible values are 'quiet' and 'verbose'",
     "tools.cmake.cmaketoolchain:generator": "User defined CMake generator to use instead of default",
     "tools.cmake.cmaketoolchain:find_package_prefer_config": "Argument for the CMAKE_FIND_PACKAGE_PREFER_CONFIG",
     "tools.cmake.cmaketoolchain:toolchain_file": "Use other existing file rather than conan_toolchain.cmake one",

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -276,7 +276,7 @@ class Conf:
         for k, v in self._values.items():
             yield k, v.value
 
-    def get(self, conf_name, default=None, check_type=None):
+    def get(self, conf_name, default=None, check_type=None, choices=None):
         """
         Get all the values of the given configuration name.
 
@@ -293,6 +293,8 @@ class Conf:
         conf_value = self._values.get(conf_name)
         if conf_value:
             v = conf_value.value
+            if choices is not None and v not in choices:
+                raise ConanException(f"Unknown value '{v}' for '{conf_name}'")
             # Some smart conversions
             if check_type is bool and not isinstance(v, bool):
                 # Perhaps, user has introduced a "false", "0" or even "off"
@@ -495,13 +497,13 @@ class ConfDefinition:
     def __bool__(self):
         return bool(self._pattern_confs)
 
-    def get(self, conf_name, default=None, check_type=None):
+    def get(self, conf_name, default=None, check_type=None, choices=None):
         """
         Get the value of the conf name requested and convert it to the [type]-like passed.
         """
         pattern, name = self._split_pattern_name(conf_name)
         return self._pattern_confs.get(pattern, Conf()).get(name, default=default,
-                                                            check_type=check_type)
+                                                            check_type=check_type, choices=choices)
 
     def show(self, fnpattern):
         """

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -51,8 +51,10 @@ BUILT_IN_CONFS = {
     "tools.build:sysroot": "Pass the --sysroot=<tools.build:sysroot> flag if available. (None by default)",
     "tools.build.cross_building:can_run": "Bool value that indicates whether is possible to run a non-native "
                                           "app on the same architecture. It's used by 'can_run' tool",
-    "tools.build:verbosity": "Verbosity of MSBuild and XCodeBuild build systems. "
+    "tools.build:verbosity": "Verbosity of build systems. "
                              "Possible values are 'quiet', 'error', 'warning', 'notice', 'status', 'verbose', 'normal', 'debug', 'v', 'trace' and 'vv'",
+    "tools.compilation:verbosity": "Verbosity of compilation tools. "
+                                   "Possible values are 'quiet', 'error', 'warning', 'notice', 'status', 'verbose', 'normal', 'debug', 'v', 'trace' and 'vv'",
     "tools.cmake.cmaketoolchain:generator": "User defined CMake generator to use instead of default",
     "tools.cmake.cmaketoolchain:find_package_prefer_config": "Argument for the CMAKE_FIND_PACKAGE_PREFER_CONFIG",
     "tools.cmake.cmaketoolchain:toolchain_file": "Use other existing file rather than conan_toolchain.cmake one",

--- a/conans/test/functional/toolchains/apple/test_xcodebuild.py
+++ b/conans/test/functional/toolchains/apple/test_xcodebuild.py
@@ -91,7 +91,8 @@ def test_project_xcodebuild(client):
     client.run("install . --build=missing")
     client.run("install . -s build_type=Debug --build=missing")
     client.run_command("xcodegen generate")
-    client.run("create . --build=missing")
+    client.run("create . --build=missing -c tools.build:verbosity=verbose -c tools.compilation:verbosity=verbose")
+    assert "xcodebuild: error: invalid option" not in client.out
     assert "hello/0.1: Hello World Release!" in client.out
     assert "App Release!" in client.out
     client.run("create . -s build_type=Debug --build=missing")

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -557,7 +557,10 @@ class CMakeInstallTest(unittest.TestCase):
                      "header.h": "# my header file"})
 
         # The create flow must work
-        client.run("create . --name=pkg --version=0.1")
+        client.run("create . --name=pkg --version=0.1 -c tools.build:verbosity=verbose -c tools.compilation:verbosity=verbose")
+        assert "--loglevel=VERBOSE" in client.out
+        assert "unrecognized option" not in client.out
+        assert "--verbose" in client.out
         self.assertIn("pkg/0.1: package(): Packaged 1 '.h' file: header.h", client.out)
         ref = RecipeReference.loads("pkg/0.1")
         pref = client.get_latest_package_reference(ref)
@@ -731,12 +734,3 @@ class TestCMakeFindPackagePreferConfig:
         client.run("build . --profile=profile_false")
         assert "using FindComandante.cmake" in client.out
 
-
-@pytest.mark.tool("cmake")
-def test_cmake_verbosity():
-    tc = TestClient()
-    tc.run("new cmake_exe -d name=pkg -d version=1.0")
-    tc.run("create . -c tools.build:verbosity=verbose -c tools.compilation:verbosity=verbose")
-    assert "--loglevel=VERBOSE" in tc.out
-    assert "unrecognized option" not in tc.out
-    assert "--verbose" in tc.out

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -736,7 +736,7 @@ class TestCMakeFindPackagePreferConfig:
 def test_cmake_verbosity():
     tc = TestClient()
     tc.run("new cmake_exe -d name=pkg -d version=1.0")
-    tc.run("create . -c tools.build:verbosity=trace -c tools.compilation:verbosity=trace")
-    assert "--loglevel=TRACE --trace" in tc.out
+    tc.run("create . -c tools.build:verbosity=verbose -c tools.compilation:verbosity=verbose")
+    assert "--loglevel=VERBOSE" in tc.out
     assert "unrecognized option" not in tc.out
     assert "--verbose" in tc.out

--- a/conans/test/functional/toolchains/cmake/test_cmake.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake.py
@@ -730,3 +730,13 @@ class TestCMakeFindPackagePreferConfig:
 
         client.run("build . --profile=profile_false")
         assert "using FindComandante.cmake" in client.out
+
+
+@pytest.mark.tool("cmake")
+def test_cmake_verbosity():
+    tc = TestClient()
+    tc.run("new cmake_exe -d name=pkg -d version=1.0")
+    tc.run("create . -c tools.build:verbosity=trace -c tools.compilation:verbosity=trace")
+    assert "--loglevel=TRACE --trace" in tc.out
+    assert "unrecognized option" not in tc.out
+    assert "--verbose" in tc.out

--- a/conans/test/functional/toolchains/meson/test_install.py
+++ b/conans/test/functional/toolchains/meson/test_install.py
@@ -110,5 +110,6 @@ class MesonInstall(TestMesonBase):
                      os.path.join("test_package", "CMakeLists.txt"): self._test_package_cmake_lists,
                      os.path.join("test_package", "src", "test_package.cpp"): test_package_cpp})
 
-        self.t.run("create . --name=hello --version=0.1")
+        self.t.run("create . --name=hello --version=0.1 -c tools.build:verbosity=v")
+        assert "--verbose" in self.t.out
         self._check_binary()

--- a/conans/test/functional/toolchains/meson/test_install.py
+++ b/conans/test/functional/toolchains/meson/test_install.py
@@ -110,6 +110,6 @@ class MesonInstall(TestMesonBase):
                      os.path.join("test_package", "CMakeLists.txt"): self._test_package_cmake_lists,
                      os.path.join("test_package", "src", "test_package.cpp"): test_package_cpp})
 
-        self.t.run("create . --name=hello --version=0.1 -c tools.build:verbosity=verbose")
+        self.t.run("create . --name=hello --version=0.1 -c tools.compilation:verbosity=verbose")
         assert "--verbose" in self.t.out
         self._check_binary()

--- a/conans/test/functional/toolchains/meson/test_install.py
+++ b/conans/test/functional/toolchains/meson/test_install.py
@@ -110,6 +110,6 @@ class MesonInstall(TestMesonBase):
                      os.path.join("test_package", "CMakeLists.txt"): self._test_package_cmake_lists,
                      os.path.join("test_package", "src", "test_package.cpp"): test_package_cpp})
 
-        self.t.run("create . --name=hello --version=0.1 -c tools.build:verbosity=v")
+        self.t.run("create . --name=hello --version=0.1 -c tools.build:verbosity=verbose")
         assert "--verbose" in self.t.out
         self._check_binary()

--- a/conans/test/functional/toolchains/meson/test_meson.py
+++ b/conans/test/functional/toolchains/meson/test_meson.py
@@ -162,7 +162,12 @@ class MesonToolchainTest(TestMesonBase):
                      "conanfile.py": conanfile,
                      "test_package/conanfile.py": test_conanfile,
                      "src/file1.txt": "", "src/file2.txt": ""})
-        self.t.run("create .")
+        self.t.run("create . -c tools.build:verbosity=quiet -c tools.compilation:verbosity=verbose")
+        # Check verbosity control
+        assert "unrecognized arguments" not in self.t.out
+        assert re.search("meson compile .*? --verbose", self.t.out)
+        assert re.search("meson install .*? --quiet", self.t.out)
+
         # Check if all the files are in the final directories
         ref = RecipeReference.loads("hello/1.0")
         pref = self.t.get_latest_package_reference(ref)

--- a/conans/test/functional/toolchains/microsoft/test_msbuild.py
+++ b/conans/test/functional/toolchains/microsoft/test_msbuild.py
@@ -455,7 +455,9 @@ class TestWin:
         settings_b = " ".join('-s:b %s="%s"' % (k, v) for k, v in settings if v)
 
         client.run("new cmake_lib -d name=hello -d version=0.1")
-        client.run(f"create . {settings_h} -c tools.microsoft.msbuild:vs_version={ide_version}")
+        client.run(f"create . {settings_h} -c tools.microsoft.msbuild:vs_version={ide_version} -c tools.build:verbosity=verbose -c tools.compilation:verbosity=verbose")
+
+        assert "/verbosity:Detailed" in client.out
 
         # Prepare the actual consumer package
         client.save({"conanfile.py": self.conanfile,

--- a/conans/test/functional/toolchains/microsoft/test_msbuild.py
+++ b/conans/test/functional/toolchains/microsoft/test_msbuild.py
@@ -457,6 +457,7 @@ class TestWin:
         client.run("new cmake_lib -d name=hello -d version=0.1")
         client.run(f"create . {settings_h} -c tools.microsoft.msbuild:vs_version={ide_version} -c tools.build:verbosity=verbose -c tools.compilation:verbosity=verbose")
 
+        assert "MSBUILD : error MSB1001: Unknown switch" not in client.out
         assert "/verbosity:Detailed" in client.out
 
         # Prepare the actual consumer package

--- a/conans/test/integration/configuration/conf/test_conf.py
+++ b/conans/test/integration/configuration/conf/test_conf.py
@@ -47,7 +47,7 @@ def test_basic_composition(client):
     assert "tools.cmake.cmaketoolchain:generator$Extra" in client.out
 
     client.run("install . -pr=profile1 -pr=profile2")
-    assert "tools.build:verbosity$notice" in client.out
+    assert "tools.build:verbosity$quiet" in client.out
     assert "tools.microsoft.msbuild:vs_version$Slow" in client.out
     assert "tools.microsoft.msbuild:max_cpu_count$High" in client.out
     assert "tools.cmake.cmaketoolchain:generator$Extra" in client.out

--- a/conans/test/integration/configuration/conf/test_conf.py
+++ b/conans/test/integration/configuration/conf/test_conf.py
@@ -35,7 +35,7 @@ def test_basic_composition(client):
         """)
     profile2 = textwrap.dedent("""\
         [conf]
-        tools.build:verbosity=notice
+        tools.build:verbosity=quiet
         tools.microsoft.msbuild:max_cpu_count=High
         tools.meson.mesontoolchain:backend=Super
         """)
@@ -71,7 +71,7 @@ def test_basic_inclusion(client):
     profile2 = textwrap.dedent("""\
         include(profile1)
         [conf]
-        tools.build:verbosity=notice
+        tools.build:verbosity=quiet
         tools.microsoft.msbuild:max_cpu_count=High
         tools.meson.mesontoolchain:backend=Super
         """)
@@ -79,7 +79,7 @@ def test_basic_inclusion(client):
                  "profile2": profile2})
 
     client.run("install . -pr=profile2")
-    assert "tools.build:verbosity$notice" in client.out
+    assert "tools.build:verbosity$quiet" in client.out
     assert "tools.microsoft.msbuild:vs_version$Slow" in client.out
     assert "tools.microsoft.msbuild:max_cpu_count$High" in client.out
     assert "tools.cmake.cmaketoolchain:generator$Extra" in client.out
@@ -95,13 +95,13 @@ def test_composition_conan_conf(client):
     save(client.cache.new_config_path, conf)
     profile = textwrap.dedent("""\
         [conf]
-        tools.build:verbosity=notice
+        tools.build:verbosity=quiet
         tools.microsoft.msbuild:max_cpu_count=High
         tools.meson.mesontoolchain:backend=Super
         """)
     client.save({"profile": profile})
     client.run("install . -pr=profile")
-    assert "tools.build:verbosity$notice" in client.out
+    assert "tools.build:verbosity$quiet" in client.out
     assert "tools.microsoft.msbuild:vs_version$Slow" in client.out
     assert "tools.microsoft.msbuild:max_cpu_count$High" in client.out
     assert "tools.cmake.cmaketoolchain:generator$Extra" in client.out
@@ -110,14 +110,14 @@ def test_composition_conan_conf(client):
 
 def test_new_config_file(client):
     conf = textwrap.dedent("""\
-        tools.build:verbosity=notice
+        tools.build:verbosity=quiet
         user.mycompany.myhelper:myconfig=myvalue
         *:tools.cmake.cmaketoolchain:generator=X
         cache:read_only=True
         """)
     save(client.cache.new_config_path, conf)
     client.run("install .")
-    assert "tools.build:verbosity$notice" in client.out
+    assert "tools.build:verbosity$quiet" in client.out
     assert "user.mycompany.myhelper:myconfig$myvalue" in client.out
     assert "tools.cmake.cmaketoolchain:generator$X" in client.out
     assert "read_only" not in client.out
@@ -144,13 +144,13 @@ def test_composition_conan_conf_overwritten_by_cli_arg(client):
     save(client.cache.new_config_path, conf)
     profile = textwrap.dedent("""\
         [conf]
-        tools.build:verbosity=notice
+        tools.build:verbosity=quiet
         tools.microsoft.msbuild:vs_version=High
         """)
     client.save({"profile": profile})
-    client.run("install . -pr=profile -c tools.build:verbosity=debug "
+    client.run("install . -pr=profile -c tools.build:verbosity=verbose "
                "-c tools.meson.mesontoolchain:backend=Super")
-    assert "tools.build:verbosity$debug" in client.out
+    assert "tools.build:verbosity$verbose" in client.out
     assert "tools.microsoft.msbuild:max_cpu_count$Slow" in client.out
     assert "tools.microsoft.msbuild:vs_version$High" in client.out
     assert "tools.meson.mesontoolchain:backend$Super" in client.out

--- a/conans/test/integration/configuration/conf/test_conf_profile.py
+++ b/conans/test/integration/configuration/conf/test_conf_profile.py
@@ -54,11 +54,11 @@ def test_cmake_config(client):
         compiler.runtime=dynamic
         build_type=Release
         [conf]
-        tools.build:verbosity=notice
+        tools.build:verbosity=quiet
         """)
     client.save({"myprofile": profile})
     client.run("create . --name=pkg --version=0.1 -pr=myprofile")
-    assert "/verbosity:Minimal" in client.out
+    assert "/verbosity:Quiet" in client.out
 
 
 def test_cmake_config_error(client):
@@ -88,13 +88,13 @@ def test_cmake_config_package(client):
         compiler.runtime=dynamic
         build_type=Release
         [conf]
-        dep*:tools.build:verbosity=notice
+        dep*:tools.build:verbosity=quiet
         """)
     client.save({"myprofile": profile})
     client.run("create . --name=pkg --version=0.1 -pr=myprofile")
     assert "/verbosity" not in client.out
     client.run("create . --name=dep --version=0.1 -pr=myprofile")
-    assert "/verbosity:Minimal" in client.out
+    assert "/verbosity:Quiet" in client.out
 
 
 def test_cmake_config_package_not_scoped(client):
@@ -107,13 +107,13 @@ def test_cmake_config_package_not_scoped(client):
         compiler.runtime=dynamic
         build_type=Release
         [conf]
-        tools.build:verbosity=notice
+        tools.build:verbosity=quiet
         """)
     client.save({"myprofile": profile})
     client.run("create . --name=pkg --version=0.1 -pr=myprofile")
-    assert "/verbosity:Minimal" in client.out
+    assert "/verbosity:Quiet" in client.out
     client.run("create . --name=dep --version=0.1 -pr=myprofile")
-    assert "/verbosity:Minimal" in client.out
+    assert "/verbosity:Quiet" in client.out
 
 
 def test_config_profile_forbidden(client):
@@ -149,11 +149,11 @@ def test_msbuild_config():
         compiler.runtime=dynamic
         build_type=Release
         [conf]
-        tools.build:verbosity=notice
+        tools.build:verbosity=quiet
         """)
     client.save({"myprofile": profile})
     client.run("create . --name=pkg --version=0.1 -pr=myprofile")
-    assert "/verbosity:Minimal" in client.out
+    assert "/verbosity:Quiet" in client.out
 
 
 @pytest.mark.tool("visual_studio")

--- a/conans/test/unittests/client/tools/apple/test_xcodebuild.py
+++ b/conans/test/unittests/client/tools/apple/test_xcodebuild.py
@@ -6,21 +6,26 @@ from conans.model.conf import ConfDefinition
 from conans.test.utils.mocks import ConanFileMock, MockSettings
 
 
-@pytest.mark.parametrize("mode", ["quiet", "error", "warning", "notice", "status", "verbose",
-                                  "normal", "debug", "v", "trace", "vv"])
+@pytest.mark.parametrize("mode", ["quiet", None, "verbose"])
 def test_verbosity_global(mode):
     conanfile = ConanFileMock()
     conf = ConfDefinition()
-    conf.loads(f"tools.build:verbosity={mode}")
+    if mode is not None:
+        conf.loads(f"tools.build:verbosity={mode}")
     conanfile.conf = conf
     conanfile.settings = MockSettings({})
     xcodebuild = XcodeBuild(conanfile)
 
     xcodebuild.build("app.xcodeproj")
-    if mode not in ("status", "verbose", "normal"):
-        assert "-quiet" in conanfile.command or "-verbose" in conanfile.command
+    if mode == "verbose":
+        assert "-verbose" in conanfile.command
+        assert "-quiet" not in conanfile.command
+    elif mode == "quiet":
+        assert "-verbose" not in conanfile.command
+        assert "-quiet" in conanfile.command
     else:
-        assert "-quiet" not in conanfile.command and "-verbose" not in conanfile.command
+        assert "-verbose" not in conanfile.command
+        assert "-quiet" not in conanfile.command
 
 
 def test_sdk_path():

--- a/conans/test/unittests/model/test_conf.py
+++ b/conans/test/unittests/model/test_conf.py
@@ -9,7 +9,7 @@ from conans.model.conf import ConfDefinition
 @pytest.fixture()
 def conf_definition():
     text = textwrap.dedent("""\
-        tools.build:verbosity=notice
+        tools.build:verbosity=quiet
         user.company.toolchain:flags=someflags
     """)
     c = ConfDefinition()
@@ -22,7 +22,7 @@ def test_conf_definition(conf_definition):
     # Round trip
     assert c.dumps() == text
     # access
-    assert c.get("tools.build:verbosity") == "notice"
+    assert c.get("tools.build:verbosity") == "quiet"
     assert c.get("user.company.toolchain:flags") == "someflags"
     assert c.get("user.microsoft.msbuild:nonexist") is None
     assert c.get("user:nonexist") is None
@@ -64,13 +64,13 @@ def test_conf_rebase(conf_definition):
     c, _ = conf_definition
     text = textwrap.dedent("""\
        user.company.toolchain:flags=newvalue
-       tools.build:verbosity=trace""")
+       tools.build:verbosity=verbose""")
     c2 = ConfDefinition()
     c2.loads(text)
     c.rebase_conf_definition(c2)
     # The c profile will have precedence, and "
     result = textwrap.dedent("""\
-        tools.build:verbosity=notice
+        tools.build:verbosity=quiet
         user.company.toolchain:flags=someflags
     """)
     assert c.dumps() == result

--- a/conans/test/unittests/model/test_conf.py
+++ b/conans/test/unittests/model/test_conf.py
@@ -256,3 +256,24 @@ def test_conf_pop():
     assert c.pop("user.microsoft.msbuild:missing") is None
     assert c.pop("user.microsoft.msbuild:missing", default="fake") == "fake"
     assert c.pop("zlib:user.company.check:shared_str") == '"False"'
+
+
+def test_conf_choices():
+    confs = textwrap.dedent("""
+    user.category:option1=1
+    user.category:option2=3""")
+    c = ConfDefinition()
+    c.loads(confs)
+    assert c.get("user.category:option1", choices=[1, 2]) == 1
+    with pytest.raises(ConanException):
+        c.get("user.category:option2", choices=[1, 2])
+
+
+def test_conf_choices_default():
+    # Does not conflict with the default value
+    confs = textwrap.dedent("""
+        user.category:option1=1""")
+    c = ConfDefinition()
+    c.loads(confs)
+    assert c.get("user.category:option1", choices=[1, 2], default=7) == 1
+    assert c.get("user.category:option2", choices=[1, 2], default=7) == 7

--- a/conans/test/unittests/model/test_conf.py
+++ b/conans/test/unittests/model/test_conf.py
@@ -53,7 +53,7 @@ def test_conf_update(conf_definition):
     c2.loads(text)
     c.update_conf_definition(c2)
     result = textwrap.dedent("""\
-        tools.build:verbosity=notice
+        tools.build:verbosity=quiet
         user.company.toolchain:flags=newvalue
         user.something:key=value
     """)


### PR DESCRIPTION
Changelog: Feature: Split build & compilation verbosity control to two confs.
Docs: https://github.com/conan-io/docs/pull/3277

Adds verbosity confs for:


| tool name | `build:verbosity` | `compilation:verbosity` |
|------|-------|-------------|
| cmake      | ✔️ | ✔️ |
| xcodebuild*| ✔️ | ✔️ |
| msbuild    | ✔️ | - |
| meson      | ✔️ | ✔️ |
---------------------

* xcodebuild is not clear to me nor to @czoido what verbosity controls, so both confs activate it! Probably want to change it

Closes #13703
Closes #12239