### PR TITLE
fix CMakeToolchain CMAKE_SYSTEM_NAME=Generic for baremetal

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -718,6 +718,7 @@ class GenericSystemBlock(Block):
         arch_build = self._conanfile.settings_build.get_safe("arch")
         cmake_system_name_map = {"Neutrino": "QNX",
                                  "": "Generic",
+                                 "baremetal": "Generic",
                                  None: "Generic"}
         if os_host != os_build:
             return cmake_system_name_map.get(os_host, os_host)

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -527,3 +527,33 @@ def test_linker_scripts_block(conanfile):
     toolchain = CMakeToolchain(conanfile)
     content = toolchain.content
     assert f'string(APPEND CONAN_EXE_LINKER_FLAGS -T"path_to_first_linker_script" -T"path_to_second_linker_script")' in content
+
+
+class TestCrossBuild:
+    @pytest.fixture
+    def conanfile_cross(self):
+        c = ConanFile()
+        c.settings = Settings({"os": ["baremetal", "Linux"],
+                               "compiler": {"gcc": {"version": ["11"], "cppstd": ["20"]}},
+                               "build_type": ["Release"],
+                               "arch": ["armv8", "x86_64"]})
+        c.settings.build_type = "Release"
+        c.settings.arch = "armv8"
+        c.settings.compiler = "gcc"
+        c.settings.compiler.version = "11"
+        c.settings.compiler.cppstd = "20"
+        c.settings.os = "baremetal"
+        c.settings_build = c.settings.copy()
+        c.settings_build.os = "Linux"
+        c.settings_build.arch = "x86_64"
+        c.conf = Conf()
+        c.folders.set_base_generators(".")
+        c._conan_node = Mock()
+        c._conan_node.dependencies = []
+        c._conan_node.transitive_deps = {}
+        return c
+
+    def test_cmake_system_name(self, conanfile_cross):
+        toolchain = CMakeToolchain(conanfile_cross)
+        content = toolchain.content
+        assert 'set(CMAKE_SYSTEM_NAME Generic)' in content


### PR DESCRIPTION
Changelog: Bugfix: fix CMakeToolchain CMAKE_SYSTEM_NAME=Generic for baremetal
Docs: Omit

Close https://github.com/conan-io/conan/issues/13735