### PR TITLE
fixing deploy->deployers naming arg and folder

### DIFF
--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -116,7 +116,7 @@ def graph_info(conan_api, parser, subparser, *args):
                            help="Show only the specified fields")
     subparser.add_argument("--package-filter", action="append",
                            help='Print information only for packages that match the patterns')
-    subparser.add_argument("--deploy", action="append",
+    subparser.add_argument("-d", "--deployer", action="append",
                            help='Deploy using the provided deployer to the output folder')
     subparser.add_argument("--build-require", action='store_true', default=False,
                            help='Whether the provided reference is a build-require')
@@ -165,9 +165,9 @@ def graph_info(conan_api, parser, subparser, *args):
         lockfile = conan_api.lockfile.update_lockfile(lockfile, deps_graph, args.lockfile_packages,
                                                       clean=args.lockfile_clean)
         conan_api.lockfile.save_lockfile(lockfile, args.lockfile_out, os.getcwd())
-        if args.deploy:
+        if args.deployer:
             base_folder = os.getcwd()
-            do_deploys(conan_api, deps_graph, args.deploy, base_folder)
+            do_deploys(conan_api, deps_graph, args.deployer, base_folder)
 
     return {"graph": deps_graph,
             "field_filter": args.filter,

--- a/conan/cli/commands/install.py
+++ b/conan/cli/commands/install.py
@@ -34,7 +34,7 @@ def install(conan_api, parser, *args):
                         help='Generators to use')
     parser.add_argument("-of", "--output-folder",
                         help='The root output folder for generated and build files')
-    parser.add_argument("--deploy", action="append",
+    parser.add_argument("-d", "--deployer", action="append",
                         help='Deploy using the provided deployer to the output folder')
     parser.add_argument("--build-require", action='store_true', default=False,
                         help='Whether the provided reference is a build-require')
@@ -86,7 +86,7 @@ def install(conan_api, parser, *args):
                                        generators=args.generator,
                                        output_folder=output_folder,
                                        source_folder=source_folder,
-                                       deploy=args.deploy
+                                       deploy=args.deployer
                                        )
 
     out.success("Install finished successfully")

--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -6,6 +6,7 @@ import yaml
 from jinja2 import FileSystemLoader, Environment
 
 from conan import conan_version
+from conan.api.output import ConanOutput
 from conan.internal.cache.cache import DataCache, RecipeLayout, PackageLayout
 from conans.client.cache.editable import EditablePackages
 from conans.client.cache.remote_registry import RemoteRegistry
@@ -27,8 +28,6 @@ PROFILES_FOLDER = "profiles"
 EXTENSIONS_FOLDER = "extensions"
 HOOKS_EXTENSION_FOLDER = "hooks"
 PLUGINS_FOLDER = "plugins"
-DEPLOYERS_EXTENSION_FOLDER = "deploy"
-CUSTOM_COMMANDS_FOLDER = "commands"
 
 
 # TODO: Rename this to ClientHome
@@ -186,7 +185,7 @@ class ClientCache(object):
 
     @property
     def custom_commands_path(self):
-        return os.path.join(self.cache_folder, EXTENSIONS_FOLDER, CUSTOM_COMMANDS_FOLDER)
+        return os.path.join(self.cache_folder, EXTENSIONS_FOLDER, "commands")
 
     @property
     def custom_generators_path(self):
@@ -203,14 +202,16 @@ class ClientCache(object):
 
     @property
     def hooks_path(self):
-        """
-        :return: Hooks folder in client cache
-        """
         return os.path.join(self.cache_folder, EXTENSIONS_FOLDER, HOOKS_EXTENSION_FOLDER)
 
     @property
     def deployers_path(self):
-        return os.path.join(self.cache_folder, EXTENSIONS_FOLDER, DEPLOYERS_EXTENSION_FOLDER)
+        deploy = os.path.join(self.cache_folder, EXTENSIONS_FOLDER, "deploy")
+        if os.path.exists(deploy):
+            ConanOutput().warning("Use 'deployers' cache folder for deployers instead of 'deploy'",
+                                  warn_tag="deprecated")
+            return deploy
+        return os.path.join(self.cache_folder, EXTENSIONS_FOLDER, "deployers")
 
     @property
     def settings(self):


### PR DESCRIPTION
Changelog: Fix: Renaming the cache "deploy" folder to "deployers" and allow ``-d, --deployer`` cli arg. ("deploy" folder will not break but will warn as deprecated).
Docs: https://github.com/conan-io/docs/pull/3209
Close https://github.com/conan-io/conan/issues/13734