### PR TITLE
auto create default global.conf

### DIFF
--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import textwrap
 from typing import List
 
 import yaml
@@ -167,8 +168,16 @@ class ClientCache(object):
                 content = template.render({"platform": platform, "os": os, "distro": distro,
                                            "conan_version": conan_version,
                                            "conan_home_folder": self.cache_folder})
-
                 self._new_config.loads(content)
+            else:  # creation of a blank global.conf file for user convenience
+                default_global_conf = textwrap.dedent("""\
+                    # Core configuration (type 'conan config list' to list possible values)
+                    # e.g, for CI systems, to raise if user input would block
+                    # core:non_interactive = True
+                    # some tools.xxx config also possible, though generally better in profiles
+                    # tools.android:ndk_path = my/path/to/android/ndk
+                    """)
+                save(self.new_config_path, default_global_conf)
         return self._new_config
 
     @property

--- a/conans/test/integration/configuration/conf/test_conf.py
+++ b/conans/test/integration/configuration/conf/test_conf.py
@@ -7,7 +7,7 @@ from mock import patch
 
 from conan import conan_version
 from conans.errors import ConanException
-from conans.util.files import save
+from conans.util.files import save, load
 from conans.test.utils.tools import TestClient
 
 
@@ -270,3 +270,10 @@ def test_nonexisting_conf_global_conf():
     c.save({"conanfile.txt": ""})
     c.run("install . ", assert_error=True)
     assert "ERROR: Unknown conf 'tools.unknown:conf'" in c.out
+
+
+def test_global_conf_auto_created():
+    c = TestClient()
+    c.run("config list")  # all commands will trigger
+    global_conf = load(c.cache.new_config_path)
+    assert "# core:non_interactive = True" in global_conf


### PR DESCRIPTION
Changelog: Feature: Auto create empty ``global.conf`` to improve UX looking for file in home.
Docs: https://github.com/conan-io/docs/pull/3211
Close https://github.com/conan-io/conan/issues/13714