### PR TITLE
avoid hitting servers for binaries when upload_policy=skip

### DIFF
--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -1,3 +1,4 @@
+from conan.api.output import ConanOutput
 from conans.client.graph.build_mode import BuildMode
 from conans.client.graph.compatibility import BinaryCompatibility
 from conans.client.graph.compute_pid import compute_package_id
@@ -23,14 +24,9 @@ class GraphBinariesAnalyzer(object):
     def _evaluate_build(node, build_mode):
         ref, conanfile = node.ref, node.conanfile
         with_deps_to_build = False
-        # For cascade mode, we need to check also the "modified" status of the lockfile if exists
-        # modified nodes have already been built, so they shouldn't be built again
+        # check dependencies, if they are being built, "cascade" will try to build this one too
         if build_mode.cascade:
-            for dep in node.dependencies:
-                dep_node = dep.dst
-                if dep_node.binary == BINARY_BUILD:
-                    with_deps_to_build = True
-                    break
+            with_deps_to_build = any(dep.dst.binary == BINARY_BUILD for dep in node.dependencies)
         if build_mode.forced(conanfile, ref, with_deps_to_build):
             node.should_build = True
             conanfile.output.info('Forced build from source')
@@ -139,7 +135,7 @@ class GraphBinariesAnalyzer(object):
         assert node.prev is None, "Node.prev should be None"
 
         self._process_node(node, build_mode)
-        if node.binary in (BINARY_MISSING,) \
+        if node.binary == BINARY_MISSING \
                 and not build_mode.should_build_missing(node.conanfile) and not node.should_build:
             self._process_compatible_packages(node)
 
@@ -187,7 +183,16 @@ class GraphBinariesAnalyzer(object):
             if not self._evaluate_clean_pkg_folder_dirty(node, package_layout):
                 break
 
-        if cache_latest_prev is None:  # This binary does NOT exist in the cache
+        if node.conanfile.upload_policy == "skip":
+            if cache_latest_prev:
+                node.binary = BINARY_CACHE
+                node.prev = cache_latest_prev.revision
+            elif build_mode.allowed(node.conanfile):
+                node.should_build = True
+                node.binary = BINARY_BUILD
+            else:
+                node.binary = BINARY_MISSING
+        elif cache_latest_prev is None:  # This binary does NOT exist in the cache
             self._evaluate_download(node)
         else:  # This binary already exists in the cache, maybe can be updated
             self._evaluate_in_cache(cache_latest_prev, node)
@@ -308,6 +313,10 @@ class GraphBinariesAnalyzer(object):
             test_mode = BuildMode(build_mode)
         else:
             main_mode = test_mode = BuildMode(build_mode)
+        if main_mode.cascade:
+            ConanOutput().warning("Using build-mode 'cascade' is generally inefficient and it "
+                                  "shouldn't be used. Use 'package_id' and 'package_id_modes' for"
+                                  "more efficient re-builds")
         for node in deps_graph.ordered_iterate():
             build_mode = test_mode if node.test_package else main_mode
             if node.recipe in (RECIPE_CONSUMER, RECIPE_VIRTUAL):

--- a/conans/test/integration/command/install/install_test.py
+++ b/conans/test/integration/command/install/install_test.py
@@ -472,3 +472,16 @@ def test_install_json_formatter():
     assert pkg_cpp_info['cmp1']["sysroot"] == "/another/sysroot"
     assert pkg_cpp_info['cmp1']["properties"] == {'pkg_config_aliases': ['compo1_alias'],
                                                   'pkg_config_name': 'compo1'}
+
+
+def test_upload_skip_binaries_not_hit_server():
+    """
+    When upload_policy = "skip", no need to try to install from servers
+    """
+    c = TestClient(servers={"default": None})  # Broken server, will raise error if used
+    conanfile = GenConanfile("pkg", "0.1").with_class_attribute('upload_policy = "skip"')
+    c.save({"conanfile.py": conanfile})
+    c.run("export .")
+    c.run("install --requires=pkg/0.1 --build=missing")
+    # This would crash if hits the server, but it doesnt
+    assert "pkg/0.1: Created package" in c.out


### PR DESCRIPTION
Changelog: Feature: Optimize and avoid hitting servers for binaries when ``upload_policy=skip``
Docs: Omit

Close https://github.com/conan-io/conan/issues/13770
