### PR TITLE
fix printing of SKIP binaries

### DIFF
--- a/conan/cli/printers/graph.py
+++ b/conan/cli/printers/graph.py
@@ -90,12 +90,15 @@ def print_graph_packages(graph):
         if node.recipe in (RECIPE_CONSUMER, RECIPE_VIRTUAL):
             continue
         if node.context == CONTEXT_BUILD:
-            build_requires[node.pref] = node.binary, node.binary_remote
+            existing = build_requires.setdefault(node.pref, [node.binary, node.binary_remote])
         else:
             if node.test:
-                test_requires[node.pref] = node.binary, node.binary_remote
+                existing = test_requires.setdefault(node.pref, [node.binary, node.binary_remote])
             else:
-                requires[node.pref] = node.binary, node.binary_remote
+                existing = requires.setdefault(node.pref, [node.binary, node.binary_remote])
+        # TO avoid showing as "skip" something that is used in other node of the graph
+        if existing[0] == BINARY_SKIP:
+            existing[0] = node.binary
 
     def _format_requires(title, reqs_to_print):
         if not reqs_to_print:

--- a/conans/test/integration/graph/test_skip_binaries.py
+++ b/conans/test/integration/graph/test_skip_binaries.py
@@ -107,7 +107,8 @@ def test_list_skip_printing():
             "app/conanfile.py": GenConanfile().with_requires("pkgb/0.1")})
     c.run("create tool")
     c.run("create pkga")
-    c.run("export pkgb")
+    c.run("create pkgb")
+    c.run("remove pkga:* -c")
     c.run("install app --build=missing")
     c.assert_listed_binary({"tool/0.1": ("da39a3ee5e6b4b0d3255bfef95601890afd80709", "Cache")},
                            build=True)

--- a/conans/test/integration/graph/test_skip_binaries.py
+++ b/conans/test/integration/graph/test_skip_binaries.py
@@ -92,3 +92,22 @@ def test_build_scripts_no_skip():
     c.run("install app")
     c.assert_listed_binary({"script/0.1": ("da39a3ee5e6b4b0d3255bfef95601890afd80709", "Cache")},
                            build=True)
+
+
+def test_list_skip_printing():
+    """ make sure that when a package is required in the graph, it is not marked as SKIP, just
+    because some other part of the graph is skipping it. In this case, a tool_require might be
+    necessary for some packages building from soures, but not for others
+    """
+    c = TestClient()
+    c.save({"tool/conanfile.py": GenConanfile("tool", "0.1"),
+            "pkga/conanfile.py": GenConanfile("pkga", "0.1").with_tool_requires("tool/0.1"),
+            "pkgb/conanfile.py": GenConanfile("pkgb", "0.1").with_requires("pkga/0.1")
+                                                            .with_tool_requires("tool/0.1"),
+            "app/conanfile.py": GenConanfile().with_requires("pkgb/0.1")})
+    c.run("create tool")
+    c.run("create pkga")
+    c.run("export pkgb")
+    c.run("install app --build=missing")
+    c.assert_listed_binary({"tool/0.1": ("da39a3ee5e6b4b0d3255bfef95601890afd80709", "Cache")},
+                           build=True)


### PR DESCRIPTION
Changelog: Fix: Fix incorrect printing of "skipped" binaries in the ``conan install/create`` commands, when they are used by some other dependencies.
Docs: Omit