### PR TITLE
Fix `conan upload` with backup sources for exported-only recipes

### DIFF
--- a/conans/client/downloaders/download_cache.py
+++ b/conans/client/downloaders/download_cache.py
@@ -45,11 +45,13 @@ class DownloadCache:
                 thread_lock.release()
 
     def get_backup_sources_files_to_upload(self, package_list):
-        """ from a package_list of packages to upload, collect from the backup-sources ccache
+        """ from a package_list of packages to upload, collect from the backup-sources cache
         the matching references to upload those backups too
         """
         files_to_upload = []
         path_backups = os.path.join(self._path, self._SOURCE_BACKUP)
+        if not os.path.exists(path_backups):
+            return []
         all_refs = {str(k) for k, v in package_list.refs() if v.get("upload")}
         for f in os.listdir(path_backups):
             if f.endswith(".json"):

--- a/conans/test/integration/cache/backup_sources_test.py
+++ b/conans/test/integration/cache/backup_sources_test.py
@@ -624,12 +624,11 @@ class TestDownloadCacheBackupSources:
     def test_upload_after_export(self):
         client = TestClient(default_server_user=True)
         download_cache_folder = temp_folder()
-        client.save({"global.conf": f"core.sources:download_cache={download_cache_folder}\n"
-                                    f"core.sources:download_urls=['origin']\n"
-                                    f"core.sources:upload_url=foo"},
+        client.save({"global.conf": "core.sources:upload_url=foo"},
                     path=client.cache.cache_folder)
 
         client.save({"conanfile.py": GenConanfile("pkg", "1.0")})
         client.run("export .")
+        # This used to crash because we were trying to list a missing dir if only exports were made
         client.run("upload * -c -r=default")
         assert "[Errno 2] No such file or directory" not in client.out

--- a/conans/test/integration/cache/backup_sources_test.py
+++ b/conans/test/integration/cache/backup_sources_test.py
@@ -3,7 +3,7 @@ import os
 import textwrap
 from unittest import mock
 from bottle import static_file, request, HTTPError
-
+from conans.test.assets.genconanfile import GenConanfile
 from conans.errors import NotFoundException
 from conans.test.utils.test_files import temp_folder
 from conans.test.utils.tools import TestClient, StoppableThreadBottle
@@ -620,3 +620,16 @@ class TestDownloadCacheBackupSources:
         client.run("create .")
         assert f"Sources for http://localhost:{http_server.port}/internet/myfile.txt found in remote backup http://localhost:{http_server.port}/downloader2/" in client.out
         assert "sha256 signature failed for" in client.out
+
+    def test_upload_after_export(self):
+        client = TestClient(default_server_user=True)
+        download_cache_folder = temp_folder()
+        client.save({"global.conf": f"core.sources:download_cache={download_cache_folder}\n"
+                                    f"core.sources:download_urls=['origin']\n"
+                                    f"core.sources:upload_url=foo"},
+                    path=client.cache.cache_folder)
+
+        client.save({"conanfile.py": GenConanfile("pkg", "1.0")})
+        client.run("export .")
+        client.run("upload * -c -r=default")
+        assert "[Errno 2] No such file or directory" not in client.out


### PR DESCRIPTION
Changelog: Bugfix: Fix `conan upload` with backup sources for exported-only recipes
Docs: Omit
