### PR TITLE
do not move cache build folders to allow debugging in all cases

### DIFF
--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -1,4 +1,4 @@
-import shutil
+import os
 
 from conan.internal.conan_app import ConanApp
 from conan.internal.integrity_check import IntegrityChecker
@@ -34,8 +34,11 @@ class CacheAPI:
     def build_path(self, pref: PkgReference):
         app = ConanApp(self.conan_api.cache_folder)
         pref = _resolve_latest_pref(app, pref)
-        ref_layout = app.cache.pkg_layout(pref)
-        return ref_layout.build()
+        pref = PkgReference.loads(repr(pref))  # do a copy
+        pref.revision = None
+        pref.timestamp = None
+        package_path = app.cache._data_cache._get_tmp_path_pref(pref)
+        return os.path.join(app.cache_folder, package_path, "b")
 
     def package_path(self, pref: PkgReference):
         app = ConanApp(self.conan_api.cache_folder)

--- a/conan/internal/cache/cache.py
+++ b/conan/internal/cache/cache.py
@@ -1,7 +1,8 @@
 import hashlib
 import os
 
-from conan.internal.cache.conan_reference_layout import RecipeLayout, PackageLayout
+from conan.internal.cache.conan_reference_layout import RecipeLayout, PackageLayout, PACKAGES_FOLDER, \
+    DOWNLOAD_EXPORT_FOLDER
 # TODO: Random folders are no longer accessible, how to get rid of them asap?
 # TODO: Add timestamp for LRU
 # TODO: We need the workflow to remove existing references.
@@ -185,7 +186,11 @@ class DataCache:
         full_path = self._full_path(new_path)
         rmdir(full_path)
 
-        renamedir(self._full_path(layout.base_folder), full_path)
+        # Do not relocate the temporary "build" folder, only the "package" one
+        for p in PACKAGES_FOLDER, DOWNLOAD_EXPORT_FOLDER:
+            existing = os.path.join(self._full_path(layout.base_folder), p)
+            if os.path.isdir(existing):
+                renamedir(existing, os.path.join(full_path, p))
         layout._base_folder = os.path.join(self.base_folder, new_path)
 
         build_id = layout.build_id


### PR DESCRIPTION
Changelog: Feature: Do not move "build" folders in cache when ``package-revision`` is computed to allow locating sources for dependencies debuggability with step-into
Docs: omit

Fix https://github.com/conan-io/conan/issues/13799

NOTE: This is mostly an experiment, no guarantees this makes sense