### PR TITLE
Add nicer error for None backup remote

### DIFF
--- a/conans/client/downloaders/caching_file_downloader.py
+++ b/conans/client/downloaders/caching_file_downloader.py
@@ -62,10 +62,11 @@ class SourcesCachingDownloader:
                 self._output.info(f"Source {urls} retrieved from local download cache")
             else:
                 with set_dirty_context_manager(cached_path):
+                    if None in backups_urls:
+                        raise ConanException("Trying to download sources from None backup remote."
+                                             f" Remotes were: {backups_urls}")
                     for backup_url in backups_urls:
-                        if backup_url is None:
-                            raise ConanException("Trying to download sources from None backup remote"
-                                                 f". Remotes were: {backups_urls}")
+
                         is_last = backup_url is backups_urls[-1]
                         if backup_url == "origin":  # recipe defined URLs
                             if self._origin_download(urls, cached_path, retry, retry_wait,

--- a/conans/client/downloaders/caching_file_downloader.py
+++ b/conans/client/downloaders/caching_file_downloader.py
@@ -63,6 +63,9 @@ class SourcesCachingDownloader:
             else:
                 with set_dirty_context_manager(cached_path):
                     for backup_url in backups_urls:
+                        if backup_url is None:
+                            raise ConanException("Trying to download sources from None backup remote"
+                                                 f". Remotes were: {backups_urls}")
                         is_last = backup_url is backups_urls[-1]
                         if backup_url == "origin":  # recipe defined URLs
                             if self._origin_download(urls, cached_path, retry, retry_wait,

--- a/conans/test/integration/cache/backup_sources_test.py
+++ b/conans/test/integration/cache/backup_sources_test.py
@@ -112,11 +112,18 @@ class TestDownloadCacheBackupSources:
             """)
 
         client.save({"global.conf": f"core.sources:download_cache={download_cache_folder}\n"
-                                    f"core.sources:download_urls=['origin', 'http://localhost:{http_server.port}/downloader/']\n"
+                                    f"core.sources:download_urls=[None, 'origin', 'http://localhost:{http_server.port}/downloader/']\n"
                                     f"core.sources:upload_url=http://localhost:{http_server.port}/uploader/"},
                     path=client.cache.cache_folder)
 
         client.save({"conanfile.py": conanfile})
+        client.run("create .", assert_error=True)
+        assert "Trying to download sources from None backup remote" in client.out
+
+        client.save({"global.conf": f"core.sources:download_cache={download_cache_folder}\n"
+                                    f"core.sources:download_urls=['origin', 'http://localhost:{http_server.port}/downloader/']\n"
+                                    f"core.sources:upload_url=http://localhost:{http_server.port}/uploader/"},
+                    path=client.cache.cache_folder)
         client.run("create .")
         client.run("upload * -c -r=default")
 


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

CI scripts might fail when inserting their own download URL. Make sure we have a nice error for those cases.

The old error was an uncaught `TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'` exception which did not make it clear what the issue was. This differed from other errors in this section of the code in that those do show what the current conf value is (Or at least the offending one), so this PR just makes it easier to debug a None in the conf that might have gotten there by some CI issue
