### PR TITLE
Fail when defining an unkown conf

### DIFF
--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -267,10 +267,7 @@ class Conf:
 
     def validate(self):
         for conf in self._values:
-            if conf.startswith("tools") or conf.startswith("core"):
-                if conf not in BUILT_IN_CONFS:
-                    raise ConanException(f"Unknown conf '{conf}'. Use 'conan config list' to "
-                                         "display existing configurations")
+            self._check_conf_name(conf)
 
     def items(self):
         # FIXME: Keeping backward compatibility
@@ -287,9 +284,7 @@ class Conf:
                            There are two default smart conversions for bool and str types.
         """
         # Skipping this check only the user.* configurations
-        if USER_CONF_PATTERN.match(conf_name) is None and conf_name not in BUILT_IN_CONFS:
-            raise ConanException(f"[conf] '{conf_name}' does not exist in configuration list. "
-                                 f" Run 'conan config list' to see all the available confs.")
+        self._check_conf_name(conf_name)
 
         conf_value = self._values.get(conf_name)
         if conf_value:
@@ -479,6 +474,12 @@ class Conf:
     def set_relative_base_folder(self, folder):
         for v in self._values.values():
             v.set_relative_base_folder(folder)
+
+    @staticmethod
+    def _check_conf_name(conf):
+        if USER_CONF_PATTERN.match(conf) is None and conf not in BUILT_IN_CONFS:
+            raise ConanException(f"[conf] '{conf}' does not exist in configuration list. "
+                                 f" Run 'conan config list' to see all the available confs.")
 
 
 class ConfDefinition:

--- a/conans/test/integration/configuration/conf/test_conf.py
+++ b/conans/test/integration/configuration/conf/test_conf.py
@@ -113,7 +113,6 @@ def test_new_config_file(client):
         tools.build:verbosity=notice
         user.mycompany.myhelper:myconfig=myvalue
         *:tools.cmake.cmaketoolchain:generator=X
-        cache:read_only=True
         """)
     save(client.cache.new_config_path, conf)
     client.run("install .")
@@ -121,6 +120,16 @@ def test_new_config_file(client):
     assert "user.mycompany.myhelper:myconfig$myvalue" in client.out
     assert "tools.cmake.cmaketoolchain:generator$X" in client.out
     assert "read_only" not in client.out
+
+    conf = textwrap.dedent("""\
+            tools.build:verbosity=notice
+            user.mycompany.myhelper:myconfig=myvalue
+            *:tools.cmake.cmaketoolchain:generator=X
+            cache:read_only=True
+            """)
+    save(client.cache.new_config_path, conf)
+    client.run("install .", assert_error=True)
+    assert "[conf] 'cache:read_only' does not exist in configuration list" in client.out
 
 
 @patch("conans.client.conf.required_version.client_version", "1.26.0")
@@ -260,8 +269,10 @@ def test_nonexisting_conf():
     c = TestClient()
     c.save({"conanfile.txt": ""})
     c.run("install . -c tools.unknown:conf=value", assert_error=True)
-    assert "ERROR: Unknown conf 'tools.unknown:conf'" in c.out
+    assert "ERROR: [conf] 'tools.unknown:conf' does not exist in configuration list" in c.out
     c.run("install . -c user.some:var=value")  # This doesn't fail
+    c.run("install . -c tool.build:verbosity=v", assert_error=True)
+    assert "ERROR: [conf] 'tool.build:verbosity' does not exist in configuration list" in c.out
 
 
 def test_nonexisting_conf_global_conf():
@@ -269,7 +280,7 @@ def test_nonexisting_conf_global_conf():
     save(c.cache.new_config_path, "tools.unknown:conf=value")
     c.save({"conanfile.txt": ""})
     c.run("install . ", assert_error=True)
-    assert "ERROR: Unknown conf 'tools.unknown:conf'" in c.out
+    assert "ERROR: [conf] 'tools.unknown:conf' does not exist in configuration list" in c.out
 
 
 def test_global_conf_auto_created():


### PR DESCRIPTION
Changelog: Fix: Fail when defining an unkown conf
Docs: Omit

The checks for conf validity had different logic when checking queried confs vs definitions. This change makes them both the same, which allows to catch typos such as `tool.build:verbosity` vs `tools.build:verbosity`.
