### PR TITLE
Added verbosity level for skipped deps

### DIFF
--- a/conan/cli/printers/graph.py
+++ b/conan/cli/printers/graph.py
@@ -122,5 +122,5 @@ def print_graph_packages(graph):
     _format_requires("Build requirements", build_requires)
 
     if skipped_requires and not output.level_allowed(LEVEL_VERBOSE):
-        output.info("Skipped binaries from", Color.BRIGHT_YELLOW)
+        output.info("Skipped binaries", Color.BRIGHT_YELLOW)
         output.info(f"{tab}{skipped_requires}", Color.BRIGHT_CYAN)

--- a/conan/cli/printers/graph.py
+++ b/conan/cli/printers/graph.py
@@ -1,4 +1,4 @@
-from conan.api.output import ConanOutput, Color
+from conan.api.output import ConanOutput, Color, LEVEL_VERBOSE
 from conans.client.graph.graph import RECIPE_CONSUMER, RECIPE_VIRTUAL, CONTEXT_BUILD, BINARY_SKIP,\
     BINARY_SYSTEM_TOOL
 
@@ -39,17 +39,12 @@ def print_graph_basic(graph):
         if not reqs_to_print:
             return
         output.info(title, Color.BRIGHT_YELLOW)
-        for ref, (status, remote, test_package) in sorted(reqs_to_print.items()):
-            orig_status = status
+        for ref, (recipe, remote, test_package) in sorted(reqs_to_print.items()):
             if remote is not None:
-                status = "{} ({})".format(status, remote.name)
+                recipe = "{} ({})".format(recipe, remote.name)
             if test_package:
-                status = f"(tp) {status}"
-            msg = "    {} - {}".format(ref.repr_notime(), status)
-            if orig_status == BINARY_SKIP:
-                output.verbose(msg, Color.BRIGHT_CYAN)
-            else:
-                output.info(msg, Color.BRIGHT_CYAN)
+                recipe = f"(tp) {recipe}"
+            output.info("    {} - {}".format(ref.repr_notime(), recipe), Color.BRIGHT_CYAN)
 
     _format_requires("Requirements", requires)
     _format_requires("Test requirements", test_requires)
@@ -91,6 +86,8 @@ def print_graph_packages(graph):
     requires = {}
     build_requires = {}
     test_requires = {}
+    skipped_requires = []
+    tab = "    "
     for node in graph.nodes:
         if node.recipe in (RECIPE_CONSUMER, RECIPE_VIRTUAL):
             continue
@@ -110,12 +107,12 @@ def print_graph_packages(graph):
             return
         output.info(title, Color.BRIGHT_YELLOW)
         for pref, (status, remote) in sorted(reqs_to_print.items(), key=repr):
-            orig_status = status
-            if remote is not None and orig_status != BINARY_SKIP:
-                status = "{} ({})".format(status, remote.name)
             name = pref.repr_notime() if status != BINARY_SYSTEM_TOOL else str(pref.ref)
-            msg = "    {} - {}".format(name, status)
-            if orig_status == BINARY_SKIP:
+            msg = f"{tab}{name} - {status}"
+            if remote is not None and status != BINARY_SKIP:
+                msg += f" ({remote.name})"
+            if status == BINARY_SKIP:
+                skipped_requires.append(str(pref.ref))
                 output.verbose(msg, Color.BRIGHT_CYAN)
             else:
                 output.info(msg, Color.BRIGHT_CYAN)
@@ -123,3 +120,7 @@ def print_graph_packages(graph):
     _format_requires("Requirements", requires)
     _format_requires("Test requirements", test_requires)
     _format_requires("Build requirements", build_requires)
+
+    if skipped_requires and not output.level_allowed(LEVEL_VERBOSE):
+        output.info("Skipped binaries from", Color.BRIGHT_YELLOW)
+        output.info(f"{tab}{skipped_requires}", Color.BRIGHT_CYAN)

--- a/conan/cli/printers/graph.py
+++ b/conan/cli/printers/graph.py
@@ -39,12 +39,17 @@ def print_graph_basic(graph):
         if not reqs_to_print:
             return
         output.info(title, Color.BRIGHT_YELLOW)
-        for ref, (recipe, remote, test_package) in sorted(reqs_to_print.items()):
+        for ref, (status, remote, test_package) in sorted(reqs_to_print.items()):
+            orig_status = status
             if remote is not None:
-                recipe = "{} ({})".format(recipe, remote.name)
+                status = "{} ({})".format(status, remote.name)
             if test_package:
-                recipe = f"(tp) {recipe}"
-            output.info("    {} - {}".format(ref.repr_notime(), recipe), Color.BRIGHT_CYAN)
+                status = f"(tp) {status}"
+            msg = "    {} - {}".format(ref.repr_notime(), status)
+            if orig_status == BINARY_SKIP:
+                output.verbose(msg, Color.BRIGHT_CYAN)
+            else:
+                output.info(msg, Color.BRIGHT_CYAN)
 
     _format_requires("Requirements", requires)
     _format_requires("Test requirements", test_requires)
@@ -105,10 +110,15 @@ def print_graph_packages(graph):
             return
         output.info(title, Color.BRIGHT_YELLOW)
         for pref, (status, remote) in sorted(reqs_to_print.items(), key=repr):
-            if remote is not None and status != BINARY_SKIP:
+            orig_status = status
+            if remote is not None and orig_status != BINARY_SKIP:
                 status = "{} ({})".format(status, remote.name)
             name = pref.repr_notime() if status != BINARY_SYSTEM_TOOL else str(pref.ref)
-            output.info("    {} - {}".format(name, status), Color.BRIGHT_CYAN)
+            msg = "    {} - {}".format(name, status)
+            if orig_status == BINARY_SKIP:
+                output.verbose(msg, Color.BRIGHT_CYAN)
+            else:
+                output.info(msg, Color.BRIGHT_CYAN)
 
     _format_requires("Requirements", requires)
     _format_requires("Test requirements", test_requires)

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -474,7 +474,7 @@ def test_private_transitive():
                                                         .with_settings("os", "build_type", "arch")})
     client.run("create dep --name=dep --version=0.1")
     client.run("create pkg --name=pkg --version=0.1")
-    client.run("install consumer -g CMakeDeps -s arch=x86_64 -s build_type=Release -of=.")
+    client.run("install consumer -g CMakeDeps -s arch=x86_64 -s build_type=Release -of=. -vv")
     client.assert_listed_binary({"dep/0.1": (NO_SETTINGS_PACKAGE_ID, "Skip")})
     data_cmake = client.load("pkg-release-x86_64-data.cmake")
     assert 'set(pkg_FIND_DEPENDENCY_NAMES "")' in data_cmake

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -474,7 +474,7 @@ def test_private_transitive():
                                                         .with_settings("os", "build_type", "arch")})
     client.run("create dep --name=dep --version=0.1")
     client.run("create pkg --name=pkg --version=0.1")
-    client.run("install consumer -g CMakeDeps -s arch=x86_64 -s build_type=Release -of=. -vv")
+    client.run("install consumer -g CMakeDeps -s arch=x86_64 -s build_type=Release -of=. -v")
     client.assert_listed_binary({"dep/0.1": (NO_SETTINGS_PACKAGE_ID, "Skip")})
     data_cmake = client.load("pkg-release-x86_64-data.cmake")
     assert 'set(pkg_FIND_DEPENDENCY_NAMES "")' in data_cmake

--- a/conans/test/functional/toolchains/microsoft/test_msbuilddeps.py
+++ b/conans/test/functional/toolchains/microsoft/test_msbuilddeps.py
@@ -858,7 +858,7 @@ def test_private_transitive():
                                                         .with_settings("os", "build_type", "arch")})
     client.run("create dep --name=dep --version=0.1")
     client.run("create pkg --name=pkg --version=0.1")
-    client.run("install consumer -g MSBuildDeps -s arch=x86_64 -s build_type=Release -vv")
+    client.run("install consumer -g MSBuildDeps -s arch=x86_64 -s build_type=Release -v")
     client.assert_listed_binary({"dep/0.1": (NO_SETTINGS_PACKAGE_ID, "Skip")})
     deps_props = client.load("consumer/conandeps.props")
     assert "conan_pkg.props" in deps_props

--- a/conans/test/functional/toolchains/microsoft/test_msbuilddeps.py
+++ b/conans/test/functional/toolchains/microsoft/test_msbuilddeps.py
@@ -858,7 +858,7 @@ def test_private_transitive():
                                                         .with_settings("os", "build_type", "arch")})
     client.run("create dep --name=dep --version=0.1")
     client.run("create pkg --name=pkg --version=0.1")
-    client.run("install consumer -g MSBuildDeps -s arch=x86_64 -s build_type=Release")
+    client.run("install consumer -g MSBuildDeps -s arch=x86_64 -s build_type=Release -vv")
     client.assert_listed_binary({"dep/0.1": (NO_SETTINGS_PACKAGE_ID, "Skip")})
     deps_props = client.load("consumer/conandeps.props")
     assert "conan_pkg.props" in deps_props

--- a/conans/test/integration/build_requires/build_requires_test.py
+++ b/conans/test/integration/build_requires/build_requires_test.py
@@ -205,7 +205,7 @@ class BuildRequiresTest(unittest.TestCase):
         t.run("create . --name=LibA --version=0.1 --user=user --channel=testing")
         t.save({"conanfile.py": GenConanfile().with_require(libA_ref)
                                               .with_tool_requires(catch_ref)})
-        t.run("install .")
+        t.run("install . -vv")
         self.assertIn("catch/0.1@user/testing from local cache", t.out)
         self.assertIn("catch/0.1@user/testing:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 - Skip",
                       t.out)

--- a/conans/test/integration/build_requires/build_requires_test.py
+++ b/conans/test/integration/build_requires/build_requires_test.py
@@ -205,7 +205,7 @@ class BuildRequiresTest(unittest.TestCase):
         t.run("create . --name=LibA --version=0.1 --user=user --channel=testing")
         t.save({"conanfile.py": GenConanfile().with_require(libA_ref)
                                               .with_tool_requires(catch_ref)})
-        t.run("install . -vv")
+        t.run("install . -v")
         self.assertIn("catch/0.1@user/testing from local cache", t.out)
         self.assertIn("catch/0.1@user/testing:5ab84d6acfe1f23c4fae0ab88f26e3a396351ac9 - Skip",
                       t.out)

--- a/conans/test/integration/build_requires/test_relocatable_toolchain.py
+++ b/conans/test/integration/build_requires/test_relocatable_toolchain.py
@@ -65,7 +65,7 @@ def test_relocatable_toolchain():
     assert "sdk/1.0: Calling package()" in c.out
     assert "sdk/1.0: SDK INFO: CUSTOM PATH: arch:x86_64=>armv8!!!" in c.out
 
-    c.run("install consumer -pr:h=embedded -pr:b=linux")
+    c.run("install consumer -pr:h=embedded -pr:b=linux -vv")
     c.assert_listed_binary({"base/1.0": ("62e589af96a19807968167026d906e63ed4de1f5", "Skip"),
                             "sdk/1.0": ("62e589af96a19807968167026d906e63ed4de1f5", "Cache")},
                            build=True)
@@ -85,7 +85,7 @@ def test_relocatable_toolchain():
 
     # we can even remove the binary!
     c.run("remove base/1.0:* -c")
-    c.run("install consumer -pr:h=embedded -pr:b=linux")
+    c.run("install consumer -pr:h=embedded -pr:b=linux -vv")
     c.assert_listed_binary({"base/1.0": ("62e589af96a19807968167026d906e63ed4de1f5", "Skip"),
                             "sdk/1.0": ("62e589af96a19807968167026d906e63ed4de1f5", "Cache")},
                            build=True)

--- a/conans/test/integration/build_requires/test_relocatable_toolchain.py
+++ b/conans/test/integration/build_requires/test_relocatable_toolchain.py
@@ -65,7 +65,7 @@ def test_relocatable_toolchain():
     assert "sdk/1.0: Calling package()" in c.out
     assert "sdk/1.0: SDK INFO: CUSTOM PATH: arch:x86_64=>armv8!!!" in c.out
 
-    c.run("install consumer -pr:h=embedded -pr:b=linux -vv")
+    c.run("install consumer -pr:h=embedded -pr:b=linux -v")
     c.assert_listed_binary({"base/1.0": ("62e589af96a19807968167026d906e63ed4de1f5", "Skip"),
                             "sdk/1.0": ("62e589af96a19807968167026d906e63ed4de1f5", "Cache")},
                            build=True)
@@ -85,7 +85,7 @@ def test_relocatable_toolchain():
 
     # we can even remove the binary!
     c.run("remove base/1.0:* -c")
-    c.run("install consumer -pr:h=embedded -pr:b=linux -vv")
+    c.run("install consumer -pr:h=embedded -pr:b=linux -v")
     c.assert_listed_binary({"base/1.0": ("62e589af96a19807968167026d906e63ed4de1f5", "Skip"),
                             "sdk/1.0": ("62e589af96a19807968167026d906e63ed4de1f5", "Cache")},
                            build=True)

--- a/conans/test/integration/graph/test_repackaging.py
+++ b/conans/test/integration/graph/test_repackaging.py
@@ -43,7 +43,7 @@ def test_repackage():
     client.run("create . --name=repackager --version=1.0 -s os=Linux -s arch=x86 -s build_type=RelWithDebInfo")
 
     client.save({"conanfile.py": GenConanfile().with_requires("repackager/1.0")}, clean_first=True)
-    client.run("install . -s os=Linux")
+    client.run("install . -s os=Linux -vv")
     assert "liba/1.0:INVALID - Skip" in client.out
     assert "libb/1.0:INVALID - Skip" in client.out
     assert "repackager/1.0: Already installed!" in client.out

--- a/conans/test/integration/graph/test_repackaging.py
+++ b/conans/test/integration/graph/test_repackaging.py
@@ -43,7 +43,7 @@ def test_repackage():
     client.run("create . --name=repackager --version=1.0 -s os=Linux -s arch=x86 -s build_type=RelWithDebInfo")
 
     client.save({"conanfile.py": GenConanfile().with_requires("repackager/1.0")}, clean_first=True)
-    client.run("install . -s os=Linux -vv")
+    client.run("install . -s os=Linux -v")
     assert "liba/1.0:INVALID - Skip" in client.out
     assert "libb/1.0:INVALID - Skip" in client.out
     assert "repackager/1.0: Already installed!" in client.out

--- a/conans/test/integration/graph/test_skip_binaries.py
+++ b/conans/test/integration/graph/test_skip_binaries.py
@@ -12,7 +12,7 @@ def test_private_skip():
     client.run("remove dep/1.0:* -c")  # Dep binary is removed not used at all
 
     client.save({"conanfile.py": GenConanfile().with_requires("pkg/1.0")})
-    client.run("create . --name=app --version=1.0 -vv")
+    client.run("create . --name=app --version=1.0 -v")
     client.assert_listed_binary({"dep/1.0": (NO_SETTINGS_PACKAGE_ID, "Skip")})
 
 
@@ -61,7 +61,7 @@ def test_shared_link_static_skip():
     client.run("remove dep/1.0:* -c")  # Dep binary is removed not used at all
 
     client.save({"conanfile.py": GenConanfile().with_requires("pkg/1.0")})
-    client.run("create . --name=app --version=1.0 -vv")
+    client.run("create . --name=app --version=1.0 -v")
     client.assert_listed_binary({"dep/1.0": (package_id, "Skip")})
 
 
@@ -78,7 +78,7 @@ def test_test_requires():
     client.run("remove gtest/1.0:* -c")  # Dep binary is removed not used at all
 
     client.save({"conanfile.py": GenConanfile().with_requires("pkg/1.0")})
-    client.run("create . --name=app --version=1.0 -vv")
+    client.run("create . --name=app --version=1.0 -v")
     client.assert_listed_binary({"gtest/1.0": (package_id, "Skip")}, test=True)
 
 

--- a/conans/test/integration/graph/test_skip_binaries.py
+++ b/conans/test/integration/graph/test_skip_binaries.py
@@ -12,7 +12,7 @@ def test_private_skip():
     client.run("remove dep/1.0:* -c")  # Dep binary is removed not used at all
 
     client.save({"conanfile.py": GenConanfile().with_requires("pkg/1.0")})
-    client.run("create . --name=app --version=1.0")
+    client.run("create . --name=app --version=1.0 -vv")
     client.assert_listed_binary({"dep/1.0": (NO_SETTINGS_PACKAGE_ID, "Skip")})
 
 
@@ -61,7 +61,7 @@ def test_shared_link_static_skip():
     client.run("remove dep/1.0:* -c")  # Dep binary is removed not used at all
 
     client.save({"conanfile.py": GenConanfile().with_requires("pkg/1.0")})
-    client.run("create . --name=app --version=1.0")
+    client.run("create . --name=app --version=1.0 -vv")
     client.assert_listed_binary({"dep/1.0": (package_id, "Skip")})
 
 
@@ -78,7 +78,7 @@ def test_test_requires():
     client.run("remove gtest/1.0:* -c")  # Dep binary is removed not used at all
 
     client.save({"conanfile.py": GenConanfile().with_requires("pkg/1.0")})
-    client.run("create . --name=app --version=1.0")
+    client.run("create . --name=app --version=1.0 -vv")
     client.assert_listed_binary({"gtest/1.0": (package_id, "Skip")}, test=True)
 
 

--- a/conans/test/integration/graph/test_skip_binaries.py
+++ b/conans/test/integration/graph/test_skip_binaries.py
@@ -1,3 +1,5 @@
+import re
+
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient, NO_SETTINGS_PACKAGE_ID
 
@@ -78,6 +80,10 @@ def test_test_requires():
     client.run("remove gtest/1.0:* -c")  # Dep binary is removed not used at all
 
     client.save({"conanfile.py": GenConanfile().with_requires("pkg/1.0")})
+    # Checking list of skipped binaries
+    client.run("create . --name=app --version=1.0")
+    assert re.search(r"Skipped binaries(\s*)\['gtest/1.0'\]", client.out)
+    # Showing the complete information about the skipped binary
     client.run("create . --name=app --version=1.0 -v")
     client.assert_listed_binary({"gtest/1.0": (package_id, "Skip")}, test=True)
 

--- a/conans/test/integration/lockfile/test_graph_overrides.py
+++ b/conans/test/integration/lockfile/test_graph_overrides.py
@@ -248,7 +248,6 @@ def test_graph_different_overrides():
     c.run("create pkga")
     c.run("create pkgb")
     c.run("lock create pkgc")
-    print(c.load("pkgc/conan.lock"))
     lock = json.loads(c.load("pkgc/conan.lock"))
     requires = "\n".join(lock["build_requires"])
     assert "toolc/0.3" in requires

--- a/conans/test/integration/package_id/test_validate.py
+++ b/conans/test/integration/package_id/test_validate.py
@@ -560,10 +560,10 @@ class TestValidateCppstd:
         client.run(f"create engine {settings} -s compiler.cppstd=17")
         client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
                                                  "Cache")})
-        client.run(f"install app {settings} -s compiler.cppstd=17")
+        client.run(f"install app {settings} -s compiler.cppstd=17 -vv")
         client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
                                                  "Skip")})
-        client.run(f"install app {settings} -s compiler.cppstd=14")
+        client.run(f"install app {settings} -s compiler.cppstd=14 -vv")
         client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
                                                  "Skip")})
         # No binary for engine exist for cppstd=11
@@ -635,18 +635,18 @@ class TestValidateCppstd:
                                                     "Build")})
         client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
                                                  "Cache")})
-        client.run(f"install app {settings} -s compiler.cppstd=17")
+        client.run(f"install app {settings} -s compiler.cppstd=17 -vv")
         client.assert_listed_binary({"engine/0.1": ("493976208e9989b554704f94f9e7b8e5ba39e5ab",
                                                     "Cache")})
         client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
                                                  "Skip")})
-        client.run(f"install app {settings} -s compiler.cppstd=14")
+        client.run(f"install app {settings} -s compiler.cppstd=14 -vv")
         client.assert_listed_binary({"engine/0.1": ("493976208e9989b554704f94f9e7b8e5ba39e5ab",
                                                     "Cache")})
         client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
                                                  "Skip")})
         # No binary for engine exist for cppstd=11
-        client.run(f"install app {settings} -s compiler.cppstd=11")
+        client.run(f"install app {settings} -s compiler.cppstd=11 -vv")
         client.assert_listed_binary({"pkg/0.1": ("8415595b7485d90fc413c2f47298aa5fb05a5468",
                                                  "Skip")})
         client.assert_listed_binary({"engine/0.1": ("493976208e9989b554704f94f9e7b8e5ba39e5ab",

--- a/conans/test/integration/package_id/test_validate.py
+++ b/conans/test/integration/package_id/test_validate.py
@@ -560,10 +560,10 @@ class TestValidateCppstd:
         client.run(f"create engine {settings} -s compiler.cppstd=17")
         client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
                                                  "Cache")})
-        client.run(f"install app {settings} -s compiler.cppstd=17 -vv")
+        client.run(f"install app {settings} -s compiler.cppstd=17 -v")
         client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
                                                  "Skip")})
-        client.run(f"install app {settings} -s compiler.cppstd=14 -vv")
+        client.run(f"install app {settings} -s compiler.cppstd=14 -v")
         client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
                                                  "Skip")})
         # No binary for engine exist for cppstd=11
@@ -635,18 +635,18 @@ class TestValidateCppstd:
                                                     "Build")})
         client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
                                                  "Cache")})
-        client.run(f"install app {settings} -s compiler.cppstd=17 -vv")
+        client.run(f"install app {settings} -s compiler.cppstd=17 -v")
         client.assert_listed_binary({"engine/0.1": ("493976208e9989b554704f94f9e7b8e5ba39e5ab",
                                                     "Cache")})
         client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
                                                  "Skip")})
-        client.run(f"install app {settings} -s compiler.cppstd=14 -vv")
+        client.run(f"install app {settings} -s compiler.cppstd=14 -v")
         client.assert_listed_binary({"engine/0.1": ("493976208e9989b554704f94f9e7b8e5ba39e5ab",
                                                     "Cache")})
         client.assert_listed_binary({"pkg/0.1": ("91faf062eb94767a31ff62a46767d3d5b41d1eff",
                                                  "Skip")})
         # No binary for engine exist for cppstd=11
-        client.run(f"install app {settings} -s compiler.cppstd=11 -vv")
+        client.run(f"install app {settings} -s compiler.cppstd=11 -v")
         client.assert_listed_binary({"pkg/0.1": ("8415595b7485d90fc413c2f47298aa5fb05a5468",
                                                  "Skip")})
         client.assert_listed_binary({"engine/0.1": ("493976208e9989b554704f94f9e7b8e5ba39e5ab",

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -422,7 +422,7 @@ def test_skip_transitive_components():
                                                    .with_requires("pkg/0.1")})
     c.run("create dep")
     c.run("create pkg")
-    c.run("install consumer -g CMakeDeps -vv")
+    c.run("install consumer -g CMakeDeps -v")
     c.assert_listed_binary({"dep": ("da39a3ee5e6b4b0d3255bfef95601890afd80709", "Skip")})
     # This used to error, as CMakeDeps was raising a KeyError
     assert "'CMakeDeps' calling 'generate()'" in c.out

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -422,7 +422,7 @@ def test_skip_transitive_components():
                                                    .with_requires("pkg/0.1")})
     c.run("create dep")
     c.run("create pkg")
-    c.run("install consumer -g CMakeDeps")
+    c.run("install consumer -g CMakeDeps -vv")
     c.assert_listed_binary({"dep": ("da39a3ee5e6b4b0d3255bfef95601890afd80709", "Skip")})
     # This used to error, as CMakeDeps was raising a KeyError
     assert "'CMakeDeps' calling 'generate()'" in c.out

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -402,7 +402,7 @@ def test_props_from_consumer_build_context_activated():
 def test_skip_transitive_components():
     """ when a transitive depenency is skipped, because its binary is not necessary
     (shared->static), the ``components[].requires`` clause pointing to that skipped dependency
-    was erroring with KeyError, as the dependency info was not there
+    was failing with KeyError, as the dependency info was not there
     """
     c = TestClient()
     pkg = textwrap.dedent("""


### PR DESCRIPTION
Changelog: Feature: Avoid showing unnecessary skipped dependencies. Now, it only shows a list of reference names if exists skipped binaries. They can be completely listed by adding `-v` (verbose mode) to the current command.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/13518

First, merge this: https://github.com/conan-io/conan/pull/13839
