### PR TITLE
Changed default -v level

### DIFF
--- a/conan/api/output.py
+++ b/conan/api/output.py
@@ -51,17 +51,6 @@ class ConanOutput:
     # Singleton
     _conan_output_level = LEVEL_STATUS
     _silent_warn_tags = []
-    _output_levels = {"quiet": LEVEL_QUIET,  # -vquiet 80
-                      "error": LEVEL_ERROR,  # -verror 70
-                      "warning": LEVEL_WARNING,  # -vwaring 60
-                      "notice": LEVEL_NOTICE,  # -vnotice 50
-                      "status": LEVEL_STATUS,  # -vstatus 40
-                      None: LEVEL_VERBOSE,  # -v 30
-                      "verbose": LEVEL_VERBOSE,  # -vverbose 30
-                      "debug": LEVEL_DEBUG,  # -vdebug 20
-                      "v": LEVEL_DEBUG,  # -vv 20
-                      "trace": LEVEL_TRACE,  # -vtrace 10
-                      "vv": LEVEL_TRACE}  # -vvv 10
 
     def __init__(self, scope=""):
         self.stream = sys.stderr
@@ -83,7 +72,18 @@ class ConanOutput:
         :param v: `str` or `None`, where `None` is the same as `verbose`.
         """
         try:
-            level = cls._output_levels[v]
+            level = {"quiet": LEVEL_QUIET,  # -vquiet 80
+                     "error": LEVEL_ERROR,  # -verror 70
+                     "warning": LEVEL_WARNING,  # -vwaring 60
+                     "notice": LEVEL_NOTICE,  # -vnotice 50
+                     "status": LEVEL_STATUS,  # -vstatus 40
+                     None: LEVEL_VERBOSE,  # -v 30
+                     "verbose": LEVEL_VERBOSE,  # -vverbose 30
+                     "debug": LEVEL_DEBUG,  # -vdebug 20
+                     "v": LEVEL_DEBUG,  # -vv 20
+                     "trace": LEVEL_TRACE,  # -vtrace 10
+                     "vv": LEVEL_TRACE  # -vvv 10
+                     }[v]
         except KeyError:
             raise ConanException(f"Invalid argument '-v{v}'")
         else:

--- a/conan/api/output.py
+++ b/conan/api/output.py
@@ -51,6 +51,17 @@ class ConanOutput:
     # Singleton
     _conan_output_level = LEVEL_STATUS
     _silent_warn_tags = []
+    _output_levels = {"quiet": LEVEL_QUIET,  # -vquiet 80
+                      "error": LEVEL_ERROR,  # -verror 70
+                      "warning": LEVEL_WARNING,  # -vwaring 60
+                      "notice": LEVEL_NOTICE,  # -vnotice 50
+                      "status": LEVEL_STATUS,  # -vstatus 40
+                      None: LEVEL_VERBOSE,  # -v 30
+                      "verbose": LEVEL_VERBOSE,  # -vverbose 30
+                      "debug": LEVEL_DEBUG,  # -vdebug 20
+                      "v": LEVEL_DEBUG,  # -vv 20
+                      "trace": LEVEL_TRACE,  # -vtrace 10
+                      "vv": LEVEL_TRACE}  # -vvv 10
 
     def __init__(self, scope=""):
         self.stream = sys.stderr
@@ -65,23 +76,18 @@ class ConanOutput:
 
     @classmethod
     def define_log_level(cls, v):
-        levels = {"quiet": LEVEL_QUIET,  # -vquiet 80
-                  "error": LEVEL_ERROR,  # -verror 70
-                  "warning": LEVEL_WARNING,  # -vwaring 60
-                  "notice": LEVEL_NOTICE,  # -vnotice 50
-                  "status": LEVEL_STATUS,  # -vstatus 40
-                  None: LEVEL_STATUS,  # -v 40
-                  "verbose": LEVEL_VERBOSE,  # -vverbose 30
-                  "debug": LEVEL_DEBUG,  # -vdebug 20
-                  "v": LEVEL_DEBUG,  # -vv 20
-                  "trace": LEVEL_TRACE,  # -vtrace 10
-                  "vv": LEVEL_TRACE,  # -vvv 10
-                  }
+        """
+        Translates the verbosity level entered by a Conan command. If it's `None` (-v),
+        it will be defaulted to `verbose` level.
 
-        level = levels.get(v)
-        if not level:
+        :param v: `str` or `None`, where `None` is the same as `verbose`.
+        """
+        try:
+            level = cls._output_levels[v]
+        except KeyError:
             raise ConanException(f"Invalid argument '-v{v}'")
-        cls._conan_output_level = level
+        else:
+            cls._conan_output_level = level
 
     @classmethod
     def level_allowed(cls, level):

--- a/conans/test/integration/command_v2/test_output_level.py
+++ b/conans/test/integration/command_v2/test_output_level.py
@@ -37,11 +37,11 @@ def test_output_level():
     assert "This is a warning" in t.out
     assert "This is a error" in t.out
 
-    # Print also verbose traces
+    # Check if -v argument is equal to VERBOSE level
     t.run("create . --name foo --version 1.0 -v")
     assert "This is a trace" not in t.out
     assert "This is a debug" not in t.out
-    assert "This is a verbose" not in t.out
+    assert "This is a verbose" in t.out
     assert "This is a info" in t.out
     assert "This is a highlight" in t.out
     assert "This is a success" in t.out


### PR DESCRIPTION
Changelog: Feature: `-v` argument defaults to the `VERBOSE` level.
Docs: omit