### PR TITLE
fix lockfile-out paths for 'graph build-order' and 'test' commands

### DIFF
--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -79,8 +79,7 @@ def graph_build_order(conan_api, parser, subparser, *args):
 
     lockfile = conan_api.lockfile.update_lockfile(lockfile, deps_graph, args.lockfile_packages,
                                                   clean=args.lockfile_clean)
-    conanfile_path = os.path.dirname(deps_graph.root.path) if deps_graph.root.path else os.getcwd()
-    conan_api.lockfile.save_lockfile(lockfile, args.lockfile_out, conanfile_path)
+    conan_api.lockfile.save_lockfile(lockfile, args.lockfile_out, cwd)
 
     return install_order_serialized
 
@@ -168,7 +167,7 @@ def graph_info(conan_api, parser, subparser, *args):
 
         lockfile = conan_api.lockfile.update_lockfile(lockfile, deps_graph, args.lockfile_packages,
                                                       clean=args.lockfile_clean)
-        conan_api.lockfile.save_lockfile(lockfile, args.lockfile_out, os.getcwd())
+        conan_api.lockfile.save_lockfile(lockfile, args.lockfile_out, cwd)
         if args.deployer:
             base_folder = os.getcwd()
             do_deploys(conan_api, deps_graph, args.deployer, base_folder)

--- a/conan/cli/commands/test.py
+++ b/conan/cli/commands/test.py
@@ -40,7 +40,7 @@ def test(conan_api, parser, *args):
                           args.update, build_modes=args.build)
     lockfile = conan_api.lockfile.update_lockfile(lockfile, deps_graph, args.lockfile_packages,
                                                   clean=args.lockfile_clean)
-    conan_api.lockfile.save_lockfile(lockfile, args.lockfile_out, os.path.dirname(path))
+    conan_api.lockfile.save_lockfile(lockfile, args.lockfile_out, cwd)
 
 
 def run_test(conan_api, path, ref, profile_host, profile_build, remotes, lockfile, update,

--- a/conans/test/integration/command/test_package_test.py
+++ b/conans/test/integration/command/test_package_test.py
@@ -366,3 +366,16 @@ def test_removing_test_package_build_folder():
     # This was crashing because not cleaned
     client.run("create .")
     assert "Removing previously existing 'test_package' build folder" in client.out
+
+
+def test_test_package_lockfile_location():
+    """ the lockfile should be in the caller cwd
+    https://github.com/conan-io/conan/issues/13850
+    """
+    c = TestClient()
+    c.save({"conanfile.py": GenConanfile("dep", "0.1"),
+            "test_package/conanfile.py": GenConanfile().with_test("pass")})
+    c.run("create . --lockfile-out=myconan.lock")
+    assert os.path.exists(os.path.join(c.current_folder, "myconan.lock"))
+    c.run("test test_package dep/0.1 --lockfile=myconan.lock --lockfile-out=myconan2.lock")
+    assert os.path.exists(os.path.join(c.current_folder, "myconan2.lock"))


### PR DESCRIPTION
Changelog: Bugfix: Fix ``--lockfile-out`` paths for 'graph build-order' and 'test' commands
Docs: Omit

Close https://github.com/conan-io/conan/issues/13850
