### PR TITLE
Cache the CMakeDeps Jinja2 templates

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -44,8 +44,15 @@ class CMakeDepsFileTemplate(object):
             raise ConanException("error generating context for '{}': {}".format(self.conanfile, e))
         if context is None:
             return
-        return Template(self.template, trim_blocks=True, lstrip_blocks=True,
-                        undefined=jinja2.StrictUndefined).render(context)
+
+        # Cache the template instance as a class attribute to greatly speed up the rendering
+        # NOTE: this assumes that self.template always returns the same string
+        template_instance = getattr(type(self), "template_instance", None)
+        if template_instance is None:
+            template_instance = Template(self.template, trim_blocks=True, lstrip_blocks=True,
+                                         undefined=jinja2.StrictUndefined)
+            setattr(type(self), "template_instance", template_instance)
+        return template_instance.render(context)
 
     def context(self):
         raise NotImplementedError()


### PR DESCRIPTION
Changelog:  Fix: Speed up the CMakeDeps generation
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.

The compilation of the Jinja2 templates is quite slow, and several templates needs to be compiled per dependency, so for larger projects with a lot of dependencies it can be quite slow. This is fixed by caching the templates per class instance. For a medium size project with around 80 packages and dependencies I saw an improvement from 1:10 seconds to 10 seconds with this fix, so it's quite a bit faster.

NOTE: I'm not particularly happy with the implementation itself, but any alternative implementation I can think of need all the template files to be modified. So I decided to go with this non-intrusive implementation. But I can change it if you prefer.

Fixes https://github.com/conan-io/conan/issues/13845