### PR TITLE
fix AutotoolsToolchain compiler_executable unix_paths

### DIFF
--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -6,7 +6,7 @@ from conan.tools.build.cross_building import cross_building
 from conan.tools.build.flags import architecture_flag, build_type_flags, cppstd_flag, build_type_link_flags, libcxx_flags
 from conan.tools.env import Environment
 from conan.tools.gnu.get_gnu_triplet import _get_gnu_triplet
-from conan.tools.microsoft import VCVars, msvc_runtime_flag
+from conan.tools.microsoft import VCVars, msvc_runtime_flag, unix_path
 from conans.errors import ConanException
 from conans.model.pkg_type import PackageType
 
@@ -152,7 +152,10 @@ class AutotoolsToolchain:
             compilers_mapping = {"c": "CC", "cpp": "CXX", "cuda": "NVCC", "fortran": "FC"}
             for comp, env_var in compilers_mapping.items():
                 if comp in compilers_by_conf:
-                    env.define(env_var, compilers_by_conf[comp])
+                    compiler = compilers_by_conf[comp]
+                    # https://github.com/conan-io/conan/issues/13780
+                    compiler = unix_path(self._conanfile, compiler)
+                    env.define(env_var, compiler)
         env.append("CPPFLAGS", ["-D{}".format(d) for d in self.defines])
         env.append("CXXFLAGS", self.cxxflags)
         env.append("CFLAGS", self.cflags)

--- a/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -525,3 +525,17 @@ def test_extra_flags_via_conf():
     assert '-mios-version-min=14 --flag1 --flag2' in env["CXXFLAGS"]
     assert '-mios-version-min=14 --flag3 --flag4' in env["CFLAGS"]
     assert '-mios-version-min=14 --flag5 --flag6' in env["LDFLAGS"]
+
+
+def test_conf_compiler_executable():
+    conanfile = ConanFileMock()
+    conanfile.conf.define("tools.build:compiler_executables", {"cpp": "C:/my/path/myg++"})
+    conanfile.conf.define("tools.microsoft.bash:subsystem", "msys2")
+    conanfile.win_bash = True
+    conanfile.settings = MockSettings(
+        {"build_type": "Release",
+         "os": "Windows"})
+    conanfile.settings_build = conanfile.settings
+    be = AutotoolsToolchain(conanfile)
+    env = be.vars()
+    assert "/c/my/path/myg++" == env["CXX"]


### PR DESCRIPTION
Changelog: Fix: Fix ``AutotoolsToolchain`` definition of  ``tools.build:compiler_executable`` for Windows subsystems
Docs: Omit

Close https://github.com/conan-io/conan/issues/13780
