### PR TITLE
Build scripts have run=True by default

### DIFF
--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -196,7 +196,7 @@ class Requirement:
             set_if_none("_libs", False)
             set_if_none("_headers", True)
         elif pkg_type is PackageType.BUILD_SCRIPTS:
-            set_if_none("_run", False)
+            set_if_none("_run", True)
             set_if_none("_libs", False)
             set_if_none("_headers", False)
             set_if_none("_visible", False)  # Conflicts might be allowed for this kind of package

--- a/conans/test/integration/graph/core/graph_manager_test.py
+++ b/conans/test/integration/graph/core/graph_manager_test.py
@@ -365,7 +365,7 @@ class TestLinear(GraphManagerTest):
             cmake = app.dependencies[0].dst
 
             # node, headers, lib, build, run
-            run = package_type in ("application", "shared-library")
+            run = package_type in ("application", "shared-library", "build-scripts")
             _check_transitive(app, [(cmake, False, False, True, run)])
 
     def test_direct_header_only(self):


### PR DESCRIPTION
Changelog: Fix: `build_scripts` now set the `run` trait to `True` by default 
Docs: https://github.com/conan-io/docs/pull/3206

After internal discussion by the team, it was decided that this is the way to go forward.