### PR TITLE
fix 13899: lockfile usage with transitive tool-dependencies

### DIFF
--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -3,7 +3,7 @@ import os
 from collections import OrderedDict
 
 from conans import DEFAULT_REVISION_V1
-from conans.client.graph.graph import RECIPE_VIRTUAL, RECIPE_CONSUMER, CONTEXT_HOST
+from conans.client.graph.graph import RECIPE_VIRTUAL, RECIPE_CONSUMER
 from conans.client.graph.python_requires import PyRequires
 from conans.client.graph.range_resolver import satisfying
 from conans.client.profile_loader import _load_profile
@@ -542,7 +542,7 @@ class GraphLock(object):
 
         for require in requires:
             try:
-                context = require.build_require_context if require.build_require_context is not None else CONTEXT_HOST
+                context = require.build_require_context if build_requires else node.context
                 locked_ref, locked_id = refs[(require.ref.name, context)]
             except KeyError:
                 t = "Build-require" if build_requires else "Require"


### PR DESCRIPTION
Changelog: Bugfix: Fix lockfile usage with transitive tool-dependencies.
Docs: Omit

Fixes: #13899

- [x] Refer to the issue that supports this Pull Request: 
       https://github.com/conan-io/conan/issues/13899
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
