### PR TITLE
Add `timeout` argument to ConanFile `run` method

### DIFF
--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -313,7 +313,7 @@ class ConanFile:
         return Path(self.generators_folder)
 
     def run(self, command, stdout=None, cwd=None, ignore_errors=False, env="", quiet=False,
-            shell=True, scope="build"):
+            shell=True, scope="build", timeout=None):
         # NOTE: "self.win_bash" is the new parameter "win_bash" for Conan 2.0
         command = self._conan_helpers.cmd_wrapper.wrap(command, conanfile=self)
         if env == "":  # This default allows not breaking for users with ``env=None`` indicating
@@ -327,7 +327,7 @@ class ConanFile:
         from conans.util.runners import conan_run
         ConanOutput().writeln(f"{self.display_name}: RUN: {command if not quiet else '*hidden*'}",
                               fg=Color.BRIGHT_BLUE)
-        retcode = conan_run(wrapped_cmd, cwd=cwd, stdout=stdout, shell=shell)
+        retcode = conan_run(wrapped_cmd, cwd=cwd, stdout=stdout, shell=shell, timeout=timeout)
         ConanOutput().writeln("")
 
         if not ignore_errors and retcode != 0:

--- a/conans/test/functional/conanfile/runner_test.py
+++ b/conans/test/functional/conanfile/runner_test.py
@@ -56,3 +56,16 @@ class Pkg(ConanFile):
         client.save({"conanfile.py": conanfile})
         client.run("source .")
         self.assertIn('conanfile.py: Buffer got msgs Hello', client.out)
+
+
+def test_run_method_timeout():
+    conanfile = textwrap.dedent("""
+                from conan import ConanFile
+                class Pkg(ConanFile):
+                    def source(self):
+                        self.run('sleep 10', timeout=1)
+                """)
+    client = TestClient()
+    client.save({"conanfile.py": conanfile})
+    client.run("source .")
+    assert "TimeoutExpired: Command 'sleep 10' timed out after 1 seconds" in client.out

--- a/conans/test/functional/conanfile/runner_test.py
+++ b/conans/test/functional/conanfile/runner_test.py
@@ -63,9 +63,9 @@ def test_run_method_timeout():
                 from conan import ConanFile
                 class Pkg(ConanFile):
                     def source(self):
-                        self.run('sleep 10', timeout=1)
+                        self.run('sleep 10', timeout=0.1)
                 """)
     client = TestClient()
     client.save({"conanfile.py": conanfile})
-    client.run("source .")
-    assert "TimeoutExpired: Command 'sleep 10' timed out after 1 seconds" in client.out
+    client.run("source .", assert_error=True)
+    assert "TimeoutExpired: Command 'sleep 10' timed out after 0.1 seconds" in client.out

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -539,14 +539,14 @@ class TestClient(object):
                     if redirect_stderr:
                         save(os.path.join(self.current_folder, redirect_stderr), self.stderr)
 
-    def run_command(self, command, cwd=None, assert_error=False):
+    def run_command(self, command, cwd=None, assert_error=False, timeout=None):
         from conans.test.utils.mocks import RedirectedTestOutput
         self.stdout = RedirectedTestOutput()  # Initialize each command
         self.stderr = RedirectedTestOutput()
         try:
             with redirect_output(self.stderr, self.stdout):
                 from conans.util.runners import conan_run
-                ret = conan_run(command, cwd=cwd or self.current_folder)
+                ret = conan_run(command, cwd=cwd or self.current_folder, timeout=timeout)
         finally:
             self.stdout = str(self.stdout)
             self.stderr = str(self.stderr)

--- a/conans/util/runners.py
+++ b/conans/util/runners.py
@@ -32,7 +32,7 @@ else:
         yield
 
 
-def conan_run(command, stdout=None, stderr=None, cwd=None, shell=True):
+def conan_run(command, stdout=None, stderr=None, cwd=None, shell=True, timeout=None):
     """
     @param shell:
     @param stderr:
@@ -52,7 +52,7 @@ def conan_run(command, stdout=None, stderr=None, cwd=None, shell=True):
         except Exception as e:
             raise ConanException("Error while running cmd\nError: %s" % (str(e)))
 
-        proc_stdout, proc_stderr = proc.communicate()
+        proc_stdout, proc_stderr = proc.communicate(timeout=timeout)
         # If the output is piped, like user provided a StringIO or testing, the communicate
         # will capture and return something when thing finished
         if proc_stdout:


### PR DESCRIPTION
Changelog: Feature: Add `timeout` argument to ConanFile `run` method
Docs: In progress

Adds a way for recipes to specify the timeout of their `self.run` calls
Also adds the same functionality to `tools.utils.run_command` to keep symmetry.