### PR TITLE
DuplicateOptionError Conan v1.60.0

### DIFF
--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -543,11 +543,10 @@ def collect_libs(conanfile, folder=None):
     return result
 
 
-# TODO: Do NOT document this yet. It is unclear the interface, maybe should be split
-def move_folder_contents(src_folder, dst_folder):
-    """ replaces the current folder contents with the contents of one child folder. This
-    is used in the SCM monorepo flow, when it is necessary to use one subproject subfolder
-    to replace the whole cloned git repo
+def move_folder_contents(conanfile, src_folder, dst_folder):
+    """ replaces the dst_folder contents with the contents of the src_folder, which can be a
+    child folder of dst_folder. This is used in the SCM monorepo flow, when it is necessary
+    to use one subproject subfolder to replace the whole cloned git repo
     /base-folder                       /base-folder
         /pkg  (src folder)                 /other/<otherfiles>
           /other/<otherfiles>              /pkg/<pkgfiles>

--- a/conans/test/functional/tools/scm/test_git.py
+++ b/conans/test/functional/tools/scm/test_git.py
@@ -510,7 +510,7 @@ class TestGitMonorepoSCMFlow:
                 sources = self.conan_data["sources"]
                 git.clone(url=sources["url"], target=".")
                 git.checkout(commit=sources["commit"])
-                move_folder_contents(os.path.join(self.source_folder, sources["folder"]),
+                move_folder_contents(self, os.path.join(self.source_folder, sources["folder"]),
                                     self.source_folder)
 
             def build(self):
@@ -598,7 +598,7 @@ class TestGitMonorepoSCMFlow:
                     # Final we want is pkg/<files> and common/<files>
                     # NOTE: This abs_path is IMPORTANT to avoid the trailing "."
                     src_folder = os.path.abspath(self.source_folder)
-                    move_folder_contents(src_folder, os.path.dirname(src_folder))
+                    move_folder_contents(self, src_folder, os.path.dirname(src_folder))
 
                 def build(self):
                     cmake = CMake(self)

--- a/conans/test/integration/remote/rest_api_test.py
+++ b/conans/test/integration/remote/rest_api_test.py
@@ -174,7 +174,7 @@ class RestApiTest(unittest.TestCase):
             tmp = temp_folder()
             files = self.api.get_recipe(ref, tmp)
             self.assertIsNotNone(files)
-            self.assertTrue(os.path.exists(os.path.join(tmp, "file999.cpp")))
+            self.assertFalse(os.path.exists(os.path.join(tmp, "file999.cpp")))
 
     def test_search(self):
         # Upload a conan1

--- a/conans/test/unittests/client/build/cmake_test.py
+++ b/conans/test/unittests/client/build/cmake_test.py
@@ -1384,46 +1384,47 @@ build_type: [ Release]
                            ("iOS", "7.0",),
                            ("watchOS", "4.0",),
                            ("tvOS", "11.0",)])
-    @mock.patch("platform.system", return_value="Darwin")
-    @mock.patch("conans.client.tools.apple.XCRun.sdk_path", return_value='/opt')
-    def test_cmake_system_version_osx(self, the_os, os_version, _, __):
-        settings = Settings.loads(get_default_settings_yml())
-        settings.os = the_os
+    def test_cmake_system_version_osx(self, the_os, os_version):
+        with mock.patch("platform.system", return_value="Darwin"):
+            with mock.patch("conans.client.tools.apple.XCRun.sdk_path", return_value='/opt'):
 
-        # No version defined
-        conanfile = ConanFileMock()
-        conanfile.settings = settings
-        cmake = CMake(conanfile)
-        self.assertFalse("CMAKE_OSX_DEPLOYMENT_TARGET" in cmake.definitions)
-        if the_os == "Macos":
-            self.assertFalse("CMAKE_SYSTEM_NAME" in cmake.definitions)
-        else:
-            self.assertTrue("CMAKE_SYSTEM_NAME" in cmake.definitions)
-        self.assertFalse("CMAKE_SYSTEM_VERSION" in cmake.definitions)
+                settings = Settings.loads(get_default_settings_yml())
+                settings.os = the_os
 
-        # Version defined using Conan env variable
-        with tools.environment_append({"CONAN_CMAKE_SYSTEM_VERSION": "23"}):
-            conanfile = ConanFileMock()
-            conanfile.settings = settings
-            cmake = CMake(conanfile)
-            self.assertEqual(cmake.definitions["CMAKE_SYSTEM_VERSION"], "23")
-            self.assertEqual(cmake.definitions["CMAKE_OSX_DEPLOYMENT_TARGET"], "23")
+                # No version defined
+                conanfile = ConanFileMock()
+                conanfile.settings = settings
+                cmake = CMake(conanfile)
+                self.assertFalse("CMAKE_OSX_DEPLOYMENT_TARGET" in cmake.definitions)
+                if the_os == "Macos":
+                    self.assertFalse("CMAKE_SYSTEM_NAME" in cmake.definitions)
+                else:
+                    self.assertTrue("CMAKE_SYSTEM_NAME" in cmake.definitions)
+                self.assertFalse("CMAKE_SYSTEM_VERSION" in cmake.definitions)
 
-        # Version defined in settings
-        settings.os.version = os_version
-        conanfile = ConanFileMock()
-        conanfile.settings = settings
-        cmake = CMake(conanfile)
-        self.assertEqual(cmake.definitions["CMAKE_SYSTEM_VERSION"], os_version)
-        self.assertEqual(cmake.definitions["CMAKE_OSX_DEPLOYMENT_TARGET"], os_version)
+                # Version defined using Conan env variable
+                with tools.environment_append({"CONAN_CMAKE_SYSTEM_VERSION": "23"}):
+                    conanfile = ConanFileMock()
+                    conanfile.settings = settings
+                    cmake = CMake(conanfile)
+                    self.assertEqual(cmake.definitions["CMAKE_SYSTEM_VERSION"], "23")
+                    self.assertEqual(cmake.definitions["CMAKE_OSX_DEPLOYMENT_TARGET"], "23")
 
-        # Version defined in settings AND using Conan env variable
-        with tools.environment_append({"CONAN_CMAKE_SYSTEM_VERSION": "23"}):
-            conanfile = ConanFileMock()
-            conanfile.settings = settings
-            cmake = CMake(conanfile)
-            self.assertEqual(cmake.definitions["CMAKE_SYSTEM_VERSION"], "23")
-            self.assertEqual(cmake.definitions["CMAKE_OSX_DEPLOYMENT_TARGET"], "23")
+                # Version defined in settings
+                settings.os.version = os_version
+                conanfile = ConanFileMock()
+                conanfile.settings = settings
+                cmake = CMake(conanfile)
+                self.assertEqual(cmake.definitions["CMAKE_SYSTEM_VERSION"], os_version)
+                self.assertEqual(cmake.definitions["CMAKE_OSX_DEPLOYMENT_TARGET"], os_version)
+
+                # Version defined in settings AND using Conan env variable
+                with tools.environment_append({"CONAN_CMAKE_SYSTEM_VERSION": "23"}):
+                    conanfile = ConanFileMock()
+                    conanfile.settings = settings
+                    cmake = CMake(conanfile)
+                    self.assertEqual(cmake.definitions["CMAKE_SYSTEM_VERSION"], "23")
+                    self.assertEqual(cmake.definitions["CMAKE_OSX_DEPLOYMENT_TARGET"], "23")
 
     @staticmethod
     def scape(args):


### PR DESCRIPTION
Dear Conan community,

I am working with Conan for the first time as part of a software development project. The software developer who provides the software I use recommends a Conan version released before v2.0.0. I installed v1.60.0 on Linux with the following command:

`sudo pip install -U "conan<2.0"`

After that I have made the configuration. 
In the next step I wanted to compile one of the samples which was also provided by the software developer. I received the following error message

`ERROR: while executing system_requirements(): System requirements: "libasound2, libasound2-dev" are missing but can´t install because tools.system.package_manager:mode is "check". Please update packages manually or set "tools.system.package_manager:mode" to "install" in the [conf] section of the profile, or in the command line using "-c tools.system.package_manager:mode=install"`

libasound2 and libasound2-dev are definitely installed and up to date.
The software manufacturer recommends adding the following lines to global.conf in case of this error

`tools.system.package_manager:mode=install`
`tools.system.package_manager:sudo=True`

Unfortunately, I cannot find a global.conf in version 1.60.0 and have not yet found any useful information on how to create one or in which path it should be stored. Therefore, I have tried to modify the global.conf accordingly

`[log]`
`run_to_output = True`
`run_to_file = False`
`level = critical`
`print_run_commands = False`

`[general]`
`default_profile = default`
`compression_level = 9`
`sysrequires_sudo = True`
`request_timeout = 60`
`default_package_id_mode = semver_direct_mode`
`revision_enabled = 1`

`[storage]`
`path = ./data`

`[proxies]`

`[hooks]`
`attribute_checker`

`[tools]`
`system.package_manager:mode = install`
`system.package_manager:sudo = True`

Unfortunately, when trying to compile the sample with this conan.conf, I get this error message

`raise DuplicateOptionError(sectname, optname, configparser.DuplicateOptionError: While reading from "/home/miti/.conan/conan.conf" [line 25]: option "system.package_manager" in section "tools" already exists`

I also tried to solve the problem with `unset`, but that didn't work either.
Unfortunately I don't know how to fix this problem, so I would be very grateful for tips on how to create the global.conf or how to adjust the conan.conf so that the compilation of the sample works. 

Thanks a lot!

n1n14