### PR TITLE
Bugfix/premakedeps - Double absolute paths

### DIFF
--- a/conan/tools/premake/premakedeps.py
+++ b/conan/tools/premake/premakedeps.py
@@ -83,11 +83,11 @@ end
 
 # Helper class that expands cpp_info meta information in lua readable string sequences
 class _PremakeTemplate(object):
-    def __init__(self, dep_cpp_info, pkg_folder):
+    def __init__(self, dep_cpp_info):
         def _format_paths(paths):
             if not paths:
                 return ""
-            return ",\n".join(f'"{pkg_folder}/{p}"'.replace("\\", "/") for p in paths)
+            return ",\n".join(f'"{p}"'.replace("\\", "/") for p in paths)
 
         def _format_flags(flags):
             if not flags:
@@ -106,7 +106,7 @@ class _PremakeTemplate(object):
         self.exelinkflags = _format_flags(dep_cpp_info.exelinkflags)
         self.frameworks = ", ".join('"%s.framework"' % p.replace('"', '\\"') for p in
                                     dep_cpp_info.frameworks) if dep_cpp_info.frameworks else ""
-        self.sysroot = f"{pkg_folder}/{dep_cpp_info.sysroot}".replace("\\", "/") \
+        self.sysroot = f"{dep_cpp_info.sysroot}".replace("\\", "/") \
             if dep_cpp_info.sysroot else ""
 
 
@@ -211,7 +211,7 @@ class PremakeDeps(object):
             var_filename = PREMAKE_VAR_FILE.format(pkgname=dep_name, config=conf_suffix)
             self._output_lua_file(var_filename, [
                 PREMAKE_TEMPLATE_VAR.format(pkgname=dep_name,
-                    config=conf_name, deps=_PremakeTemplate(dep_aggregate, dep.package_folder))
+                    config=conf_name, deps=_PremakeTemplate(dep_aggregate))
             ])
 
             # Create list of all available profiles by searching on disk


### PR DESCRIPTION
OK... as it seems the only thing that I have keeps as is from the old premake5 generator is now falling on my feet...

Changelog: Bugfix: Fix "double" absolute paths in premakedeps.
Docs: Omit

Conan 2.0.5 seems to already factor in the package path when calling `aggregated_components()`
The premake5 implementation manually did this. This resulted in a "double" absolute path.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
