### PR TITLE
Add missing values to `package_manager:mode` in `conan config install`

### DIFF
--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -84,7 +84,7 @@ BUILT_IN_CONFS = {
     "tools.intel:installation_path": "Defines the Intel oneAPI installation root path",
     "tools.intel:setvars_args": "Custom arguments to be passed onto the setvars.sh|bat script from Intel oneAPI",
     "tools.system.package_manager:tool": "Default package manager tool: 'apt-get', 'yum', 'dnf', 'brew', 'pacman', 'choco', 'zypper', 'pkg' or 'pkgutil'",
-    "tools.system.package_manager:mode": "Mode for package_manager tools: 'check' or 'install'",
+    "tools.system.package_manager:mode": "Mode for package_manager tools: 'check', 'report', 'report-installed' or 'install'",
     "tools.system.package_manager:sudo": "Use 'sudo' when invoking the package manager tools in Linux (False by default)",
     "tools.system.package_manager:sudo_askpass": "Use the '-A' argument if using sudo in Linux to invoke the system package manager (False by default)",
     "tools.apple:sdk_path": "Path to the SDK to be used",


### PR DESCRIPTION
Changelog: Fix: Add missing values to `package_manager:mode` in `conan config install`.
Docs: omit
