### PR TITLE
Add tool configuration to specify CMake executable path (#12701)

### DIFF
--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -49,7 +49,7 @@ class CMake(object):
         self._toolchain_file = configure_preset.get("toolchainFile")
         self._cache_variables = configure_preset["cacheVariables"]
 
-        self._cmake_program = "cmake"  # Path to CMake should be handled by environment
+        self._cmake_program = conanfile.conf.get("tools.cmake:cmake_program", default="cmake")
 
     def configure(self, variables=None, build_script_folder=None, cli_args=None):
         """

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -63,6 +63,7 @@ BUILT_IN_CONFS = {
     "tools.cmake.cmaketoolchain:system_processor": "Define CMAKE_SYSTEM_PROCESSOR in CMakeToolchain",
     "tools.cmake.cmaketoolchain:toolset_arch": "Toolset architecture to be used as part of CMAKE_GENERATOR_TOOLSET in CMakeToolchain",
     "tools.cmake.cmake_layout:build_folder_vars": "Settings and Options that will produce a different build folder and different CMake presets names",
+    "tools.cmake:cmake_program": "Path to CMake executable",
     "tools.files.download:retry": "Number of retries in case of failure when downloading",
     "tools.files.download:retry_wait": "Seconds to wait between download attempts",
     "tools.gnu:make_program": "Indicate path to make program",

--- a/conans/test/unittests/tools/cmake/test_cmake_presets_definitions.py
+++ b/conans/test/unittests/tools/cmake/test_cmake_presets_definitions.py
@@ -30,6 +30,17 @@ def conanfile():
     return c
 
 
+def test_cmake_cmake_program(conanfile):
+    mycmake = "C:\\mycmake.exe"
+    conanfile.conf.define("tools.cmake:cmake_program", mycmake)
+
+    with mock.patch("platform.system", mock.MagicMock(return_value='Windows')):
+        write_cmake_presets(conanfile, "the_toolchain.cmake", "MinGW Makefiles", {})
+
+    cmake = CMake(conanfile)
+    assert cmake._cmake_program == mycmake
+
+
 def test_cmake_make_program(conanfile):
     def run(command):
         assert '-DCMAKE_MAKE_PROGRAM="C:/mymake.exe"' in command
@@ -42,4 +53,3 @@ def test_cmake_make_program(conanfile):
 
     cmake = CMake(conanfile)
     cmake.configure()
-


### PR DESCRIPTION
Changelog: Feature: Add a `tools.cmake:cmake_program` configuration item to allow specifying the location of the desired CMake executable.
Docs: https://github.com/conan-io/docs/pull/3232

 Fixes: #12701

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
