### PR TITLE
[fix] Fix custom commands in a layer not able to do a local import

### DIFF
--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -56,6 +56,7 @@ class Cli:
         # layers
         for folder in os.listdir(custom_commands_path):
             layer_folder = os.path.join(custom_commands_path, folder)
+            sys.path.append(layer_folder)
             if not os.path.isdir(layer_folder):
                 continue
             for module in pkgutil.iter_modules([layer_folder]):

--- a/conans/test/integration/command_v2/custom_commands_test.py
+++ b/conans/test/integration/command_v2/custom_commands_test.py
@@ -218,30 +218,19 @@ class TestCustomCommands:
         client.run("install")
         assert "Hello world" in client.out
 
-    def test_custom_command_import_from_other_commands(self):
+    def test_custom_command_local_import(self):
         mycode = textwrap.dedent("""
-            from conan.cli.command import conan_command
             from conan.api.output import cli_out_write
 
 
             def write_output(folder):
                 cli_out_write(f"Conan cache folder from cmd_mycode: {folder}")
-
-
-            @conan_command(group="custom commands")
-            def mycode(conan_api, parser, *args, **kwargs):
-                \"""
-                this is my code custom command, it will print mycode folder
-                \"""
-                folder = "mycode folder"
-                write_folder(folder)
-
         """)
         mycommand = textwrap.dedent("""
             import os
 
             from conan.cli.command import conan_command
-            from cmd_mycode import write_output
+            from mycode import write_output
 
 
             @conan_command(group="custom commands")
@@ -257,7 +246,7 @@ class TestCustomCommands:
         mycommand_file_path = os.path.join(client.cache_folder, 'extensions',
                                            'commands', 'cmd_mycommand.py')
         mycode_file_path = os.path.join(client.cache_folder, 'extensions',
-                                        'commands', 'cmd_mycode.py')
+                                        'commands', 'mycode.py')
         client.save({
             mycode_file_path: mycode,
             mycommand_file_path: mycommand

--- a/conans/test/integration/command_v2/custom_commands_test.py
+++ b/conans/test/integration/command_v2/custom_commands_test.py
@@ -244,13 +244,13 @@ class TestCustomCommands:
 
         client = TestClient()
         mycommand_file_path = os.path.join(client.cache_folder, 'extensions',
-                                           'commands', 'cmd_mycommand.py')
+                                           'commands', 'danimtb', 'cmd_mycommand.py')
         mycode_file_path = os.path.join(client.cache_folder, 'extensions',
-                                        'commands', 'mycode.py')
+                                        'commands', 'danimtb', 'mycode.py')
         client.save({
             mycode_file_path: mycode,
             mycommand_file_path: mycommand
         })
-        client.run("mycommand")
+        client.run("danimtb:mycommand")
         foldername = os.path.basename(client.cache_folder)
         assert f'Conan cache folder from cmd_mycode: {foldername}' in client.out

--- a/conans/test/integration/command_v2/custom_commands_test.py
+++ b/conans/test/integration/command_v2/custom_commands_test.py
@@ -217,3 +217,51 @@ class TestCustomCommands:
         assert "Hello world" in client.out
         client.run("install")
         assert "Hello world" in client.out
+
+    def test_custom_command_import_from_other_commands(self):
+        mycode = textwrap.dedent("""
+            from conan.cli.command import conan_command
+            from conan.api.output import cli_out_write
+
+
+            def write_output(folder):
+                cli_out_write(f"Conan cache folder from cmd_mycode: {folder}")
+
+
+            @conan_command(group="custom commands")
+            def mycode(conan_api, parser, *args, **kwargs):
+                \"""
+                this is my code custom command, it will print mycode folder
+                \"""
+                folder = "mycode folder"
+                write_folder(folder)
+
+        """)
+        mycommand = textwrap.dedent("""
+            import os
+
+            from conan.cli.command import conan_command
+            from cmd_mycode import write_output
+
+
+            @conan_command(group="custom commands")
+            def mycommand(conan_api, parser, *args, **kwargs):
+                \"""
+                this is my custom command, it will print the location of the cache folder
+                \"""
+                folder = os.path.basename(conan_api.cache_folder)
+                write_output(folder)
+            """)
+
+        client = TestClient()
+        mycommand_file_path = os.path.join(client.cache_folder, 'extensions',
+                                           'commands', 'cmd_mycommand.py')
+        mycode_file_path = os.path.join(client.cache_folder, 'extensions',
+                                        'commands', 'cmd_mycode.py')
+        client.save({
+            mycode_file_path: mycode,
+            mycommand_file_path: mycommand
+        })
+        client.run("mycommand")
+        foldername = os.path.basename(client.cache_folder)
+        assert f'Conan cache folder from cmd_mycode: {foldername}' in client.out


### PR DESCRIPTION
closes https://github.com/conan-io/conan/issues/13942

Changelog: Fix: Fix custom commands in a layer not able to do a local import.
Docs: Omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
