### PR TITLE
Improve graph conflict message when Conan can't show one of the conflicting recipes

### DIFF
--- a/conan/cli/formatters/graph/graph.py
+++ b/conan/cli/formatters/graph/graph.py
@@ -3,7 +3,6 @@ import os
 
 from jinja2 import Template, select_autoescape
 
-
 from conan.api.output import cli_out_write
 from conan.cli.formatters.graph.graph_info_text import filter_graph
 from conan.cli.formatters.graph.info_graph_dot import graph_info_dot

--- a/conan/cli/formatters/graph/graph.py
+++ b/conan/cli/formatters/graph/graph.py
@@ -111,7 +111,7 @@ def format_graph_html(result):
         error = {
             "label": graph.error.require.ref,
             "type": "conflict",
-            "from": graph.error.node.ref or graph.error.base_previous.ref,
+            "from": graph.error.node.id or graph.error.base_previous.id,
             "prev_require": graph.error.prev_require.ref
         }
     cli_out_write(_render_graph(graph, error, template, template_folder))

--- a/conan/cli/formatters/graph/graph.py
+++ b/conan/cli/formatters/graph/graph.py
@@ -111,8 +111,7 @@ def format_graph_html(result):
             "type": "conflict",
             "from": graph.error.node.id or graph.error.base_previous.id,
             "prev_node": graph.error.prev_node,
-            "should_highlight_node": lambda node: node.id == graph.error.prev_node.id or
-                                                  node.id == graph.error.node.id
+            "should_highlight_node": lambda node: node.id == graph.error.node.id
         }
     else:
         error = {

--- a/conan/cli/formatters/graph/graph.py
+++ b/conan/cli/formatters/graph/graph.py
@@ -106,13 +106,20 @@ def format_graph_html(result):
     template_folder = os.path.join(conan_api.cache_folder, "templates")
     user_template = os.path.join(template_folder, "graph.html")
     template = load(user_template) if os.path.isfile(user_template) else graph_info_html
-    error = None
     if isinstance(graph.error, GraphConflictError):
         error = {
             "label": graph.error.require.ref,
             "type": "conflict",
             "from": graph.error.node.id or graph.error.base_previous.id,
-            "prev_require": graph.error.prev_require.ref
+            "prev_node": graph.error.prev_node,
+            "should_highlight_node": lambda node: node.id == graph.error.prev_node.id or
+                                                  node.id == graph.error.node.id
+        }
+    else:
+        error = {
+            "type": "unknown",
+            "error:": graph.error,
+            "should_highlight_node": lambda node: False
         }
     cli_out_write(_render_graph(graph, error, template, template_folder))
     if graph.error:

--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -95,14 +95,15 @@ graph_info_html = """
                 edges.push({from: {{ error["from"] }},
                             to: "{{ error["type"] }}",
                             dashes: true,
-                            title: "Bad require",
+                            title: "Conflict",
                             physics: false,
+                            color: "red",
                             arrows: "to;from"})
 
                 edges.push({from: {{ error["prev_node"].id }},
                             to: "{{ error["type"] }}",
                             color: "red",
-                            title: "Conflict"})
+                            title: "Problematic require"})
             {% endif %}
 
             var nodes = new vis.DataSet(nodes);

--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -88,13 +88,7 @@ graph_info_html = """
                 })
 
                 {% if error["from"] is not none %}
-                    var i = nodes.findIndex(e => e["label"] === "{{ error["from"] }}")
-                    if (i !== -1) {
-                        var conflictOriginId = nodes[i]["id"];
-                        edges.push({from: conflictOriginId, to: "{{ error["type"] }}", color: "red", dashes: true, title: "Conflict"})
-                    }
-
-
+                    edges.push({from: {{ error["from"] }}, to: "{{ error["type"] }}", color: "red", dashes: true, title: "Conflict"})
                 {% endif %}
             {% endif %}
 

--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -79,6 +79,7 @@ graph_info_html = """
             ]
 
             {% if error is not none and error["type"] == "conflict" %}
+                // Add some helpful visualizations for conflicts
                 nodes.push({
                     id: "{{ error["type"] }}",
                     label: "{{ error["label"] }}",

--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -45,7 +45,7 @@ graph_info_html = """
         <div style="clear:both"></div>
 
         <script type="text/javascript">
-            var nodes = new vis.DataSet([
+            var nodes = [
                 {%- for node in graph.nodes %}
                     {
                         id: {{ node.id }},
@@ -69,12 +69,37 @@ graph_info_html = """
                                    '</ul>'
                     }{%- if not loop.last %},{% endif %}
                 {%- endfor %}
-            ]);
-            var edges = new vis.DataSet([
+            ]
+            var edges = [
                 {%- for src, dst in graph.edges %}
                     { from: {{ src.id }}, to: {{ dst.id }} }{%- if not loop.last %},{% endif %}
                 {%- endfor %}
-            ]);
+            ]
+
+            {% if error is not none and error["type"] == "conflict" %}
+                nodes.push({
+                    id: "{{ error["type"] }}",
+                    label: "{{ error["label"] }}",
+                    shape: "circle",
+                    font: { color: "white" },
+                    color: "red",
+                    fulllabel: '<h3>{{ error["label"] }}</h3><p>This node creates a conflict in the dependency graph with {{ error["prev_require"] }}</p>',
+                    shapeProperties: { borderDashes: [5, 5] }
+                })
+
+                {% if error["from"] is not none %}
+                    var i = nodes.findIndex(e => e["label"] === "{{ error["from"] }}")
+                    if (i !== -1) {
+                        var conflictOriginId = nodes[i]["id"];
+                        edges.push({from: conflictOriginId, to: "{{ error["type"] }}", color: "red", dashes: true, title: "Conflict"})
+                    }
+
+
+                {% endif %}
+            {% endif %}
+
+            var nodes = new vis.DataSet(nodes);
+            var edges = new vis.DataSet(edges);
 
             var container = document.getElementById('mynetwork');
             var controls = document.getElementById('controls');

--- a/conans/client/graph/graph_error.py
+++ b/conans/client/graph/graph_error.py
@@ -15,8 +15,18 @@ class GraphConflictError(GraphError):
         self.base_previous = base_previous
 
     def __str__(self):
-        return f"Version conflict: {self.node.ref}->{self.require.ref}, "\
-               f"{self.base_previous.ref}->{self.prev_require.ref}."
+        if self.node.ref is not None and self.base_previous.ref is not None:
+            return f"Version conflict: {self.node.ref}->{self.require.ref}, " \
+                   f"{self.base_previous.ref}->{self.prev_require.ref}."
+        else:
+            conflicting_node = self.node.ref or self.base_previous.ref
+            conflicting_node_msg = ""
+            if conflicting_node is not None:
+                conflicting_node_msg = f"\nConflict originates from {conflicting_node}\n"
+            return f"Version conflict: " \
+                   f"Conflict between {self.require.ref} and {self.prev_require.ref} in the graph." \
+                   f"{conflicting_node_msg}" \
+                   f"\nRun conan graph info ... --format=html to inspect the graph errors."
 
 
 class GraphLoopError(GraphError):
@@ -27,7 +37,7 @@ class GraphLoopError(GraphError):
         self.ancestor = ancestor
 
     def __str__(self):
-        return "There is a cycle/loop in the graph:\n"\
+        return "There is a cycle/loop in the graph:\n" \
                f"    Initial ancestor: {self.ancestor}\n" \
                f"    Require: {self.require.ref}\n" \
                f"    Dependency: {self.node}"

--- a/conans/client/graph/graph_error.py
+++ b/conans/client/graph/graph_error.py
@@ -26,7 +26,8 @@ class GraphConflictError(GraphError):
             return f"Version conflict: " \
                    f"Conflict between {self.require.ref} and {self.prev_require.ref} in the graph." \
                    f"{conflicting_node_msg}" \
-                   f"\nRun conan graph info ... --format=html to inspect the graph errors."
+                   f"\nRun conan graph info with your recipe and add --format=html " \
+                   f"to inspect the graph errors in an easier to visualize way."
 
 
 class GraphLoopError(GraphError):

--- a/conans/test/integration/command/info/test_graph_info_graphical.py
+++ b/conans/test/integration/command/info/test_graph_info_graphical.py
@@ -190,4 +190,4 @@ def test_graph_info_html_output():
     tc.run("new cmake_lib -d name=math -d version=1.0 -d requires=lib/2.0 -f")
     tc.run("export .")
     tc.run("graph info --requires=math/1.0 --requires=ui/1.0 --format=html", assert_error=True)
-    print(tc.out)
+    assert "// Add some helpful visualizations for conflicts" in tc.out

--- a/conans/test/integration/command/info/test_graph_info_graphical.py
+++ b/conans/test/integration/command/info/test_graph_info_graphical.py
@@ -177,3 +177,17 @@ def test_user_templates():
     assert template_folder in c.stdout
     c.run("graph info --requires=lib/0.1 --format=dot")
     assert template_folder in c.stdout
+
+
+def test_graph_info_html_output():
+    tc = TestClient()
+    tc.run("new cmake_lib -d name=lib -d version=1.0")
+    tc.run("export .")
+    tc.run("new cmake_lib -d name=lib -d version=2.0 -f")
+    tc.run("export .")
+    tc.run("new cmake_lib -d name=ui -d version=1.0 -d requires=lib/1.0 -f")
+    tc.run("export .")
+    tc.run("new cmake_lib -d name=math -d version=1.0 -d requires=lib/2.0 -f")
+    tc.run("export .")
+    tc.run("graph info --requires=math/1.0 --requires=ui/1.0 --format=html", assert_error=True)
+    print(tc.out)

--- a/conans/test/integration/graph/conflict_diamond_test.py
+++ b/conans/test/integration/graph/conflict_diamond_test.py
@@ -64,3 +64,7 @@ class TestConflictDiamondTest:
             c.assert_overrides({"math/1.0": [f"math/{v}"],
                                 "math/1.0.1": [f"math/{v}#8e1a7a5ce869d8c54ae3d33468fd657c"]})
             c.assert_listed_require({f"math/{v}": "Cache"})
+
+        c.run("install --requires=engine/1.0  --requires=ai/1.0", assert_error=True)
+        assert "Conflict between math/1.0.1 and math/1.0 in the graph"
+        assert "Conflict originates from ai/1.0"


### PR DESCRIPTION
Changelog: Fix: Improve graph conflict message when Conan can't show one of the conflicting recipes.
Docs: Omit

The error now looks like:

```
ERROR: Version conflict: Conflict between math/1.0.1 and math/1.0 in the graph.
       Conflict originates from ai/1.0
       Run conan graph info ... --format=html to inspect the graph errors.

```
The graph output with conflict errors now looks like this:

<img width="775" alt="image" src="https://github.com/conan-io/conan/assets/5364255/003a41ea-4b39-4a84-a722-d8df56f0b5ff">


Pinging @SSE4 