### PR TITLE
fix source folder output

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -332,8 +332,6 @@ class BinaryInstaller:
             conanfile = n.conanfile
             # Call the info method
             conanfile.folders.set_base_package(pkg_folder)
-            conanfile.folders.set_base_source(None)
-            conanfile.folders.set_base_build(None)
             self._call_package_info(conanfile, pkg_folder, is_editable=False)
 
     def _handle_node_editable(self, install_node):
@@ -402,7 +400,8 @@ class BinaryInstaller:
                 self._hook_manager.execute("pre_package_info", conanfile=conanfile)
 
                 if hasattr(conanfile, "package_info"):
-                    with conanfile_remove_attr(conanfile, ['info'], "package_info"):
+                    with conanfile_remove_attr(conanfile, ['info', "source_folder", "build_folder"],
+                                               "package_info"):
                         MockInfoProperty.package = str(conanfile)
                         conanfile.package_info()
 

--- a/conans/test/integration/command/test_forced_download_source.py
+++ b/conans/test/integration/command/test_forced_download_source.py
@@ -1,3 +1,5 @@
+import json
+import os
 import textwrap
 
 import pytest
@@ -27,10 +29,16 @@ def client():
 def test_install(client):
     client.run("install --requires=dep/0.1")
     assert "RUNNING SOURCE" not in client.out
-    client.run("install --requires=dep/0.1 -c tools.build:download_source=True")
+    client.run("install --requires=dep/0.1 -c tools.build:download_source=True --format=json")
     assert "RUNNING SOURCE" in client.out
-    client.run("install --requires=dep/0.1 -c tools.build:download_source=True")
+    graph = json.loads(client.stdout)
+    zlib = graph["graph"]["nodes"][1]
+    assert os.path.exists(zlib["source_folder"])
+    client.run("install --requires=dep/0.1 -c tools.build:download_source=True --format=json")
     assert "RUNNING SOURCE" not in client.out
+    graph = json.loads(client.stdout)
+    zlib = graph["graph"]["nodes"][1]
+    assert os.path.exists(zlib["source_folder"])
 
 
 def test_info(client):

--- a/conans/test/integration/conanfile/folders_access_test.py
+++ b/conans/test/integration/conanfile/folders_access_test.py
@@ -82,8 +82,6 @@ class AConan(ConanFile):
         assert(self.package_folder == os.getcwd())
         assert(isinstance(self.package_path, Path))
         assert(str(self.package_path) == self.package_folder)
-        assert(self.source_folder is None)
-        assert(self.build_folder is None)
 """
 
 


### PR DESCRIPTION
Changelog: Bugfix: Define ``source_folder`` correctly in the json output when ``-c tools.build:download_source=True``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/13951
