### PR TITLE
test_requires shouldn't affect package_id

### DIFF
--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -355,13 +355,15 @@ class Requirement:
         if self.package_id_mode:
             return
 
+        if self.test:
+            return  # test_requires never affect the binary_id
         dep_conanfile = dep_node.conanfile
         dep_pkg_type = dep_conanfile.package_type
         if self.build:
             build_mode = getattr(dep_conanfile, "build_mode", build_mode)
             if build_mode and self.direct:
                 self.package_id_mode = build_mode
-            return  # At the moment no defaults
+            return
 
         if pkg_type is PackageType.HEADER:
             self.package_id_mode = "unrelated_mode"

--- a/conans/test/integration/package_id/test_package_id_test_requires.py
+++ b/conans/test/integration/package_id/test_package_id_test_requires.py
@@ -19,3 +19,23 @@ def test_package_id_not_affected_test_requires(build_mode):
     c.run("list engine:*")
     assert "engine/1.0" in c.out
     assert "gtest" not in c.out
+
+
+def test_package_id_not_affected_test_requires_transitive():
+    """
+    By default, transitive deps of test_requires do not affect the package_id
+    """
+    c = TestClient()
+
+    c.save({"zlib/conanfile.py": GenConanfile("zlib", "1.0"),
+            "gtest/conanfile.py": GenConanfile("gtest", "1.0").with_requires("zlib/1.0"),
+            "engine/conanfile.py": GenConanfile("engine", "1.0").with_test_requires("gtest/1.0")})
+    c.run("create zlib")
+    c.run("create gtest")
+    c.run("create engine")
+    print(c.out)
+    c.run("list engine:*")
+    print(c.out)
+    assert "engine/1.0" in c.out
+    assert "gtest" not in c.out
+    assert "zlib" not in c.out

--- a/conans/test/integration/package_id/test_package_id_test_requires.py
+++ b/conans/test/integration/package_id/test_package_id_test_requires.py
@@ -1,0 +1,21 @@
+import pytest
+
+from conans.test.utils.tools import GenConanfile, TestClient
+from conans.util.files import save
+
+
+@pytest.mark.parametrize("build_mode", [None, "patch_mode"])
+def test_package_id_not_affected_test_requires(build_mode):
+    """
+    By default, test_requires do not affect the package_id
+    """
+    c = TestClient()
+    if build_mode is not None:
+        save(c.cache.new_config_path, "core.package_id:default_build_mode={build_mode}")
+    c.save({"gtest/conanfile.py": GenConanfile("gtest", "1.0"),
+            "engine/conanfile.py": GenConanfile("engine", "1.0").with_test_requires("gtest/1.0")})
+    c.run("create gtest")
+    c.run("create engine")
+    c.run("list engine:*")
+    assert "engine/1.0" in c.out
+    assert "gtest" not in c.out

--- a/conans/test/integration/package_id/test_package_id_test_requires.py
+++ b/conans/test/integration/package_id/test_package_id_test_requires.py
@@ -33,9 +33,7 @@ def test_package_id_not_affected_test_requires_transitive():
     c.run("create zlib")
     c.run("create gtest")
     c.run("create engine")
-    print(c.out)
     c.run("list engine:*")
-    print(c.out)
     assert "engine/1.0" in c.out
     assert "gtest" not in c.out
     assert "zlib" not in c.out


### PR DESCRIPTION
Changelog: Bugfix: ``test_requires`` were affecting the ``package_id`` of consumers as regular ``requires``, but they shouldn't.
Docs: Omit

Close https://github.com/conan-io/conan/issues/13965
