### PR TITLE
fixing editables with root definition

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -343,8 +343,9 @@ class BinaryInstaller:
         conanfile_path = editable["path"]
         output_folder = editable.get("output_folder")
 
-        # TODO: Check, this assumes the folder is always the conanfile one
         base_path = os.path.dirname(conanfile_path)
+        base_path = base_path if conanfile.folders.root is None else \
+            os.path.normpath(os.path.join(base_path, conanfile.folders.root))
         conanfile.folders.set_base_folders(base_path, output_folder)
         output = conanfile.output
         output.info("Rewriting files of editable package "

--- a/conans/test/integration/editable/test_editable_layout.py
+++ b/conans/test/integration/editable/test_editable_layout.py
@@ -1,0 +1,36 @@
+import os
+import textwrap
+
+from conans.test.utils.tools import TestClient
+
+
+def test_editable_folders_root():
+    """ Editables with self.folders.root = ".." should work too
+    """
+    c = TestClient()
+    sub1 = textwrap.dedent("""
+        from conan import ConanFile
+
+        class Pkg(ConanFile):
+            name = "pkg"
+            version = "0.1"
+            def layout(self):
+                self.folders.root = ".."
+                self.folders.build = "mybuild"
+                self.cpp.build.libdirs = ["mylibdir"]
+        """)
+    sub2 = textwrap.dedent("""
+        from conan import ConanFile
+
+        class Pkg(ConanFile):
+            requires = "pkg/0.1"
+            def generate(self):
+                pkg_libdir = self.dependencies["pkg"].cpp_info.libdir
+                self.output.info(f"PKG LIBDIR {pkg_libdir}")
+        """)
+    c.save({"sub1/conanfile.py": sub1,
+            "sub2/conanfile.py": sub2})
+    c.run("editable add sub1")
+    c.run("install sub2")
+    libdir = os.path.join(c.current_folder, "mybuild", "mylibdir")
+    assert f"conanfile.py: PKG LIBDIR {libdir}" in c.out


### PR DESCRIPTION
Changelog: Bugfix: Fix problem with ``editable`` packages when defining ``self.folders.root=".."`` parent directory.
Docs: Omit

Close https://github.com/conan-io/conan/issues/13982

