### PR TITLE
make functional test not use mocks

### DIFF
--- a/conans/test/functional/toolchains/gnu/test_pkg_config.py
+++ b/conans/test/functional/toolchains/gnu/test_pkg_config.py
@@ -1,61 +1,70 @@
-import os
+import textwrap
 
 import pytest
 
-from conan.tools.gnu.pkgconfig import PkgConfig
-from conans.errors import ConanException
-from conans.model.build_info import CppInfo
-from conans.test.utils.mocks import ConanFileMock
-from conans.test.utils.test_files import temp_folder
-from conans.util.files import save
-
-libastral_pc = """
-PC FILE EXAMPLE:
-
-prefix=/usr/local
-exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
-includedir=${prefix}/include
-
-Name: libastral
-Description: Interface library for Astral data flows
-Version: 6.6.6
-Libs: -L${libdir}/libastral -lastral -lm -Wl,--whole-archive
-Cflags: -I${includedir}/libastral -D_USE_LIBASTRAL
-"""
+from conans.test.utils.tools import TestClient
 
 
 @pytest.mark.tool("pkg_config")
 class TestPkgConfig:
+    """ This test uses the pkg_config in the system
+    """
     def test_negative(self):
-        conanfile = ConanFileMock()
-        pkg_config = PkgConfig(conanfile, 'libsomething_that_does_not_exist_in_the_world')
-        with pytest.raises(ConanException):
-            pkg_config.libs()
+        c = TestClient()
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            from conan.tools.gnu import PkgConfig
+
+            class Pkg(ConanFile):
+                def generate(self):
+                    pkg_config = PkgConfig(self, "something_that_not_exist")
+                    pkg_config.libs
+                """)
+        c.save({"conanfile.py": conanfile})
+        c.run("install .", assert_error=True)
+        assert "Package something_that_not_exist was not found" in c.out
 
     def test_pc(self):
-        tmp_dir = temp_folder()
-        filename = os.path.join(tmp_dir, 'libastral.pc')
-        save(filename, libastral_pc)
+        c = TestClient()
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            from conan.tools.gnu import PkgConfig
+            from conans.model.build_info import CppInfo
 
-        conanfile = ConanFileMock()
-        pkg_config = PkgConfig(conanfile, "libastral", pkg_config_path=tmp_dir)
+            class Pkg(ConanFile):
+                def generate(self):
+                    pkg_config = PkgConfig(self, "libastral", pkg_config_path=".")
+                    self.output.info(f"PROVIDES: {pkg_config.provides}")
+                    self.output.info(f"VERSION: {pkg_config.version}")
+                    self.output.info(f"VARIABLES: {pkg_config.variables['prefix']}")
 
-        assert pkg_config.provides == "libastral = 6.6.6"
-        assert pkg_config.version == "6.6.6"
-        assert pkg_config.includedirs == ['/usr/local/include/libastral']
-        assert pkg_config.defines == ['_USE_LIBASTRAL']
-        assert pkg_config.libs == ['astral', 'm']
-        assert pkg_config.libdirs == ['/usr/local/lib/libastral']
-        assert pkg_config.linkflags == ['-Wl,--whole-archive']
-        assert pkg_config.variables['prefix'] == '/usr/local'
+                    cpp_info = CppInfo()
+                    pkg_config.fill_cpp_info(cpp_info, is_system=False, system_libs=["m"])
 
-        cpp_info = CppInfo()
-        pkg_config.fill_cpp_info(cpp_info, is_system=False, system_libs=["m"])
+                    assert cpp_info.includedirs == ['/usr/local/include/libastral']
+                    assert cpp_info.defines == ['_USE_LIBASTRAL']
+                    assert cpp_info.libs == ['astral']
+                    assert cpp_info.system_libs == ['m']
+                    assert cpp_info.libdirs == ['/usr/local/lib/libastral']
+                    assert cpp_info.sharedlinkflags == ['-Wl,--whole-archive']
+            """)
+        libastral_pc = textwrap.dedent("""\
+            PC FILE EXAMPLE:
 
-        assert cpp_info.includedirs == ['/usr/local/include/libastral']
-        assert cpp_info.defines == ['_USE_LIBASTRAL']
-        assert cpp_info.libs == ['astral']
-        assert cpp_info.system_libs == ['m']
-        assert cpp_info.libdirs == ['/usr/local/lib/libastral']
-        assert cpp_info.sharedlinkflags == ['-Wl,--whole-archive']
+            prefix=/usr/local
+            exec_prefix=${prefix}
+            libdir=${exec_prefix}/lib
+            includedir=${prefix}/include
+
+            Name: libastral
+            Description: Interface library for Astral data flows
+            Version: 6.6.6
+            Libs: -L${libdir}/libastral -lastral -lm -Wl,--whole-archive
+            Cflags: -I${includedir}/libastral -D_USE_LIBASTRAL
+            """)
+        c.save({"conanfile.py": conanfile,
+                "libastral.pc": libastral_pc})
+        c.run("install .")
+        assert "conanfile.py: PROVIDES: libastral = 6.6.6" in c.out
+        assert "conanfile.py: VERSION: 6.6.6" in c.out
+        assert "conanfile.py: VARIABLES: /usr/local" in c.out

--- a/conans/test/utils/mocks.py
+++ b/conans/test/utils/mocks.py
@@ -1,5 +1,4 @@
 import os
-from collections import namedtuple
 from io import StringIO
 
 
@@ -103,8 +102,8 @@ class MockConanfile(ConanFile):
 
 class ConanFileMock(ConanFile):
 
-    def __init__(self, shared=None):
-        self.display_name = ""
+    def __init__(self, display_name=""):
+        self.display_name = display_name
         self._conan_node = None
         self.command = None
         self._commands = []
@@ -113,8 +112,6 @@ class ConanFileMock(ConanFile):
         self.settings_build = MockSettings({"os": "Linux", "arch": "x86_64"})
         self.settings_target = None
         self.options = Options()
-        if shared is not None:
-            self.options = namedtuple("options", "shared")(shared)
         self.generators = []
         self.captured_env = {}
         self.folders = Folders()


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

It makes changes in PkgConfig fail unnecessarily just because of broken mocks (related PR: https://github.com/conan-io/conan/pull/13985)