### PR TITLE
Add test with custom text in deprecated field of recipe

### DIFF
--- a/conans/test/integration/deprecated/test_deprecated.py
+++ b/conans/test/integration/deprecated/test_deprecated.py
@@ -28,3 +28,14 @@ class TestDeprecated:
 
         t.run("create taskflow.py --user=conan --channel=stable")
         assert "Deprecated\n    cpp-taskflow/1.0@conan/stable: taskflow" in t.out
+
+    def test_deprecated_custom_text(self):
+        tc = TestClient()
+        tc.save({"old/conanfile.py": GenConanfile("maths", 1.0).with_deprecated('"This is not secure, use maths/[>=2.0]"'),
+                 "new/conanfile.py": GenConanfile("maths", 2.0)})
+
+        tc.run("create new/conanfile.py")
+        tc.run("create old/conanfile.py")
+        assert "maths/1.0: This is not secure, use maths/[>=2.0]" in tc.out
+        tc.run("install --requires=maths/1.0")
+        assert "maths/1.0: This is not secure, use maths/[>=2.0]" in tc.out


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Shows that a custom text can be used in the deprecated field of a recipe.

For my comment in https://github.com/conan-io/conan-center-index/pull/17499