### PR TITLE
global cpp_info can be used to initialize components

### DIFF
--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -89,6 +89,13 @@ class _Component:
             self.libdirs = ["lib"]
             self.bindirs = ["bin"]
 
+    def copy(self):
+        result = _Component()
+        for k, v in self.serialize().items():
+            if v is not None:
+                setattr(result, f"_{k}", copy.copy(v))
+        return result
+
     def serialize(self):
         return {
             "includedirs": self._includedirs,
@@ -398,9 +405,9 @@ class _Component:
 class CppInfo:
 
     def __init__(self, set_defaults=False):
-        self.components = defaultdict(lambda: _Component(set_defaults))
         # Main package is a component with None key
         self._package = _Component(set_defaults)
+        self.components = defaultdict(lambda: self._package.copy())
         self._aggregated = None  # A _NewComponent object with all the components aggregated
 
     def __getattr__(self, attr):

--- a/conans/test/functional/layout/test_editable_cmake_components.py
+++ b/conans/test/functional/layout/test_editable_cmake_components.py
@@ -32,6 +32,7 @@ def test_editable_cmake_components():
 
             def layout(self):
                 cmake_layout(self, src_folder="src")
+                self.cpp.source.includedirs = []
                 self.cpp.source.components["hello"].includedirs = ["."]
                 self.cpp.source.components["bye"].includedirs = ["."]
                 bt = "." if self.settings.os != "Windows" else str(self.settings.build_type)

--- a/conans/test/integration/command/create_test.py
+++ b/conans/test/integration/command/create_test.py
@@ -572,6 +572,8 @@ def test_create_format_json_and_deps_cpp_info():
                 self.cpp_info.set_property("pkg_config_name", "pkg_other_name")
                 self.cpp_info.set_property("pkg_config_aliases", ["pkg_alias1", "pkg_alias2"])
                 self.cpp_info.components["cmp1"].libs = ["libcmp1"]
+                self.cpp_info.components["cmp1"].libdirs = ["lib"]
+                self.cpp_info.components["cmp1"].bindirs = ["bin"]
                 self.cpp_info.components["cmp1"].set_property("pkg_config_name", "compo1")
                 self.cpp_info.components["cmp1"].set_property("pkg_config_aliases", ["compo1_alias"])
                 self.cpp_info.components["cmp1"].sysroot = "/another/sysroot"
@@ -584,7 +586,7 @@ def test_create_format_json_and_deps_cpp_info():
     info = json.loads(client.stdout)
     nodes = info["graph"]["nodes"]
     hello_pkg_ref = 'hello/0.1#18d5440ae45afc4c36139a160ac071c7'
-    pkg_pkg_ref = 'pkg/0.2#926714b5fb0a994f47ec37e071eba1da'
+    pkg_pkg_ref = 'pkg/0.2#9f5308218357a92d0e14f8acdf6b5636'
     hello_cpp_info = pkg_cpp_info = None
     for n in nodes.values():
         ref = n["ref"]

--- a/conans/test/integration/command/install/install_test.py
+++ b/conans/test/integration/command/install/install_test.py
@@ -415,6 +415,8 @@ def test_install_json_formatter():
                 self.cpp_info.set_property("pkg_config_name", "pkg_other_name")
                 self.cpp_info.set_property("pkg_config_aliases", ["pkg_alias1", "pkg_alias2"])
                 self.cpp_info.components["cmp1"].libs = ["libcmp1"]
+                self.cpp_info.components["cmp1"].libdirs = ["lib"]
+                self.cpp_info.components["cmp1"].bindirs = ["bin"]
                 self.cpp_info.components["cmp1"].set_property("pkg_config_name", "compo1")
                 self.cpp_info.components["cmp1"].set_property("pkg_config_aliases", ["compo1_alias"])
                 self.cpp_info.components["cmp1"].sysroot = "/another/sysroot"
@@ -427,7 +429,7 @@ def test_install_json_formatter():
     info = json.loads(client.stdout)
     nodes = info["graph"]["nodes"]
     hello_pkg_ref = 'hello/0.1'  # no revision available
-    pkg_pkg_ref = 'pkg/0.2#926714b5fb0a994f47ec37e071eba1da'
+    pkg_pkg_ref = 'pkg/0.2#9f5308218357a92d0e14f8acdf6b5636'
     hello_cpp_info = pkg_cpp_info = None
     for _, n in nodes.items():
         ref = n["ref"]


### PR DESCRIPTION
Changelog: Feature: Global ``cpp_info`` can be used to initialize components values.
Docs: omit

This is a long standing issue, where users that define ``self.cpp_info.includedirs = ["myinclude"]`` are surprised that individual components will not use the ``myinclude`` folder too.

There could be different approaches to this, I have implemented the following:

- Components are initialized at first instantiation from the values of the global ``cpp_info``
- That means that later changes to ``self.cpp_info`` are not taken into account.


