### PR TITLE
Add conan version as separated command

### DIFF
--- a/conan/cli/commands/version.py
+++ b/conan/cli/commands/version.py
@@ -1,6 +1,4 @@
-import os
-
-from conan.api.output import cli_out_write
+from conan.cli.commands.list import print_serial
 from conan.cli.command import conan_command
 from conan.cli.formatters import default_json_formatter
 from conan import conan_version
@@ -8,16 +6,7 @@ import platform
 import sys
 
 
-def version_text_formatter(versions, root=None):
-    for key, value in versions.items():
-        if isinstance(value, dict):
-            version_text_formatter(value, root=key)
-        else:
-            key = f"{root}.{key}" if root else key
-            cli_out_write(f"{key}: {value}")
-
-
-@conan_command(group="Consumer", formatters={"text": version_text_formatter, "json": default_json_formatter})
+@conan_command(group="Consumer", formatters={"text": print_serial, "json": default_json_formatter})
 def version(conan_api, parser, *args):
     """
     Give information about the Conan client version.

--- a/conan/cli/commands/version.py
+++ b/conan/cli/commands/version.py
@@ -1,0 +1,21 @@
+import os
+
+from conan.api.output import cli_out_write
+from conan.cli.command import conan_command
+from conan.cli.formatters import default_json_formatter
+from conan import conan_version
+
+
+def version_text_formatter(version):
+    cli_out_write(f"Conan version {version['version']}")
+
+
+@conan_command(group="Consumer", formatters={"text": version_text_formatter, "json": default_json_formatter})
+def version(conan_api, parser, *args):
+    """
+    Give information about the Conan client version.
+    """
+
+    result = {'version': str(conan_version)}
+    return result
+

--- a/conan/cli/commands/version.py
+++ b/conan/cli/commands/version.py
@@ -14,8 +14,8 @@ def version(conan_api, parser, *args):
 
     return {'version': str(conan_version),
             'python': {
-                'version': platform.python_version(),
-                'sys_version': sys.version,
+                'version': platform.python_version().replace('\n', ''),
+                'sys_version': sys.version.replace('\n', ''),
                 }
             }
 

--- a/conan/cli/commands/version.py
+++ b/conan/cli/commands/version.py
@@ -4,10 +4,17 @@ from conan.api.output import cli_out_write
 from conan.cli.command import conan_command
 from conan.cli.formatters import default_json_formatter
 from conan import conan_version
+import platform
+import sys
 
 
-def version_text_formatter(version):
-    cli_out_write(f"Conan version {version['version']}")
+def version_text_formatter(versions, root=None):
+    for key, value in versions.items():
+        if isinstance(value, dict):
+            version_text_formatter(value, root=key)
+        else:
+            key = f"{root}.{key}" if root else key
+            cli_out_write(f"{key}: {value}")
 
 
 @conan_command(group="Consumer", formatters={"text": version_text_formatter, "json": default_json_formatter})
@@ -16,6 +23,10 @@ def version(conan_api, parser, *args):
     Give information about the Conan client version.
     """
 
-    result = {'version': str(conan_version)}
-    return result
+    return {'version': str(conan_version),
+            'python': {
+                'version': platform.python_version(),
+                'sys_version': sys.version,
+                }
+            }
 

--- a/conans/test/integration/command_v2/test_version.py
+++ b/conans/test/integration/command_v2/test_version.py
@@ -19,10 +19,12 @@ def test_version_json():
 
 def _validate_text_output(output):
     lines = output.splitlines()
+    python_version = platform.python_version().replace("\n", "")
+    sys_version = sys.version.replace("\n", "")
     assert f'version: {__version__}' in lines
     assert 'python' in lines
-    assert f'  version: {platform.python_version()}' in lines
-    assert f'  sys_version: {sys.version}' in lines
+    assert f'  version: {python_version}' in lines
+    assert f'  sys_version: {sys_version}' in lines
 
 
 def test_version_text():

--- a/conans/test/integration/command_v2/test_version.py
+++ b/conans/test/integration/command_v2/test_version.py
@@ -6,6 +6,9 @@ import sys
 
 
 def test_version_json():
+    """
+    Conan version command should be able to output a json with the version and python version.
+    """
     t = TestClient()
     t.run("version --format=json")
     js = json.loads(t.stdout)
@@ -14,13 +17,28 @@ def test_version_json():
     assert js["python"]["sys_version"] == sys.version
 
 
+def _validate_text_output(output):
+    lines = output.splitlines()
+    assert f'version: {__version__}' in lines
+    assert 'python' in lines
+    assert f'  version: {platform.python_version()}' in lines
+    assert f'  sys_version: {sys.version}' in lines
+
+
 def test_version_text():
+    """
+    Conan version command should be able to output a raw text with the version and python version.
+    """
     t = TestClient()
     t.run("version --format=text")
-    assert [f'version: {__version__}', 'python', f'  version: {platform.python_version()}', f'  sys_version: {sys.version}'] == t.out.splitlines()
+    _validate_text_output(t.out)
 
 
 def test_version_raw():
+    """
+    Conan version command should be able to output a raw text with the version and python version,
+    when no format is specified.
+    """
     t = TestClient()
     t.run("version")
-    assert [f'version: {__version__}', 'python', f'  version: {platform.python_version()}', f'  sys_version: {sys.version}'] == t.out.splitlines()
+    _validate_text_output(t.out)

--- a/conans/test/integration/command_v2/test_version.py
+++ b/conans/test/integration/command_v2/test_version.py
@@ -17,10 +17,10 @@ def test_version_json():
 def test_version_text():
     t = TestClient()
     t.run("version --format=text")
-    assert [f'version: {__version__}', f'python.version: {platform.python_version()}', f'python.sys_version: {sys.version}'] == t.out.splitlines()
+    assert [f'version: {__version__}', 'python', f'  version: {platform.python_version()}', f'  sys_version: {sys.version}'] == t.out.splitlines()
 
 
 def test_version_raw():
     t = TestClient()
     t.run("version")
-    assert [f'version: {__version__}', f'python.version: {platform.python_version()}', f'python.sys_version: {sys.version}'] == t.out.splitlines()
+    assert [f'version: {__version__}', 'python', f'  version: {platform.python_version()}', f'  sys_version: {sys.version}'] == t.out.splitlines()

--- a/conans/test/integration/command_v2/test_version.py
+++ b/conans/test/integration/command_v2/test_version.py
@@ -5,6 +5,14 @@ import platform
 import sys
 
 
+def _python_version():
+    return platform.python_version().replace("\n", "")
+
+
+def _sys_version():
+    return sys.version.replace("\n", "")
+
+
 def test_version_json():
     """
     Conan version command should be able to output a json with the version and python version.
@@ -13,18 +21,8 @@ def test_version_json():
     t.run("version --format=json")
     js = json.loads(t.stdout)
     assert js["version"] == __version__
-    assert js["python"]["version"] == platform.python_version()
-    assert js["python"]["sys_version"] == sys.version
-
-
-def _validate_text_output(output):
-    lines = output.splitlines()
-    python_version = platform.python_version().replace("\n", "")
-    sys_version = sys.version.replace("\n", "")
-    assert f'version: {__version__}' in lines
-    assert 'python' in lines
-    assert f'  version: {python_version}' in lines
-    assert f'  sys_version: {sys_version}' in lines
+    assert js["python"]["version"] == _python_version()
+    assert js["python"]["sys_version"] == _sys_version()
 
 
 def test_version_text():
@@ -44,3 +42,11 @@ def test_version_raw():
     t = TestClient()
     t.run("version")
     _validate_text_output(t.out)
+
+
+def _validate_text_output(output):
+    lines = output.splitlines()
+    assert f'version: {__version__}' in lines
+    assert 'python' in lines
+    assert f'  version: {_python_version()}' in lines
+    assert f'  sys_version: {_sys_version()}' in lines

--- a/conans/test/integration/command_v2/test_version.py
+++ b/conans/test/integration/command_v2/test_version.py
@@ -1,19 +1,26 @@
 from conans.test.utils.tools import TestClient
+from conan import __version__
+import json
+import platform
+import sys
 
 
 def test_version_json():
     t = TestClient()
     t.run("version --format=json")
-    assert ['{', '    "version": "2.0.4"', '}'] == t.out.splitlines()
+    js = json.loads(t.stdout)
+    assert js["version"] == __version__
+    assert js["python"]["version"] == platform.python_version()
+    assert js["python"]["sys_version"] == sys.version
 
 
 def test_version_text():
     t = TestClient()
     t.run("version --format=text")
-    assert ['Conan version 2.0.4'] == t.out.splitlines()
+    assert [f'version: {__version__}', f'python.version: {platform.python_version()}', f'python.sys_version: {sys.version}'] == t.out.splitlines()
 
 
 def test_version_raw():
     t = TestClient()
     t.run("version")
-    assert ['Conan version 2.0.4'] == t.out.splitlines()
+    assert [f'version: {__version__}', f'python.version: {platform.python_version()}', f'python.sys_version: {sys.version}'] == t.out.splitlines()

--- a/conans/test/integration/command_v2/test_version.py
+++ b/conans/test/integration/command_v2/test_version.py
@@ -1,0 +1,19 @@
+from conans.test.utils.tools import TestClient
+
+
+def test_version_json():
+    t = TestClient()
+    t.run("version --format=json")
+    assert ['{', '    "version": "2.0.4"', '}'] == t.out.splitlines()
+
+
+def test_version_text():
+    t = TestClient()
+    t.run("version --format=text")
+    assert ['Conan version 2.0.4'] == t.out.splitlines()
+
+
+def test_version_raw():
+    t = TestClient()
+    t.run("version")
+    assert ['Conan version 2.0.4'] == t.out.splitlines()


### PR DESCRIPTION
Changelog: Feature: Add new command `conan version` to format the output.
Docs: https://github.com/conan-io/docs/pull/3243

The `--version` option stays as usual, but `conan version` offer format output.

closes https://github.com/conan-io/conan/issues/13952

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
