### PR TITLE
[feature] Allow '~' pattern as alternative for '!' to exclude references

### DIFF
--- a/conan/api/model.py
+++ b/conan/api/model.py
@@ -119,6 +119,10 @@ class ListPattern:
         else:
             self.package_id = self.package_id or package_id
 
+    @staticmethod
+    def _only_latest(rev):
+        return rev in ["!latest", "~latest"]
+
     @property
     def is_latest_rrev(self):
         return self.rrev == "latest"
@@ -132,7 +136,7 @@ class ListPattern:
             raise ConanException(f"Recipe '{self.ref}' not found")
 
     def filter_rrevs(self, rrevs):
-        if self.rrev == "!latest":
+        if self._only_latest(self.rrev):
             return rrevs[1:]
         rrevs = [r for r in rrevs if fnmatch.fnmatch(r.revision, self.rrev)]
         if not rrevs:
@@ -150,7 +154,7 @@ class ListPattern:
         return prefs
 
     def filter_prevs(self, prevs):
-        if self.prev == "!latest":
+        if self._only_latest(self.prev):
             return prevs[1:]
         prevs = [p for p in prevs if fnmatch.fnmatch(p.revision, self.prev)]
         if not prevs:

--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -15,6 +15,8 @@ _help_build_policies = '''Optional, specify which packages to build from source.
                        pattern uses 'fnmatch' style wildcards.
     --build=![pattern] Excluded packages, which will not be built from the source, whose package
                        reference matches the pattern. The pattern uses 'fnmatch' style wildcards.
+    --build=~[pattern] Excluded packages, which will not be built from the source, whose package
+                       reference matches the pattern. The pattern uses 'fnmatch' style wildcards.
     --build=missing:[pattern] Build from source if a compatible binary does not exist, only for
                               packages matching pattern.
 '''

--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -13,8 +13,6 @@ _help_build_policies = '''Optional, specify which packages to build from source.
                        source.
     --build=[pattern]  Build packages from source whose package reference matches the pattern. The
                        pattern uses 'fnmatch' style wildcards.
-    --build=![pattern] Excluded packages, which will not be built from the source, whose package
-                       reference matches the pattern. The pattern uses 'fnmatch' style wildcards.
     --build=~[pattern] Excluded packages, which will not be built from the source, whose package
                        reference matches the pattern. The pattern uses 'fnmatch' style wildcards.
     --build=missing:[pattern] Build from source if a compatible binary does not exist, only for

--- a/conans/client/graph/build_mode.py
+++ b/conans/client/graph/build_mode.py
@@ -9,7 +9,7 @@ class BuildMode:
                    => ["hello/0.1@foo/bar"] if user wrote "--build hello/0.1@foo/bar"
                    => False if user wrote "never"
                    => True if user wrote "missing"
-                   => ["!foo"] means exclude when building all from sources
+                   => ["!foo"] or ["~foo"] means exclude when building all from sources
     """
     def __init__(self, params):
         self.missing = False
@@ -48,7 +48,7 @@ class BuildMode:
                         # "conan install --requires=pkg/0.1@ --build=pkg/0.1@"
                         clean_pattern = param[:-1] if param.endswith("@") else param
                         clean_pattern = clean_pattern.replace("@#", "#")
-                        if clean_pattern and clean_pattern[0] == "!":
+                        if clean_pattern and clean_pattern[0] in ["!", "~"]:
                             self._excluded_patterns.append(clean_pattern[1:])
                         else:
                             self.patterns.append(clean_pattern)

--- a/conans/model/recipe_ref.py
+++ b/conans/model/recipe_ref.py
@@ -159,7 +159,7 @@ class RecipeReference:
 
     def matches(self, pattern, is_consumer):
         negate = False
-        if pattern.startswith("!"):
+        if pattern.startswith("!") or pattern.startswith("~"):
             pattern = pattern[1:]
             negate = True
 

--- a/conans/search/search.py
+++ b/conans/search/search.py
@@ -19,6 +19,8 @@ def filter_packages(query, results: Dict[PkgReference, dict]):
     try:
         if "!" in query:
             raise ConanException("'!' character is not allowed")
+        if "~" in query:
+            raise ConanException("'~' character is not allowed")
         if " not " in query or query.startswith("not "):
             raise ConanException("'not' operator is not allowed")
         postfix = infix_to_postfix(query) if query else []

--- a/conans/test/functional/graph/test_graph_build_mode.py
+++ b/conans/test/functional/graph/test_graph_build_mode.py
@@ -134,8 +134,8 @@ def test_install_build_all_with_double_skip(build_arg, bar, foo, foobar, build_a
         When --build=* is passed with another package, not all packages must be built from sources.
         The arguments order matter, that's why we need to run twice.
     """
-    for argument in ["--build=!foo/* --build=!bar/* {}".format(build_arg),
-                     "{} --build=!foo/* --build=!bar/*".format(build_arg)]:
+    for argument in ["--build=!foo/* --build=~bar/* {}".format(build_arg),
+                     "{} --build=!foo/* --build=~bar/*".format(build_arg)]:
         build_all.run("install --requires=foobar/1.0@user/testing {}".format(argument))
 
         build_all.assert_listed_binary({"bar/1.0@user/testing": (bar_id, bar),
@@ -155,11 +155,11 @@ def test_report_matches(build_all):
     # FIXME assert "No package matching 'baz' pattern found." in build_all.out
     build_all.assert_listed_binary({"foobar/1.0@user/testing": (foobar_id, "Build")})
 
-    build_all.run("install --requires=foobar/1.0@user/testing --build=* --build=!baz/* --build=blah")
+    build_all.run("install --requires=foobar/1.0@user/testing --build=* --build=~baz/* --build=blah")
     # FIXME assert "No package matching 'blah' pattern found." in build_all.out
     # FIXME assert "No package matching 'baz' pattern found." in build_all.out
     build_all.assert_listed_binary({"foobar/1.0@user/testing": (foobar_id, "Build")})
-    build_all.run("install --requires=foobar/1.0@user/testing --build=* --build=!baz/* --build=!blah")
+    build_all.run("install --requires=foobar/1.0@user/testing --build=* --build=!baz/* --build=~blah")
     # FIXME  assert "No package matching 'blah' pattern found." in build_all.out
     # FIXME assert "No package matching 'baz' pattern found." in build_all.out
     build_all.assert_listed_binary({"foobar/1.0@user/testing": (foobar_id, "Build")})

--- a/conans/test/integration/command/remove_test.py
+++ b/conans/test/integration/command/remove_test.py
@@ -249,6 +249,7 @@ def test_new_remove_recipes_expressions(populated_client, with_remote, data):
     {"remove": "bar*#*50", "rrevs": [bar_rrev, bar_rrev2]},
     {"remove": "bar*#latest", "rrevs": [bar_rrev2]},  # latest is bar_rrev
     {"remove": "bar*#!latest", "rrevs": [bar_rrev]},  # latest is bar_rrev
+    {"remove": "bar*#~latest", "rrevs": [bar_rrev]},  # latest is bar_rrev
 ])
 def test_new_remove_recipe_revisions_expressions(populated_client, with_remote, data):
     r = "-r default" if with_remote else ""
@@ -311,6 +312,7 @@ def test_new_remove_package_expressions(populated_client, with_remote, data):
     {"remove": '{}#'.format(bar_rrev2_release), "prevs": []},
     {"remove": '{}#latest'.format(bar_rrev2_release), "prevs": [bar_rrev2_release_prev1]},
     {"remove": '{}#!latest'.format(bar_rrev2_release), "prevs": [bar_rrev2_release_prev2]},
+    {"remove": '{}#~latest'.format(bar_rrev2_release), "prevs": [bar_rrev2_release_prev2]},
 ])
 def test_new_remove_package_revisions_expressions(populated_client, with_remote, data):
     # Remove the ones we are not testing here


### PR DESCRIPTION
Changelog: Feature: Allow "~" symbol as a exclude pattern for references
Docs: missing

Close https://github.com/conan-io/conan/issues/13834

- [x] Refer to the issue that supports this Pull Request: closes https://github.com/conan-io/conan/issues/13834
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
