### PR TITLE
upload --dry-run and tests fixes

### DIFF
--- a/conan/api/subapi/graph.py
+++ b/conan/api/subapi/graph.py
@@ -1,5 +1,3 @@
-import os
-
 from conan.api.output import ConanOutput
 from conan.internal.conan_app import ConanApp
 from conans.client.graph.graph import Node, RECIPE_CONSUMER, CONTEXT_HOST, RECIPE_VIRTUAL, \
@@ -7,10 +5,7 @@ from conans.client.graph.graph import Node, RECIPE_CONSUMER, CONTEXT_HOST, RECIP
 from conans.client.graph.graph_binaries import GraphBinariesAnalyzer
 from conans.client.graph.graph_builder import DepsGraphBuilder
 from conans.client.graph.profile_node_definer import initialize_conanfile_profile, consumer_definer
-from conans.client.loader import parse_conanfile
-
 from conans.errors import ConanException
-
 from conans.model.recipe_ref import RecipeReference
 
 
@@ -191,10 +186,3 @@ class GraphAPI:
         conan_app = ConanApp(self.conan_api.cache_folder)
         binaries_analyzer = GraphBinariesAnalyzer(conan_app)
         binaries_analyzer.evaluate_graph(graph, build_mode, lockfile, remotes, update)
-
-    def load_conanfile_class(self, path):
-        """ Given a path to a conanfile.py file, it loads its class (not instance) to allow
-        inspecting the class attributes, like 'name', 'version', 'description', 'options' etc"""
-        path = os.path.join(os.getcwd(), path)
-        _, ret = parse_conanfile(path)
-        return ret

--- a/conan/cli/commands/upload.py
+++ b/conan/cli/commands/upload.py
@@ -33,6 +33,8 @@ def upload(conan_api: ConanAPI, parser, *args):
                         help='Perform an integrity check, using the manifests, before upload')
     parser.add_argument('-c', '--confirm', default=False, action='store_true',
                         help='Upload all matching recipes without confirmation')
+    parser.add_argument('--dry-run', default=False, action='store_true',
+                        help='Do not execute the real upload')
 
     args = parser.parse_args(*args)
 
@@ -55,6 +57,9 @@ def upload(conan_api: ConanAPI, parser, *args):
         _ask_confirm_upload(conan_api, package_list)
 
     conan_api.upload.prepare(package_list, enabled_remotes)
+    if args.dry_run:
+        return  # Missing return of pkg_list for serialization and json inspection
+
     conan_api.upload.upload(package_list, remote)
 
     conan_api.upload.upload_backup_sources(package_list)

--- a/conan/cli/commands/upload.py
+++ b/conan/cli/commands/upload.py
@@ -1,12 +1,32 @@
 from conan.api.conan_api import ConanAPI
 from conan.api.model import ListPattern, MultiPackagesList
+from conan.api.output import cli_out_write
 from conan.cli import make_abs_path
 from conan.cli.command import conan_command, OnceArgument
+from conan.cli.commands.list import print_list_json, print_serial
 from conans.client.userio import UserInput
 from conan.errors import ConanException
 
 
-@conan_command(group="Creator")
+def summary_upload_list(results):
+    """ Do litte format modification to serialized
+    list bundle so it looks prettier on text output
+    """
+    cli_out_write("Upload summary:")
+    info = results["results"]
+    new_info = {}
+    for remote, remote_info in info.items():
+        for ref, content in remote_info.items():
+            for rev, rev_content in content["revisions"].items():
+                prevs = rev_content.get('packages')
+                if prevs:
+                    new_info.setdefault(f"{ref}:{rev}", list(prevs))
+    info = new_info
+    print_serial(info)
+
+
+@conan_command(group="Creator", formatters={"text": summary_upload_list,
+                                            "json": print_list_json})
 def upload(conan_api: ConanAPI, parser, *args):
     """
     Upload packages to a remote.
@@ -36,7 +56,7 @@ def upload(conan_api: ConanAPI, parser, *args):
     parser.add_argument('-c', '--confirm', default=False, action='store_true',
                         help='Upload all matching recipes without confirmation')
     parser.add_argument('--dry-run', default=False, action='store_true',
-                        help='Do not execute the real upload')
+                        help='Do not execute the real upload (experimental)')
     parser.add_argument("-l", "--list", help="Package list file")
 
     args = parser.parse_args(*args)
@@ -69,12 +89,17 @@ def upload(conan_api: ConanAPI, parser, *args):
         _ask_confirm_upload(conan_api, package_list)
 
     conan_api.upload.prepare(package_list, enabled_remotes)
-    if args.dry_run:
-        return  # Missing return of pkg_list for serialization and json inspection
 
-    conan_api.upload.upload(package_list, remote)
+    if not args.dry_run:
+        conan_api.upload.upload(package_list, remote)
+        conan_api.upload.upload_backup_sources(package_list)
 
-    conan_api.upload.upload_backup_sources(package_list)
+    pkglist = MultiPackagesList()
+    pkglist.add(remote.name, package_list)
+    return {
+        "results": pkglist.serialize(),
+        "conan_api": conan_api
+    }
 
 
 def _ask_confirm_upload(conan_api, upload_data):

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -158,9 +158,8 @@ class PackagePreparator:
     def _prepare_package(self, pref, prev_bundle):
         pkg_layout = self._app.cache.pkg_layout(pref)
         if pkg_layout.package_is_dirty():
-            raise ConanException("Package %s is corrupted, aborting upload.\n"
-                                 "Remove it with 'conan remove %s -p=%s'"
-                                 % (pref, pref.ref, pref.package_id))
+            raise ConanException(f"Package {pref} is corrupted, aborting upload.\n"
+                                 f"Remove it with 'conan remove {pref}'")
         cache_files = self._compress_package_files(pkg_layout, pref)
         prev_bundle["files"] = cache_files
 

--- a/conans/client/rest/file_uploader.py
+++ b/conans/client/rest/file_uploader.py
@@ -1,4 +1,3 @@
-import os
 import time
 from copy import copy
 
@@ -52,8 +51,9 @@ class FileUploader(object):
         return response
 
     def upload(self, url, abs_path, auth=None, dedup=False, retry=None, retry_wait=None,
-               headers=None, display_name=None):
-        retry = retry if retry is not None else self._config.get("core.upload:retry", default=1, check_type=int)
+               headers=None):
+        retry = retry if retry is not None else self._config.get("core.upload:retry", default=1,
+                                                                 check_type=int)
         retry_wait = retry_wait if retry_wait is not None else \
             self._config.get("core.upload:retry_wait", default=5, check_type=int)
 
@@ -67,7 +67,7 @@ class FileUploader(object):
 
         for counter in range(retry + 1):
             try:
-                return self._upload_file(url, abs_path, headers, auth, display_name)
+                return self._upload_file(url, abs_path, headers, auth)
             except (NotFoundException, ForbiddenException, AuthenticationException,
                     RequestErrorException):
                 raise
@@ -80,14 +80,7 @@ class FileUploader(object):
                         self._output.info("Waiting %d seconds to retry..." % retry_wait)
                     time.sleep(retry_wait)
 
-    def _upload_file(self, url, abs_path,  headers, auth, display_name):
-        file_size = os.stat(abs_path).st_size
-        file_name = os.path.basename(abs_path)
-        description = "Uploading {}".format(file_name)
-        post_description = "Uploaded {}".format(
-            file_name) if not display_name else "Uploaded {} -> {}".format(file_name, display_name)
-
-        # self._output.info(description)
+    def _upload_file(self, url, abs_path,  headers, auth):
         with open(abs_path, mode='rb') as file_handler:
             try:
                 response = self._requester.put(url, data=file_handler, verify=self._verify_ssl,

--- a/conans/client/rest/rest_client_v2.py
+++ b/conans/client/rest/rest_client_v2.py
@@ -118,9 +118,6 @@ class RestV2Methods(RestCommonMethods):
         output = ConanOutput()
         for filename in sorted(files):
             # As the filenames are sorted, the last one is always "conanmanifest.txt"
-            if output and not output.is_terminal:
-                msg = "-> %s" % filename
-                output.info(msg)
             resource_url = urls[filename]
             try:
                 headers = {}

--- a/conans/test/integration/command/upload/test_upload_patterns.py
+++ b/conans/test/integration/command/upload/test_upload_patterns.py
@@ -175,3 +175,7 @@ class TestUploadPatternErrors:
         pid = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
         error = f"ERROR: Package revision 'pkg/0.1#{rrev}:{pid}#prev' not found"
         self.assert_error(f"pkg/0.1#{rrev}:{pid}#prev", error, client)
+
+    def test_bad_package_query(self, client):
+        error = "Invalid package query: blah. Invalid expression: blah"
+        self.assert_error("* -p blah", error, client)

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -766,6 +766,12 @@ class TestClient(object):
                                str(self.out)).group(1)
         return PkgReference.loads(pref)
 
+    def created_package_folder(self, ref):
+        pref = self.created_package_reference(ref)
+        prev = self.cache.get_latest_package_reference(pref)
+        pkg_folder = self.cache.pkg_layout(prev).package()
+        return pkg_folder
+
     def exported_recipe_revision(self):
         return re.search(r": Exported: .*#(\S+)", str(self.out)).group(1)
 


### PR DESCRIPTION
Changelog: Feature: Add ``conan upload --dry-run`` equivalent to 1.X ``conan upload --skip-upload``.
Docs: https://github.com/conan-io/docs/pull/3274

Also, recover or remove some xfailed tests (the PR started there, then realized that the ``--dry-run`` feature was not there, and I recall it being used by some users in 1.X


