### PR TITLE
return the correct graph for conan create command

### DIFF
--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -54,7 +54,6 @@ def create(conan_api, parser, *args):
 
     deps_graph = None
     if not is_python_require:
-        # TODO: This section might be overlapping with ``graph_compute()``
         requires = [ref] if not args.build_require else None
         tool_requires = [ref] if args.build_require else None
         # FIXME: Dirty: package type still raw, not processed yet
@@ -89,11 +88,10 @@ def create(conan_api, parser, *args):
         #  - decide update policy "--test_package_update"
         tested_python_requires = ref.repr_notime() if is_python_require else None
         from conan.cli.commands.test import run_test
-        deps_graph = run_test(conan_api, test_conanfile_path, ref, profile_host, profile_build,
-                              remotes, lockfile, update=False, build_modes=args.build,
-                              tested_python_requires=tested_python_requires)
-        lockfile = conan_api.lockfile.update_lockfile(lockfile, deps_graph, args.lockfile_packages,
-                                                      clean=args.lockfile_clean)
+        # The test_package do not make the "conan create" command return a different graph or
+        # produce a different lockfile. The result is always the same, irrespective of test_package
+        run_test(conan_api, test_conanfile_path, ref, profile_host, profile_build, remotes, lockfile,
+                 update=False, build_modes=args.build, tested_python_requires=tested_python_requires)
 
     conan_api.lockfile.save_lockfile(lockfile, args.lockfile_out, cwd)
     return {"graph": deps_graph,

--- a/conan/cli/commands/test.py
+++ b/conan/cli/commands/test.py
@@ -4,12 +4,13 @@ from conan.api.output import ConanOutput
 from conan.cli.command import conan_command, OnceArgument
 from conan.cli.commands.create import test_package, _check_tested_reference_matches
 from conan.cli.args import add_lockfile_args, add_common_install_arguments
+from conan.cli.formatters.graph import format_graph_json
 from conan.cli.printers import print_profiles
 from conan.cli.printers.graph import print_graph_basic, print_graph_packages
 from conans.model.recipe_ref import RecipeReference
 
 
-@conan_command(group="Creator")
+@conan_command(group="Creator", formatters={"json": format_graph_json})
 def test(conan_api, parser, *args):
     """
     Test a package from a test_package folder.
@@ -41,6 +42,9 @@ def test(conan_api, parser, *args):
     lockfile = conan_api.lockfile.update_lockfile(lockfile, deps_graph, args.lockfile_packages,
                                                   clean=args.lockfile_clean)
     conan_api.lockfile.save_lockfile(lockfile, args.lockfile_out, cwd)
+
+    return {"graph": deps_graph,
+            "conan_api": conan_api}
 
 
 def run_test(conan_api, path, ref, profile_host, profile_build, remotes, lockfile, update,

--- a/conans/test/integration/command/test_package_test.py
+++ b/conans/test/integration/command/test_package_test.py
@@ -1,3 +1,4 @@
+import json
 import os
 import textwrap
 import unittest
@@ -16,6 +17,14 @@ class TestPackageTest(unittest.TestCase):
                      "test_package/conanfile.py": GenConanfile().with_test("pass")})
         client.run("create . --user=lasote --channel=stable")
         self.assertIn("hello/0.1@lasote/stable: Created package", client.out)
+
+    def test_basic_json(self):
+        client = TestClient()
+        client.save({CONANFILE: GenConanfile("hello", "0.1"),
+                     "test_package/conanfile.py": GenConanfile().with_test("pass")})
+        client.run("create . --format=json")
+        graph = json.loads(client.stdout)
+        assert graph["graph"]["nodes"]["1"]["ref"] == "hello/0.1#a90ba236e5310a473dae9f767a41db91"
 
     def test_test_only(self):
         test_conanfile = GenConanfile().with_test("pass")

--- a/conans/test/integration/lockfile/test_lock_requires.py
+++ b/conans/test/integration/lockfile/test_lock_requires.py
@@ -449,11 +449,16 @@ class TestLockTestPackage:
 
     def test_create_lock_tool_requires_test(self, client):
         """ same as above, but the full lockfile including the "test_package" can be
-        obtained with a single "conan create"
+        obtained with a "conan test"
         """
         c = client
         with c.chdir("app"):
-            c.run("create . --lockfile-out=conan.lock")
+            c.run("create . --lockfile-out=conan.lock -tf=")
+            lock = c.load("conan.lock")
+            assert "cmake/1.0" not in lock
+            assert "dep/1.0" in lock
+            c.run("test test_package app/1.0 --lockfile-partial --lockfile=conan.lock "
+                  "--lockfile-out=conan.lock")
             lock = c.load("conan.lock")
             assert "cmake/1.0" in lock
             assert "dep/1.0" in lock


### PR DESCRIPTION
Changelog: Bugfix: ``conan create`` command returns always the same output for ``--format=json`` result graph, irrespective of test_package existence.
Changelog: Feature: ``conan test`` command learned the ``--format=json`` formatter.
Docs: https://github.com/conan-io/docs/pull/3273


