### PR TITLE
Add prefix to pkgconfig root

### DIFF
--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -149,6 +149,10 @@ class _PCContentGenerator:
 
     shortened_template = textwrap.dedent("""\
         prefix={{ prefix_path }}
+        {% if pkg_config_custom_content %}
+        # Custom PC content
+        {{ pkg_config_custom_content }}
+        {% endif %}
 
         Name: {{ name }}
         Description: {{ description }}
@@ -201,8 +205,14 @@ class _PCContentGenerator:
             else self._dep.package_folder
         prefix_path = root_folder.replace("\\", "/")
 
+        if info.cpp_info:
+            custom_content = info.cpp_info.get_property("pkg_config_custom_content")
+        else:
+            custom_content = None
+
         context = {
             "prefix_path": prefix_path,
+            "pkg_config_custom_content": custom_content,
             "name": info.name,
             "description": info.description,
             "version": self._dep.ref.version,
@@ -353,8 +363,8 @@ class _PCGenerator:
         # Issue related: https://github.com/conan-io/conan/issues/10341
         pkg_name = _get_package_name(self._dep, self._build_context_suffix)
         if f"{pkg_name}.pc" not in pc_files:
-            package_info = _PCInfo(pkg_name, pkg_requires, f"Conan package: {pkg_name}", None,
-                                   _get_package_aliases(self._dep))
+            package_info = _PCInfo(pkg_name, pkg_requires, f"Conan package: {pkg_name}",
+                                   self._dep.cpp_info, _get_package_aliases(self._dep))
             # It'll be enough creating a shortened PC file. This file will be like an alias
             pc_files[f"{package_info.name}.pc"] = self._content_generator.shortened_content(package_info)
             for alias in package_info.aliases:

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -148,6 +148,8 @@ class _PCContentGenerator:
     """)
 
     shortened_template = textwrap.dedent("""\
+        prefix={{ prefix_path }}
+
         Name: {{ name }}
         Description: {{ description }}
         Version: {{ version }}
@@ -195,7 +197,12 @@ class _PCContentGenerator:
     def shortened_content(self, info):
         assert isinstance(info, _PCInfo)
 
+        root_folder = self._dep.recipe_folder if self._dep.package_folder is None \
+            else self._dep.package_folder
+        prefix_path = root_folder.replace("\\", "/")
+
         context = {
+            "prefix_path": prefix_path,
             "name": info.name,
             "description": info.description,
             "version": self._dep.ref.version,

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -166,15 +166,17 @@ class _PCContentGenerator:
         self._conanfile = conanfile
         self._dep = dep
 
-    def content(self, info):
-        assert isinstance(info, _PCInfo) and info.cpp_info is not None
-
+    def _get_prefix_path(self):
         # If editable, package_folder can be None
         root_folder = self._dep.recipe_folder if self._dep.package_folder is None \
             else self._dep.package_folder
-        version = info.cpp_info.get_property("component_version") or self._dep.ref.version
+        return root_folder.replace("\\", "/")
 
-        prefix_path = root_folder.replace("\\", "/")
+    def content(self, info):
+        assert isinstance(info, _PCInfo) and info.cpp_info is not None
+
+        prefix_path = self._get_prefix_path()
+        version = info.cpp_info.get_property("component_version") or self._dep.ref.version
         libdirs = _get_formatted_dirs(info.cpp_info.libdirs, prefix_path)
         includedirs = _get_formatted_dirs(info.cpp_info.includedirs, prefix_path)
         custom_content = info.cpp_info.get_property("pkg_config_custom_content")
@@ -200,18 +202,10 @@ class _PCContentGenerator:
 
     def shortened_content(self, info):
         assert isinstance(info, _PCInfo)
-
-        root_folder = self._dep.recipe_folder if self._dep.package_folder is None \
-            else self._dep.package_folder
-        prefix_path = root_folder.replace("\\", "/")
-
-        if info.cpp_info:
-            custom_content = info.cpp_info.get_property("pkg_config_custom_content")
-        else:
-            custom_content = None
-
+        custom_content = info.cpp_info.get_property("pkg_config_custom_content") if info.cpp_info \
+            else None
         context = {
-            "prefix_path": prefix_path,
+            "prefix_path": self._get_prefix_path(),
             "pkg_config_custom_content": custom_content,
             "name": info.name,
             "description": info.description,

--- a/conans/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -380,13 +380,20 @@ def test_pkg_config_name_full_aliases():
     """
     client = TestClient()
     conanfile = textwrap.dedent("""
+        import textwrap
         from conan import ConanFile
 
         class Recipe(ConanFile):
 
             def package_info(self):
+                custom_content = textwrap.dedent(\"""
+                datadir=${prefix}/share
+                schemasdir=${datadir}/mylib/schemas
+                \""")
                 self.cpp_info.set_property("pkg_config_name", "pkg_other_name")
                 self.cpp_info.set_property("pkg_config_aliases", ["pkg_alias1", "pkg_alias2"])
+                # Custom content only added to root pc file -> pkg_other_name.pc
+                self.cpp_info.set_property("pkg_config_custom_content", custom_content)
                 self.cpp_info.components["cmp1"].libs = ["libcmp1"]
                 self.cpp_info.components["cmp1"].set_property("pkg_config_name", "compo1")
                 self.cpp_info.components["cmp1"].set_property("pkg_config_aliases", ["compo1_alias"])
@@ -434,8 +441,20 @@ def test_pkg_config_name_full_aliases():
     assert content == pc_content
 
     pc_content = client.load("pkg_other_name.pc")
-    assert "Description: Conan package: pkg_other_name" in pc_content
-    assert "Requires: compo1" in pc_content
+    content = textwrap.dedent(f"""\
+    {prefix}
+    # Custom PC content
+
+    datadir=${{prefix}}/share
+    schemasdir=${{datadir}}/mylib/schemas
+
+
+    Name: pkg_other_name
+    Description: Conan package: pkg_other_name
+    Version: 0.3
+    Requires: compo1
+    """)
+    assert content == pc_content
 
     pc_content = client.load("pkg_alias1.pc")
     content = textwrap.dedent(f"""\

--- a/conans/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -418,11 +418,14 @@ def test_pkg_config_name_full_aliases():
     client.run("install .")
 
     pc_content = client.load("compo1.pc")
+    prefix = pc_content.splitlines()[0]
     assert "Description: Conan component: pkg_other_name-compo1" in pc_content
     assert "Requires" not in pc_content
 
     pc_content = client.load("compo1_alias.pc")
-    content = textwrap.dedent("""\
+    content = textwrap.dedent(f"""\
+    {prefix}
+
     Name: compo1_alias
     Description: Alias compo1_alias for compo1
     Version: 0.3
@@ -435,7 +438,9 @@ def test_pkg_config_name_full_aliases():
     assert "Requires: compo1" in pc_content
 
     pc_content = client.load("pkg_alias1.pc")
-    content = textwrap.dedent("""\
+    content = textwrap.dedent(f"""\
+    {prefix}
+
     Name: pkg_alias1
     Description: Alias pkg_alias1 for pkg_other_name
     Version: 0.3
@@ -444,7 +449,9 @@ def test_pkg_config_name_full_aliases():
     assert content == pc_content
 
     pc_content = client.load("pkg_alias2.pc")
-    content = textwrap.dedent("""\
+    content = textwrap.dedent(f"""\
+    {prefix}
+
     Name: pkg_alias2
     Description: Alias pkg_alias2 for pkg_other_name
     Version: 0.3


### PR DESCRIPTION
Changelog: Bugfix: Add prefix var and any custom content (through the `pkg_config_custom_content` property) to already generated pkg-config root .pc files by `PkgConfigDeps`.
Docs: omit

Fixes #14049 