### PR TITLE
remove unused (only in testing) get_timestamps

### DIFF
--- a/conan/api/subapi/list.py
+++ b/conan/api/subapi/list.py
@@ -56,14 +56,7 @@ class ListAPI:
         if remote:
             results = app.remote_manager.get_package_revisions_references(pref, remote=remote)
         else:
-            refs = app.cache.get_package_revisions_references(pref, only_latest_prev=False)
-            results = []
-            for ref in refs:
-                # TODO: Why another call, and why get_package_revisions_references doesn't return
-                #  already the timestamps?
-                timestamp = app.cache.get_package_timestamp(ref)
-                ref.timestamp = timestamp
-                results.append(ref)
+            results = app.cache.get_package_revisions_references(pref, only_latest_prev=False)
         return results
 
     def packages_configurations(self, ref: RecipeReference,

--- a/conan/internal/cache/cache.py
+++ b/conan/internal/cache/cache.py
@@ -166,12 +166,6 @@ class DataCache:
     def get_matching_build_id(self, ref, build_id):
         return self._db.get_matching_build_id(ref, build_id)
 
-    def get_recipe_timestamp(self, ref):
-        return self._db.get_recipe_timestamp(ref)
-
-    def get_package_timestamp(self, pref):
-        return self._db.get_package_timestamp(pref)
-
     def remove_recipe(self, layout: RecipeLayout):
         layout.remove()
         # FIXME: This is clearing package binaries from DB, but not from disk/layout

--- a/conan/internal/cache/db/cache_database.py
+++ b/conan/internal/cache/db/cache_database.py
@@ -22,15 +22,6 @@ class CacheDatabase:
         matching_prevs = self.get_package_revisions_references(ref)
         return len(matching_prevs) > 0
 
-    def get_recipe_timestamp(self, ref):
-        # TODO: Remove this once the ref contains the timestamp
-        ref_data = self.try_get_recipe(ref)
-        return ref_data["ref"].timestamp  # Must exist
-
-    def get_package_timestamp(self, ref):
-        ref_data = self.try_get_package(ref)
-        return ref_data["pref"].timestamp
-
     def get_latest_recipe_reference(self, ref):
         # TODO: This logic could be done directly in DB
         rrevs = self.get_recipe_revisions_references(ref, True)

--- a/conan/internal/cache/db/recipes_table.py
+++ b/conan/internal/cache/db/recipes_table.py
@@ -33,16 +33,6 @@ class RecipesDBTable(BaseDbTable):
             [f'{k}="{v}" ' if v is not None else f'{k} IS NULL' for k, v in where_dict.items()])
         return where_expr
 
-    def _set_clause(self, ref: RecipeReference, path=None):
-        set_dict = {
-            self.columns.reference: str(ref),
-            self.columns.rrev: ref.revision,
-            self.columns.path: path,
-            self.columns.timestamp: ref.timestamp,
-        }
-        set_expr = ', '.join([f'{k} = "{v}"' for k, v in set_dict.items() if v is not None])
-        return set_expr
-
     def get(self, ref: RecipeReference):
         """ Returns the row matching the reference or fails """
         where_clause = self._where_clause(ref)

--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -92,12 +92,6 @@ class ClientCache(object):
     def remove_package_layout(self, layout):
         self._data_cache.remove_package(layout)
 
-    def get_recipe_timestamp(self, ref):
-        return self._data_cache.get_recipe_timestamp(ref)
-
-    def get_package_timestamp(self, ref):
-        return self._data_cache.get_package_timestamp(ref)
-
     def update_recipe_timestamp(self, ref):
         """ when the recipe already exists in cache, but we get a new timestamp from a server
         that would affect its order in our cache """

--- a/conans/test/integration/cache/cache2_update_test.py
+++ b/conans/test/integration/cache/cache2_update_test.py
@@ -102,7 +102,7 @@ class TestUpdateFlows:
         latest_rrev = self.client.cache.get_latest_recipe_reference(RecipeReference.loads("liba/1.0.0@"))
         # check that we have stored REV1 in client with the same date from the server0
         assert latest_rrev.timestamp == self.server_times["server0"]
-        assert self.client.cache.get_recipe_timestamp(latest_rrev) == self.server_times["server0"]
+        assert latest_rrev.timestamp == self.server_times["server0"]
 
         # | CLIENT      | CLIENT2    | SERVER0    | SERVER1   | SERVER2    |
         # |-------------|------------|------------|-----------|------------|
@@ -141,7 +141,7 @@ class TestUpdateFlows:
         latest_rrev = self.client.cache.get_latest_recipe_reference(self.liba)
         self.client.assert_listed_require({"liba/1.0.0": "Updated (server2)"})
         assert "liba/1.0.0: Downloaded package" in self.client.out
-        assert self.client.cache.get_recipe_timestamp(latest_rrev) == self.server_times["server2"]
+        assert latest_rrev.timestamp == self.server_times["server2"]
 
         # we create a newer revision in client
         self.client.run("remove * -c")
@@ -193,7 +193,8 @@ class TestUpdateFlows:
         assert f"liba/1.0.0: Retrieving package {NO_SETTINGS_PACKAGE_ID}" \
                " from remote 'server2'" in self.client2.out
 
-        assert self.client2.cache.get_recipe_timestamp(rev_to_upload) == self.server_times["server2"]
+        rev_to_upload = self.client2.cache.get_latest_recipe_reference(rev_to_upload)
+        assert rev_to_upload.timestamp == self.server_times["server2"]
 
         # | CLIENT      | CLIENT2    | SERVER0    | SERVER1   | SERVER2    |
         # |-------------|------------|------------|-----------|------------|
@@ -276,7 +277,8 @@ class TestUpdateFlows:
 
         latest_cache_revision = self.client.cache.get_latest_recipe_reference(server_rrev_norev)
         assert latest_cache_revision != server_rrev
-        assert self.the_time == self.client.cache.get_recipe_timestamp(server_rrev)
+        latest_cache_revision = self.client.cache.get_latest_recipe_reference(server_rrev)
+        assert self.the_time == latest_cache_revision.timestamp
         self.client.assert_listed_require({"liba/1.0.0": "Cache (Updated date) (server2)"})
 
         self.client.run("remove * -c")
@@ -308,7 +310,7 @@ class TestUpdateFlows:
         # --> results: update revision date in cache, do not install anything
 
         latest_rrev_cache = self.client.cache.get_latest_recipe_reference(self.liba)
-        assert latest_server_time == self.client.cache.get_recipe_timestamp(latest_rrev_cache)
+        assert latest_server_time == latest_rrev_cache.timestamp
         self.client.assert_listed_require({"liba/1.0.0": "Cache (Updated date) (server2)"})
 
         # | CLIENT      | CLIENT2    | SERVER0    | SERVER1   | SERVER2    |
@@ -333,7 +335,7 @@ class TestUpdateFlows:
         # --> results: install from server2
 
         latest_rrev_cache = self.client.cache.get_latest_recipe_reference(self.liba)
-        assert latest_server_time == self.client.cache.get_recipe_timestamp(latest_rrev_cache)
+        assert latest_server_time == latest_rrev_cache.timestamp
         self.client.assert_listed_require({"liba/1.0.0": "Downloaded (server2)"})
 
         # | CLIENT      | CLIENT2    | SERVER0    | SERVER1   | SERVER2    |
@@ -381,7 +383,7 @@ class TestUpdateFlows:
         self.client.assert_listed_require({"liba/1.0.0": "Downloaded (server0)"})
 
         latest_rrev = self.client.cache.get_latest_recipe_reference(RecipeReference.loads("liba/1.0.0@"))
-        assert self.client.cache.get_recipe_timestamp(latest_rrev) == self.server_times["server0"]
+        assert latest_rrev.timestamp == self.server_times["server0"]
 
         # | CLIENT         | CLIENT2        | SERVER0        | SERVER1        | SERVER2        |
         # |----------------|----------------|----------------|----------------|----------------|

--- a/conans/test/integration/command/install/install_update_test.py
+++ b/conans/test/integration/command/install/install_update_test.py
@@ -79,8 +79,8 @@ def test_update_not_date():
 
     ref = RecipeReference.loads("hello0/1.0@lasote/stable")
 
-    initial_recipe_timestamp = client.cache.get_recipe_timestamp(client.cache.get_latest_recipe_reference(ref))
-    initial_package_timestamp = client.cache.get_package_timestamp(prev)
+    initial_recipe_timestamp = client.cache.get_latest_recipe_reference(ref).timestamp
+    initial_package_timestamp = prev.timestamp
 
     time.sleep(1)
 
@@ -90,8 +90,8 @@ def test_update_not_date():
     client.run("export . --user=lasote --channel=stable")
     client.run("install --requires=hello0/1.0@lasote/stable --build='*'")
 
-    rebuild_recipe_timestamp = client.cache.get_recipe_timestamp(client.cache.get_latest_recipe_reference(ref))
-    rebuild_package_timestamp = client.cache.get_package_timestamp(client.get_latest_package_reference(ref))
+    rebuild_recipe_timestamp = client.cache.get_latest_recipe_reference(ref).timestamp
+    rebuild_package_timestamp = client.get_latest_package_reference(ref).timestamp
 
     assert rebuild_recipe_timestamp != initial_recipe_timestamp
     assert rebuild_package_timestamp != initial_package_timestamp
@@ -105,8 +105,8 @@ def test_update_not_date():
 
     client.assert_listed_require({"hello0/1.0@lasote/stable": "Newer"})
 
-    failed_update_recipe_timestamp = client.cache.get_recipe_timestamp(client.cache.get_latest_recipe_reference(ref))
-    failed_update_package_timestamp = client.cache.get_package_timestamp(client.get_latest_package_reference(ref))
+    failed_update_recipe_timestamp = client.cache.get_latest_recipe_reference(ref).timestamp
+    failed_update_package_timestamp = client.get_latest_package_reference(ref).timestamp
 
     assert rebuild_recipe_timestamp == failed_update_recipe_timestamp
     assert rebuild_package_timestamp == failed_update_package_timestamp


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Removing dead code (only used in testing), because refs already contain timestamp, no need for a separate query