### PR TITLE
Fix/cli argparse

### DIFF
--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -169,7 +169,7 @@ class Cli:
             raise ConanException("Unknown command %s" % str(exc))
 
         try:
-            command.run(self._conan_api, self._commands[command_argument].parser, args[0][1:])
+            command.run(self._conan_api, args[0][1:])
         except Exception as e:
             # must be a local-import to get updated value
             if ConanOutput.level_allowed(LEVEL_TRACE):

--- a/conan/cli/command.py
+++ b/conan/cli/command.py
@@ -43,13 +43,20 @@ class BaseConanCommand:
                                  "commands should provide a documentation string explaining "
                                  "its use briefly.".format(self._name))
 
+    @staticmethod
+    def _init_log_levels(parser):
+        parser.add_argument("-v", default="status", nargs='?',
+                            help="Level of detail of the output. Valid options from less verbose "
+                                 "to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, "
+                                 "-v or -vverbose, -vv or -vdebug, -vvv or -vtrace")
+
     @property
     def _help_formatters(self):
         """
         Formatters that are shown as available in help, 'text' formatter
         should not appear
         """
-        return [formatter for formatter in list(self._formatters) if formatter != "text"]
+        return [formatter for formatter in self._formatters if formatter != "text"]
 
     def _init_formatters(self, parser):
         formatters = self._help_formatters
@@ -57,12 +64,6 @@ class BaseConanCommand:
             help_message = "Select the output format: {}".format(", ".join(formatters))
             parser.add_argument('-f', '--format', action=OnceArgument, help=help_message)
 
-    @staticmethod
-    def _init_log_levels(parser):
-        parser.add_argument("-v", default="status", nargs='?',
-                            help="Level of detail of the output. Valid options from less verbose "
-                                 "to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, "
-                                 "-v or -vverbose, -vv or -vdebug, -vvv or -vtrace")
     @property
     def name(self):
         return self._name

--- a/conans/test/integration/conan_api/test_cli.py
+++ b/conans/test/integration/conan_api/test_cli.py
@@ -1,0 +1,23 @@
+from conan.api.conan_api import ConanAPI
+from conan.cli.cli import Cli
+from conans.test.utils.mocks import RedirectedTestOutput
+from conans.test.utils.test_files import temp_folder
+from conans.test.utils.tools import redirect_output
+
+
+def test_cli():
+    """ make sure the CLi can be reused
+    https://github.com/conan-io/conan/issues/14044
+    """
+    folder = temp_folder()
+    api = ConanAPI(cache_folder=folder)
+    cli = Cli(api)
+    cli2 = Cli(api)
+
+    stdout = RedirectedTestOutput()
+    stderr = RedirectedTestOutput()
+    with redirect_output(stderr, stdout):
+        cli.run(["list", "*"])
+        cli.run(["list", "*"])
+        cli2.run(["list", "*"])
+        cli.run(["list", "*"])


### PR DESCRIPTION
Changelog: Fix: Allow internal ``Cli`` object to be called more than once.
Docs: Omit

The main change is a refactor, not creating the ArgumentParser when the commands are imported, but when the commands are executed, because otherwise it is not possible to call a ``Cli.run()`` again.

Close https://github.com/conan-io/conan/issues/14044
