### PR TITLE
Git.clone change folder to target one

### DIFF
--- a/conan/tools/scm/git.py
+++ b/conan/tools/scm/git.py
@@ -164,8 +164,6 @@ class Git(object):
         self._conanfile.output.info("Cloning git repo")
         target_path = f'"{target}"' if target else ""  # quote in case there are spaces in path
         self.run('clone "{}" {} {}'.format(url, " ".join(args), target_path))
-        if target:
-            self.folder = target
 
     def fetch_commit(self, url, commit):
         """

--- a/conan/tools/scm/git.py
+++ b/conan/tools/scm/git.py
@@ -162,7 +162,10 @@ class Git(object):
             url = url.replace("\\", "/")  # Windows local directory
         mkdir(self.folder)
         self._conanfile.output.info("Cloning git repo")
-        self.run('clone "{}" {} {}'.format(url, " ".join(args), target))
+        target_path = f'"{target}"' if target else ""  # quote in case there are spaces in path
+        self.run('clone "{}" {} {}'.format(url, " ".join(args), target_path))
+        if target:
+            self.folder = target
 
     def fetch_commit(self, url, commit):
         """

--- a/conans/test/functional/tools/scm/test_git.py
+++ b/conans/test/functional/tools/scm/test_git.py
@@ -233,12 +233,12 @@ class TestGitBasicClone:
                     # git.checkout(commit="{commit}")
 
                     git = Git(self)
-                    git.clone(url="{url}", target="target") # git clone url target
-                    git.folder = "target"                   # cd target
+                    git.clone(url="{url}", target="tar get") # git clone url target
+                    git.folder = "tar get"                   # cd target
                     git.checkout(commit="{commit}")         # git checkout commit
 
-                    self.output.info("MYCMAKE: {{}}".format(load(self, "target/CMakeLists.txt")))
-                    self.output.info("MYFILE: {{}}".format(load(self, "target/src/myfile.h")))
+                    self.output.info("MYCMAKE: {{}}".format(load(self, "tar get/CMakeLists.txt")))
+                    self.output.info("MYFILE: {{}}".format(load(self, "tar get/src/myfile.h")))
                 """)
         folder = os.path.join(temp_folder(), "myrepo")
         url, commit = create_local_git_repo(files={"src/myfile.h": "myheader!",

--- a/conans/test/functional/tools/scm/test_git.py
+++ b/conans/test/functional/tools/scm/test_git.py
@@ -211,8 +211,7 @@ class TestGitBasicClone:
         assert c.load("source/CMakeLists.txt") == "mycmake"
 
     def test_clone_target(self):
-        # Clone to a different target folder, then need to define a new Git, changing the
-        # folder
+        # Clone to a different target folder
         # https://github.com/conan-io/conan/issues/14058
         conanfile = textwrap.dedent("""
             import os
@@ -228,10 +227,15 @@ class TestGitBasicClone:
                     self.folders.source = "source"
 
                 def source(self):
+                    # Alternative, first defining the folder
+                    # git = Git(self, "target")
+                    # git.clone(url="{url}", target=".")
+                    # git.checkout(commit="{commit}")
+
                     git = Git(self)
-                    target = os.path.join(self.source_folder, "target")
-                    git.clone(url="{url}", target=target)
-                    git.checkout(commit="{commit}")
+                    git.clone(url="{url}", target="target") # git clone url target
+                    git.folder = "target"                   # cd target
+                    git.checkout(commit="{commit}")         # git checkout commit
 
                     self.output.info("MYCMAKE: {{}}".format(load(self, "target/CMakeLists.txt")))
                     self.output.info("MYFILE: {{}}".format(load(self, "target/src/myfile.h")))

--- a/conans/test/functional/tools/scm/test_git.py
+++ b/conans/test/functional/tools/scm/test_git.py
@@ -210,6 +210,45 @@ class TestGitBasicClone:
         assert c.load("source/src/myfile.h") == "myheader!"
         assert c.load("source/CMakeLists.txt") == "mycmake"
 
+    def test_clone_target(self):
+        # Clone to a different target folder, then need to define a new Git, changing the
+        # folder
+        # https://github.com/conan-io/conan/issues/14058
+        conanfile = textwrap.dedent("""
+            import os
+            from conan import ConanFile
+            from conan.tools.scm import Git
+            from conan.tools.files import load
+
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "0.1"
+
+                def layout(self):
+                    self.folders.source = "source"
+
+                def source(self):
+                    git = Git(self)
+                    target = os.path.join(self.source_folder, "target")
+                    git.clone(url="{url}", target=target)
+                    git.checkout(commit="{commit}")
+
+                    self.output.info("MYCMAKE: {{}}".format(load(self, "target/CMakeLists.txt")))
+                    self.output.info("MYFILE: {{}}".format(load(self, "target/src/myfile.h")))
+                """)
+        folder = os.path.join(temp_folder(), "myrepo")
+        url, commit = create_local_git_repo(files={"src/myfile.h": "myheader!",
+                                                   "CMakeLists.txt": "mycmake"}, folder=folder)
+        # This second commit will NOT be used, as I will use the above commit in the conanfile
+        save_files(path=folder, files={"src/myfile.h": "my2header2!"})
+        git_add_changes_commit(folder=folder)
+
+        c = TestClient()
+        c.save({"conanfile.py": conanfile.format(url=url, commit=commit)})
+        c.run("create .")
+        assert "pkg/0.1: MYCMAKE: mycmake" in c.out
+        assert "pkg/0.1: MYFILE: myheader!" in c.out
+
 
 @pytest.mark.tool("git")
 class TestGitShallowClone:


### PR DESCRIPTION
Changelog: Fix: Allow spaces in path in ``Git`` helper.
Docs: https://github.com/conan-io/docs/pull/3271

Close https://github.com/conan-io/conan/issues/14058


