### PR TITLE
Fixes #14062: Profile detect selects wrong default compiler on FreeBSD

### DIFF
--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -112,7 +112,7 @@ def _get_default_compiler():
 
     if platform.system() == "Windows":
         return vs or cc or gcc or clang
-    elif platform.system() == "Darwin":
+    elif platform.system() in ["Darwin", "FreeBSD"]:
         return clang or cc or gcc
     elif platform.system() == "SunOS":
         return sun_cc or cc or gcc or clang


### PR DESCRIPTION
Changelog: Bugfix: Set clang as the default FreeBSD detected compiler.
Docs: Omit

`FreeBSD` is family of `Darwin`, that's why I chose to put it with `Darwin`.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
