### PR TITLE
Redundant None checks

### DIFF
--- a/conan/tools/build/flags.py
+++ b/conan/tools/build/flags.py
@@ -178,7 +178,7 @@ def cppstd_flag(settings):
             "apple-clang": _cppstd_apple_clang,
             "msvc": _cppstd_msvc,
             "intel-cc": _cppstd_intel_cc,
-            "mcst-lcc": _cppstd_mcst_lcc}.get(compiler, None)
+            "mcst-lcc": _cppstd_mcst_lcc}.get(compiler)
     flag = None
     if func:
         flag = func(Version(compiler_version), str(cppstd))
@@ -203,7 +203,7 @@ def cppstd_msvc_flag(visual_version, cppstd):
     if visual_version >= "193":
         v23 = "c++latest"
 
-    return {"14": v14, "17": v17, "20": v20, "23": v23}.get(str(cppstd), None)
+    return {"14": v14, "17": v17, "20": v20, "23": v23}.get(str(cppstd))
 
 def _cppstd_msvc(visual_version, cppstd):
     flag = cppstd_msvc_flag(visual_version, cppstd)
@@ -256,7 +256,7 @@ def _cppstd_apple_clang(clang_version, cppstd):
             "14": v14, "gnu14": vgnu14,
             "17": v17, "gnu17": vgnu17,
             "20": v20, "gnu20": vgnu20,
-            "23": v23, "gnu23": vgnu23}.get(cppstd, None)
+            "23": v23, "gnu23": vgnu23}.get(cppstd)
 
     return "-std=%s" % flag if flag else None
 
@@ -312,7 +312,7 @@ def _cppstd_clang(clang_version, cppstd):
             "14": v14, "gnu14": vgnu14,
             "17": v17, "gnu17": vgnu17,
             "20": v20, "gnu20": vgnu20,
-            "23": v23, "gnu23": vgnu23}.get(cppstd, None)
+            "23": v23, "gnu23": vgnu23}.get(cppstd)
     return "-std=%s" % flag if flag else None
 
 
@@ -461,5 +461,5 @@ def _cppstd_intel_cc(_, cppstd):
             "14": v14, "gnu14": vgnu14,
             "17": v17, "gnu17": vgnu17,
             "20": v20, "gnu20": vgnu20,
-            "23": v23, "gnu23": vgnu23}.get(cppstd, None)
+            "23": v23, "gnu23": vgnu23}.get(cppstd)
     return "-std=%s" % flag if flag else None


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Lookup returns None when not found, so no default None needed and if it didn't have a value it was already None.
I'm not a Python expert, just getting my feet wet.

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
