### PR TITLE
default build profile is no longer none

### DIFF
--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -13,7 +13,7 @@ BUILT_IN_CONFS = {
     "core:non_interactive": "Disable interactive user input, raises error if input necessary",
     "core:skip_warnings": "Do not show warnings in this list",
     "core:default_profile": "Defines the default host profile ('default' by default)",
-    "core:default_build_profile": "Defines the default build profile (None by default)",
+    "core:default_build_profile": "Defines the default build profile ('default' by default)",
     "core:allow_uppercase_pkg_names": "Temporarily (will be removed in 2.X) allow uppercase names",
     "core.version_ranges:resolve_prereleases": "Whether version ranges can resolve to pre-releases or not",
     "core.upload:retry": "Number of retries in case of failure when uploading to Conan server",


### PR DESCRIPTION
Changelog: Fix: Fix description for the conf entry for default build profile used.
Docs: https://github.com/conan-io/docs/pull/3252

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.

Saw this while poking around 😄 seems like it was missed in the migration

https://github.com/conan-io/conan/blob/648dda21964a04b6b49d67b3a3b2cb3c745c7b7b/conans/client/profile_loader.py#L103