### PR TITLE
deprecate AutoPackage

### DIFF
--- a/conan/tools/files/packager.py
+++ b/conan/tools/files/packager.py
@@ -38,6 +38,9 @@ class AutoPackager(object):
         self.patterns.build.include = ["*.h", "*.hpp", "*.hxx"]
         self.patterns.build.lib = ["*.so", "*.so.*", "*.a", "*.lib", "*.dylib"]
         self.patterns.build.bin = ["*.exe", "*.dll"]
+        conanfile.output.warning("AutoPackager is **** deprecated ****", warn_tag="deprecated")
+        conanfile.output.warning("AutoPackager **** will be removed ****", warn_tag="deprecated")
+        conanfile.output.warning("Use explicit copy() calls instead", warn_tag="deprecated")
 
     def run(self):
         cf = self._conanfile
@@ -58,8 +61,8 @@ class AutoPackager(object):
                     self._package_cppinfo("build", cf.cpp.build.components[cname],
                                           cf.cpp.package.components[cname])
         else:  # No components declared
-           self._package_cppinfo("source", cf.cpp.source, cf.cpp.package)
-           self._package_cppinfo("build", cf.cpp.build, cf.cpp.package)
+            self._package_cppinfo("source", cf.cpp.source, cf.cpp.package)
+            self._package_cppinfo("build", cf.cpp.build, cf.cpp.package)
 
     def _package_cppinfo(self, origin_name, origin_cppinfo, dest_cppinfo):
         """

--- a/conans/test/functional/layout/test_layout_autopackage.py
+++ b/conans/test/functional/layout/test_layout_autopackage.py
@@ -89,6 +89,7 @@ def test_auto_package_no_components():
     """
     client.save({"conanfile.py": conan_file})
     client.run("create . --name=lib --version=1.0")
+    assert "AutoPackager is **** deprecated ****" in client.out
     package_id = client.created_package_id("lib/1.0")
 
     ref = RecipeReference.loads("lib/1.0@")


### PR DESCRIPTION
Changelog: Fix: Deprecate ``AutoPackage`` remnant from Conan 1.X.
Docs: https://github.com/conan-io/docs/pull/3253

