### PR TITLE
Add functionality to cmake_lib template

### DIFF
--- a/conan/internal/api/new/cmake_lib.py
+++ b/conan/internal/api/new/cmake_lib.py
@@ -155,13 +155,13 @@ void {{package_name}}(){
 
     // MSVC runtime
     #if defined(_DEBUG)
-        #if defined(_MT) and defined(_DLL)
+        #if defined(_MT) && defined(_DLL)
         std::cout << "  {{name}}/{{version}}: MSVC runtime: MultiThreadedDebugDLL\n";
         #elif defined(_MT)
         std::cout << "  {{name}}/{{version}}: MSVC runtime: MultiThreadedDebug\n";
         #endif
     #else
-        #if defined(_MT) and defined(_DLL)
+        #if defined(_MT) && defined(_DLL)
         std::cout << "  {{name}}/{{version}}: MSVC runtime: MultiThreadedDLL\n";
         #elif defined(_MT)
         std::cout << "  {{name}}/{{version}}: MSVC runtime: MultiThreaded\n";

--- a/conan/internal/api/new/cmake_lib.py
+++ b/conan/internal/api/new/cmake_lib.py
@@ -230,7 +230,7 @@ void {{package_name}}(){
 
 void {{package_name}}_print_vector(const std::vector<std::string> &strings) {
     for(std::vector<std::string>::const_iterator it = strings.begin(); it != strings.end(); ++it) {
-        std::cout << "{{package_name}}/{{version}} " <<  *it << std::endl;
+        std::cout << "{{package_name}}/{{version}} " << *it << std::endl;
     }
 }
 """

--- a/conan/internal/api/new/cmake_lib.py
+++ b/conan/internal/api/new/cmake_lib.py
@@ -153,6 +153,21 @@ void {{package_name}}(){
     std::cout << "  {{name}}/{{version}}: _GLIBCXX_USE_CXX11_ABI "<< _GLIBCXX_USE_CXX11_ABI << "\n";
     #endif
 
+    // MSVC runtime
+    #if defined(_DEBUG)
+        #if defined(_MT) and defined(_DLL)
+        std::cout << "  {{name}}/{{version}}: MSVC runtime: MultiThreadedDebugDLL\n";
+        #elif defined(_MT)
+        std::cout << "  {{name}}/{{version}}: MSVC runtime: MultiThreadedDebug\n";
+        #endif
+    #else
+        #if defined(_MT) and defined(_DLL)
+        std::cout << "  {{name}}/{{version}}: MSVC runtime: MultiThreadedDLL\n";
+        #elif defined(_MT)
+        std::cout << "  {{name}}/{{version}}: MSVC runtime: MultiThreaded\n";
+        #endif
+    #endif
+
     // COMPILER VERSIONS
     #if _MSC_VER
     std::cout << "  {{name}}/{{version}}: _MSC_VER" << _MSC_VER<< "\n";

--- a/conan/internal/api/new/cmake_lib.py
+++ b/conan/internal/api/new/cmake_lib.py
@@ -91,6 +91,9 @@ install(TARGETS {{name}})
 
 source_h = """#pragma once
 
+#include <vector>
+#include <string>
+
 {% set define_name = package_name.upper() %}
 #ifdef _WIN32
   #define {{define_name}}_EXPORT __declspec(dllexport)
@@ -99,6 +102,7 @@ source_h = """#pragma once
 #endif
 
 {{define_name}}_EXPORT void {{package_name}}();
+{{define_name}}_EXPORT void {{package_name}}_print_vector(const std::vector<std::string> &strings);
 """
 
 source_cpp = r"""#include <iostream>
@@ -223,6 +227,12 @@ void {{package_name}}(){
     std::cout << "  {{name}}/{{version}}: __CYGWIN__" << __CYGWIN__<< "\n";
     #endif
 }
+
+void {{package_name}}_print_vector(const std::vector<std::string> &strings) {
+    for(std::vector<std::string>::const_iterator it = strings.begin(); it != strings.end(); ++it) {
+        std::cout << "{{package_name}}/{{version}} " <<  *it << std::endl;
+    }
+}
 """
 
 
@@ -271,9 +281,16 @@ target_link_libraries(example {{name}}::{{name}})
 
 
 test_main = """#include "{{name}}.h"
+#include <vector>
+#include <string>
 
 int main() {
     {{package_name}}();
+    
+    std::vector<std::string> vec;
+    vec.push_back("test_package");
+
+    {{package_name}}_print_vector(vec);
 }
 """
 


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Two small features added to the `cmake-lib` template:

* Print the msvc runtime variant used - use the macros described in the [documentation](https://learn.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library?view=msvc-170#remarks) to determine at compile time which runtime library is being used - this can be useful in tests to assert that the intended runtime is used

* Add function to the template library that passes `std::vector<std::string>` in its arguments, and call it from the `test_package` - this can be a good way of exercising the correct C++ runtime is used on both the calling site and the library. If there are mismatches, this could cause iterator debug level errors with Visual C++, or linker errors due to libstdc++ C++11 ABI.
