### PR TITLE
import conan tools improve

### DIFF
--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -2,7 +2,7 @@ import os
 
 from conans.util.runners import check_output_runner
 from conan.tools.build import cmd_args_to_string
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 def is_apple_os(conanfile):

--- a/conan/tools/apple/xcodebuild.py
+++ b/conan/tools/apple/xcodebuild.py
@@ -1,5 +1,5 @@
 from conan.tools.apple import to_apple_arch
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 class XcodeBuild(object):

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 from jinja2 import Template
 
 from conan.internal import check_duplicated_generator
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.dependencies import get_transitive_requires
 from conans.util.files import load, save
 from conan.tools.apple.apple import _to_apple_arch

--- a/conan/tools/build/__init__.py
+++ b/conan/tools/build/__init__.py
@@ -8,7 +8,7 @@ from conan.tools.build.cppstd import check_max_cppstd, check_min_cppstd, \
 from conan.tools.build.cpu import build_jobs
 from conan.tools.build.cross_building import cross_building, can_run
 from conan.tools.build.stdcpp_library import stdcpp_library
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 CONAN_TOOLCHAIN_ARGS_FILE = "conanbuild.conf"
 CONAN_TOOLCHAIN_ARGS_SECTION = "toolchain"

--- a/conan/tools/build/cppstd.py
+++ b/conan/tools/build/cppstd.py
@@ -1,6 +1,6 @@
 import operator
 
-from conans.errors import ConanInvalidConfiguration, ConanException
+from conan.errors import ConanInvalidConfiguration, ConanException
 from conans.model.version import Version
 
 

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -5,7 +5,7 @@ from conan.tools.cmake.presets import load_cmake_presets
 from conan.tools.cmake.utils import is_multi_configuration
 from conan.tools.files import chdir, mkdir
 from conan.tools.microsoft.msbuild import msbuild_verbosity_cmd_line_arg
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 def _cmake_cmd_line_args(conanfile, generator):

--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -9,9 +9,9 @@ from conan.tools.cmake.cmakedeps.templates.macros import MacrosTemplate
 from conan.tools.cmake.cmakedeps.templates.target_configuration import TargetConfigurationTemplate
 from conan.tools.cmake.cmakedeps.templates.target_data import ConfigDataTemplate
 from conan.tools.cmake.cmakedeps.templates.targets import TargetsTemplate
+from conan.tools.files import save
 from conans.client.generators import relativize_generated_file
-from conans.errors import ConanException
-from conans.util.files import save
+from conan.errors import ConanException
 
 
 class CMakeDeps(object):
@@ -42,7 +42,7 @@ class CMakeDeps(object):
         # Current directory is the generators_folder
         generator_files = self.content
         for generator_file, content in generator_files.items():
-            save(generator_file, content)
+            save(self._conanfile, generator_file, content)
 
     @property
     def content(self):

--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -1,7 +1,7 @@
 import jinja2
 from jinja2 import Template
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 class CMakeDepsFileTemplate(object):

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -4,7 +4,7 @@ import textwrap
 from conan.tools.cmake.cmakedeps import FIND_MODE_NONE, FIND_MODE_CONFIG, FIND_MODE_MODULE, \
     FIND_MODE_BOTH
 from conan.tools.cmake.cmakedeps.templates import CMakeDepsFileTemplate
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.dependencies import get_transitive_requires
 
 

--- a/conan/tools/cmake/layout.py
+++ b/conan/tools/cmake/layout.py
@@ -1,7 +1,7 @@
 import os
 
 from conans.client.graph.graph import RECIPE_CONSUMER, RECIPE_EDITABLE
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 def cmake_layout(conanfile, generator=None, src_folder=".", build_folder="build"):

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -7,7 +7,7 @@ from conan.tools.cmake.layout import get_build_folder_custom_vars
 from conan.tools.cmake.utils import is_multi_configuration
 from conan.tools.microsoft import is_msvc
 from conans.client.graph.graph import RECIPE_CONSUMER
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.util.files import save, load
 
 

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -15,7 +15,7 @@ from conan.tools.cmake.toolchain import CONAN_TOOLCHAIN_FILENAME
 from conan.tools.intel import IntelCC
 from conan.tools.microsoft.visual import msvc_version_to_toolset_version
 from conans.client.subsystems import deduce_subsystem, WINDOWS
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.util.files import load
 
 

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -17,7 +17,7 @@ from conan.tools.intel import IntelCC
 from conan.tools.microsoft import VCVars
 from conan.tools.microsoft.visual import vs_ide_version
 from conans.client.generators import relativize_generated_file
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.options import _PackageOption
 from conans.util.files import save
 

--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 
 from conans.client.generators import relativize_generated_file
 from conans.client.subsystems import deduce_subsystem, WINDOWS, subsystem_path
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.recipe_ref import ref_matches
 from conans.util.files import save
 

--- a/conan/tools/files/conandata.py
+++ b/conan/tools/files/conandata.py
@@ -2,7 +2,7 @@ import os
 
 import yaml
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.util.files import load, save
 
 

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -10,7 +10,7 @@ from shutil import which
 
 
 from conans.client.downloaders.caching_file_downloader import SourcesCachingDownloader
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.util.files import rmdir as _internal_rmdir, human_size
 from conans.util.sha import check_with_algorithm_sum
 

--- a/conan/tools/files/packager.py
+++ b/conan/tools/files/packager.py
@@ -1,6 +1,6 @@
 import os
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 class _PatternEntry(object):

--- a/conan/tools/files/patches.py
+++ b/conan/tools/files/patches.py
@@ -4,7 +4,7 @@ import shutil
 
 import patch_ng
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.util.files import mkdir
 
 

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -7,7 +7,7 @@ from conan.tools.build.flags import architecture_flag, build_type_flags, cppstd_
 from conan.tools.env import Environment
 from conan.tools.gnu.get_gnu_triplet import _get_gnu_triplet
 from conan.tools.microsoft import VCVars, msvc_runtime_flag, unix_path
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.pkg_type import PackageType
 
 

--- a/conan/tools/gnu/get_gnu_triplet.py
+++ b/conan/tools/gnu/get_gnu_triplet.py
@@ -1,4 +1,4 @@
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 def _get_gnu_triplet(os_, arch, compiler=None):

--- a/conan/tools/gnu/pkgconfig.py
+++ b/conan/tools/gnu/pkgconfig.py
@@ -1,6 +1,6 @@
 from conan.tools.build import cmd_args_to_string
 from conan.tools.env import Environment
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.util.runners import check_output_runner
 
 

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -6,7 +6,7 @@ from jinja2 import Template, StrictUndefined
 
 from conan.internal import check_duplicated_generator
 from conan.tools.gnu.gnudeps_flags import GnuDepsFlags
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.dependencies import get_transitive_requires
 from conans.util.files import save
 

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -5,7 +5,7 @@ import textwrap
 from jinja2 import Template
 
 from conan.internal import check_duplicated_generator
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.util.files import save
 
 

--- a/conan/tools/intel/intel_cc.py
+++ b/conan/tools/intel/intel_cc.py
@@ -22,7 +22,7 @@ import platform
 import textwrap
 
 from conan.internal import check_duplicated_generator
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 def _is_using_intel_oneapi(compiler_version):

--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -2,7 +2,7 @@ import os
 
 from conan.tools.build import build_jobs
 from conan.tools.meson.toolchain import MesonToolchain
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 class Meson(object):

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -11,7 +11,7 @@ from conan.tools.build.flags import libcxx_flags
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.meson.helpers import *
 from conan.tools.microsoft import VCVars, msvc_runtime_flag
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.util.files import save
 
 

--- a/conan/tools/microsoft/layout.py
+++ b/conan/tools/microsoft/layout.py
@@ -1,7 +1,7 @@
 import os
 
 from conan.tools.microsoft.msbuild import msbuild_arch
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 def vs_layout(conanfile):

--- a/conan/tools/microsoft/msbuild.py
+++ b/conan/tools/microsoft/msbuild.py
@@ -1,4 +1,4 @@
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 def msbuild_verbosity_cmd_line_arg(conanfile):

--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -7,7 +7,7 @@ from xml.dom import minidom
 from jinja2 import Template
 
 from conan.internal import check_duplicated_generator
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.dependencies import get_transitive_requires
 from conans.util.files import load, save
 

--- a/conan/tools/microsoft/toolchain.py
+++ b/conan/tools/microsoft/toolchain.py
@@ -8,7 +8,7 @@ from conan.internal import check_duplicated_generator
 from conan.tools.build import build_jobs
 from conan.tools.intel.intel_cc import IntelCC
 from conan.tools.microsoft.visual import VCVars, msvs_toolset
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.util.files import save, load
 
 

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -3,7 +3,7 @@ import textwrap
 
 from conan.internal import check_duplicated_generator
 from conans.client.conf.detect_vs import vs_installation_path
-from conans.errors import ConanException, ConanInvalidConfiguration
+from conan.errors import ConanException, ConanInvalidConfiguration
 from conan.tools.scm import Version
 from conan.tools.intel.intel_cc import IntelCC
 

--- a/conan/tools/qbs/qbs.py
+++ b/conan/tools/qbs/qbs.py
@@ -1,7 +1,7 @@
 import os
 
 from conan.tools.build import build_jobs
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 def _configuration_dict_to_commandlist(name, config_dict):

--- a/conan/tools/qbs/qbsprofile.py
+++ b/conan/tools/qbs/qbsprofile.py
@@ -6,7 +6,7 @@ from io import StringIO
 from jinja2 import Template
 
 from conan.internal import check_duplicated_generator
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.util.files import save
 
 _profile_name = 'conan'

--- a/conan/tools/scm/git.py
+++ b/conan/tools/scm/git.py
@@ -1,7 +1,7 @@
 import os
 
 from conan.tools.files import chdir
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.util.files import mkdir
 from conans.util.runners import check_output_runner
 

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -2,7 +2,7 @@ import platform
 
 from conan.tools.build import cross_building
 from conans.client.graph.graph import CONTEXT_BUILD
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 class _SystemPackageManagerTool(object):


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

I am concerned of excessive importing ``from conans`` in our own ``conan.tools`` that users copying/forking it, will also contain too many ``from conans`` imports that are private and will eventually break. So:

- Quick fix for exceptions that is an issue one
- Open the conversation about ``save, load`` helpers