### PR TITLE
make CppInfo an importable tool

### DIFF
--- a/conan/tools/__init__.py
+++ b/conan/tools/__init__.py
@@ -1,0 +1,8 @@
+from conans.model.build_info import CppInfo as _CppInfo
+
+
+def CppInfo(conanfile):
+    # Creation of a CppInfo object, to decouple the creation from the actual internal location
+    # that at the moment doesn't require a ``conanfile`` argument, but might require in the future
+    # and allow us to refactor the location of conans.model.build_info import CppInfo
+    return _CppInfo()

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -1,7 +1,7 @@
 from conan.internal import check_duplicated_generator
+from conan.tools import CppInfo
 from conan.tools.env import Environment
 from conan.tools.gnu.gnudeps_flags import GnuDepsFlags
-from conans.model.build_info import CppInfo
 
 
 class AutotoolsDeps:
@@ -18,7 +18,7 @@ class AutotoolsDeps:
         return self._ordered_deps
 
     def _get_cpp_info(self):
-        ret = CppInfo()
+        ret = CppInfo(self._conanfile)
         for dep in self.ordered_deps:
             dep_cppinfo = dep.cpp_info.aggregated_components()
             # In case we have components, aggregate them, we do not support isolated

--- a/conan/tools/microsoft/nmakedeps.py
+++ b/conan/tools/microsoft/nmakedeps.py
@@ -1,8 +1,8 @@
 import os
 
 from conan.internal import check_duplicated_generator
+from conan.tools import CppInfo
 from conan.tools.env import Environment
-from conans.model.build_info import CppInfo
 
 
 class NMakeDeps(object):
@@ -16,7 +16,7 @@ class NMakeDeps(object):
 
     # TODO: This is similar from AutotoolsDeps: Refactor and make common
     def _get_cpp_info(self):
-        ret = CppInfo()
+        ret = CppInfo(self._conanfile)
         deps = self._conanfile.dependencies.host.topological_sort
         deps = [dep for dep in reversed(deps.values())]
         for dep in deps:

--- a/conans/test/integration/conanfile/test_cpp_info_serialize.py
+++ b/conans/test/integration/conanfile/test_cpp_info_serialize.py
@@ -1,0 +1,40 @@
+import json
+import textwrap
+
+from conans.test.utils.tools import TestClient
+
+
+def test_cpp_info_serialize_round_trip():
+    """ test that serialize and deserialize CppInfo works
+    """
+    # TODO: Define standard name for file
+    c = TestClient()
+    conanfile = textwrap.dedent("""\
+        import os
+        from conan import ConanFile
+        from conan.tools import CppInfo
+
+        class Pkg(ConanFile):
+            name = "pkg"
+            version = "0.1"
+
+            def package(self):
+                cpp_info = CppInfo(self)
+                cpp_info.includedirs = ["myinc"]
+                cpp_info.libs = ["mylib", "myother"]
+                cpp_info.libdirs = ["mylibs"]
+                p = os.path.join(self.package_folder, "cpp_info.json")
+                cpp_info.save(p)
+
+            def package_info(self):
+                cpp_info = CppInfo(self).load("cpp_info.json")
+                self.cpp_info = cpp_info
+        """)
+
+    c.save({"conanfile.py": conanfile})
+    c.run("create . --format=json")
+    graph = json.loads(c.stdout)
+    cpp_info = graph["graph"]["nodes"]["1"]["cpp_info"]["root"]
+    assert cpp_info["includedirs"][0].endswith("myinc")
+    assert cpp_info["libdirs"][0].endswith("mylibs")
+    assert cpp_info["libs"] == ["mylib", "myother"]


### PR DESCRIPTION
Changelog: Feature: Make ``CppInfo`` a public, documented, importable tool for generators that need to aggregate them.
Docs: https://github.com/conan-io/docs/pull/3268

Close https://github.com/conan-io/conan/issues/13758 (https://github.com/conan-io/conan/issues/13758#issuecomment-1546659903), but:

- It might be necessary to backport this to Conan 1.X for compatibility? 

Probably better wait. Conan 1.X uses ``NewCppInfo`` instead, so it is going to be challenging. Lets move forward with 2.0 only, and see what happens and user feedback.
