### PR TITLE
raise if graph has errors for build-order

### DIFF
--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -67,6 +67,8 @@ def graph_build_order(conan_api, parser, subparser, *args):
         deps_graph = conan_api.graph.load_graph_requires(args.requires, args.tool_requires,
                                                          profile_host, profile_build, lockfile,
                                                          remotes, args.build, args.update)
+    print_graph_basic(deps_graph)
+    deps_graph.report_graph_error()
     conan_api.graph.analyze_binaries(deps_graph, args.build, remotes=remotes, update=args.update,
                                      lockfile=lockfile)
     print_graph_packages(deps_graph)

--- a/conans/test/integration/command_v2/test_info_build_order.py
+++ b/conans/test/integration/command_v2/test_info_build_order.py
@@ -383,5 +383,5 @@ def test_info_build_order_broken_recipe():
     c.save({"conanfile.py": dep})
     c.run("export .")
     c.run("graph build-order --requires=dep/0.1 --format=json", assert_error=True)
-    assert "ImportError: cannot import name 'ConanFile' from 'conans'" in c.out
+    assert "ImportError" in c.out
     assert "It is possible that this recipe is not Conan 2.0 ready" in c.out


### PR DESCRIPTION
Changelog: Bugfix: Raise if ``conan graph build-order`` graph has any errors, instead of quietly doing nothing and outputting and empty json.
Docs: Omit

Close https://github.com/conan-io/conan/issues/14104