### PR TITLE
fix wrong timestamp of old revision download

### DIFF
--- a/conan/api/subapi/download.py
+++ b/conan/api/subapi/download.py
@@ -28,6 +28,11 @@ class DownloadAPI:
 
         output.info(f"Downloading recipe '{ref.repr_notime()}'")
         app.remote_manager.get_recipe(ref, remote, metadata)
+        # Respect the timestamp of the server, the ``get_recipe()`` doesn't do it internally
+        # Best would be that ``get_recipe()`` returns the timestamp in the same call
+        server_ref = app.remote_manager.get_recipe_revision_reference(ref, remote)
+        assert server_ref == ref
+        app.cache.update_recipe_timestamp(server_ref)
 
         layout = app.cache.ref_layout(ref)
         conan_file_path = layout.conanfile()

--- a/conans/client/graph/proxy.py
+++ b/conans/client/graph/proxy.py
@@ -37,10 +37,7 @@ class ConanProxy:
             recipe_layout = self._cache.recipe_layout(reference)
             ref = recipe_layout.reference  # latest revision if it was not defined
         except ConanException:
-            recipe_layout = None
-
-        # NOT in disk, must be retrieved from remotes
-        if recipe_layout is None:
+            # NOT in disk, must be retrieved from remotes
             # we will only check all servers for latest revision if we did a --update
             remote, new_ref = self._download_recipe(reference, remotes, output, update, check_update)
             recipe_layout = self._cache.ref_layout(new_ref)

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -55,10 +55,8 @@ class RemoteManager(object):
         try:
             zipped_files = self._call_remote(remote, "get_recipe", ref, download_export, metadata,
                                              only_metadata=False)
-            # TODO: Optimize this call, it is slow to always query all revisions
-            remote_refs = self._call_remote(remote, "get_recipe_revisions_references", ref)
-            ref_time = remote_refs[0].timestamp
-            ref.timestamp = ref_time
+            # The timestamp of the ``ref`` from the server has been already obtained by ConanProxy
+            # or it will be obtained explicitly by the ``conan download``
             # filter metadata files
             # This could be also optimized in download, avoiding downloading them, for performance
             zipped_files = {k: v for k, v in zipped_files.items() if not k.startswith(METADATA)}


### PR DESCRIPTION
Changelog: Bugfix: Solve bug in timestamp of non-latest revision download from the server.
Docs: Omit

Close https://github.com/conan-io/conan/issues/14108