### PR TITLE
new arm64ec arch

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -708,7 +708,8 @@ class GenericSystemBlock(Block):
             return {"x86": "Win32",
                     "x86_64": "x64",
                     "armv7": "ARM",
-                    "armv8": "ARM64"}.get(arch)
+                    "armv8": "ARM64",
+                    "arm64ec": "ARM64EC"}.get(arch)
         return None
 
     def _get_generic_system_name(self):

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -55,7 +55,7 @@ os:
     VxWorks:
         version: ["7"]
 arch: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64,
-       armv4, armv4i, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3,
+       armv4, armv4i, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, arm64ec,
        sparc, sparcv9,
        mips, mips64, avr, s390, s390x, asm.js, wasm, sh4le,
        e2k-v2, e2k-v3, e2k-v4, e2k-v5, e2k-v6, e2k-v7,


### PR DESCRIPTION
Changelog: Feature: Add new ``arm64ec`` architecture, used to define CMAKE_GENERATOR_PLATFORM.
Docs: https://github.com/conan-io/docs/pull/3266

Close https://github.com/conan-io/conan/issues/13825

It will probably require more work, Ninja generator, CXXFLAGS, testing, etc, but requires Win11, etc
