### PR TITLE
Fix absolute build folder location (#14162)

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -44,7 +44,10 @@ class _PackageBuilder(object):
         # This function decides if the build folder should be re-used (not build again)
         # and returns the build folder
         skip_build = False
-        build_folder = package_layout.build()
+        if os.path.isabs(conanfile.folders.build):
+            build_folder = conanfile.folders.build
+        else:
+            build_folder = package_layout.build()
         recipe_build_id = build_id(conanfile)
         pref = package_layout.reference
         if recipe_build_id is not None and pref.package_id != recipe_build_id:


### PR DESCRIPTION
Changelog: Bugfix: Allow setting absolute path for build folder in package layout (#14162)
Docs: N/A

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.