### PR TITLE
Don't use realpath() to determine cache location (#14136)

### DIFF
--- a/conan/internal/cache/cache.py
+++ b/conan/internal/cache/cache.py
@@ -17,7 +17,7 @@ from conans.util.files import rmdir, renamedir
 class DataCache:
 
     def __init__(self, base_folder, db_filename):
-        self._base_folder = os.path.realpath(base_folder)
+        self._base_folder = os.path.abspath(base_folder)
         self._db = CacheDatabase(filename=db_filename)
 
     def _create_path(self, relative_path, remove_contents=True):

--- a/conans/test/integration/configuration/test_custom_symlinked_home.py
+++ b/conans/test/integration/configuration/test_custom_symlinked_home.py
@@ -1,0 +1,21 @@
+import os
+import platform
+
+import pytest
+
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.test_files import temp_folder
+from conans.test.utils.tools import TestClient
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="Uses symlinks")
+def test_custom_symlinked_home():
+    base_cache = temp_folder()
+    real_cache = os.path.join(base_cache, "real_cache")
+    symlink_cache = os.path.join(base_cache, "symlink_cache")
+    os.symlink(symlink_cache, real_cache)
+    c = TestClient(cache_folder=symlink_cache)
+    c.save({"conanfile.py": GenConanfile("pkg", "0.1")})
+    c.run("create .")
+    assert "symlink_cache" in c.out
+    assert "real_cache" not in c.out

--- a/conans/test/integration/configuration/test_custom_symlinked_home.py
+++ b/conans/test/integration/configuration/test_custom_symlinked_home.py
@@ -5,17 +5,24 @@ import pytest
 
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.test_files import temp_folder
-from conans.test.utils.tools import TestClient
+from conans.test.utils.tools import TestClient, NO_SETTINGS_PACKAGE_ID
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="Uses symlinks")
 def test_custom_symlinked_home():
     base_cache = temp_folder()
     real_cache = os.path.join(base_cache, "real_cache")
+    os.makedirs(real_cache)
     symlink_cache = os.path.join(base_cache, "symlink_cache")
-    os.symlink(symlink_cache, real_cache)
+    os.symlink(real_cache, symlink_cache)
     c = TestClient(cache_folder=symlink_cache)
     c.save({"conanfile.py": GenConanfile("pkg", "0.1")})
     c.run("create .")
+    assert "symlink_cache" in c.out
+    assert "real_cache" not in c.out
+    c.run("cache path pkg/0.1")
+    assert "symlink_cache" in c.out
+    assert "real_cache" not in c.out
+    c.run(f"cache path pkg/0.1:{NO_SETTINGS_PACKAGE_ID}")
     assert "symlink_cache" in c.out
     assert "real_cache" not in c.out


### PR DESCRIPTION
Changelog: Fix: Respect symlinked path for cache location.
Docs: Omit

Close #14136

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.