### PR TITLE
Fixes #14166: Add strip option to cmake.install tool

### DIFF
--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -133,7 +133,7 @@ class CMake(object):
     def build(self, build_type=None, target=None, cli_args=None, build_tool_args=None):
         self._build(build_type, target, cli_args, build_tool_args)
 
-    def install(self, build_type=None, component=None, strip=False):
+    def install(self, build_type=None, component=None):
         mkdir(self._conanfile, self._conanfile.package_folder)
 
         bt = build_type or self._conanfile.settings.get_safe("build_type")
@@ -147,7 +147,9 @@ class CMake(object):
         arg_list = ["--install", build_folder, build_config, "--prefix", pkg_folder]
         if component:
             arg_list.extend(["--component", component])
-        if strip:
+
+        do_strip = self._conanfile.conf.get("tools.cmake.install:strip", check_type=bool)
+        if do_strip:
             arg_list.append("--strip")
         arg_list = " ".join(filter(None, arg_list))
         command = "%s %s" % (self._cmake_program, arg_list)

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -133,7 +133,7 @@ class CMake(object):
     def build(self, build_type=None, target=None, cli_args=None, build_tool_args=None):
         self._build(build_type, target, cli_args, build_tool_args)
 
-    def install(self, build_type=None, component=None):
+    def install(self, build_type=None, component=None, strip=False):
         mkdir(self._conanfile, self._conanfile.package_folder)
 
         bt = build_type or self._conanfile.settings.get_safe("build_type")
@@ -147,6 +147,8 @@ class CMake(object):
         arg_list = ["--install", build_folder, build_config, "--prefix", pkg_folder]
         if component:
             arg_list.extend(["--component", component])
+        if strip:
+            arg_list.append("--strip")
         arg_list = " ".join(filter(None, arg_list))
         command = "%s %s" % (self._cmake_program, arg_list)
         self._conanfile.output.info("CMake command: %s" % command)

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -148,7 +148,7 @@ class CMake(object):
         if component:
             arg_list.extend(["--component", component])
 
-        do_strip = self._conanfile.conf.get("tools.cmake.install:strip", check_type=bool)
+        do_strip = self._conanfile.conf.get("tools.cmake:install_strip", check_type=bool)
         if do_strip:
             arg_list.append("--strip")
         arg_list = " ".join(filter(None, arg_list))

--- a/conans/test/unittests/tools/cmake/test_cmake_install.py
+++ b/conans/test/unittests/tools/cmake/test_cmake_install.py
@@ -31,9 +31,38 @@ def test_run_install_component():
     conanfile.settings = settings
     conanfile.folders.set_base_package(temp_folder())
 
-    # Choose generator to match generic setttings
+    # Choose generator to match generic settings
     write_cmake_presets(conanfile, "toolchain", "Visual Studio 14 2015", {})
     cmake = CMake(conanfile)
     cmake.install(component="foo")
 
     assert "--component foo" in conanfile.command
+
+
+def test_run_install_strip():
+    """
+    Testing that the install/strip rule is called
+    Issue related: https://github.com/conan-io/conan/issues/14166
+    """
+
+    settings = Settings.loads(get_default_settings_yml())
+    settings.os = "Linux"
+    settings.arch = "x86_64"
+    settings.build_type = "Release"
+    settings.compiler = "gcc"
+    settings.compiler.version = "11"
+
+    conanfile = ConanFileMock()
+
+    conanfile.conf = Conf()
+    conanfile.conf["tools.cmake.install:strip"] = True
+
+    conanfile.folders.generators = "."
+    conanfile.folders.set_base_generators(temp_folder())
+    conanfile.settings = settings
+    conanfile.folders.set_base_package(temp_folder())
+
+    write_cmake_presets(conanfile, "toolchain", "Unix Makefiles", {})
+    cmake = CMake(conanfile)
+    cmake.install()
+    assert "--strip" in conanfile.command

--- a/conans/test/unittests/tools/cmake/test_cmake_install.py
+++ b/conans/test/unittests/tools/cmake/test_cmake_install.py
@@ -55,7 +55,7 @@ def test_run_install_strip():
     conanfile = ConanFileMock()
 
     conanfile.conf = Conf()
-    conanfile.conf["tools.cmake.install:strip"] = True
+    conanfile.conf["tools.cmake:install_strip"] = True
 
     conanfile.folders.generators = "."
     conanfile.folders.set_base_generators(temp_folder())


### PR DESCRIPTION
Changelog: Feature: Add new ``tools.cmake:install_strip`` conf to add ``--strip`` option to cmake install.
Docs: https://github.com/conan-io/docs/pull/3281

Fix: #14166


- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [X] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
