### PR TITLE
Fix/XcodeDeps enable custom configurations (#14149)

### DIFF
--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -35,7 +35,7 @@ def _xcconfig_settings_filename(settings):
     return _format_name(name)
 
 
-def _xcconfig_conditional(settings):
+def _xcconfig_conditional(settings, configuration):
     sdk_condition = "*"
     arch = settings.get_safe("arch")
     architecture = _to_apple_arch(arch) or arch
@@ -43,7 +43,7 @@ def _xcconfig_conditional(settings):
     if sdk:
         sdk_condition = "{}{}".format(sdk, settings.get_safe("os.sdk_version") or "*")
 
-    return "[config={}][arch={}][sdk={}]".format(settings.get_safe("build_type"), architecture, sdk_condition)
+    return "[config={}][arch={}][sdk={}]".format(configuration, architecture, sdk_condition)
 
 
 def _add_includes_to_file_or_create(filename, template, files_to_include):
@@ -149,7 +149,7 @@ class XcodeDeps(object):
             'cxx_compiler_flags': " ".join('"{}"'.format(p.replace('"', '\\"')) for p in _merged_vars("cxxflags")),
             'linker_flags': " ".join('"{}"'.format(p.replace('"', '\\"')) for p in _merged_vars("sharedlinkflags")),
             'exe_flags': " ".join('"{}"'.format(p.replace('"', '\\"')) for p in _merged_vars("exelinkflags")),
-            'condition': _xcconfig_conditional(self._conanfile.settings)
+            'condition': _xcconfig_conditional(self._conanfile.settings, self.configuration)
         }
 
         if not require.headers:

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -24,10 +24,10 @@ def _format_name(name):
     return name.lower()
 
 
-def _xcconfig_settings_filename(settings):
+def _xcconfig_settings_filename(settings, configuration):
     arch = settings.get_safe("arch")
     architecture = _to_apple_arch(arch) or arch
-    props = [("configuration", settings.get_safe("build_type")),
+    props = [("configuration", configuration),
              ("architecture", architecture),
              ("sdk name", settings.get_safe("os.sdk")),
              ("sdk version", settings.get_safe("os.sdk_version"))]
@@ -231,7 +231,7 @@ class XcodeDeps(object):
     def get_content_for_component(self, require, pkg_name, component_name, package_folder, transitive_internal, transitive_external):
         result = {}
 
-        conf_name = _xcconfig_settings_filename(self._conanfile.settings)
+        conf_name = _xcconfig_settings_filename(self._conanfile.settings, self.configuration)
 
         props_name = "conan_{}_{}{}.xcconfig".format(pkg_name, component_name, conf_name)
         result[props_name] = self._conf_xconfig_file(require, pkg_name, component_name, package_folder, transitive_internal)

--- a/conan/tools/apple/xcodetoolchain.py
+++ b/conan/tools/apple/xcodetoolchain.py
@@ -78,7 +78,7 @@ class XcodeToolchain(object):
                                                          self._cppstd) if self._cppstd else ""
     @property
     def _vars_xconfig_filename(self):
-        return "conantoolchain{}{}".format(_xcconfig_settings_filename(self._conanfile.settings),
+        return "conantoolchain{}{}".format(_xcconfig_settings_filename(self._conanfile.settings, self.configuration),
                                                                        self.extension)
 
     @property

--- a/conan/tools/apple/xcodetoolchain.py
+++ b/conan/tools/apple/xcodetoolchain.py
@@ -64,17 +64,17 @@ class XcodeToolchain(object):
 
     @property
     def _macosx_deployment_target(self):
-        return 'MACOSX_DEPLOYMENT_TARGET{}={}'.format(_xcconfig_conditional(self._conanfile.settings),
+        return 'MACOSX_DEPLOYMENT_TARGET{}={}'.format(_xcconfig_conditional(self._conanfile.settings, self.configuration),
                                                       self.os_version) if self.os_version else ""
 
     @property
     def _clang_cxx_library(self):
-        return 'CLANG_CXX_LIBRARY{}={}'.format(_xcconfig_conditional(self._conanfile.settings),
+        return 'CLANG_CXX_LIBRARY{}={}'.format(_xcconfig_conditional(self._conanfile.settings, self.configuration),
                                                self.libcxx) if self.libcxx else ""
 
     @property
     def _clang_cxx_language_standard(self):
-        return 'CLANG_CXX_LANGUAGE_STANDARD{}={}'.format(_xcconfig_conditional(self._conanfile.settings),
+        return 'CLANG_CXX_LANGUAGE_STANDARD{}={}'.format(_xcconfig_conditional(self._conanfile.settings, self.configuration),
                                                          self._cppstd) if self._cppstd else ""
     @property
     def _vars_xconfig_filename(self):

--- a/conans/test/integration/toolchains/apple/test_xcodedeps.py
+++ b/conans/test/integration/toolchains/apple/test_xcodedeps.py
@@ -40,11 +40,11 @@ def expected_files(current_folder, configuration, architecture, sdk_version):
     return files
 
 
-def check_contents(client, deps, configuration, architecture, sdk_version):
+def check_contents(client, deps, build_type, architecture, sdk_version, custom_config_name=None):
     for dep_name in deps:
         dep_xconfig = client.load("conan_{dep}_{dep}.xcconfig".format(dep=dep_name))
         conf_name = "conan_{}_{}{}.xcconfig".format(dep_name, dep_name,
-                                                 _get_filename(configuration, architecture, sdk_version))
+                                                 _get_filename(build_type, architecture, sdk_version))
 
         assert '#include "{}"'.format(conf_name) in dep_xconfig
         for var in _expected_dep_xconfig:
@@ -53,7 +53,8 @@ def check_contents(client, deps, configuration, architecture, sdk_version):
 
         conan_conf = client.load(conf_name)
         for var in _expected_conf_xconfig:
-            assert var.format(name=dep_name, configuration=configuration, architecture=architecture,
+            xcode_config_name = custom_config_name if custom_config_name else build_type
+            assert var.format(name=dep_name, configuration=xcode_config_name, architecture=architecture,
                               sdk="macosx", sdk_version=sdk_version) in conan_conf
 
 
@@ -88,6 +89,64 @@ def test_generator_files():
 
         check_contents(client, ["hello", "goodbye"], build_type, "x86_64", "12.1")
 
+
+@pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
+def test_generator_files_with_custom_config():
+    client = TestClient()
+
+    client.save({"hello.py": GenConanfile().with_settings("os", "arch", "compiler", "build_type")
+                                           .with_package_info(cpp_info={"libs": ["hello"],
+                                                                        "frameworks": ['framework_hello']},
+                                                              env_info={})})
+    client.run("export hello.py --name=hello --version=0.1")
+
+    client.save({"goodbye.py": GenConanfile().with_settings("os", "arch", "compiler", "build_type")
+                                             .with_package_info(cpp_info={"libs": ["goodbye"],
+                                                                          "frameworks": ['framework_goodbye']},
+                                                                env_info={})})
+    client.run("export goodbye.py --name=goodbye --version=0.1")
+
+    conanfile_py = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.apple import XcodeDeps
+        class LibConan(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+            options = {"XcodeConfigName": [None, "ANY"]}
+            default_options = {"XcodeConfigName": None}
+            requires = "hello/0.1", "goodbye/0.1"
+            
+            def generate(self):
+                xcode = XcodeDeps(self)
+                if self.options.get_safe("XcodeConfigName"):
+                    xcode.configuration = str(self.options.get_safe("XcodeConfigName"))
+                xcode.generate()
+        """)
+
+    client.save({"conanfile.py": conanfile_py})
+    custom_config_name = "CustomConfig"
+
+    for use_custom_config in [True, False]:
+        for build_type in ["Release", "Debug"]:
+            cli_command = "install . -s build_type={} -s arch=x86_64 -s os.sdk_version=12.1  --build missing".format(build_type)
+            if use_custom_config:
+                cli_command += " -o XcodeConfigName={}".format(custom_config_name)
+
+            client.run(cli_command)
+            
+            for config_file in expected_files(client.current_folder, build_type, "x86_64", "12.1"):
+                assert os.path.isfile(config_file)
+
+            conandeps = client.load("conandeps.xcconfig")
+            assert '#include "conan_hello.xcconfig"' in conandeps
+            assert '#include "conan_goodbye.xcconfig"' in conandeps
+
+            conan_config = client.load("conan_config.xcconfig")
+            assert '#include "conandeps.xcconfig"' in conan_config
+
+            if use_custom_config:
+                check_contents(client, ["hello", "goodbye"], build_type, "x86_64", "12.1", custom_config_name)
+            else:
+                check_contents(client, ["hello", "goodbye"], build_type, "x86_64", "12.1")
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
 def test_xcodedeps_aggregate_components():

--- a/conans/test/integration/toolchains/apple/test_xcodedeps.py
+++ b/conans/test/integration/toolchains/apple/test_xcodedeps.py
@@ -95,14 +95,12 @@ def test_generator_files_with_custom_config():
     client = TestClient()
 
     client.save({"hello.py": GenConanfile().with_settings("os", "arch", "compiler", "build_type")
-                                           .with_package_info(cpp_info={"libs": ["hello"],
-                                                                        "frameworks": ['framework_hello']},
+                                           .with_package_info(cpp_info={"libs": ["hello"]},
                                                               env_info={})})
     client.run("export hello.py --name=hello --version=0.1")
 
     client.save({"goodbye.py": GenConanfile().with_settings("os", "arch", "compiler", "build_type")
-                                             .with_package_info(cpp_info={"libs": ["goodbye"],
-                                                                          "frameworks": ['framework_goodbye']},
+                                             .with_package_info(cpp_info={"libs": ["goodbye"]},
                                                                 env_info={})})
     client.run("export goodbye.py --name=goodbye --version=0.1")
 
@@ -132,7 +130,7 @@ def test_generator_files_with_custom_config():
                 cli_command += " -o XcodeConfigName={}".format(custom_config_name)
 
             client.run(cli_command)
-            
+
             for config_file in expected_files(client.current_folder, build_type, "x86_64", "12.1"):
                 assert os.path.isfile(config_file)
 


### PR DESCRIPTION
Changelog: Fix: Use ``configuration`` in ``XcodeDeps`` instead of always ``build_type``.
Docs: Omit

fixes #14149 

* adds support for Xcode custom configurations as it is already [documented](https://docs.conan.io/2/reference/tools/apple/xcodedeps.html#custom-configurations) but not actually implemented
* adds unit test

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
