### PR TITLE
new cmake config version compat

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/config_version.py
+++ b/conan/tools/cmake/cmakedeps/templates/config_version.py
@@ -1,6 +1,7 @@
 import textwrap
 
 from conan.tools.cmake.cmakedeps.templates import CMakeDepsFileTemplate
+from conans.errors import ConanException
 
 """
     foo-config-version.cmake
@@ -19,18 +20,28 @@ class ConfigVersionTemplate(CMakeDepsFileTemplate):
 
     @property
     def context(self):
-        return {"version": self.conanfile.ref.version}
+        policy = self.conanfile.cpp_info.get_property("cmake_package_version_compat")
+        if policy is None:
+            policy = "SameMajorVersion"
+        if policy not in ("AnyNewerVersion", "SameMajorVersion", "SameMinorVersion", "ExactVersion"):
+            raise ConanException(f"Unknown cmake_package_version_compat={policy} in {self.conanfile}")
+        return {"version": self.conanfile.ref.version,
+                "policy": policy}
 
     @property
     def template(self):
         # https://gitlab.kitware.com/cmake/cmake/blob/master/Modules/BasicConfigVersion-SameMajorVersion.cmake.in
         # This will be at XXX-config-version.cmake
-        ret = textwrap.dedent("""
+        # AnyNewerVersion|SameMajorVersion|SameMinorVersion|ExactVersion
+        ret = textwrap.dedent("""\
             set(PACKAGE_VERSION "{{ version }}")
 
             if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
                 set(PACKAGE_VERSION_COMPATIBLE FALSE)
             else()
+                {% if policy == "AnyNewerVersion" %}
+                set(PACKAGE_VERSION_COMPATIBLE TRUE)
+                {% elif policy == "SameMajorVersion" %}
                 if("{{ version }}" MATCHES "^([0-9]+)\\\\.")
                     set(CVF_VERSION_MAJOR {{ '${CMAKE_MATCH_1}' }})
                 else()
@@ -42,6 +53,37 @@ class ConfigVersionTemplate(CMakeDepsFileTemplate):
                 else()
                     set(PACKAGE_VERSION_COMPATIBLE FALSE)
                 endif()
+                {% elif policy == "SameMinorVersion" %}
+                if("{{ version }}" MATCHES "^([0-9]+)\\.([0-9]+)")
+                    set(CVF_VERSION_MAJOR "${CMAKE_MATCH_1}")
+                    set(CVF_VERSION_MINOR "${CMAKE_MATCH_2}")
+                else()
+                    set(CVF_VERSION_MAJOR "{{ version }}")
+                    set(CVF_VERSION_MINOR "")
+                endif()
+                if((PACKAGE_FIND_VERSION_MAJOR STREQUAL CVF_VERSION_MAJOR) AND
+                    (PACKAGE_FIND_VERSION_MINOR STREQUAL CVF_VERSION_MINOR))
+                  set(PACKAGE_VERSION_COMPATIBLE TRUE)
+                else()
+                  set(PACKAGE_VERSION_COMPATIBLE FALSE)
+                endif()
+                {% elif policy == "ExactVersion" %}
+                if("{{ version }}" MATCHES "^([0-9]+)\\.([0-9]+)\\.([0-9]+)")
+                    set(CVF_VERSION_MAJOR "${CMAKE_MATCH_1}")
+                    set(CVF_VERSION_MINOR "${CMAKE_MATCH_2}")
+                    set(CVF_VERSION_MINOR "${CMAKE_MATCH_3}")
+                else()
+                    set(CVF_VERSION_MAJOR "{{ version }}")
+                    set(CVF_VERSION_MINOR "")
+                    set(CVF_VERSION_PATCH "")
+                endif()
+                if((PACKAGE_FIND_VERSION_MAJOR STREQUAL CVF_VERSION_MAJOR) AND
+                    (PACKAGE_FIND_VERSION_MINOR STREQUAL CVF_VERSION_MINOR) AND
+                    (PACKAGE_FIND_VERSION_PATCH STREQUAL CVF_VERSION_PATCH))
+                  set(PACKAGE_VERSION_COMPATIBLE TRUE)
+                else()
+                  set(PACKAGE_VERSION_COMPATIBLE FALSE)
+                {% endif %}
 
                 if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
                     set(PACKAGE_VERSION_EXACT TRUE)

--- a/conan/tools/cmake/cmakedeps/templates/config_version.py
+++ b/conan/tools/cmake/cmakedeps/templates/config_version.py
@@ -20,11 +20,11 @@ class ConfigVersionTemplate(CMakeDepsFileTemplate):
 
     @property
     def context(self):
-        policy = self.conanfile.cpp_info.get_property("cmake_package_version_compat")
+        policy = self.conanfile.cpp_info.get_property("cmake_config_version_compat")
         if policy is None:
             policy = "SameMajorVersion"
         if policy not in ("AnyNewerVersion", "SameMajorVersion", "SameMinorVersion", "ExactVersion"):
-            raise ConanException(f"Unknown cmake_package_version_compat={policy} in {self.conanfile}")
+            raise ConanException(f"Unknown cmake_config_version_compat={policy} in {self.conanfile}")
         return {"version": self.conanfile.ref.version,
                 "policy": policy}
 
@@ -83,6 +83,7 @@ class ConfigVersionTemplate(CMakeDepsFileTemplate):
                   set(PACKAGE_VERSION_COMPATIBLE TRUE)
                 else()
                   set(PACKAGE_VERSION_COMPATIBLE FALSE)
+                endif()
                 {% endif %}
 
                 if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -249,11 +249,11 @@ def test_cmake_config_version_compat_rejected(policy):
         """)
     client = TestClient()
     client.save({"conanfile.py": conanfile})
-    client.run("create . --name=test --version=2.2.1")
+    client.run("create . --name=mytest --version=2.2.1")
 
     conanfile = textwrap.dedent("""
         [requires]
-        test/2.2.1
+        mytest/2.2.1
 
         [generators]
         CMakeDeps
@@ -265,7 +265,8 @@ def test_cmake_config_version_compat_rejected(policy):
     cmakelists = textwrap.dedent(f"""
         cmake_minimum_required(VERSION 3.15)
         project(consumer NONE)
-        find_package(test {version_to_reject} CONFIG REQUIRED)
+        message(STATUS "CMAKE VERSION=${{CMAKE_VERSION}}")
+        find_package(mytest {version_to_reject} CONFIG REQUIRED)
         """)
 
     client.save({"conanfile.txt": conanfile,

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -272,6 +272,7 @@ def test_cmake_config_version_compat_rejected(policy):
                  "CMakeLists.txt": cmakelists}, clean_first=True)
     client.run("install .")
     client.run_command('cmake .', assert_error=True)
+    print(client.out)
     assert "The following configuration files were considered but not accepted" in client.out
     assert "2.2.1" in client.out
 

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -257,6 +257,7 @@ def test_cmake_config_version_compat_rejected(policy):
 
         [generators]
         CMakeDeps
+        CMakeToolchain
         """)
     version_to_reject = {"AnyNewerVersion": "3.0",
                          "SameMajorVersion": "1.0",
@@ -272,7 +273,7 @@ def test_cmake_config_version_compat_rejected(policy):
     client.save({"conanfile.txt": conanfile,
                  "CMakeLists.txt": cmakelists}, clean_first=True)
     client.run("install .")
-    client.run_command('cmake .', assert_error=True)
+    client.run_command('cmake . -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake', assert_error=True)
     print(client.out)
     assert "The following configuration files were considered but not accepted" in client.out
     assert "2.2.1" in client.out

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -107,7 +107,7 @@ def test_system_libs():
 
         class Test(ConanFile):
             name = "test"
-            version = "0.1"
+            version = "2.0"
             settings = "build_type"
             def package(self):
                 save(self, os.path.join(self.package_folder, "lib/lib1.lib"), "")
@@ -119,6 +119,7 @@ def test_system_libs():
                     self.cpp_info.system_libs.append("sys1d")
                 else:
                     self.cpp_info.system_libs.append("sys1")
+                self.cpp_info.set_property("cmake_package_version_compat", "AnyNewerVersion")
         """)
     client = TestClient()
     client.save({"conanfile.py": conanfile})
@@ -127,7 +128,7 @@ def test_system_libs():
 
     conanfile = textwrap.dedent("""
         [requires]
-        test/0.1
+        test/2.0
 
         [generators]
         CMakeDeps
@@ -137,7 +138,7 @@ def test_system_libs():
         project(consumer NONE)
         set(CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR})
         set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
-        find_package(test)
+        find_package(test 1.0)
         message("System libs release: ${test_SYSTEM_LIBS_RELEASE}")
         message("Libraries to Link release: ${test_LIBS_RELEASE}")
         message("System libs debug: ${test_SYSTEM_LIBS_DEBUG}")
@@ -183,7 +184,7 @@ def test_system_libs_no_libs():
 
         class Test(ConanFile):
             name = "test"
-            version = "0.1"
+            version = "0.1.1"
             settings = "build_type"
 
             def package_info(self):
@@ -191,6 +192,7 @@ def test_system_libs_no_libs():
                     self.cpp_info.system_libs.append("sys1d")
                 else:
                     self.cpp_info.system_libs.append("sys1")
+                self.cpp_info.set_property("cmake_package_version_compat", "SameMinorVersion")
         """)
     client = TestClient()
     client.save({"conanfile.py": conanfile})
@@ -199,7 +201,7 @@ def test_system_libs_no_libs():
 
     conanfile = textwrap.dedent("""
         [requires]
-        test/0.1
+        test/0.1.1
 
         [generators]
         CMakeDeps
@@ -209,7 +211,7 @@ def test_system_libs_no_libs():
         project(consumer NONE)
         set(CMAKE_PREFIX_PATH ${CMAKE_BINARY_DIR})
         set(CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
-        find_package(test)
+        find_package(test 0.1)
         message("System libs Release: ${test_SYSTEM_LIBS_RELEASE}")
         message("Libraries to Link release: ${test_LIBS_RELEASE}")
         message("System libs Debug: ${test_SYSTEM_LIBS_DEBUG}")
@@ -688,7 +690,7 @@ def test_cmake_target_runtime_dlls():
     client.run_command("cmake -S . -B build/ -DCMAKE_TOOLCHAIN_FILE=build/generators/conan_toolchain.cmake")
     client.run_command("cmake --build build --config Release")
     client.run_command("build\\Release\\foo.exe")
-    
+
     assert os.path.exists(os.path.join(client.current_folder, "build", "Release", "hello.dll"))
     assert "hello/1.0: Hello World Release!" in client.out # if the DLL wasn't copied, the application would not run and show output
 

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -274,7 +274,6 @@ def test_cmake_config_version_compat_rejected(policy):
                  "CMakeLists.txt": cmakelists}, clean_first=True)
     client.run("install .")
     client.run_command('cmake . -DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake', assert_error=True)
-    print(client.out)
     assert "The following configuration files were considered but not accepted" in client.out
     assert "2.2.1" in client.out
 

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -549,3 +549,51 @@ def test_system_libs_transitivity():
     app = c.load("app/header-release-data.cmake")
     assert "set(header_SYSTEM_LIBS_RELEASE dl)" in app
     assert "set(header_FRAMEWORKS_RELEASE CoreDriver)" in app
+
+
+class TestCMakeVersionConfigCompat:
+    """
+    https://github.com/conan-io/conan/issues/13809
+    """
+    def test_cmake_version_config_compatibility(self):
+        c = TestClient()
+        dep = textwrap.dedent("""\
+            from conan import ConanFile
+            class Pkg(ConanFile):
+                name = "dep"
+                version = "0.1"
+                def package_info(self):
+                    self.cpp_info.set_property("cmake_package_version_compat", "AnyNewerVersion")
+                """)
+
+        c.save({"conanfile.py": dep})
+        c.run("create .")
+        c.run("install --requires=dep/0.1 -g CMakeDeps")
+        dep = c.load("dep-config-version.cmake")
+        expected = textwrap.dedent("""\
+            if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
+                set(PACKAGE_VERSION_COMPATIBLE FALSE)
+            else()
+                set(PACKAGE_VERSION_COMPATIBLE TRUE)
+
+                if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+                    set(PACKAGE_VERSION_EXACT TRUE)
+                endif()
+            endif()""")
+        assert expected in dep
+
+    def test_cmake_version_config_compatibility_error(self):
+        c = TestClient()
+        dep = textwrap.dedent("""\
+            from conan import ConanFile
+            class Pkg(ConanFile):
+                name = "dep"
+                version = "0.1"
+                def package_info(self):
+                    self.cpp_info.set_property("cmake_package_version_compat", "Unknown")
+                """)
+
+        c.save({"conanfile.py": dep})
+        c.run("create .")
+        c.run("install --requires=dep/0.1 -g CMakeDeps", assert_error=True)
+        assert "Unknown cmake_package_version_compat=Unknown in dep/0.1" in c.out

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -563,7 +563,7 @@ class TestCMakeVersionConfigCompat:
                 name = "dep"
                 version = "0.1"
                 def package_info(self):
-                    self.cpp_info.set_property("cmake_package_version_compat", "AnyNewerVersion")
+                    self.cpp_info.set_property("cmake_config_version_compat", "AnyNewerVersion")
                 """)
 
         c.save({"conanfile.py": dep})
@@ -590,10 +590,10 @@ class TestCMakeVersionConfigCompat:
                 name = "dep"
                 version = "0.1"
                 def package_info(self):
-                    self.cpp_info.set_property("cmake_package_version_compat", "Unknown")
+                    self.cpp_info.set_property("cmake_config_version_compat", "Unknown")
                 """)
 
         c.save({"conanfile.py": dep})
         c.run("create .")
         c.run("install --requires=dep/0.1 -g CMakeDeps", assert_error=True)
-        assert "Unknown cmake_package_version_compat=Unknown in dep/0.1" in c.out
+        assert "Unknown cmake_config_version_compat=Unknown in dep/0.1" in c.out


### PR DESCRIPTION
Changelog: Feature: New ``cpp_info.set_property("cmake_package_version_compat" , "AnyNewerVersion")`` for ``CMakeDeps`` generator.
Docs: https://github.com/conan-io/docs/pull/3292

Close https://github.com/conan-io/conan/issues/13809
