### PR TITLE
Always indicate when patches are applied (#14165)

### DIFF
--- a/conan/tools/files/patches.py
+++ b/conan/tools/files/patches.py
@@ -39,7 +39,7 @@ def patch(conanfile, base_path=None, patch_file=None, patch_string=None, strip=0
     :param kwargs: Extra parameters that can be added and will contribute to output information
     """
 
-    patch_type = kwargs.get('patch_type')
+    patch_type = kwargs.get('patch_type') or ("file" if patch_file else "string")
     patch_description = kwargs.get('patch_description')
 
     if patch_type or patch_description:
@@ -96,8 +96,11 @@ def apply_conandata_patches(conanfile):
         if "patch_file" in it:
             # The patch files are located in the root src
             entry = it.copy()
-            patch_file = os.path.join(conanfile.export_sources_folder, entry.pop("patch_file"))
-            patch(conanfile, patch_file=patch_file, **entry)
+            patch_file = entry.pop("patch_file")
+            patch_file_path = os.path.join(conanfile.export_sources_folder, patch_file)
+            if not "patch_description" in entry:
+                entry["patch_description"] = patch_file
+            patch(conanfile, patch_file=patch_file_path, **entry)
         elif "patch_string" in it:
             patch(conanfile, **it)
         else:

--- a/conans/test/unittests/tools/files/test_patches.py
+++ b/conans/test/unittests/tools/files/test_patches.py
@@ -121,7 +121,7 @@ def test_single_patch_description(mock_patch_ng):
         conanfile = ConanFileMock()
         conanfile.display_name = 'mocked/ref'
         patch(conanfile, patch_file='patch-file', patch_description='patch_description')
-    assert 'mocked/ref: Apply patch: patch_description\n' == output.getvalue()
+    assert 'mocked/ref: Apply patch (file): patch_description\n' == output.getvalue()
 
 
 def test_single_patch_extra_fields(mock_patch_ng):
@@ -173,8 +173,10 @@ def test_multiple_no_version(mock_patch_ng):
              'patch_description': 'Needed to build with modern clang compilers.'}
         ]}
         apply_conandata_patches(conanfile)
+    assert 'mocked/ref: Apply patch (file): patches/0001-buildflatbuffers-cmake.patch\n' \
+           in output.getvalue()
     assert 'mocked/ref: Apply patch (backport): Needed to build with modern clang compilers.\n' \
-           == output.getvalue()
+           in output.getvalue()
 
 
 def test_multiple_with_version(mock_patch_ng):
@@ -210,8 +212,10 @@ def test_multiple_with_version(mock_patch_ng):
 
         conanfile.version = "1.11.0"
         apply_conandata_patches(conanfile)
+        assert 'mocked/ref: Apply patch (file): patches/0001-buildflatbuffers-cmake.patch\n' \
+               in output.getvalue()
         assert 'mocked/ref: Apply patch (backport): Needed to build with modern clang compilers.\n' \
-               == output.getvalue()
+               in output.getvalue()
 
         # Ensure the function is not mutating the `conan_data` structure
         assert conanfile.conan_data == conandata_contents


### PR DESCRIPTION
Changelog: Fix: Enable existing status-message code in the `patch()` function.
Docs: Omit

Close  #14165

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.