### PR TITLE
Fix --format=html output for graphs with conflict errors

### DIFF
--- a/conan/cli/formatters/graph/graph.py
+++ b/conan/cli/formatters/graph/graph.py
@@ -105,20 +105,14 @@ def format_graph_html(result):
     template_folder = os.path.join(conan_api.cache_folder, "templates")
     user_template = os.path.join(template_folder, "graph.html")
     template = load(user_template) if os.path.isfile(user_template) else graph_info_html
+    error = {
+        "type": "unknown",
+        "context": graph.error,
+        "should_highlight_node": lambda node: False
+    }
     if isinstance(graph.error, GraphConflictError):
-        error = {
-            "label": graph.error.require.ref,
-            "type": "conflict",
-            "from": graph.error.node.id or graph.error.base_previous.id,
-            "prev_node": graph.error.prev_node,
-            "should_highlight_node": lambda node: node.id == graph.error.node.id
-        }
-    else:
-        error = {
-            "type": "unknown",
-            "error:": graph.error,
-            "should_highlight_node": lambda node: False
-        }
+        error["type"] = "conflict"
+        error["should_highlight_node"] = lambda node: node.id == graph.error.node.id
     cli_out_write(_render_graph(graph, error, template, template_folder))
     if graph.error:
         raise graph.error

--- a/conans/test/integration/command/info/test_graph_info_graphical.py
+++ b/conans/test/integration/command/info/test_graph_info_graphical.py
@@ -190,4 +190,22 @@ def test_graph_info_html_output():
     tc.run("new cmake_lib -d name=math -d version=1.0 -d requires=lib/2.0 -f")
     tc.run("export .")
     tc.run("graph info --requires=math/1.0 --requires=ui/1.0 --format=html", assert_error=True)
-    assert "// Add some helpful visualizations for conflicts" in tc.out
+    assert "// Add error conflict node" in tc.out
+    assert "// Add edge from node that introduces the conflict to the new error node" in tc.out
+    assert "// Add edge from base node to the new error node" not in tc.out
+    assert "// Add edge from previous node that already had conflicting dependency" in tc.out
+
+    tc.run("new cmake_lib -d name=libiconv -d version=1.0 -d requires=lib/2.0 -f")
+    tc.run("export .")
+    tc.run("new cmake_lib -d name=boost -d version=1.0 -d requires=libiconv/1.0 -f")
+    tc.run("export .")
+    tc.run("new cmake_lib -d name=openimageio -d version=1.0 -d requires=boost/1.0 -d requires=lib/1.0 -f")
+    tc.run("export .")
+    tc.run("graph info . --format=html", assert_error=True)
+    assert "// Add error conflict node" in tc.out
+    assert "// Add edge from node that introduces the conflict to the new error node" in tc.out
+    assert "// Add edge from base node to the new error node" in tc.out
+    assert "// Add edge from previous node that already had conflicting dependency" not in tc.out
+    # There used to be a few bugs with weird graphs, check for regressions
+    assert "jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'context'" not in tc.out
+    assert "from: ," not in tc.out


### PR DESCRIPTION
Changelog: Bugfix: Improve display of graph conflicts in `conan graph info` in html format.
Docs: Omit

@czoido found a case (from which a simplified version is now in the tests) where the graph was not properly printed with conflicts. This PR aims to fix that, and to make it more robust against the rest of possible configurations
