### PR TITLE
Locate otool and install_name_tool with xcrun

### DIFF
--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -204,6 +204,9 @@ def fix_apple_shared_install_name(conanfile):
     *install_name_tool* utility available in macOS to set ``@rpath``.
     """
 
+    if not is_apple_os(conanfile):
+        return
+
     xcrun = XCRun(conanfile)
     otool = xcrun.otool
     install_name_tool = xcrun.install_name_tool
@@ -299,10 +302,9 @@ def fix_apple_shared_install_name(conanfile):
                     command = f"{install_name_tool} {executable} -add_rpath {entry}"
                     conanfile.run(command)
 
-    if is_apple_os(conanfile):
-        substitutions = _fix_dylib_files(conanfile)
+    substitutions = _fix_dylib_files(conanfile)
 
-        # Only "fix" executables if dylib files were patched, otherwise
-        # there is nothing to do.
-        if substitutions:
-            _fix_executables(conanfile, substitutions)
+    # Only "fix" executables if dylib files were patched, otherwise
+    # there is nothing to do.
+    if substitutions:
+        _fix_executables(conanfile, substitutions)

--- a/conans/test/unittests/tools/apple/test_apple_tools.py
+++ b/conans/test/unittests/tools/apple/test_apple_tools.py
@@ -68,5 +68,5 @@ def test_get_dylib_install_name():
     for mock_output in (single_arch, universal_binary):
         with mock.patch("conan.tools.apple.apple.check_output_runner") as mock_output_runner:
             mock_output_runner.return_value = mock_output
-            install_name = _get_dylib_install_name("/path/to/libwebp.7.dylib")
+            install_name = _get_dylib_install_name("otool", "/path/to/libwebp.7.dylib")
             assert "/absolute/path/lib/libwebp.7.dylib" == install_name


### PR DESCRIPTION
Changelog: Feature: The `fix_apple_shared_install_name` tool now uses `xcrun` to resolve the `otool` and `install_name_tool` programs.
Docs: Omit

Closes #14188 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
