### PR TITLE
Clarification in the help of conan cache path for package references

### DIFF
--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -22,9 +22,9 @@ def cache_path(conan_api: ConanAPI, parser, subparser, *args):
     """
     subparser.add_argument("reference", help="Recipe reference or Package reference")
     subparser.add_argument("--folder", choices=['export_source', 'source', 'build', 'metadata'],
-                           help="Path to show. The 'build'"
-                                " requires a package reference. If not specified it shows 'exports'"
-                                " path ")
+                           help="Path to show. The 'build' requires a package reference. "
+                                "If not specified it shows 'exports' path for recipe references "
+                                "and 'package' folder for package references.")
 
     args = parser.parse_args(*args)
     try:

--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -23,7 +23,7 @@ def cache_path(conan_api: ConanAPI, parser, subparser, *args):
     subparser.add_argument("reference", help="Recipe reference or Package reference")
     subparser.add_argument("--folder", choices=['export_source', 'source', 'build', 'metadata'],
                            help="Path to show. The 'build' requires a package reference. "
-                                "If not specified it shows 'exports' path for recipe references "
+                                "If the argument is not passed, it shows 'exports' path for recipe references "
                                 "and 'package' folder for package references.")
 
     args = parser.parse_args(*args)


### PR DESCRIPTION
Changelog: Fix: Add clarification for the default folder shown when querying a package reference.
Docs: https://github.com/conan-io/docs/pull/3290

Closes: https://github.com/conan-io/conan/issues/14198