### PR TITLE
Add package_type=library to lib new

### DIFF
--- a/conan/internal/api/new/autotools_lib.py
+++ b/conan/internal/api/new/autotools_lib.py
@@ -13,6 +13,7 @@ from conan.tools.apple import fix_apple_shared_install_name
 class {{package_name}}Conan(ConanFile):
     name = "{{name}}"
     version = "{{version}}"
+    package_type = "library"
 
     # Optional metadata
     license = "<Put the package license here>"

--- a/conan/internal/api/new/basic.py
+++ b/conan/internal/api/new/basic.py
@@ -15,6 +15,9 @@ from conan import ConanFile
 class BasicConanfile(ConanFile):
 ''' + _conanfile_header + '''\
 
+    # Check the documentation for the rest of the available attributes
+
+
     # The requirements method allows you to define the dependencies of your recipe
     def requirements(self):
         # Each call to self.requires() will add the corresponding requirement

--- a/conan/internal/api/new/bazel_lib.py
+++ b/conan/internal/api/new/bazel_lib.py
@@ -9,6 +9,7 @@ from conan.tools.files import copy
 class {{package_name}}Recipe(ConanFile):
     name = "{{name}}"
     version = "{{version}}"
+    package_type = "library"
 
     # Binary configuration
     settings = "os", "compiler", "build_type", "arch"

--- a/conan/internal/api/new/cmake_lib.py
+++ b/conan/internal/api/new/cmake_lib.py
@@ -5,6 +5,7 @@ from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
 class {{package_name}}Recipe(ConanFile):
     name = "{{name}}"
     version = "{{version}}"
+    package_type = "library"
 
     # Optional metadata
     license = "<Put the package license here>"
@@ -286,7 +287,7 @@ test_main = """#include "{{name}}.h"
 
 int main() {
     {{package_name}}();
-    
+
     std::vector<std::string> vec;
     vec.push_back("test_package");
 

--- a/conan/internal/api/new/meson_lib.py
+++ b/conan/internal/api/new/meson_lib.py
@@ -9,6 +9,7 @@ from conan.tools.files import copy
 class {{package_name}}Conan(ConanFile):
     name = "{{name}}"
     version = "{{version}}"
+    package_type = "library"
 
     # Binary configuration
     settings = "os", "compiler", "build_type", "arch"


### PR DESCRIPTION
Changelog: Fix: Add missing `package_type` to `conan new` lib templates.
Docs: Omit

Found while reproducing some issues with @jcar87 and @czoido 

I've left out msbuild because its template is distinctly different from the rest, we might want to take a look into it separately