### PR TITLE
Allow `tools.gnu:make_program` to work in every case

### DIFF
--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -28,11 +28,11 @@ class _CMakePresets:
             if "CMAKE_SH" not in cache_variables:
                 cache_variables["CMAKE_SH"] = "CMAKE_SH-NOTFOUND"
 
-            cmake_make_program = conanfile.conf.get("tools.gnu:make_program",
-                                                    default=cache_variables.get("CMAKE_MAKE_PROGRAM"))
-            if cmake_make_program:
-                cmake_make_program = cmake_make_program.replace("\\", "/")
-                cache_variables["CMAKE_MAKE_PROGRAM"] = cmake_make_program
+        cmake_make_program = conanfile.conf.get("tools.gnu:make_program",
+                                                default=cache_variables.get("CMAKE_MAKE_PROGRAM"))
+        if cmake_make_program:
+            cmake_make_program = cmake_make_program.replace("\\", "/")
+            cache_variables["CMAKE_MAKE_PROGRAM"] = cmake_make_program
 
         if "CMAKE_POLICY_DEFAULT_CMP0091" not in cache_variables:
             cache_variables["CMAKE_POLICY_DEFAULT_CMP0091"] = "NEW"

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -552,6 +552,11 @@ def test_toolchain_cache_variables():
     assert "-DCMAKE_TOOLCHAIN_FILE=" in client.out
     assert f"-G {_format_val('MinGW Makefiles')}" in client.out
 
+    client.run("install . --name=mylib --version=1.0 -c tools.gnu:make_program='MyMake'")
+    presets = json.loads(client.load("CMakePresets.json"))
+    cache_variables = presets["configurePresets"][0]["cacheVariables"]
+    assert cache_variables["CMAKE_MAKE_PROGRAM"] == "MyMake"
+
 
 def test_android_c_library():
     client = TestClient()


### PR DESCRIPTION
Changelog: Fix: Allow `tools.gnu:make_program` to affect every CMake configuration.
Docs: Omit

The PR that implemented it was https://github.com/conan-io/conan/pull/10770 and already had a check for only mingw, but sadly no insight into _why_ it was gated off of the rest of configurations. After checking a bit and not seeing anything that might be _wrong_ with allowing it, I'm proposing to allow it in every configuration

Closes https://github.com/conan-io/conan/issues/14197