### PR TITLE
Support multiple custom global generators

### DIFF
--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -58,7 +58,7 @@ def load_cache_generators(path):
         mod, _ = load_python_file(full_path)
         for name, value in inspect.getmembers(mod):
             if inspect.isclass(value) and not name.startswith("_"):
-                result = {name: value}
+                result[name] = value
     return result
 
 

--- a/conans/test/integration/generators/test_custom_global_generators.py
+++ b/conans/test/integration/generators/test_custom_global_generators.py
@@ -79,3 +79,38 @@ def test_custom_global_generator_imports():
     c.run("install . -g MyCustomGenerator")
     assert "conanfile.txt: Generator 'MyCustomGenerator' calling 'generate()'" in c.out
     assert "conanfile.txt: MYGENERATE WORKS!!" in c.out
+
+
+def test_custom_global_generator_multiple():
+    """
+    multiple custom generators with different names load correctly
+    """
+    c = TestClient()
+    for num in range(3):
+        generator = textwrap.dedent(f"""
+            class MyGenerator{num}:
+                def __init__(self, conanfile):
+                    self._conanfile = conanfile
+                def generate(self):
+                    self._conanfile.output.info(f"MyGenerator{num}!!")
+            """)
+        save(os.path.join(c.cache.custom_generators_path, f"mygen{num}.py"), generator)
+    conanfile = textwrap.dedent("""
+        [requires]
+        pkg/0.1
+
+        [generators]
+        MyGenerator0
+        MyGenerator1
+        MyGenerator2
+        """)
+    c.save({"pkg/conanfile.py": GenConanfile("pkg", "0.1"),
+            "conanfile.txt": conanfile})
+    c.run("create pkg")
+    c.run("install .")
+    assert "conanfile.txt: Generator 'MyGenerator0' calling 'generate()'" in c.out
+    assert "conanfile.txt: Generator 'MyGenerator1' calling 'generate()'" in c.out
+    assert "conanfile.txt: Generator 'MyGenerator2' calling 'generate()'" in c.out
+    assert "conanfile.txt: MyGenerator0!!" in c.out
+    assert "conanfile.txt: MyGenerator1!!" in c.out
+    assert "conanfile.txt: MyGenerator2!!" in c.out


### PR DESCRIPTION
Changelog: Bugfix: Fix conan not finding generator by name when multiple custom global generators are detected.
Docs: omit

Hi!
Noticed this when migrating my generators from 1.X to 2.0. Looks like `result` is always populated only with the last class that it found on the way, not sure if this is intended.

Looking forward to the review!

- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
