### PR TITLE
optimize db creation

### DIFF
--- a/conan/internal/cache/db/cache_database.py
+++ b/conan/internal/cache/db/cache_database.py
@@ -1,3 +1,5 @@
+import os
+
 from conan.internal.cache.db.packages_table import PackagesDBTable
 from conan.internal.cache.db.recipes_table import RecipesDBTable
 from conans.model.package_ref import PkgReference
@@ -11,6 +13,9 @@ class CacheDatabase:
     def __init__(self, filename):
         self._recipes = RecipesDBTable(filename)
         self._packages = PackagesDBTable(filename)
+        if not os.path.isfile(filename):
+            self._recipes.create_table()
+            self._packages.create_table()
 
     def exists_prev(self, ref):
         # TODO: This logic could be done directly against DB

--- a/conan/internal/cache/db/table.py
+++ b/conan/internal/cache/db/table.py
@@ -16,13 +16,12 @@ class BaseDbTable:
         column_names: List[str] = [it[0] for it in self.columns_description]
         self.row_type = namedtuple('_', column_names)
         self.columns = self.row_type(*column_names)
-        self.create_table()
 
     @contextmanager
     def db_connection(self):
+        connection = sqlite3.connect(self.filename, isolation_level=None,
+                                     timeout=1, check_same_thread=False)
         try:
-            connection = sqlite3.connect(self.filename, isolation_level=None,
-                                        timeout=1, check_same_thread=False)
             yield connection
         finally:
             connection.close()


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

This is relevant and related to the necessary LRU migration. I was confused that the CREATE of the table was being called lots of times in every Conan invocation (2 table create per api call at least, total a bunch of times for every command) 