### PR TITLE
[PkgConfigDeps] `pkg_config_custom_content` property overwrites variables

### DIFF
--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -157,8 +157,8 @@ class _PCContentGenerator:
         gnudeps_flags = GnuDepsFlags(self._conanfile, cpp_info)
         libdirsflags = ['-L"${%s}"' % d for d in libdirvars]
         system_libs = ["-l%s" % l for l in (cpp_info.libs + cpp_info.system_libs)]
-        shared_flags = [f for f in (cpp_info.sharedlinkflags + cpp_info.exelinkflags)]
-        framework_flags = [f for f in (gnudeps_flags.frameworks + gnudeps_flags.framework_paths)]
+        shared_flags = cpp_info.sharedlinkflags + cpp_info.exelinkflags
+        framework_flags = gnudeps_flags.frameworks + gnudeps_flags.framework_paths
         return " ".join(libdirsflags + system_libs + shared_flags + framework_flags)
 
     def _get_cflags(self, includedirvars, cpp_info):

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -88,8 +88,7 @@ def _get_formatted_dirs(folder_name, folders, prefix_path_):
             directory = os.path.relpath(directory, prefix_path_).replace("\\", "/")
         suffix = str(i) if i else ""
         var_name = f"{folder_name}{suffix}"
-        ret[var_name] = "%s%s" % (prefix, directory)
-        ret.setdefault(f"%%{folder_name}vars", []).append(var_name)
+        ret[var_name] = f"{prefix}{directory}"
     return ret
 
 
@@ -100,9 +99,7 @@ class _PCContentGenerator:
 
     template = textwrap.dedent("""\
         {% for k, v in pc_variables.items() %}
-        {% if not k.startswith('%%') %}
         {{ "{}={}".format(k, v) }}
-        {% endif %}
         {% endfor %}
 
         Name: {{ name }}
@@ -185,8 +182,10 @@ class _PCContentGenerator:
         if info.cpp_info is not None:
             context.update({
                 "version": info.cpp_info.get_property("component_version") or self._dep.ref.version,
-                "cflags": self._get_cflags(pc_variables.get("%%includedirvars", []), info.cpp_info),
-                "libflags": self._get_lib_flags(pc_variables.get("%%libdirvars", []), info.cpp_info)
+                "cflags": self._get_cflags([d for d in pc_variables if d.startswith("includedir")],
+                                           info.cpp_info),
+                "libflags": self._get_lib_flags([d for d in pc_variables if d.startswith("libdir")],
+                                                info.cpp_info)
             })
         return context
 

--- a/conans/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -173,9 +173,10 @@ def test_custom_content():
 
             def package_info(self):
                 custom_content = textwrap.dedent(\"""
+                        bindir=${prefix}/my/bin/folder
+                        fakelibdir=${prefix}/my/lib/folder
                         datadir=${prefix}/share
                         schemasdir=${datadir}/mylib/schemas
-                        bindir=${prefix}/bin
                     \""")
                 self.cpp_info.set_property("pkg_config_custom_content", custom_content)
                 self.cpp_info.includedirs = ["include"]
@@ -188,9 +189,11 @@ def test_custom_content():
 
     pc_content = client.load("pkg.pc")
     assert "libdir=${prefix}/lib" in pc_content
+    assert "fakelibdir=${prefix}/my/lib/folder" in pc_content
     assert "datadir=${prefix}/share" in pc_content
     assert "schemasdir=${datadir}/mylib/schemas" in pc_content
-    assert "bindir=${prefix}/bin" in pc_content
+    assert "bindir=${prefix}/bin" not in pc_content
+    assert "bindir=${prefix}/my/bin/folder" in pc_content
     assert "Name: pkg" in pc_content
 
 

--- a/conans/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -94,9 +94,7 @@ def test_empty_dirs():
     expected = textwrap.dedent("""
         Name: mylib
         Description: Conan package: mylib
-        Version: 0.1
-        Libs:%s
-        Cflags: """ % " ")  # ugly hack for trailing whitespace removed by IDEs
+        Version: 0.1""")
     assert "\n".join(pc_content.splitlines()[1:]) == expected
 
 
@@ -449,15 +447,17 @@ def test_pkg_config_name_full_aliases():
     pc_content = client.load("pkg_other_name.pc")
     content = textwrap.dedent(f"""\
     {prefix}
-    # Custom PC content
-
+    libdir=${{prefix}}/lib
+    includedir=${{prefix}}/include
+    bindir=${{prefix}}/bin
     datadir=${{prefix}}/share
     schemasdir=${{datadir}}/mylib/schemas
-
 
     Name: pkg_other_name
     Description: Conan package: pkg_other_name
     Version: 0.3
+    Libs: -L"${{libdir}}"
+    Cflags: -I"${{includedir}}"
     Requires: compo1
     """)
     assert content == pc_content

--- a/conans/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -186,13 +186,23 @@ def test_custom_content():
     client.run("install --requires=pkg/0.1@ -g PkgConfigDeps")
 
     pc_content = client.load("pkg.pc")
-    assert "libdir=${prefix}/lib" in pc_content
-    assert "fakelibdir=${prefix}/my/lib/folder" in pc_content
-    assert "datadir=${prefix}/share" in pc_content
-    assert "schemasdir=${datadir}/mylib/schemas" in pc_content
-    assert "bindir=${prefix}/bin" not in pc_content
-    assert "bindir=${prefix}/my/bin/folder" in pc_content
-    assert "Name: pkg" in pc_content
+    prefix = pc_content.splitlines()[0]
+    expected = textwrap.dedent(f"""\
+    {prefix}
+    libdir=${{prefix}}/lib
+    includedir=${{prefix}}/include
+    bindir=${{prefix}}/my/bin/folder
+    fakelibdir=${{prefix}}/my/lib/folder
+    datadir=${{prefix}}/share
+    schemasdir=${{datadir}}/mylib/schemas
+
+    Name: pkg
+    Description: Conan package: pkg
+    Version: 0.1
+    Libs: -L"${{libdir}}"
+    Cflags: -I"${{includedir}}"
+    """)
+    assert expected == pc_content
 
 
 def test_custom_content_and_version_components():


### PR DESCRIPTION
Changelog: Feature: Let `pkg_config_custom_content` overwrite default `*.pc` variables created by `PkgConfigDeps`.
Changelog: Feature: Let `pkg_config_custom_content` be a dict-like object too.
Docs: https://github.com/conan-io/docs/pull/3293

UPDATED:
* Simplified internal `PkgConfigDeps` logic: only one template and more straightforward, one context, Python is formatting the template, etc.
* `pkg_config_custom_content` overwrites Conan-defined freeform variables, not keyword metadata ones.
* `pkg_config_custom_content` could be defined as a dictionary instead of a string.
