### PR TITLE
fix leaking of CMakeDeps lib_suffix variable

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/macros.py
+++ b/conan/tools/cmake/cmakedeps/templates/macros.py
@@ -58,9 +58,12 @@ class MacrosTemplate(CMakeDepsFileTemplate):
                    set(_LIB_NAME CONAN_LIB::${package_name}_${_LIBRARY_NAME}${config_suffix})
 
                    if(is_host_windows AND library_type STREQUAL "SHARED")
+                     # Store and reset the variable, so it doesn't leak
+                     set(_OLD_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
                      set(CMAKE_FIND_LIBRARY_SUFFIXES .dll ${CMAKE_FIND_LIBRARY_SUFFIXES})
                      find_library(CONAN_SHARED_FOUND_LIBRARY NAMES ${_LIBRARY_NAME} PATHS ${package_bindir}
                                   NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+                     set(CMAKE_FIND_LIBRARY_SUFFIXES ${_OLD_CMAKE_FIND_LIBRARY_SUFFIXES})
                      if(NOT CONAN_SHARED_FOUND_LIBRARY)
                        message(STATUS "Cannot locate shared library: ${_LIBRARY_NAME}")
                        message(DEBUG "DLL library not found, creating UNKNOWN IMPORTED target")


### PR DESCRIPTION
Changelog: Bugfix: Fix leaking of ``CMakeDeps`` ``CMAKE_FIND_LIBRARY_SUFFIXES`` variable.
Docs: Omit

Close https://github.com/conan-io/conan/issues/14225
