### PR TITLE
Allow `upload --list` to accept empty lists

### DIFF
--- a/conan/cli/commands/upload.py
+++ b/conan/cli/commands/upload.py
@@ -1,6 +1,6 @@
 from conan.api.conan_api import ConanAPI
 from conan.api.model import ListPattern, MultiPackagesList
-from conan.api.output import cli_out_write
+from conan.api.output import cli_out_write, ConanOutput
 from conan.cli import make_abs_path
 from conan.cli.command import conan_command, OnceArgument
 from conan.cli.commands.list import print_list_json, print_serial
@@ -96,8 +96,11 @@ def upload(conan_api: ConanAPI, parser, *args):
         if not args.dry_run:
             conan_api.upload.upload(package_list, remote)
             conan_api.upload.upload_backup_sources(package_list)
-    elif not args.list:
-        # Don't error on no recipes for automated workflows using list
+    elif args.list:
+        # Don't error on no recipes for automated workflows using list,
+        # but warn to tell the user that no packages were uploaded
+        ConanOutput().warning(f"No packages were uploaded because the package list is empty.")
+    else:
         raise ConanException("No recipes found matching pattern '{}'".format(args.pattern))
 
     pkglist = MultiPackagesList()

--- a/conans/test/integration/command/upload/upload_test.py
+++ b/conans/test/integration/command/upload/upload_test.py
@@ -99,6 +99,12 @@ class UploadTest(unittest.TestCase):
         assert "Uploading recipe 'hello0/1.2.1@" in client.out
         assert "Uploading package 'hello0/1.2.1@" in client.out
 
+    def test_pattern_upload_no_recipes(self):
+        client = TestClient(default_server_user=True)
+        client.save({"conanfile.py": conanfile})
+        client.run("upload bogus/*@dummy/testing --confirm -r default", assert_error=True)
+        self.assertIn("No recipes found matching pattern 'bogus/*@dummy/testing'", client.out)
+
     def test_broken_sources_tgz(self):
         # https://github.com/conan-io/conan/issues/2854
         client = TestClient(default_server_user=True)

--- a/conans/test/integration/command_v2/test_combined_pkglist_flows.py
+++ b/conans/test/integration/command_v2/test_combined_pkglist_flows.py
@@ -48,6 +48,7 @@ class TestListUpload:
         # No binaries should be uploaded since the pkglist is empty, but the command
         # should not error
         client.run("upload --list=pkglist.json -r=default")
+        assert "No packages were uploaded because the package list is empty." in client.out
 
 
 class TestGraphCreatedUpload:

--- a/conans/test/integration/command_v2/test_combined_pkglist_flows.py
+++ b/conans/test/integration/command_v2/test_combined_pkglist_flows.py
@@ -37,6 +37,18 @@ class TestListUpload:
             assert f"Uploading recipe '{r}'" in client.out
         assert str(client.out).count("Uploading package") == 2
 
+    def test_list_upload_empty_list(self, client):
+        client.run(f"install --requires=zlib/1.0.0@user/channel -f json",
+                   redirect_stdout="install_graph.json")
+
+        # Generate an empty pkglist.json
+        client.run(f"list --format=json --graph=install_graph.json --graph-binaries=bogus",
+                   redirect_stdout="pkglist.json")
+
+        # No binaries should be uploaded since the pkglist is empty, but the command
+        # should not error
+        client.run("upload --list=pkglist.json -r=default")
+
 
 class TestGraphCreatedUpload:
     def test_create_upload(self):


### PR DESCRIPTION
Changelog: Fix: Using `upload` with the `--list` argument now permits empty recipe lists.
Docs: Omit

My approach was to still error on recipe patterns that are empty when not using a list. Therefore, I added two tests -- one to ensure that passing a `--list` argument that had no recipes in it was valid, and the second to ensure passing a non-matching pattern still errored with the "No recipes found matching pattern" message.

Fixes #14203
