### PR TITLE
conan test missing binary message

### DIFF
--- a/conans/client/graph/install_graph.py
+++ b/conans/client/graph/install_graph.py
@@ -185,8 +185,10 @@ class InstallGraph:
     def __init__(self, deps_graph=None):
         self._nodes = {}  # ref with rev: _InstallGraphNode
 
+        self._is_test_package = False
         if deps_graph is not None:
             self._initialize_deps_graph(deps_graph)
+            self._is_test_package = deps_graph.root.conanfile.tested_reference_str is not None
 
     @staticmethod
     def load(filename):
@@ -278,8 +280,7 @@ class InstallGraph:
         if missing:
             self._raise_missing(missing)
 
-    @staticmethod
-    def _raise_missing(missing):
+    def _raise_missing(self, missing):
         # TODO: Remove out argument
         # TODO: A bit dirty access to .pref
         missing_prefs = set(n.nodes[0].pref for n in missing)  # avoid duplicated
@@ -299,15 +300,22 @@ class InstallGraph:
               f"{conanfile.info.dumps()}"
         conanfile.output.warning(msg)
         missing_pkgs = "', '".join(list(sorted([str(pref.ref) for pref in missing_prefs])))
-        if len(missing_prefs) >= 5:
-            build_str = "--build=missing"
+        if self._is_test_package:
+            build_msg = "'conan test' tested packages must exist, and '--build' argument " \
+                        "is used only for the 'test_package' dependencies, not for the tested " \
+                        "dependencies"
         else:
-            build_str = " ".join(list(sorted(["--build=%s" % str(pref.ref) for pref in missing_prefs])))
+            if len(missing_prefs) >= 5:
+                build_str = "--build=missing"
+            else:
+                build_str = " ".join(list(sorted(["--build=%s" % str(pref.ref)
+                                                  for pref in missing_prefs])))
+            build_msg = f"or try to build locally from sources using the '{build_str}' argument"
 
         raise ConanException(textwrap.dedent(f'''\
            Missing prebuilt package for '{missing_pkgs}'
            Check the available packages using 'conan list {ref}:* -r=remote'
-           or try to build locally from sources using the '{build_str}' argument
+           {build_msg}
 
            More Info at 'https://docs.conan.io/2/knowledge/faq.html#error-missing-prebuilt-package'
            '''))

--- a/conans/test/integration/command/test_package_test.py
+++ b/conans/test/integration/command/test_package_test.py
@@ -388,3 +388,17 @@ def test_test_package_lockfile_location():
     assert os.path.exists(os.path.join(c.current_folder, "myconan.lock"))
     c.run("test test_package dep/0.1 --lockfile=myconan.lock --lockfile-out=myconan2.lock")
     assert os.path.exists(os.path.join(c.current_folder, "myconan2.lock"))
+
+
+def test_package_missing_binary_msg():
+    # https://github.com/conan-io/conan/issues/13904
+    c = TestClient()
+    c.save({"conanfile.py": GenConanfile("dep", "0.1"),
+            "test_package/conanfile.py": GenConanfile().with_test("pass")})
+    c.run("export .")
+    c.run("test test_package dep/0.1", assert_error=True)
+    assert "ERROR: Missing binary: dep/0.1" in c.out
+    assert "'conan test' tested packages must exist" in c.out
+    c.run("test test_package dep/0.1 --build=dep/0.1", assert_error=True)
+    assert "ERROR: Missing binary: dep/0.1" in c.out
+    assert "'conan test' tested packages must exist" in c.out


### PR DESCRIPTION
Changelog: Fix: Improve error message when missing binaries with ``conan test`` command.
Docs: Omit

Close https://github.com/conan-io/conan/issues/13904
