### PR TITLE
Replace 'quiet' cmake loglevel with 'error'

### DIFF
--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -240,4 +240,6 @@ class CMake(object):
         :return:
         """
         log_level = self._conanfile.conf.get("tools.build:verbosity", choices=("quiet", "verbose"))
+        if log_level == "quiet":
+            log_level = "error"
         return ["--loglevel=" + log_level.upper()] if log_level is not None else []


### PR DESCRIPTION
Changelog: Bugfix: Fix `CMake Error: Invalid level specified for --loglevel` when `tools.build:verbosity` is set to `quiet`.
Docs: omit

I believe this was partially missed from #13729.

- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
