### PR TITLE
[Meson] Formatting Meson `prefix` parameter

### DIFF
--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -47,7 +47,7 @@ class Meson(object):
         cmd += "".join([f'{cmd_param} "{meson_option}"' for meson_option in meson_filenames])
         cmd += ' "{}" "{}"'.format(build_folder, source_folder)
         if self._conanfile.package_folder:
-            cmd += ' -Dprefix="{}"'.format(self._conanfile.package_folder)
+            cmd += ' -Dprefix="{}"'.format(self._conanfile.package_folder.replace("\\", "/"))
         if reconfigure:
             cmd += ' --reconfigure'
         self._conanfile.output.info("Meson configure cmd: {}".format(cmd))

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -32,11 +32,6 @@ class MesonToolchain(object):
     [constants]
     preprocessor_definitions = [{% for it, value in preprocessor_definitions.items() -%}
     '-D{{ it }}="{{ value}}"'{%- if not loop.last %}, {% endif %}{% endfor %}]
-    # Constants to be overridden by conan_meson_deps_flags.ini (if exists)
-    deps_c_args = []
-    deps_c_link_args = []
-    deps_cpp_args = []
-    deps_cpp_link_args = []
 
     [project options]
     {% for it, value in project_options.items() -%}
@@ -69,16 +64,16 @@ class MesonToolchain(object):
     {% if backend %}backend = '{{backend}}' {% endif %}
     {% if pkg_config_path %}pkg_config_path = '{{pkg_config_path}}'{% endif %}
     # C/C++ arguments
-    c_args = {{c_args}} + preprocessor_definitions + deps_c_args
-    c_link_args = {{c_link_args}} + deps_c_link_args
-    cpp_args = {{cpp_args}} + preprocessor_definitions + deps_cpp_args
-    cpp_link_args = {{cpp_link_args}} + deps_cpp_link_args
+    c_args = {{c_args}} + preprocessor_definitions
+    c_link_args = {{c_link_args}}
+    cpp_args = {{cpp_args}} + preprocessor_definitions
+    cpp_link_args = {{cpp_link_args}}
     {% if is_apple_system %}
     # Objective-C/C++ arguments
-    objc_args = {{objc_args}} + preprocessor_definitions + deps_c_args
-    objc_link_args = {{objc_link_args}} + deps_c_link_args
-    objcpp_args = {{objcpp_args}} + preprocessor_definitions + deps_cpp_args
-    objcpp_link_args = {{objcpp_link_args}} + deps_cpp_link_args
+    objc_args = {{objc_args}} + preprocessor_definitions
+    objc_link_args = {{objc_link_args}}
+    objcpp_args = {{objcpp_args}} + preprocessor_definitions
+    objcpp_link_args = {{objcpp_link_args}}
     {% endif %}
 
     {% for context, values in cross_build.items() %}

--- a/conans/test/functional/toolchains/meson/test_meson.py
+++ b/conans/test/functional/toolchains/meson/test_meson.py
@@ -294,3 +294,5 @@ def test_meson_using_prefix_path_in_application():
                  "src/main.c": main_c,
                  "meson.build": meson_build})
     client.run("build .")
+    assert "unrecognized character escape sequence" not in str(client.out)  # if Visual
+    assert "unknown escape sequence" not in str(client.out)  # if mingw


### PR DESCRIPTION
Changelog: Bugfix: Meson `prefix` param is passed as UNIX path.
Docs: omit
Close: https://github.com/conan-io/conan/issues/14213

Minor changes:
* Removed some useless variables.