### PR TITLE
cli: elaborate error message in "search"

### DIFF
--- a/conan/cli/commands/search.py
+++ b/conan/cli/commands/search.py
@@ -22,7 +22,7 @@ def search(conan_api: ConanAPI, parser, *args):
     args = parser.parse_args(*args)
     ref_pattern = ListPattern(args.reference, rrev=None)
     if ref_pattern.package_id is not None or ref_pattern.rrev is not None:
-        raise ConanException("Incorrect search pattern")
+        raise ConanException("Specifying a recipe revision or package ID is not allowed")
 
     remotes = conan_api.remotes.list(args.remote)
     if not remotes:


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Specifying package revision in Conan 2.0 causes a non-informative "Incorrect search pattern". I stumbled on that while looking at issue #8563. This commit expands the error message a bit.

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
