### PR TITLE
flush output msgs

### DIFF
--- a/conan/api/output.py
+++ b/conan/api/output.py
@@ -156,6 +156,7 @@ class ConanOutput:
             ret += "{}".format(msg)
 
         self.stream.write("{}\n".format(ret))
+        self.stream.flush()
 
     def trace(self, msg):
         if self._conan_output_level <= LEVEL_TRACE:


### PR DESCRIPTION
Changelog: Fix: ``flush()`` output streams after every message write.
Docs: Omit

Close https://github.com/conan-io/conan/issues/14298
