### PR TITLE
fixed pyyaml installation due to cython update

### DIFF
--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -20,4 +20,4 @@ OAUTH_TOKEN = "oauth_token"
 SERVER_CAPABILITIES = [COMPLEX_SEARCH_CAPABILITY, REVISIONS]  # Server is always with revisions
 DEFAULT_REVISION_V1 = "0"
 
-__version__ = '1.59.0'
+__version__ = '1.59.0-dev'

--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -20,4 +20,4 @@ OAUTH_TOKEN = "oauth_token"
 SERVER_CAPABILITIES = [COMPLEX_SEARCH_CAPABILITY, REVISIONS]  # Server is always with revisions
 DEFAULT_REVISION_V1 = "0"
 
-__version__ = '1.59.0-dev'
+__version__ = '1.59.0'

--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -1,7 +1,7 @@
 requests>=2.25, <3.0.0
 urllib3>=1.26.6, <1.27
 colorama>=0.3.3, <0.5.0
-PyYAML>=3.11, <=6.0
+PyYAML==6.0.1
 patch-ng>=1.17.4, <1.18
 fasteners>=0.14.1
 six>=1.10.0,<=1.16.0


### PR DESCRIPTION
Changelog: (Fix | Bugfix): PyYAML installation fix

- Problem occured at my company this morning, fixed it like this:
`pip install "cython<3.0.0" && pip install --no-build-isolation pyyaml==6.0`
but its a workaround, so here is an actual fix.

- I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- I've followed the PEP8 style guides for Python code.

Its a follow up on issue in PyYAML: https://github.com/yaml/pyyaml/issues/724