### PR TITLE
allowing pyyaml 6.0.X

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -1,7 +1,7 @@
 requests>=2.25, <3.0.0
 urllib3>=1.26.6, <1.27
 colorama>=0.3.3, <0.5.0
-PyYAML>=3.11, <=6.0
+PyYAML>=3.11, <6.1
 patch-ng>=1.17.4, <1.18
 fasteners>=0.14.1
 six>=1.10.0,<=1.16.0


### PR DESCRIPTION
Changelog: Fix: Allow Pyyaml 6.0.X versions to avoid cython 3.0 issues.
Docs: Omit

Close https://github.com/conan-io/conan/issues/14319

Conan 1.59 and 1.60 already depends on ``PyYAML>=3.11, <=6.0``, so they include the valid 6.0 version. The problem reported in https://github.com/conan-io/conan/issues/14319 affects to previous PyYAML<6 versions, but as long as the new, working one is included, it shouldn't be a blocker for new installations of Conan, and strictly forbidding PyYAML<6 probably is too much, as there are users that might want to force cython version and keep an older PyYAML version.


