### PR TITLE
fix CMakeUserPresets inherits

### DIFF
--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -263,19 +263,22 @@ class _IncludingPresets:
         # so things doesn't break for multi-platform, when inherits don't exist
         collected_targets = {}
         types = "configurePresets", "buildPresets", "testPresets"
-        for file in ("CMakePresets.json", "CMakeUserPresests.json"):
+        for file in ("CMakePresets.json", "CMakeUserPresets.json"):
             user_file = os.path.join(output_dir, file)
             if os.path.exists(user_file):
                 user_json = json.loads(load(user_file))
                 for preset_type in types:
-                    conan_inherits = []
                     for preset in user_json.get(preset_type, []):
                         inherits = preset.get("inherits", [])
                         if isinstance(inherits, str):
                             inherits = [inherits]
-                        conan_inherits.extend([i for i in inherits if i.startswith(preset_prefix)])
-                    if len(conan_inherits):
-                        collected_targets.setdefault(preset_type, []).extend(list(set(conan_inherits)))
+                        inherits = [i for i in inherits if i.startswith(preset_prefix)]
+                        if inherits:
+                            existing = collected_targets.setdefault(preset_type, [])
+                            for i in inherits:
+                                if i not in existing:
+                                    existing.append(i)
+
         return collected_targets
 
     @staticmethod

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -406,7 +406,8 @@ def test_cmake_presets_binary_dir_available():
     assert presets["configurePresets"][0]["binaryDir"] == build_dir
 
 
-def test_cmake_presets_shared_preset():
+@pytest.mark.parametrize("presets", ["CMakePresets.json", "CMakeUserPresets.json"])
+def test_cmake_presets_shared_preset(presets):
     """valid user preset file is created when multiple project presets inherit
     from the same conan presets.
     """
@@ -456,9 +457,9 @@ def test_cmake_presets_shared_preset():
             tc.generate()
     """)
 
-    client.save({"CMakePresets.json": project_presets,
+    client.save({presets: project_presets,
                  "conanfile.py": conanfile,
-                 "CMakeLists.txt": "" })  #File must exist for Conan to do Preset things.
+                 "CMakeLists.txt": ""})  # File must exist for Conan to do Preset things.
 
     client.run("install . -s build_type=Debug")
 


### PR DESCRIPTION
Changelog: Bugfix: Fix ``CMakeUserPresets`` inherits from conan generated presets due to typo.
Docs: Omit
