### PR TITLE
revision_mode = 'scm_folder': Only check if conanfile_path is dirty

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -93,9 +93,9 @@ def _calc_revision(scoped_output, path, manifest, revision_mode):
     if revision_mode == "hash":
         revision = manifest.summary_hash
     else:
+        f = '-- "."' if revision_mode == "scm_folder" else ""
         try:
             with chdir(path):
-                f = '-- "."' if revision_mode == "scm_folder" else ""
                 revision = check_output_runner(f'git rev-list HEAD -n 1 --full-history {f}').strip()
         except Exception as exc:
             error_msg = "Cannot detect revision using '{}' mode from repository at " \
@@ -103,7 +103,7 @@ def _calc_revision(scoped_output, path, manifest, revision_mode):
             raise ConanException("{}: {}".format(error_msg, exc))
 
         with chdir(path):
-            if bool(check_output_runner('git status -s').strip()):
+            if bool(check_output_runner(f'git status -s {f}').strip()):
                 raise ConanException("Can't have a dirty repository using revision_mode='scm' and doing"
                                      " 'conan export', please commit the changes and run again.")
 

--- a/conans/test/functional/command/export_test.py
+++ b/conans/test/functional/command/export_test.py
@@ -47,6 +47,11 @@ class TestRevisionModeSCM:
         t.run(f"export pkgb --name=pkgb --version=0.1")
         assert t.exported_recipe_revision() == commit_b
 
+        # if pkgb is dirty, we should still be able to correctly create pkga in 'scm_folder' mode
+        t.save({"pkgb/conanfile.py": conanfile + "\n#new comment"})
+        t.run(f"export pkga --name=pkga --version=0.1")
+        assert t.exported_recipe_revision() == commit
+
     def test_auto_revision_without_commits(self):
         """If we have a repo but without commits, it has to fail when the revision_mode=scm"""
         t = TestClient()


### PR DESCRIPTION
Changelog: Fix: Allow repository being dirty outside of `conanfile.py` folder when using `revision_mode = "scm_folder"`.
Docs: omit

Hi!
I thought that it makes more sense to check `git status` only for current directory, as Conan needs only that directory to calculate its revision. I usually have quite a dirty repo, and don't really like that Conan chokes on it :)

- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
