### PR TITLE
fix the package signing plugin not verifying sources

### DIFF
--- a/conans/client/pkg_sign.py
+++ b/conans/client/pkg_sign.py
@@ -35,8 +35,9 @@ class PkgSignaturesPlugin:
                 if pkg_bundle["upload"]:
                     _sign(pref, pkg_bundle["files"], self._cache.pkg_layout(pref).download_package())
 
-    def verify(self, ref, folder):
+    def verify(self, ref, folder, files):
         if self._plugin_verify_function is None:
             return
         metadata_sign = os.path.join(folder, METADATA, "sign")
-        self._plugin_verify_function(ref, artifacts_folder=folder, signature_folder=metadata_sign)
+        self._plugin_verify_function(ref, artifacts_folder=folder, signature_folder=metadata_sign,
+                                     files=files)

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -60,7 +60,7 @@ class RemoteManager(object):
             if "conanmanifest.txt" not in zipped_files:
                 raise ConanException(f"Corrupted {ref} in '{remote.name}' remote: "
                                      f"no conanmanifest.txt")
-            self._signer.verify(ref, download_export)
+            self._signer.verify(ref, download_export, files=zipped_files)
         except BaseException:  # So KeyboardInterrupt also cleans things
             ConanOutput(scope=str(ref)).error(f"Error downloading from remote '{remote.name}'")
             self._cache.remove_recipe_layout(layout)
@@ -103,6 +103,7 @@ class RemoteManager(object):
             mkdir(export_sources_folder)  # create the folder even if no source files
             return
 
+        self._signer.verify(ref, download_folder, files=zipped_files)
         tgz_file = zipped_files[EXPORT_SOURCES_TGZ_NAME]
         uncompress_file(tgz_file, export_sources_folder, scope=str(ref))
 
@@ -149,7 +150,7 @@ class RemoteManager(object):
             for f in ("conaninfo.txt", "conanmanifest.txt", "conan_package.tgz"):
                 if f not in zipped_files:
                     raise ConanException(f"Corrupted {pref} in '{remote.name}' remote: no {f}")
-            self._signer.verify(pref, download_pkg_folder)
+            self._signer.verify(pref, download_pkg_folder, zipped_files)
 
             tgz_file = zipped_files.pop(PACKAGE_TGZ_NAME, None)
             package_folder = layout.package()


### PR DESCRIPTION
Changelog: Bugfix: Fix Package signing plugin not verifying the downloaded sources.
Docs: https://github.com/conan-io/docs/pull/3304

Close https://github.com/conan-io/conan/issues/14313
