### PR TITLE
no user/channel pattern matches

### DIFF
--- a/conans/client/graph/build_mode.py
+++ b/conans/client/graph/build_mode.py
@@ -40,14 +40,11 @@ class BuildMode:
                 else:
                     if param.startswith("missing:"):
                         clean_pattern = param[len("missing:"):]
-                        clean_pattern = clean_pattern[:-1] if param.endswith("@") else clean_pattern
-                        clean_pattern = clean_pattern.replace("@#", "#")
                         self.build_missing_patterns.append(clean_pattern)
                     else:
                         # Remove the @ at the end, to match for
                         # "conan install --requires=pkg/0.1@ --build=pkg/0.1@"
-                        clean_pattern = param[:-1] if param.endswith("@") else param
-                        clean_pattern = clean_pattern.replace("@#", "#")
+                        clean_pattern = param
                         if clean_pattern and clean_pattern[0] in ["!", "~"]:
                             self._excluded_patterns.append(clean_pattern[1:])
                         else:

--- a/conans/model/recipe_ref.py
+++ b/conans/model/recipe_ref.py
@@ -167,6 +167,9 @@ class RecipeReference:
         if pattern.endswith("@"):  # it means we want to match only without user/channel
             pattern = pattern[:-1]
             no_user_channel = True
+        elif "@#" in pattern:
+            pattern = pattern.replace("@#", "#")
+            no_user_channel = True
 
         condition = ((pattern == "&" and is_consumer) or
                       fnmatch.fnmatchcase(str(self), pattern) or

--- a/conans/model/recipe_ref.py
+++ b/conans/model/recipe_ref.py
@@ -163,9 +163,16 @@ class RecipeReference:
             pattern = pattern[1:]
             negate = True
 
+        no_user_channel = False
+        if pattern.endswith("@"):  # it means we want to match only without user/channel
+            pattern = pattern[:-1]
+            no_user_channel = True
+
         condition = ((pattern == "&" and is_consumer) or
                       fnmatch.fnmatchcase(str(self), pattern) or
                       fnmatch.fnmatchcase(self.repr_notime(), pattern))
+        if no_user_channel:
+            condition = condition and not self.user and not self.channel
         if negate:
             return not condition
         return condition


### PR DESCRIPTION
Changelog: Feature: Implement ``...@`` as a pattern for indicating matches with packages without user/channel.
Docs: https://github.com/conan-io/docs/pull/3337

Close https://github.com/conan-io/conan/issues/14315