### PR TITLE
make last slash in backup sources urls optional

### DIFF
--- a/conans/client/downloaders/caching_file_downloader.py
+++ b/conans/client/downloaders/caching_file_downloader.py
@@ -108,6 +108,7 @@ class SourcesCachingDownloader:
         don't want silently skipping a backup because it is down.
         """
         try:
+            backup_url = backup_url if backup_url.endswith("/") else backup_url + "/"
             self._file_downloader.download(backup_url + sha256, cached_path, sha256=sha256)
             self._file_downloader.download(backup_url + sha256 + ".json", cached_path + ".json")
             self._output.info(f"Sources for {urls} found in remote backup {backup_url}")

--- a/conans/test/integration/cache/backup_sources_test.py
+++ b/conans/test/integration/cache/backup_sources_test.py
@@ -284,8 +284,8 @@ class TestDownloadCacheBackupSources:
                     """)
 
         client.save({"global.conf": f"core.sources:download_cache={download_cache_folder}\n"
-                                    f"core.sources:download_urls=['http://localhost:{http_server.port}/downloader/', 'origin']\n"
-                                    f"core.sources:upload_url=http://localhost:{http_server.port}/uploader/"},
+                                    f"core.sources:download_urls=['http://localhost:{http_server.port}/downloader', 'origin']\n"
+                                    f"core.sources:upload_url=http://localhost:{http_server.port}/uploader"},
                     path=client.cache.cache_folder)
 
         client.save({"conanfile.py": conanfile})


### PR DESCRIPTION
Changelog: Fix: Make backup sources ``core.sources`` conf not mandate the final slash.
Docs: Omit

Close https://github.com/conan-io/conan/issues/14341
