### PR TITLE
Allowing pyyaml 6.0.X (backport #14323) 

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -1,7 +1,7 @@
 requests>=2.25, <3.0.0
 urllib3>=1.26.6, <1.27
 colorama>=0.3.3, <0.5.0
-PyYAML>=3.11, <=6.0
+PyYAML>=3.11, <6.1
 patch-ng>=1.17.4, <1.18
 fasteners>=0.14.1
 six>=1.10.0,<=1.16.0


### PR DESCRIPTION
Changelog: Fix: Allow Pyyaml 6.0.X versions to avoid cython 3.0 problems. (backport #14323)
Docs: Omit

Closes: https://github.com/conan-io/conan/issues/14319