### PR TITLE
detect msvc and version when CC/CXX point to cl.exe

### DIFF
--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -45,7 +45,7 @@ def _msvc_cl_compiler(compiler_exe="cl"):
         if not "Microsoft" in first_line:
             return None
         compiler = "msvc"
-        version_regex = re.search(r"(?P<major>[0-9]+)\.(?P<minor>[0-9]+)\.([0-9]+)\.?([0-9]+)?", out)
+        version_regex = re.search(r"(?P<major>[0-9]+)\.(?P<minor>[0-9]+)\.([0-9]+)\.?([0-9]+)?", first_line)
         if not version_regex:
             return None
         # 19.36.32535 -> 193

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -34,6 +34,17 @@ def _gcc_compiler(compiler_exe="gcc"):
             return compiler, installed_version
     except Exception:
         return None
+    
+def _msvc_cl_compiler(compiler_exe="cl"):
+    try:
+        ret, out = detect_runner(f"{compiler_exe} /?")
+        if ret != 0 or not "Microsoft" in out:
+            return None
+        compiler = "msvc"
+        full_version = re.search(r"([0-9]+)\.([0-9]+)\.([0-9]+)\.?([0-9]+)?", out).group()
+        
+    except Exception:
+        return None
 
 
 def _clang_compiler(compiler_exe="clang"):
@@ -96,6 +107,9 @@ def _get_default_compiler():
             return gcc
         if platform.system() == "SunOS" and command.lower() == "cc":
             return _sun_cc_compiler(command)
+        if platform.system() == "Windows" and command.endswith(("cl", "cl.exe")) and not "clang" in command:
+            vs = _msvc_cl_compiler(command)
+
         # I am not able to find its version
         output.error("Not able to automatically detect '%s' version" % command)
         return None

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -37,12 +37,20 @@ def _gcc_compiler(compiler_exe="gcc"):
     
 def _msvc_cl_compiler(compiler_exe="cl"):
     try:
-        ret, out = detect_runner(f"{compiler_exe} /?")
-        if ret != 0 or not "Microsoft" in out:
+        compiler_exe = compiler_exe.strip('"')
+        ret, out = detect_runner(f'"{compiler_exe}" /?')
+        if ret != 0:
+            return None
+        first_line = out.splitlines()[0]
+        if not "Microsoft" in first_line:
             return None
         compiler = "msvc"
-        full_version = re.search(r"([0-9]+)\.([0-9]+)\.([0-9]+)\.?([0-9]+)?", out).group()
-        
+        version_regex = re.search(r"(?P<major>[0-9]+)\.(?P<minor>[0-9]+)\.([0-9]+)\.?([0-9]+)?", out)
+        if not version_regex:
+            return None
+        # 19.36.32535 -> 193
+        version = f"{version_regex.group('major')}{version_regex.group('minor')[0]}"
+        return (compiler, version)
     except Exception:
         return None
 
@@ -107,8 +115,8 @@ def _get_default_compiler():
             return gcc
         if platform.system() == "SunOS" and command.lower() == "cc":
             return _sun_cc_compiler(command)
-        if platform.system() == "Windows" and command.endswith(("cl", "cl.exe")) and not "clang" in command:
-            vs = _msvc_cl_compiler(command)
+        if platform.system() == "Windows" and command.rstrip('"').endswith(("cl", "cl.exe")) and not "clang" in command:
+            return _msvc_cl_compiler(command)
 
         # I am not able to find its version
         output.error("Not able to automatically detect '%s' version" % command)

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -146,8 +146,8 @@ class DetectCompilersTest(unittest.TestCase):
             output = RedirectedTestOutput()
             with redirect_output(output):
                 with environment_update({"CC": var, "PATH": cl_location}):
-                    result = detect_defaults_settings()
+                    c.run("profile detect --name=./cl-profile")
 
-            result = dict(result)
-            assert result['compiler'] == "msvc"
-            assert str(result['compiler.version']) == "191"
+            profile = c.load("cl-profile")
+            assert "compiler=msvc" in profile
+            assert "compiler.version=191" in profile

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -134,7 +134,15 @@ class DetectCompilersTest(unittest.TestCase):
         c = TestClient()
 
         # extract location of cl.exe
-        vcvars = vcvars_command(version="15", architecture="x64")
-        command = f"{vcvars} && where cl.exe"
-        
+        vcvars = vcvars_command(version="17", architecture="x64")
+        ret = c.run_command(f"{vcvars} && where cl.exe")
+        assert ret == 0
+        cl_location = c.out.splitlines()[-1]
+        assert os.path.isfile(cl_location)
 
+        output = RedirectedTestOutput()
+        with redirect_output(output):
+            with environment_update({"CC": cl_location}):
+                result = detect_defaults_settings()
+        # result is a list of tuples (name, value) so converting it to dict
+        result = dict(result)

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -146,7 +146,7 @@ class DetectCompilersTest(unittest.TestCase):
             output = RedirectedTestOutput()
             with redirect_output(output):
                 with environment_update({"CC": var, "PATH": cl_location}):
-                    c.run("profile detect --name=./cl-profile")
+                    c.run("profile detect --name=./cl-profile --force")
 
             profile = c.load("cl-profile")
             assert "compiler=msvc" in profile

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -12,7 +12,7 @@ from conans.test.utils.tools import TestClient, redirect_output
 from conans.util.env import environment_update
 from conans.util.files import save
 from conans.util.runners import check_output_runner
-
+from conan.tools.microsoft.visual import vcvars_command
 
 class TestProfile(unittest.TestCase):
 
@@ -128,3 +128,13 @@ class DetectCompilersTest(unittest.TestCase):
         assert "MyProfile2' already exists" in c.out
 
         c.run("profile detect --name=./MyProfile2 --force")  # will not raise error
+    
+    @pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows and msvc")
+    def test_profile_new_msvc_vcvars(self):
+        c = TestClient()
+
+        # extract location of cl.exe
+        vcvars = vcvars_command(version="15", architecture="x64")
+        command = f"{vcvars} && where cl.exe"
+        
+


### PR DESCRIPTION
Changelog: Feature: `conan profile detect` can now detect the version of msvc when invoked within a Visual Studio prompt where `CC` or `CXX` are defined and pointing to the `cl` compiler executable
Docs: Omit


This PR fixes issue where `conan profile detect` is invoked from an active Visual Studio prompt that _also_ happens to have `CC` or `CXX` defined. This may be unusual for a developer to actively configure a prompt like this, but Visual Studio invoke may invoke CMake in such an environment, and this may cause issues if `conan profile detect` needs to run when using `cmake-conan`.

This assumes that `cl.exe /?`always prints the copyright and the version in the first line. It doesn't assume a specific text since it can be localized to different languages, but it does assume that the string contains `Microsoft` and that the version contains 3 or more components. We also avoid running this logic if `clang` is part of the string - e.g. `clang-cl` would not be handled and would fall back to the current behaviour. 

Tests cover defining `CC` in multiple ways, e.g. `cl` and `cl.exe` (falls back to finding it in PATH), or the full path to `cl.exe`, which may be surrounded in double quotes as the path is very likely to contain spaces if it's installed in the default location.
