### PR TITLE
Avoid passing compiler options into rc.exe

### DIFF
--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -78,7 +78,6 @@ class MSBuildDeps(object):
             <ResourceCompile>
               <AdditionalIncludeDirectories>$(Conan{{name}}IncludeDirectories)%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
               <PreprocessorDefinitions>$(Conan{{name}}PreprocessorDefinitions)%(PreprocessorDefinitions)</PreprocessorDefinitions>
-              <AdditionalOptions>$(Conan{{name}}CompilerFlags) %(AdditionalOptions)</AdditionalOptions>
             </ResourceCompile>
           </ItemDefinitionGroup>
           {% else %}

--- a/conan/tools/microsoft/toolchain.py
+++ b/conan/tools/microsoft/toolchain.py
@@ -34,7 +34,6 @@ class MSBuildToolchain(object):
             </Link>
             <ResourceCompile>
               <PreprocessorDefinitions>{{ defines }}%(PreprocessorDefinitions)</PreprocessorDefinitions>
-              <AdditionalOptions>{{ compiler_flags }} %(AdditionalOptions)</AdditionalOptions>
             </ResourceCompile>
           </ItemDefinitionGroup>
           <PropertyGroup Label="Configuration">

--- a/conans/test/integration/toolchains/microsoft/test_msbuildtoolchain.py
+++ b/conans/test/integration/toolchains/microsoft/test_msbuildtoolchain.py
@@ -39,7 +39,6 @@ def test_msbuildtoolchain_props_with_extra_flags():
     expected_resource_compile = """
     <ResourceCompile>
       <PreprocessorDefinitions>DEF1;DEF2;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalOptions>--flag1 --flag2 --flag3 --flag4 %(AdditionalOptions)</AdditionalOptions>
     </ResourceCompile>"""
     assert expected_cl_compile in toolchain
     assert expected_link in toolchain

--- a/conans/test/unittests/tools/microsoft/test_msbuild.py
+++ b/conans/test/unittests/tools/microsoft/test_msbuild.py
@@ -151,7 +151,6 @@ def test_resource_compile():
           <PreprocessorDefinitions>
              MYTEST=MYVALUE;%(PreprocessorDefinitions)
           </PreprocessorDefinitions>
-          <AdditionalOptions> %(AdditionalOptions)</AdditionalOptions>
         </ResourceCompile>"""
 
     props_file = load(props_file)  # Remove all blanks and CR to compare
@@ -274,7 +273,6 @@ def test_msbuildtoolchain_changing_flags_via_attributes():
     expected_resource_compile = """
     <ResourceCompile>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalOptions>/flag1 /flag2 %(AdditionalOptions)</AdditionalOptions>
     </ResourceCompile>"""
     assert expected_cl_compile in toolchain
     assert expected_link in toolchain


### PR DESCRIPTION
Changelog: Fix: `MSBuildToolchain`/`MSBuildDeps`: Avoid passing C/C++ compiler options as options for `ResourceCompile`.
Docs: omit

Fixes #12819.

See my https://github.com/conan-io/conan/issues/12819#issuecomment-1649786786.

More details: `ResourceCompile` is executed via [`rc.exe`](https://learn.microsoft.com/en-us/windows/win32/menurc/using-rc-the-rc-command-line-), which shares preprocessor flags with `cl.exe` (i.e. `AdditionalIncludeDirectories` and `PreprocessorDefinitions` in MSBuild terms), but set of compile options is completely different from `cl.exe`, so it looks wrong to add them here.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
