### PR TITLE
Fix CMakeToolchain generator if used with CMAKE_SYSROOT

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -428,6 +428,12 @@ class FindFiles(Block):
         list(PREPEND CMAKE_INCLUDE_PATH {{ cmake_include_path }})
         {% endif %}
 
+        # The CMAKE_SYSROOT should not be prefixed to conan cache directories.
+        # Therefore prepend each CMAKE_MODULE_PATH to CMAKE_FIND_ROOT_PATH as well
+        if(CMAKE_SYSROOT)
+            list(PREPEND CMAKE_FIND_ROOT_PATH ${CMAKE_MODULE_PATH})
+        endif()
+
         {% if cross_building %}
         if(NOT DEFINED CMAKE_FIND_ROOT_PATH_MODE_PACKAGE OR CMAKE_FIND_ROOT_PATH_MODE_PACKAGE STREQUAL "ONLY")
             set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE "BOTH")

--- a/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
+++ b/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
@@ -160,8 +160,79 @@ def test_cmaketoolchain_path_find_package_editable():
         assert "Conan: Target declared" not in client.out
         assert "HELLO FROM THE hello FIND PACKAGE!" in client.out
 
-
 @pytest.mark.tool("cmake")
+def test_cmaketoolchain_path_find_package_override_sysroot():
+    """ make sure a package in editable mode that contains a xxxConfig.cmake file can find that
+    file in the user folder
+    """
+    client = TestClient(path_with_spaces=False)
+
+    find_sysroot = textwrap.dedent("""
+        MESSAGE(FATAL_ERROR "this hello should not be found")
+        """)
+    conanfile_sysroot = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.files import copy
+        class TestConan(ConanFile):
+            name = "sysroot"
+            version = "0.1"
+            exports_sources = "*"
+            def package(self):
+                copy(self, "*", self.source_folder, self.package_folder)
+            def package_info(self):
+                self.conf_info.define("tools.build:sysroot", self.package_folder)
+        """)
+    conanfile_hello = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.files import copy
+        class TestConan(ConanFile):
+            settings = "os", "compiler", "arch", "build_type"
+            exports_sources = "*"
+            def package(self):
+                copy(self, "*", self.source_folder, self.package_folder)
+            def package_info(self):
+                self.cpp_info.builddirs.append("cmake")
+        """)
+    find_hello = textwrap.dedent("""
+        SET(hello_FOUND 1)
+        MESSAGE("HELLO FROM THE hello FIND PACKAGE!")
+        """)
+    conanfile_consumer = textwrap.dedent("""
+        [requires]
+        hello/0.1
+        [generators]
+        CMakeToolchain
+        """)
+    cmake_consumer = textwrap.dedent("""\
+        cmake_minimum_required(VERSION 3.15)
+        set(CMAKE_CXX_COMPILER_WORKS 1)
+        project(MyHello CXX)
+        find_package(hello REQUIRED)
+        """)
+    profile_sysroot = textwrap.dedent("""
+        [tool_requires]
+        sysroot/0.1@
+        """)
+    client.save({"sysroot/conanfile.py": conanfile_sysroot,
+                 "sysroot/lib/cmake/hello/helloConfig.cmake": find_sysroot,
+                 "dep/conanfile.py": conanfile_hello,
+                 "dep/cmake/helloConfig.cmake": find_hello,
+                 "consumer/conanfile.txt": conanfile_consumer,
+                 "consumer/CMakeLists.txt": cmake_consumer,
+                 "consumer/sysroot.profile": profile_sysroot,
+                 })
+
+    with client.chdir("sysroot"):
+        client.run("create . --name sysroot --version 0.1")
+    with client.chdir("dep"):
+        client.run("export . --name hello --version 0.1")
+    with client.chdir("consumer"):
+        client.run("install . -pr:h=default -pr:h=sysroot.profile --build=missing")
+        with client.chdir("build"):
+            client.run_command("cmake .. -DCMAKE_TOOLCHAIN_FILE=../conan_toolchain.cmake")
+    assert "HELLO FROM THE hello FIND PACKAGE!" in client.out
+
+
 @pytest.mark.parametrize(
     "settings",
     [


### PR DESCRIPTION
Issue #14386

Changelog: Bugfix: Fix CMakeToolchain generator if used with CMAKE_SYSROOT
Docs: https://github.com/conan-io/docs/pull/XXXX

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
