### PR TITLE
cmake: add support for cli_args in install()

### DIFF
--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -163,7 +163,7 @@ class CMake(object):
         self._conanfile.output.info("Running CMake.build()")
         self._build(build_type, target, cli_args, build_tool_args)
 
-    def install(self, build_type=None, component=None):
+    def install(self, build_type=None, component=None, cli_args=None):
         """
         Equivalent to run ``cmake --build . --target=install``
 
@@ -172,6 +172,9 @@ class CMake(object):
                            It can fail if the build is single configuration (e.g. Unix Makefiles),
                            as in that case the build type must be specified at configure time,
                            not build type.
+        :param cli_args: A list of arguments ``[arg1, arg2, ...]`` for the underlying
+                         build system that will be passed to the command line:
+                         ``cmake --install ... arg1 arg2``
         """
         self._conanfile.output.info("Running CMake.install()")
         mkdir(self._conanfile, self._conanfile.package_folder)
@@ -192,6 +195,11 @@ class CMake(object):
         do_strip = self._conanfile.conf.get("tools.cmake:install_strip", check_type=bool)
         if do_strip:
             arg_list.append("--strip")
+
+        if cli_args:
+            if "--install" in cli_args:
+                raise ConanException("Do not pass '--install' argument to 'install()'")
+            arg_list.extend(cli_args)
 
         arg_list = " ".join(filter(None, arg_list))
         command = "%s %s" % (self._cmake_program, arg_list)

--- a/conans/test/unittests/tools/cmake/test_cmake_install.py
+++ b/conans/test/unittests/tools/cmake/test_cmake_install.py
@@ -63,3 +63,59 @@ def test_run_install_strip():
     cmake = CMake(conanfile)
     cmake.install()
     assert "--strip" in conanfile.command
+
+
+def test_run_install_cli_args():
+    """
+    Testing that the passing cli_args to install works
+    Issue related: https://github.com/conan-io/conan/issues/14235
+    """
+
+    settings = Settings.loads(get_default_settings_yml())
+    settings.os = "Linux"
+    settings.arch = "x86_64"
+    settings.build_type = "Release"
+    settings.compiler = "gcc"
+    settings.compiler.version = "11"
+
+    conanfile = ConanFileMock()
+
+    conanfile.conf = Conf()
+
+    conanfile.folders.generators = "."
+    conanfile.folders.set_base_generators(temp_folder())
+    conanfile.settings = settings
+    conanfile.folders.set_base_package(temp_folder())
+
+    write_cmake_presets(conanfile, "toolchain", "Unix Makefiles", {})
+    cmake = CMake(conanfile)
+    cmake.install(cli_args=["--prefix=/tmp"])
+    assert "--prefix=/tmp" in conanfile.command
+
+
+def test_run_install_cli_args_strip():
+    """
+    Testing that the install/strip rule is called when using cli_args
+    Issue related: https://github.com/conan-io/conan/issues/14235
+    """
+
+    settings = Settings.loads(get_default_settings_yml())
+    settings.os = "Linux"
+    settings.arch = "x86_64"
+    settings.build_type = "Release"
+    settings.compiler = "gcc"
+    settings.compiler.version = "11"
+
+    conanfile = ConanFileMock()
+
+    conanfile.conf = Conf()
+
+    conanfile.folders.generators = "."
+    conanfile.folders.set_base_generators(temp_folder())
+    conanfile.settings = settings
+    conanfile.folders.set_base_package(temp_folder())
+
+    write_cmake_presets(conanfile, "toolchain", "Unix Makefiles", {})
+    cmake = CMake(conanfile)
+    cmake.install(cli_args=["--strip"])
+    assert "--strip" in conanfile.command


### PR DESCRIPTION
This commit fixes #14235

Changelog: Feature: Add ``cli_args`` argument for ``CMake.install()``.
Docs: https://github.com/conan-io/docs/pull/3314

- [X] Refer to the issue that supports this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
