### PR TITLE
conan 2.x: added test for find_package() of CMakeToolchain (#14334)

### DIFF
--- a/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
+++ b/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
@@ -175,7 +175,10 @@ def test_cmaketoolchain_path_find_package_editable():
 @pytest.mark.parametrize(
     "find_root_path_modes", [find_root_path_modes_default, find_root_path_modes_cross_build],
 )
-def test_cmaketoolchain_path_find_package_real_config(settings, find_root_path_modes):
+@pytest.mark.parametrize(
+    "builddir", ["os.path.join('hello', 'cmake')", "self.package_folder"],
+)
+def test_cmaketoolchain_path_find_package_real_config(settings, find_root_path_modes, builddir):
     client = TestClient()
 
     conanfile = textwrap.dedent("""
@@ -199,8 +202,8 @@ def test_cmaketoolchain_path_find_package_real_config(settings, find_root_path_m
                 cmake.install()
 
             def package_info(self):
-                self.cpp_info.builddirs.append(os.path.join("hello", "cmake"))
-        """)
+                self.cpp_info.builddirs.append({})
+        """.format(builddir))
     cmake = textwrap.dedent("""
         cmake_minimum_required(VERSION 3.15)
         project(MyHello NONE)

--- a/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
+++ b/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
@@ -176,7 +176,7 @@ def test_cmaketoolchain_path_find_package_editable():
     "find_root_path_modes", [find_root_path_modes_default, find_root_path_modes_cross_build],
 )
 @pytest.mark.parametrize(
-    "builddir", ["os.path.join('hello', 'cmake')", "self.package_folder"],
+    "builddir", ["os.path.join('hello', 'cmake')", "self.package_folder", '"."'],
 )
 def test_cmaketoolchain_path_find_package_real_config(settings, find_root_path_modes, builddir):
     client = TestClient()


### PR DESCRIPTION
ensure that CMAKE_PREFIX_PATH can be set to self.package_folder, with a new explicit test

Changelog: Omit
Docs: Omit



- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
