### PR TITLE
conan 1.x: add explicitly defined "builddirs" of "host" dependencies to CMAKE_PREFIX_PATH

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -540,6 +540,9 @@ class FindFiles(Block):
                 nf = os.path.normpath(req.package_folder)
                 host_build_paths_root.extend(p for p in cppinfo.builddirs if os.path.normpath(p) == nf)
                 host_build_paths_noroot.extend(p for p in cppinfo.builddirs if os.path.normpath(p) != nf)
+                if len([p for p in cppinfo.builddirs if os.path.normpath(p) == nf]) > 1:
+                    # package_folder was additionally appended to builddirs by the user
+                    host_build_paths_noroot.append(nf)
             else:
                 host_build_paths_root = []
                 host_build_paths_noroot.extend(p for p in cppinfo.builddirs)

--- a/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
+++ b/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
@@ -173,7 +173,10 @@ def test_cmaketoolchain_path_find_package_editable():
 @pytest.mark.parametrize(
     "find_root_path_modes", [find_root_path_modes_default, find_root_path_modes_cross_build],
 )
-def test_cmaketoolchain_path_find_package_real_config(settings, find_root_path_modes):
+@pytest.mark.parametrize(
+    "builddir", ['self.package_folder', 'os.path.join("hello", "cmake")', '"."'],
+)
+def test_cmaketoolchain_path_find_package_real_config(settings, find_root_path_modes, builddir):
     client = TestClient()
 
     conanfile = textwrap.dedent("""
@@ -197,8 +200,8 @@ def test_cmaketoolchain_path_find_package_real_config(settings, find_root_path_m
                 cmake.install()
 
             def package_info(self):
-                self.cpp_info.builddirs.append(os.path.join("hello", "cmake"))
-        """)
+                self.cpp_info.builddirs.append({})
+        """.format(builddir))
     cmake = textwrap.dedent("""
         cmake_minimum_required(VERSION 3.15)
         project(MyHello NONE)


### PR DESCRIPTION
Changelog: (Bugfix): add explicitly defined "builddirs" of "host" dependencies to CMAKE_PREFIX_PATH
Docs: https://github.com/conan-io/docs/pull/XXXX

This PR solves #14334 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. (How to do it for bugfixes?)
