### PR TITLE
Add format 'cyclonedx' as output format for the graph command

### DIFF
--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -4,7 +4,7 @@ from conan.api.output import ConanOutput, cli_out_write, Color
 from conan.cli import make_abs_path
 from conan.cli.args import common_graph_args, validate_common_graph_args
 from conan.cli.command import conan_command, conan_subcommand
-from conan.cli.formatters.graph import format_graph_html, format_graph_json, format_graph_dot
+from conan.cli.formatters.graph import format_graph_html, format_graph_json, format_graph_dot, format_graph_cyclonedx
 from conan.cli.formatters.graph.graph_info_text import format_graph_info
 from conan.cli.printers.graph import print_graph_packages, print_graph_basic
 from conan.internal.deploy import do_deploys
@@ -106,6 +106,7 @@ def graph_build_order_merge(conan_api, parser, subparser, *args):
 @conan_subcommand(formatters={"text": format_graph_info,
                               "html": format_graph_html,
                               "json": format_graph_json,
+                              "cyclonedx": format_graph_cyclonedx,
                               "dot": format_graph_dot})
 def graph_info(conan_api, parser, subparser, *args):
     """

--- a/conan/cli/formatters/graph/__init__.py
+++ b/conan/cli/formatters/graph/__init__.py
@@ -1,3 +1,4 @@
 from .graph import format_graph_html
 from .graph import format_graph_dot
 from .graph import format_graph_json
+from .graph import format_graph_cyclonedx

--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -1,5 +1,7 @@
 from collections import OrderedDict
 
+from packageurl import PackageURL
+
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
 
@@ -228,6 +230,29 @@ class Node(object):
         result["context"] = self.context
         result["test"] = self.test
         return result
+
+    def package_url(self):
+        """
+        Creates a PURL following https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst
+        """
+        qualifiers = {
+            "prev": self.prev
+        }
+        if self.ref.user:
+            qualifiers["user"] = self.ref.user
+        if self.ref.channel:
+            qualifiers["channel"] = self.ref.channel
+        if self.ref.revision:
+            qualifiers["rref"] = self.ref.revision
+        if self.remote:
+            qualifiers["repository_url"] = self.remote
+        else:
+            qualifiers["repository_url"] = "https://center.conan.io"
+        return PackageURL(
+            type="conan",
+            name=self.name,
+            version=str(self.ref.version),
+            qualifiers=qualifiers)
 
     def overrides(self):
 

--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -7,3 +7,4 @@ fasteners>=0.15
 distro>=1.4.0, <=1.8.0; sys_platform == 'linux' or sys_platform == 'linux2'
 Jinja2>=3.0, <4.0.0
 python-dateutil>=2.8.0, <3
+packageurl-python>=0.10.0


### PR DESCRIPTION
Changelog: Feature: Add format 'cyclonedx' as output format for the graph command
Docs: https://github.com/conan-io/docs/pull/XXXX

Close https://github.com/conan-io/conan/issues/9787

The new output format `cyclonedx` for the graph command creates a SBOM in CycloneDX JSON 1.4 format to be parsed by dependency management / vulnerability tools like https://www.dependencytrack.org/

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
