### PR TITLE
fix DB concurrency DB is locked

### DIFF
--- a/conan/internal/cache/db/table.py
+++ b/conan/internal/cache/db/table.py
@@ -19,8 +19,7 @@ class BaseDbTable:
 
     @contextmanager
     def db_connection(self):
-        connection = sqlite3.connect(self.filename, isolation_level=None,
-                                     timeout=1, check_same_thread=False)
+        connection = sqlite3.connect(self.filename, isolation_level=None, timeout=10)
         try:
             yield connection
         finally:


### PR DESCRIPTION
Changelog: Bugfix: Avoid ``DB is locked`` error when ``core.download:parallel`` is defined.
Docs: Omit

Fix https://github.com/conan-io/conan/issues/13924
