### PR TITLE
allow remotes to resolve python_requires in 'editable add'

### DIFF
--- a/conan/api/subapi/local.py
+++ b/conan/api/subapi/local.py
@@ -42,10 +42,10 @@ class LocalAPI:
         return path
 
     def editable_add(self, path, name=None, version=None, user=None, channel=None, cwd=None,
-                     output_folder=None):
+                     output_folder=None, remotes=None):
         path = self._conan_api.local.get_conanfile_path(path, cwd, py=True)
         app = ConanApp(self._conan_api.cache_folder)
-        conanfile = app.loader.load_named(path, name, version, user, channel)
+        conanfile = app.loader.load_named(path, name, version, user, channel, remotes=remotes)
         ref = RecipeReference(conanfile.name, conanfile.version, conanfile.user, conanfile.channel)
         # Retrieve conanfile.py from target_path
         target_path = self._conan_api.local.get_conanfile_path(path=path, cwd=cwd, py=True)

--- a/conan/cli/commands/editable.py
+++ b/conan/cli/commands/editable.py
@@ -23,11 +23,17 @@ def editable_add(conan_api, parser, subparser, *args):
     add_reference_args(subparser)
     subparser.add_argument("-of", "--output-folder",
                            help='The root output folder for generated and build files')
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("-r", "--remote", action="append", default=None,
+                       help='Look in the specified remote or remotes server')
+    group.add_argument("-nr", "--no-remote", action="store_true",
+                       help='Do not use remote, resolve exclusively in the cache')
     args = parser.parse_args(*args)
 
+    remotes = conan_api.remotes.list(args.remote) if not args.no_remote else []
     cwd = os.getcwd()
     ref = conan_api.local.editable_add(args.path, args.name, args.version, args.user, args.channel,
-                                       cwd, args.output_folder)
+                                       cwd, args.output_folder, remotes=remotes)
     ConanOutput().success("Reference '{}' in editable mode".format(ref))
 
 

--- a/conans/client/graph/python_requires.py
+++ b/conans/client/graph/python_requires.py
@@ -102,7 +102,7 @@ class PyRequireLoader(object):
         if graph_lock:
             graph_lock.resolve_locked_pyrequires(requirement)
         # If the lock hasn't resolved the range, and it hasn't failed (it is partial), resolve it
-        self._range_resolver.resolve(requirement, "py_require", remotes, update)
+        self._range_resolver.resolve(requirement, "python_requires", remotes, update)
         ref = requirement.ref
         return ref
 

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -37,8 +37,8 @@ class RangeResolver:
                 resolved_ref = remote_resolved_ref
 
         if resolved_ref is None:
-            raise ConanException("Version range '%s' from requirement '%s' required by '%s' "
-                                 "could not be resolved" % (version_range, require, base_conanref))
+            raise ConanException(f"Version range '{version_range}' from requirement '{require.ref}' "
+                                 f"required by '{base_conanref}' could not be resolved")
 
         # To fix Cache behavior, we remove the revision information
         resolved_ref.revision = None  # FIXME: Wasting information already obtained from server?


### PR DESCRIPTION
Changelog: Feature: Allow remotes to automatically resolve missing ``python_requires`` in 'editable add'.
Docs: https://github.com/conan-io/docs/pull/3345

Close https://github.com/conan-io/conan/issues/14411
