### PR TITLE
cmaketoolchain: add user_presets_path config

### DIFF
--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -184,6 +184,8 @@ class CMakeToolchain(object):
         if toolchain_file is None:  # The main toolchain file generated only if user dont define
             save(os.path.join(self._conanfile.generators_folder, self.filename), self.content)
             ConanOutput(str(self._conanfile)).info(f"CMakeToolchain generated: {self.filename}")
+        user_presets_path = self._conanfile.conf.get("tools.cmake.cmaketoolchain:user_presets_path",
+                                                     self.user_presets_path)
         # If we're using Intel oneAPI, we need to generate the environment file and run it
         if self._conanfile.settings.get_safe("compiler") == "intel-cc":
             IntelCC(self._conanfile).generate()
@@ -207,7 +209,7 @@ class CMakeToolchain(object):
                 cache_variables[name] = value
 
         write_cmake_presets(self._conanfile, toolchain, self.generator, cache_variables,
-                            self.user_presets_path, self.presets_prefix)
+                            user_presets_path, self.presets_prefix)
 
     def _get_generator(self, recipe_generator):
         # Returns the name of the generator to be used by CMake

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -59,6 +59,7 @@ BUILT_IN_CONFS = {
     "tools.cmake.cmaketoolchain:find_package_prefer_config": "Argument for the CMAKE_FIND_PACKAGE_PREFER_CONFIG",
     "tools.cmake.cmaketoolchain:toolchain_file": "Use other existing file rather than conan_toolchain.cmake one",
     "tools.cmake.cmaketoolchain:user_toolchain": "Inject existing user toolchains at the beginning of conan_toolchain.cmake",
+    "tools.cmake.cmaketoolchain:user_presets_path": "Use other file for user presets rather than CMakeUserPresets.json",
     "tools.cmake.cmaketoolchain:system_name": "Define CMAKE_SYSTEM_NAME in CMakeToolchain",
     "tools.cmake.cmaketoolchain:system_version": "Define CMAKE_SYSTEM_VERSION in CMakeToolchain",
     "tools.cmake.cmaketoolchain:system_processor": "Define CMAKE_SYSTEM_PROCESSOR in CMakeToolchain",

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -72,6 +72,16 @@ def test_cmake_toolchain_custom_toolchain():
     assert "binaryDir" in presets["configurePresets"][0]
 
 
+def test_cmake_toolchain_custom_user_presets_path():
+    client = TestClient(path_with_spaces=False)
+    client.run("new cmake_exe -d name=hello -d version=0.1")
+    save(client.cache.new_config_path, "tools.cmake.cmaketoolchain:user_presets_path=ConanPresets.json")
+
+    client.run("install .")
+    assert not os.path.exists(os.path.join(client.current_folder, "CMakeUserPresets.json"))
+    assert os.path.exists(os.path.join(client.current_folder, "ConanPresets.json"))
+
+
 @pytest.mark.skipif(platform.system() != "Darwin",
                     reason="Single config test, Linux CI still without 3.23")
 @pytest.mark.tool("cmake", "3.23")


### PR DESCRIPTION
CMake documentation [1] states:

	If `CMakePresets.json` and `CMakeUserPresets.json` are both present,
	`CMakeUserPresets.json` implicitly includes `CMakePresets.json`,
	even with no include field, in all versions of the format.

	If a preset file contains presets that inherit from presets in another
	file, the file must include the other file either directly or
	indirectly. Include cycles are not allowed among files. If `a.json`
	includes `b.json`, `b.json` cannot include `a.json`.

Since conan generates `CMakeUserPresets.json` by default, it's not possible to inherit from the presets specified by Conan by default. This can be changed by settings `CMakeToolchain.user_presets_path` to a custom value. However, for some project this single line might be the only reason to switch from `conanfile.txt` to `conanfile.py`.

This commit adds new configuration
`tools.cmake.cmaketoolchain:user_presets_path` so that `CMakeToolchain.user_presets_path` can be changed via command-line argument.

[1]: https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#includes

Changelog: (Feature): Added config `tools.cmake.cmaketoolchain:user_presets_path` to change the user presets path via command-line argument.
Docs: https://github.com/conan-io/docs/pull/XXXX

- [ ] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
