### PR TITLE
Fix pkgconfig name collision on Windows

### DIFF
--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -336,7 +336,7 @@ class _PCGenerator:
         # if it does not already exist in components one
         # Issue related: https://github.com/conan-io/conan/issues/10341
         pkg_name = _get_package_name(self._dep, self._build_context_suffix)
-        if f"{pkg_name}.pc" not in pc_files:
+        if not f"{pkg_name}.pc".lower() in [x.lower() for x in pc_files]:
             package_info = _PCInfo(pkg_name, pkg_requires, f"Conan package: {pkg_name}",
                                    self._dep.cpp_info, _get_package_aliases(self._dep))
             # It'll be enough creating a shortened PC file. This file will be like an alias


### PR DESCRIPTION
Changelog: (Bugfix): Fix pkgconfig name collision on Windows

This fix is related to https://github.com/conan-io/conan/issues/10341. The previous fix did not take into account cases insensitive filesystems. As a result the issue was still present on Windows. OpenEXR 2.x is an example of affected recipe. The "OpenEXR.pc" file for the "openexr_ilmimf" component was overwritten by "openexr.pc" created based on package name.

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
