### PR TITLE
serialize conf_info

### DIFF
--- a/conan/cli/commands/inspect.py
+++ b/conan/cli/commands/inspect.py
@@ -41,7 +41,7 @@ def inspect(conan_api, parser, *args):
     conanfile = conan_api.local.inspect(path, remotes=remotes, lockfile=lockfile)
     result = conanfile.serialize()
     # Some of the serialization info is not initialized so it's pointless to show it to the user
-    for item in ("cpp_info", "system_requires", "recipe_folder"):
+    for item in ("cpp_info", "system_requires", "recipe_folder", "conf_info"):
         if item in result:
             del result[item]
 

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -160,6 +160,7 @@ class ConanFile:
         result["package_folder"] = self.package_folder
 
         result["cpp_info"] = self.cpp_info.serialize()
+        result["conf_info"] = self.conf_info.serialize()
         result["label"] = self.display_name
         return result
 

--- a/conans/test/integration/command/install/install_test.py
+++ b/conans/test/integration/command/install/install_test.py
@@ -485,3 +485,25 @@ def test_upload_skip_binaries_not_hit_server():
     c.run("install --requires=pkg/0.1 --build=missing")
     # This would crash if hits the server, but it doesnt
     assert "pkg/0.1: Created package" in c.out
+
+
+def test_install_json_format():
+    # https://github.com/conan-io/conan/issues/14414
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+
+        class MyTest(ConanFile):
+            name = "pkg"
+            version = "0.1"
+            settings = "build_type"
+
+            def package_info(self):
+                self.conf_info.define("user.myteam:myconf", "myvalue")
+        """)
+    client.save({"conanfile.py": conanfile})
+    client.run("create .")
+    client.run("install --requires=pkg/0.1 --format=json")
+    data = json.loads(client.stdout)
+    conf_info = data["graph"]["nodes"]["1"]["conf_info"]
+    assert {'user.myteam:myconf': 'myvalue'} == conf_info


### PR DESCRIPTION
Changelog: Fix: Serialize ``conf_info`` in ``--format=json`` output.
Docs: Omit

Close https://github.com/conan-io/conan/issues/14414
