### PR TITLE
send traces to stderr

### DIFF
--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -219,7 +219,7 @@ class Cli:
             return exception.code
 
         assert isinstance(exception, Exception)
-        print(traceback.format_exc())
+        output.error(traceback.format_exc())
         msg = exception_message_safe(exception)
         output.error(msg)
         return ERROR_UNEXPECTED


### PR DESCRIPTION
Changelog: Fix: Do not print non-captured stacktraces to ``stdout`` but to ``stderr``.
Docs: Omit

Also for https://github.com/conan-io/conan/issues/14430