### PR TITLE
new tools.deployer:symlinks conf for deployers

### DIFF
--- a/conan/internal/deploy.py
+++ b/conan/internal/deploy.py
@@ -1,5 +1,7 @@
 import os
+import shutil
 
+from conan.api.output import ConanOutput
 from conans.client.cache.cache import ClientCache
 from conans.client.loader import load_python_file
 from conans.errors import ConanException
@@ -51,9 +53,6 @@ def full_deploy(graph, output_folder):
     """
     # TODO: This deployer needs to be put somewhere else
     # TODO: Document that this will NOT work with editables
-    import os
-    import shutil
-
     conanfile = graph.root.conanfile
     conanfile.output.info(f"Conan built-in full deployer to {output_folder}")
     for dep in conanfile.dependencies.values():
@@ -66,10 +65,22 @@ def full_deploy(graph, output_folder):
             folder_name = os.path.join(folder_name, build_type)
         if arch:
             folder_name = os.path.join(folder_name, arch)
-        new_folder = os.path.join(output_folder, folder_name)
-        rmdir(new_folder)
-        shutil.copytree(dep.package_folder, new_folder, symlinks=True)
-        dep.set_deploy_folder(new_folder)
+        _deploy_single(dep, conanfile, output_folder, folder_name)
+
+
+def _deploy_single(dep, conanfile, output_folder, folder_name):
+    new_folder = os.path.join(output_folder, folder_name)
+    rmdir(new_folder)
+    symlinks = conanfile.conf.get("tools.deployer:symlinks", check_type=bool, default=True)
+    try:
+        shutil.copytree(dep.package_folder, new_folder, symlinks=symlinks)
+    except Exception as e:
+        if "WinError 1314" in str(e):
+            ConanOutput().error("full_deploy: Symlinks in Windows require admin privileges "
+                                "or 'Developer mode = ON'")
+        raise ConanException(f"full_deploy: The copy of '{dep}' files failed: {e}.\nYou can "
+                             f"use 'tools.deployer:symlinks' conf to disable symlinks")
+    dep.set_deploy_folder(new_folder)
 
 
 def direct_deploy(graph, output_folder):
@@ -78,9 +89,6 @@ def direct_deploy(graph, output_folder):
     """
     # TODO: This deployer needs to be put somewhere else
     # TODO: Document that this will NOT work with editables
-    import os
-    import shutil
-
     output_folder = os.path.join(output_folder, "direct_deploy")
     conanfile = graph.root.conanfile
     conanfile.output.info(f"Conan built-in pkg deployer to {output_folder}")
@@ -88,7 +96,4 @@ def direct_deploy(graph, output_folder):
     # dependency, the "reference" package. If the argument is a local path, then all direct
     # dependencies
     for dep in conanfile.dependencies.filter({"direct": True}).values():
-        new_folder = os.path.join(output_folder, dep.ref.name)
-        rmdir(new_folder)
-        shutil.copytree(dep.package_folder, new_folder, symlinks=True)
-        dep.set_deploy_folder(new_folder)
+        _deploy_single(dep, conanfile, output_folder, dep.ref.name)

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -66,6 +66,7 @@ BUILT_IN_CONFS = {
     "tools.cmake.cmake_layout:build_folder_vars": "Settings and Options that will produce a different build folder and different CMake presets names",
     "tools.cmake:cmake_program": "Path to CMake executable",
     "tools.cmake:install_strip": "Add --strip to cmake.instal()",
+    "tools.deployer:symlinks": "Set to False to disable deployers copying symlinks",
     "tools.files.download:retry": "Number of retries in case of failure when downloading",
     "tools.files.download:retry_wait": "Seconds to wait between download attempts",
     "tools.gnu:make_program": "Indicate path to make program",


### PR DESCRIPTION
Changelog: Feature: New ``tools.deployer:symlinks`` configuration to disable symlinks copy in deployers.
Changelog: Fix: Better error message when a built-in deployer failed to copy files.
Docs: https://github.com/conan-io/docs/pull/3335

Close https://github.com/conan-io/conan/issues/14456
Close https://github.com/conan-io/conan/issues/14451
