### PR TITLE
Implement conf that avoids binary skipping in the graph

### DIFF
--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -22,7 +22,7 @@ def create(conan_api, parser, *args):
     add_common_install_arguments(parser)
     parser.add_argument("--build-require", action='store_true', default=False,
                         help='Whether the package being created is a build-require (to be used'
-                             'as tool_requires() by other packages)')
+                             ' as tool_requires() by other packages)')
     parser.add_argument("-tf", "--test-folder", action=OnceArgument,
                         help='Alternative test folder name. By default it is "test_package". '
                              'Use "" to skip the test stage')

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -345,7 +345,8 @@ class GraphBinariesAnalyzer(object):
                         continue
                 self._evaluate_node(node, build_mode)
 
-        self._skip_binaries(deps_graph)
+        if self._cache.new_config.get("core.graph:skip_binaries", check_type=bool, default=True):
+            self._skip_binaries(deps_graph)
 
     @staticmethod
     def _skip_binaries(graph):

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -345,8 +345,7 @@ class GraphBinariesAnalyzer(object):
                         continue
                 self._evaluate_node(node, build_mode)
 
-        if self._cache.new_config.get("core.graph:skip_binaries", check_type=bool, default=True):
-            self._skip_binaries(deps_graph)
+        self._skip_binaries(deps_graph)
 
     @staticmethod
     def _skip_binaries(graph):
@@ -363,5 +362,5 @@ class GraphBinariesAnalyzer(object):
                     required_nodes.add(dep_node)
 
         for node in graph.nodes:
-            if node not in required_nodes:
+            if node not in required_nodes and node.conanfile.conf.get("tools.graph:skip_binaries", check_type=bool, default=True):
                 node.binary = BINARY_SKIP

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -23,8 +23,6 @@ BUILT_IN_CONFS = {
     "core.download:retry_wait": "Seconds to wait between download attempts from Conan server",
     "core.download:download_cache": "Define path to a file download cache",
     "core.cache:storage_path": "Absolute path where the packages and database are stored",
-    # TODO. Find better name
-    "core.graph:skip_binaries": "Lorem Ipsum",
     # Sources backup
     "core.sources:download_cache": "Folder to store the sources backup",
     "core.sources:download_urls": "List of URLs to download backup sources from",
@@ -71,6 +69,8 @@ BUILT_IN_CONFS = {
     "tools.deployer:symlinks": "Set to False to disable deployers copying symlinks",
     "tools.files.download:retry": "Number of retries in case of failure when downloading",
     "tools.files.download:retry_wait": "Seconds to wait between download attempts",
+    # TODO. Find better name
+    "tools.graph:skip_binaries": "Lorem Ipsum",
     "tools.gnu:make_program": "Indicate path to make program",
     "tools.gnu:define_libcxx11_abi": "Force definition of GLIBCXX_USE_CXX11_ABI=1 for libstdc++11",
     "tools.gnu:pkg_config": "Path to pkg-config executable used by PkgConfig build helper",

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -23,6 +23,8 @@ BUILT_IN_CONFS = {
     "core.download:retry_wait": "Seconds to wait between download attempts from Conan server",
     "core.download:download_cache": "Define path to a file download cache",
     "core.cache:storage_path": "Absolute path where the packages and database are stored",
+    # TODO. Find better name
+    "core.graph:skip_binaries": "Lorem Ipsum",
     # Sources backup
     "core.sources:download_cache": "Folder to store the sources backup",
     "core.sources:download_urls": "List of URLs to download backup sources from",

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -69,7 +69,7 @@ BUILT_IN_CONFS = {
     "tools.deployer:symlinks": "Set to False to disable deployers copying symlinks",
     "tools.files.download:retry": "Number of retries in case of failure when downloading",
     "tools.files.download:retry_wait": "Seconds to wait between download attempts",
-    "tools.graph:skip_binaries": "Allow binary skipping in the graph",
+    "tools.graph:skip_binaries": "Allow the graph to skip binaries not needed in the current configuration (True by default)",
     "tools.gnu:make_program": "Indicate path to make program",
     "tools.gnu:define_libcxx11_abi": "Force definition of GLIBCXX_USE_CXX11_ABI=1 for libstdc++11",
     "tools.gnu:pkg_config": "Path to pkg-config executable used by PkgConfig build helper",

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -69,8 +69,7 @@ BUILT_IN_CONFS = {
     "tools.deployer:symlinks": "Set to False to disable deployers copying symlinks",
     "tools.files.download:retry": "Number of retries in case of failure when downloading",
     "tools.files.download:retry_wait": "Seconds to wait between download attempts",
-    # TODO. Find better name
-    "tools.graph:skip_binaries": "Lorem Ipsum",
+    "tools.graph:skip_binaries": "Allow binary skipping in the graph",
     "tools.gnu:make_program": "Indicate path to make program",
     "tools.gnu:define_libcxx11_abi": "Force definition of GLIBCXX_USE_CXX11_ABI=1 for libstdc++11",
     "tools.gnu:pkg_config": "Path to pkg-config executable used by PkgConfig build helper",

--- a/conans/test/integration/graph/test_skip_binaries.py
+++ b/conans/test/integration/graph/test_skip_binaries.py
@@ -149,7 +149,7 @@ def test_conf_skip():
     client.run("create . --name=libb --version=1.0")
 
     client.save({"conanfile.py": GenConanfile().with_requires("liba/1.0", "libb/1.0")})
-    client.run("create . --name=app --version=1.0 -v")
+    client.run("create . --name=app --version=0.0 -v")
     client.assert_listed_binary({"maths/1.0": (NO_SETTINGS_PACKAGE_ID, "Skip")})
     client.assert_listed_binary({"ai/1.0": (NO_SETTINGS_PACKAGE_ID, "Skip")})
 
@@ -161,6 +161,6 @@ def test_conf_skip():
     client.assert_listed_binary({"maths/1.0": (NO_SETTINGS_PACKAGE_ID, "Cache")})
     client.assert_listed_binary({"ai/1.0": (NO_SETTINGS_PACKAGE_ID, "Skip")})
 
-    client.run("create . --name=app --version=1.0 -v -c *:tools.graph:skip_binaries=True")
+    client.run("create . --name=app --version=3.0 -v -c *:tools.graph:skip_binaries=True")
     client.assert_listed_binary({"maths/1.0": (NO_SETTINGS_PACKAGE_ID, "Skip")})
     client.assert_listed_binary({"ai/1.0": (NO_SETTINGS_PACKAGE_ID, "Skip")})

--- a/conans/test/integration/graph/test_skip_binaries.py
+++ b/conans/test/integration/graph/test_skip_binaries.py
@@ -17,6 +17,14 @@ def test_private_skip():
     client.run("create . --name=app --version=1.0 -v")
     client.assert_listed_binary({"dep/1.0": (NO_SETTINGS_PACKAGE_ID, "Skip")})
 
+    # Ensure the skip_binaries conf is able to avoid skips
+    client.save_home({"global.conf": "core.graph:skip_binaries=False"})
+    client.save({"conanfile.py": GenConanfile()})
+    client.run("create . --name=dep --version=1.0")
+    client.save({"conanfile.py": GenConanfile().with_requires("pkg/1.0")})
+    client.run("create . --name=app --version=1.0 -v")
+    client.assert_listed_binary({"dep/1.0": (NO_SETTINGS_PACKAGE_ID, "Cache")})
+
 
 def test_private_no_skip():
     # app -> pkg -(private)-> dep

--- a/conans/test/integration/graph/test_skip_binaries.py
+++ b/conans/test/integration/graph/test_skip_binaries.py
@@ -18,12 +18,21 @@ def test_private_skip():
     client.assert_listed_binary({"dep/1.0": (NO_SETTINGS_PACKAGE_ID, "Skip")})
 
     # Ensure the skip_binaries conf is able to avoid skips
-    client.save_home({"global.conf": "core.graph:skip_binaries=False"})
     client.save({"conanfile.py": GenConanfile()})
-    client.run("create . --name=dep --version=1.0")
-    client.save({"conanfile.py": GenConanfile().with_requires("pkg/1.0")})
-    client.run("create . --name=app --version=1.0 -v")
-    client.assert_listed_binary({"dep/1.0": (NO_SETTINGS_PACKAGE_ID, "Cache")})
+    client.run("create . --name=maths --version=1.0")
+    client.run("create . --name=ai --version=1.0")
+    client.save({"conanfile.py": GenConanfile().with_requires("maths/1.0", "ai/1.0")})
+    client.run("create . --name=app --version=1.0 -v -c *:tools.graph:skip_binaries=True")
+    client.assert_listed_binary({"maths/1.0": (NO_SETTINGS_PACKAGE_ID, "Skip")})
+    client.assert_listed_binary({"ai/1.0": (NO_SETTINGS_PACKAGE_ID, "Skip")})
+
+    client.run("create . --name=app --version=1.0 -v -c *:tools.graph:skip_binaries=False")
+    client.assert_listed_binary({"maths/1.0": (NO_SETTINGS_PACKAGE_ID, "Cache")})
+    client.assert_listed_binary({"ai/1.0": (NO_SETTINGS_PACKAGE_ID, "Cache")})
+
+    client.run("create . --name=app --version=2.0 -v -c maths/*:tools.graph:skip_binaries=False")
+    client.assert_listed_binary({"maths/1.0": (NO_SETTINGS_PACKAGE_ID, "Cache")})
+    client.assert_listed_binary({"ai/1.0": (NO_SETTINGS_PACKAGE_ID, "Skip")})
 
 
 def test_private_no_skip():
@@ -126,3 +135,32 @@ def test_list_skip_printing():
     c.run("install app --build=missing")
     c.assert_listed_binary({"tool/0.1": ("da39a3ee5e6b4b0d3255bfef95601890afd80709", "Cache")},
                            build=True)
+
+
+def test_conf_skip():
+    client = TestClient()
+    client.save({"conanfile.py": GenConanfile()})
+    client.run("create . --name=maths --version=1.0")
+    client.run("create . --name=ai --version=1.0")
+
+    client.save({"conanfile.py": GenConanfile().with_requirement("maths/1.0", visible=False)})
+    client.run("create . --name=liba --version=1.0")
+    client.save({"conanfile.py": GenConanfile().with_requirement("ai/1.0", visible=False)})
+    client.run("create . --name=libb --version=1.0")
+
+    client.save({"conanfile.py": GenConanfile().with_requires("liba/1.0", "libb/1.0")})
+    client.run("create . --name=app --version=1.0 -v")
+    client.assert_listed_binary({"maths/1.0": (NO_SETTINGS_PACKAGE_ID, "Skip")})
+    client.assert_listed_binary({"ai/1.0": (NO_SETTINGS_PACKAGE_ID, "Skip")})
+
+    client.run("create . --name=app --version=1.0 -v -c *:tools.graph:skip_binaries=False")
+    client.assert_listed_binary({"maths/1.0": (NO_SETTINGS_PACKAGE_ID, "Cache")})
+    client.assert_listed_binary({"ai/1.0": (NO_SETTINGS_PACKAGE_ID, "Cache")})
+
+    client.run("create . --name=app --version=2.0 -v -c maths/*:tools.graph:skip_binaries=False")
+    client.assert_listed_binary({"maths/1.0": (NO_SETTINGS_PACKAGE_ID, "Cache")})
+    client.assert_listed_binary({"ai/1.0": (NO_SETTINGS_PACKAGE_ID, "Skip")})
+
+    client.run("create . --name=app --version=1.0 -v -c *:tools.graph:skip_binaries=True")
+    client.assert_listed_binary({"maths/1.0": (NO_SETTINGS_PACKAGE_ID, "Skip")})
+    client.assert_listed_binary({"ai/1.0": (NO_SETTINGS_PACKAGE_ID, "Skip")})

--- a/conans/test/integration/graph/test_skip_binaries.py
+++ b/conans/test/integration/graph/test_skip_binaries.py
@@ -17,23 +17,6 @@ def test_private_skip():
     client.run("create . --name=app --version=1.0 -v")
     client.assert_listed_binary({"dep/1.0": (NO_SETTINGS_PACKAGE_ID, "Skip")})
 
-    # Ensure the skip_binaries conf is able to avoid skips
-    client.save({"conanfile.py": GenConanfile()})
-    client.run("create . --name=maths --version=1.0")
-    client.run("create . --name=ai --version=1.0")
-    client.save({"conanfile.py": GenConanfile().with_requires("maths/1.0", "ai/1.0")})
-    client.run("create . --name=app --version=1.0 -v -c *:tools.graph:skip_binaries=True")
-    client.assert_listed_binary({"maths/1.0": (NO_SETTINGS_PACKAGE_ID, "Skip")})
-    client.assert_listed_binary({"ai/1.0": (NO_SETTINGS_PACKAGE_ID, "Skip")})
-
-    client.run("create . --name=app --version=1.0 -v -c *:tools.graph:skip_binaries=False")
-    client.assert_listed_binary({"maths/1.0": (NO_SETTINGS_PACKAGE_ID, "Cache")})
-    client.assert_listed_binary({"ai/1.0": (NO_SETTINGS_PACKAGE_ID, "Cache")})
-
-    client.run("create . --name=app --version=2.0 -v -c maths/*:tools.graph:skip_binaries=False")
-    client.assert_listed_binary({"maths/1.0": (NO_SETTINGS_PACKAGE_ID, "Cache")})
-    client.assert_listed_binary({"ai/1.0": (NO_SETTINGS_PACKAGE_ID, "Skip")})
-
 
 def test_private_no_skip():
     # app -> pkg -(private)-> dep


### PR DESCRIPTION
Changelog: Feature: Add `tools.graph:skip_binaries` to control binary skipping in the graph.
Docs: https://github.com/conan-io/docs/pull/3342
Docs: https://github.com/conan-io/docs/pull/3341

Tests missing, will asign someone once I write them up :)

Motivation comes from https://github.com/conan-io/conan-extensions/issues/65 (Pinging @fschoenm) even though this was a known issue before that. Another alternative for that specific issue is listed in its comments, but this change stands on its own either way.
