### PR TITLE
Warn of unknown version range options

### DIFF
--- a/conans/model/version_range.py
+++ b/conans/model/version_range.py
@@ -94,6 +94,9 @@ class VersionRange:
             if "include_prerelease" in t:
                 prereleases = True
                 break
+            else:
+                from conan.api.output import ConanOutput
+                ConanOutput().warning(f'Unrecognized version range option "{t}" in "{expression}"')
         version_expr = tokens[0]
         self.condition_sets = []
         for alternative in version_expr.split("||"):

--- a/conans/model/version_range.py
+++ b/conans/model/version_range.py
@@ -95,8 +95,12 @@ class VersionRange:
                 prereleases = True
                 break
             else:
+                t = t.strip()
                 from conan.api.output import ConanOutput
-                ConanOutput().warning(f'Unrecognized version range option "{t}" in "{expression}"')
+                if len(t) == 0 or t[0].isalpha():
+                    ConanOutput().warning(f'Unrecognized version range option "{t}" in "{expression}"')
+                else:
+                    ConanOutput().error(f'"{t}" in version range "{expression}" is not a valid option')
         version_expr = tokens[0]
         self.condition_sets = []
         for alternative in version_expr.split("||"):

--- a/conans/model/version_range.py
+++ b/conans/model/version_range.py
@@ -96,11 +96,11 @@ class VersionRange:
                 break
             else:
                 t = t.strip()
-                from conan.api.output import ConanOutput
-                if len(t) == 0 or t[0].isalpha():
+                if len(t) > 0 and t[0].isalpha():
+                    from conan.api.output import ConanOutput
                     ConanOutput().warning(f'Unrecognized version range option "{t}" in "{expression}"')
                 else:
-                    ConanOutput().error(f'"{t}" in version range "{expression}" is not a valid option')
+                    raise ConanException(f'"{t}" in version range "{expression}" is not a valid option')
         version_expr = tokens[0]
         self.condition_sets = []
         for alternative in version_expr.split("||"):

--- a/conans/test/integration/graph/core/test_version_ranges.py
+++ b/conans/test/integration/graph/core/test_version_ranges.py
@@ -418,11 +418,11 @@ def test_different_user_channel_resolved_correctly():
 
 def test_unknown_options():
     c = TestClient()
+    c.save({"conanfile.py": GenConanfile("lib", "2.0")})
+    c.run("create .")
 
     c.run("graph info --requires=lib/[>1.2,<1.4]", assert_error=True)
     assert '"<1.4" in version range ">1.2,<1.4" is not a valid option' in c.out
 
-    c.save({"conanfile.py": GenConanfile("lib", "2.0")})
-    c.run("create .")
     c.run("graph info --requires=lib/[>1.2,unknown_conf]")
     assert 'WARN: Unrecognized version range option "unknown_conf" in ">1.2,unknown_conf"' in c.out

--- a/conans/test/integration/graph/core/test_version_ranges.py
+++ b/conans/test/integration/graph/core/test_version_ranges.py
@@ -420,7 +420,7 @@ def test_unknown_options():
     c = TestClient()
 
     c.run("graph info --requires=lib/[>1.2,<1.4]", assert_error=True)
-    assert 'ERROR: "<1.4" in version range ">1.2,<1.4" is not a valid option' in c.out
+    assert '"<1.4" in version range ">1.2,<1.4" is not a valid option' in c.out
 
     c.run("graph info --requires=lib/[>1.2,unknown_conf]", assert_error=True)
     assert 'WARN: Unrecognized version range option "unknown_conf" in ">1.2,unknown_conf"' in c.out

--- a/conans/test/integration/graph/core/test_version_ranges.py
+++ b/conans/test/integration/graph/core/test_version_ranges.py
@@ -418,6 +418,9 @@ def test_different_user_channel_resolved_correctly():
 
 def test_unknown_options():
     c = TestClient()
-    c.save({"conanfile.py": GenConanfile("pkg", "1.0").with_requirement("lib/[>1.2, <1.4]")})
-    c.run("install .", assert_error=True)
-    assert 'Unrecognized version range option " <1.4" in ">1.2, <1.4"' in c.out
+
+    c.run("graph info --requires=lib/[>1.2,<1.4]", assert_error=True)
+    assert 'ERROR: "<1.4" in version range ">1.2,<1.4" is not a valid option' in c.out
+
+    c.run("graph info --requires=lib/[>1.2,unknown_conf]", assert_error=True)
+    assert 'WARN: Unrecognized version range option "unknown_conf" in ">1.2,unknown_conf"' in c.out

--- a/conans/test/integration/graph/core/test_version_ranges.py
+++ b/conans/test/integration/graph/core/test_version_ranges.py
@@ -414,3 +414,10 @@ def test_different_user_channel_resolved_correctly():
     client2.run("install --requires=lib/[>=1.0]@conan/testing")
     assert f"lib/1.0@conan/testing: Retrieving package {NO_SETTINGS_PACKAGE_ID} " \
            f"from remote 'server2' " in client2.out
+
+
+def test_unknown_options():
+    c = TestClient()
+    c.save({"conanfile.py": GenConanfile("pkg", "1.0").with_requirement("lib/[>1.2, <1.4]")})
+    c.run("install .", assert_error=True)
+    assert 'Unrecognized version range option " <1.4" in ">1.2, <1.4"' in c.out

--- a/conans/test/integration/graph/core/test_version_ranges.py
+++ b/conans/test/integration/graph/core/test_version_ranges.py
@@ -422,5 +422,7 @@ def test_unknown_options():
     c.run("graph info --requires=lib/[>1.2,<1.4]", assert_error=True)
     assert '"<1.4" in version range ">1.2,<1.4" is not a valid option' in c.out
 
-    c.run("graph info --requires=lib/[>1.2,unknown_conf]", assert_error=True)
+    c.save({"conanfile.py": GenConanfile("lib", "2.0")})
+    c.run("create .")
+    c.run("graph info --requires=lib/[>1.2,unknown_conf]")
     assert 'WARN: Unrecognized version range option "unknown_conf" in ">1.2,unknown_conf"' in c.out

--- a/conans/test/integration/py_requires/python_requires_test.py
+++ b/conans/test/integration/py_requires/python_requires_test.py
@@ -114,7 +114,7 @@ class PyRequiresExtendTest(unittest.TestCase):
         reuse = textwrap.dedent("""
             from conan import ConanFile
             class PkgTest(ConanFile):
-                python_requires = "base/[>1.0,<1.2]@user/testing"
+                python_requires = "base/[>1.0 <1.2]@user/testing"
                 python_requires_extend = "base.MyConanfileBase"
             """)
 


### PR DESCRIPTION
Changelog: Feature: Warn of unknown version range options.
Docs: Omit

As part of the fixes that came from https://github.com/conan-io/conan-center-index/pull/18513

As discussed with @czoido, I don't think this should break to allow for new options being used in older Conan versions, so a warning is the next best thing