### PR TITLE
Add support for Apple visionOS to Conan 1.x

### DIFF
--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -8,9 +8,9 @@ from conans.errors import ConanException
 
 
 def is_apple_os(conanfile):
-    """returns True if OS is Apple one (Macos, iOS, watchOS or tvOS"""
+    """returns True if OS is Apple one (Macos, iOS, watchOS, tvOS or visionOS)"""
     os_ = conanfile.settings.get_safe("os")
-    return str(os_) in ['Macos', 'iOS', 'watchOS', 'tvOS']
+    return str(os_) in ['Macos', 'iOS', 'watchOS', 'tvOS', 'visionOS']
 
 
 def to_apple_arch(conanfile):
@@ -24,12 +24,14 @@ def _guess_apple_sdk_name(os_, arch):
         return {'Macos': 'macosx',
                 'iOS': 'iphonesimulator',
                 'watchOS': 'watchsimulator',
-                'tvOS': 'appletvsimulator'}.get(str(os_))
+                'tvOS': 'appletvsimulator',
+                'visionOS': 'xrsimulator'}.get(str(os_))
     else:
         return {'Macos': 'macosx',
                 'iOS': 'iphoneos',
                 'watchOS': 'watchos',
-                'tvOS': 'appletvos'}.get(str(os_), None)
+                'tvOS': 'appletvos',
+                'visionOS': 'xros'}.get(str(os_), None)
 
 
 def apple_sdk_name(settings):
@@ -62,7 +64,9 @@ def apple_min_version_flag(conanfile):
             'watchos': '-mwatchos-version-min',
             'watchsimulator': '-mwatchos-simulator-version-min',
             'appletvos': '-mtvos-version-min',
-            'appletvsimulator': '-mtvos-simulator-version-min'}.get(str(os_sdk))
+            'appletvsimulator': '-mtvos-simulator-version-min',
+            'xros': '-mxros-version-min',
+            'xrsimulator': '-mxros-simulator-version-min'}.get(str(os_sdk))
     if os_subsystem == 'catalyst':
         # especial case, despite Catalyst is macOS, it requires an iOS version argument
         flag = '-mios-version-min'

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -431,7 +431,7 @@ class AppleSystemBlock(Block):
         if host_os_version:
             # https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html
             # Despite the OSX part in the variable name(s) they apply also to other SDKs than
-            # macOS like iOS, tvOS, or watchOS.
+            # macOS like iOS, tvOS, watchOS or visionOS.
             ctxt_toolchain["cmake_osx_deployment_target"] = host_os_version
 
         return ctxt_toolchain
@@ -810,7 +810,7 @@ class GenericSystemBlock(Block):
         os_host = self._conanfile.settings.get_safe("os")
         arch_host = self._conanfile.settings.get_safe("arch")
         arch_build = self._conanfile.settings_build.get_safe("arch")
-        return os_host in ('iOS', 'watchOS', 'tvOS') or (
+        return os_host in ('iOS', 'watchOS', 'tvOS', 'visionOS') or (
                 os_host == 'Macos' and arch_host != arch_build)
 
     def _get_cross_build(self):

--- a/conan/tools/gnu/get_gnu_triplet.py
+++ b/conan/tools/gnu/get_gnu_triplet.py
@@ -80,6 +80,7 @@ def _get_gnu_triplet(os_, arch, compiler=None):
                  "iOS": "apple-ios",
                  "watchOS": "apple-watchos",
                  "tvOS": "apple-tvos",
+                 "visionOS": "apple-xros",
                  # NOTE: it technically must be "asmjs-unknown-emscripten" or
                  # "wasm32-unknown-emscripten", but it's not recognized by old config.sub versions
                  "Emscripten": "local-emscripten",

--- a/conan/tools/meson/helpers.py
+++ b/conan/tools/meson/helpers.py
@@ -7,6 +7,7 @@ _meson_system_map = {
     'iOS': 'darwin',
     'watchOS': 'darwin',
     'tvOS': 'darwin',
+    'visionOS': 'darwin',
     'FreeBSD': 'freebsd',
     'Emscripten': 'emscripten',
     'Linux': 'linux',

--- a/conan/tools/qbs/qbsprofile.py
+++ b/conan/tools/qbs/qbsprofile.py
@@ -72,6 +72,7 @@ _target_platform = {
     'iOS': 'ios',
     'watchOS': 'watchos',
     'tvOS': 'tvos',
+    'visionOS': 'xros',
     'FreeBSD': 'freebsd',
     'SunOS': 'solaris',
     'AIX': 'aix',

--- a/conans/client/build/cmake_flags.py
+++ b/conans/client/build/cmake_flags.py
@@ -221,6 +221,7 @@ class CMakeDefinitionsBuilder(object):
                                          "iOS": apple_system_name or "iOS",
                                          "tvOS": apple_system_name or "tvOS",
                                          "watchOS": apple_system_name or "watchOS",
+                                         "visionOS": apple_system_name or "visionOS",
                                          "Neutrino": "QNX",
                                          "": "Generic",
                                          None: "Generic"}

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -19,7 +19,7 @@ _t_default_settings_yml = Template(textwrap.dedent("""
 
     # Only for building cross compilation tools, 'os_target/arch_target' is the system for
     # which the tools generate code
-    os_target: [Windows, Linux, Macos, Android, iOS, watchOS, tvOS, FreeBSD, SunOS, AIX, Arduino, Neutrino]
+    os_target: [Windows, Linux, Macos, Android, iOS, watchOS, tvOS, visionOS, FreeBSD, SunOS, AIX, Arduino, Neutrino]
     arch_target: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asm.js, wasm, sh4le, e2k-v2, e2k-v3, e2k-v4, e2k-v5, e2k-v6, e2k-v7, xtensalx6, xtensalx106, xtensalx7]
 
     # Rest of the settings are "host" settings:
@@ -58,6 +58,10 @@ _t_default_settings_yml = Template(textwrap.dedent("""
             sdk: [None, "appletvos", "appletvsimulator"]
             sdk_version: [None, "11.3", "11.4", "12.0", "12.1", "12.2", "12.4",
                           "13.0", "13.1", "13.2", "13.4", "14.0", "14.2", "14.3", "14.5", "15.0", "15.2", "15.4", "16.0", "16.1"]
+        visionOS:
+            version: ["1.0"]
+            sdk: [None, "xros", "xrsimulator"]
+            sdk_version: [None, "1.0"]
         Macos:
             version: [None, "10.6", "10.7", "10.8", "10.9", "10.10", "10.11", "10.12", "10.13", "10.14", "10.15", "11.0", "12.0", "13.0"]
             sdk: [None, "macosx"]
@@ -126,7 +130,7 @@ _t_default_settings_yml = Template(textwrap.dedent("""
             runtime_type: [None, Debug, Release]
             runtime_version: [None, v140, v141, v142, v143]
         apple-clang: &apple_clang
-            version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0", "12.0", "13", "13.0", "13.1", "14", "14.0"]
+            version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0", "12.0", "13", "13.0", "13.1", "14", "14.0", "15", "15.0"]
             libcxx: [libstdc++, libc++]
             cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
         intel:

--- a/conans/client/generators/b2.py
+++ b/conans/client/generators/b2.py
@@ -245,7 +245,7 @@ class B2Generator(Generator):
                 'Linux': 'linux',
                 'Macos': 'darwin',
                 'Android': 'android',
-                'iOS': 'darwin', 'watchOS': 'darwin', 'tvOS': 'darwin',
+                'iOS': 'darwin', 'watchOS': 'darwin', 'tvOS': 'darwin', 'visionOS': 'darwin',
                 'FreeBSD': 'freebsd',
                 'SunOS': 'solaris',
                 'Arduino': 'linux',

--- a/conans/client/migrations_settings.py
+++ b/conans/client/migrations_settings.py
@@ -4502,4 +4502,161 @@ cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
 settings_1_60_1 = settings_1_60_0
 settings_1_60_2 = settings_1_60_1
 
-settings_1_61_0 = settings_1_60_2
+settings_1_61_0 = """
+# Only for cross building, 'os_build/arch_build' is the system that runs Conan
+os_build: [Windows, WindowsStore, Linux, Macos, FreeBSD, SunOS, AIX, VxWorks]
+arch_build: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, sh4le, e2k-v2, e2k-v3, e2k-v4, e2k-v5, e2k-v6, e2k-v7]
+
+# Only for building cross compilation tools, 'os_target/arch_target' is the system for
+# which the tools generate code
+os_target: [Windows, Linux, Macos, Android, iOS, watchOS, tvOS, visionOS, FreeBSD, SunOS, AIX, Arduino, Neutrino]
+arch_target: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asm.js, wasm, sh4le, e2k-v2, e2k-v3, e2k-v4, e2k-v5, e2k-v6, e2k-v7, xtensalx6, xtensalx106, xtensalx7]
+
+# Rest of the settings are "host" settings:
+# - For native building/cross building: Where the library/program will run.
+# - For building cross compilation tools: Where the cross compiler will run.
+os:
+    Windows:
+        subsystem: [None, cygwin, msys, msys2, wsl]
+    WindowsStore:
+        version: ["8.1", "10.0"]
+    WindowsCE:
+        platform: ANY
+        version: ["5.0", "6.0", "7.0", "8.0"]
+    Linux:
+    iOS:
+        version: &ios_version
+                 ["7.0", "7.1", "8.0", "8.1", "8.2", "8.3", "9.0", "9.1", "9.2", "9.3", "10.0", "10.1", "10.2", "10.3",
+                  "11.0", "11.1", "11.2", "11.3", "11.4", "12.0", "12.1", "12.2", "12.3", "12.4",
+                  "13.0", "13.1", "13.2", "13.3", "13.4", "13.5", "13.6", "13.7",
+                  "14.0", "14.1", "14.2", "14.3", "14.4", "14.5", "14.6", "14.7", "14.8",
+                  "15.0", "15.1", "15.2", "15.3", "15.4", "15.5", "15.6", "16.0", "16.1"]
+        sdk: [None, "iphoneos", "iphonesimulator"]
+        sdk_version: [None, "11.3", "11.4", "12.0", "12.1", "12.2", "12.4",
+                      "13.0", "13.1", "13.2", "13.4", "13.5", "13.6", "13.7",
+                      "14.0", "14.1", "14.2", "14.3", "14.4", "14.5", "15.0", "15.2", "15.4", "15.5", "16.0", "16.1"]
+    watchOS:
+        version: ["4.0", "4.1", "4.2", "4.3", "5.0", "5.1", "5.2", "5.3", "6.0", "6.1", "6.2",
+                  "7.0", "7.1", "7.2", "7.3", "7.4", "7.5", "7.6", "8.0", "8.1", "8.3", "8.4", "8.5", "8.6", "8.7", "9.0", "9.1"]
+        sdk: [None, "watchos", "watchsimulator"]
+        sdk_version: [None, "4.3", "5.0", "5.1", "5.2", "5.3", "6.0", "6.1", "6.2",
+                      "7.0", "7.1", "7.2", "7.4", "8.0", "8.0.1", "8.3", "8.5", "9.0", "9.1"]
+    tvOS:
+        version: ["11.0", "11.1", "11.2", "11.3", "11.4", "12.0", "12.1", "12.2", "12.3", "12.4",
+                  "13.0", "13.2", "13.3", "13.4", "14.0", "14.2", "14.3", "14.4", "14.5", "14.6", "14.7",
+                  "15.0", "15.1", "15.2", "15.3", "15.4", "15.5", "15.6", "16.0", "16.1"]
+        sdk: [None, "appletvos", "appletvsimulator"]
+        sdk_version: [None, "11.3", "11.4", "12.0", "12.1", "12.2", "12.4",
+                      "13.0", "13.1", "13.2", "13.4", "14.0", "14.2", "14.3", "14.5", "15.0", "15.2", "15.4", "16.0", "16.1"]
+    visionOS:
+        version: ["1.0"]
+        sdk: [None, "xros", "xrsimulator"]
+        sdk_version: [None, "1.0"]
+    Macos:
+        version: [None, "10.6", "10.7", "10.8", "10.9", "10.10", "10.11", "10.12", "10.13", "10.14", "10.15", "11.0", "12.0", "13.0"]
+        sdk: [None, "macosx"]
+        sdk_version: [None, "10.13", "10.14", "10.15", "11.0", "11.1", "11.3", "12.0", "12.1", "12.3", "13.0", "13.1"]
+        subsystem:
+            None:
+            catalyst:
+                ios_version: *ios_version
+    Android:
+        api_level: ANY
+    FreeBSD:
+    SunOS:
+    AIX:
+    Arduino:
+        board: ANY
+    Emscripten:
+    Neutrino:
+        version: ["6.4", "6.5", "6.6", "7.0", "7.1"]
+    baremetal:
+    VxWorks:
+        version: ["7"]
+arch: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64, armv4, armv4i, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, sparc, sparcv9, mips, mips64, avr, s390, s390x, asm.js, wasm, sh4le, e2k-v2, e2k-v3, e2k-v4, e2k-v5, e2k-v6, e2k-v7, xtensalx6, xtensalx106, xtensalx7]
+compiler:
+    sun-cc:
+        version: ["5.10", "5.11", "5.12", "5.13", "5.14", "5.15"]
+        threads: [None, posix]
+        libcxx: [libCstd, libstdcxx, libstlport, libstdc++]
+    gcc: &gcc
+        version: ["4.1", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9",
+                  "5", "5.1", "5.2", "5.3", "5.4", "5.5",
+                  "6", "6.1", "6.2", "6.3", "6.4", "6.5",
+                  "7", "7.1", "7.2", "7.3", "7.4", "7.5",
+                  "8", "8.1", "8.2", "8.3", "8.4", "8.5",
+                  "9", "9.1", "9.2", "9.3", "9.4", "9.5",
+                  "10", "10.1", "10.2", "10.3", "10.4",
+                  "11", "11.1", "11.2", "11.3",
+                  "12", "12.1", "12.2", "12.3",
+                  "13", "13.1"]
+        libcxx: [libstdc++, libstdc++11]
+        threads: [None, posix, win32]  # Windows MinGW
+        exception: [None, dwarf2, sjlj, seh]  # Windows MinGW
+        cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
+    Visual Studio: &visual_studio
+        runtime: [MD, MT, MTd, MDd]
+        version: ["8", "9", "10", "11", "12", "14", "15", "16", "17"]
+        toolset: [None, v90, v100, v110, v110_xp, v120, v120_xp,
+                  v140, v140_xp, v140_clang_c2, LLVM-vs2012, LLVM-vs2012_xp,
+                  LLVM-vs2013, LLVM-vs2013_xp, LLVM-vs2014, LLVM-vs2014_xp,
+                  LLVM-vs2017, LLVM-vs2017_xp, v141, v141_xp, v141_clang_c2, v142,
+                  llvm, ClangCL, v143]
+        cppstd: [None, 14, 17, 20, 23]
+    msvc:
+        version: [170, 180, 190, 191, 192, 193]
+        update: [None, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        runtime: [static, dynamic]
+        runtime_type: [Debug, Release]
+        cppstd: [98, 14, 17, 20, 23]
+        toolset: [None, v110_xp, v120_xp, v140_xp, v141_xp]
+    clang:
+        version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
+                  "5.0", "6.0", "7.0", "7.1",
+                  "8", "9", "10", "11", "12", "13", "14", "15", "16"]
+        libcxx: [None, libstdc++, libstdc++11, libc++, c++_shared, c++_static]
+        cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
+        runtime: [None, MD, MT, MTd, MDd, static, dynamic]
+        runtime_type: [None, Debug, Release]
+        runtime_version: [None, v140, v141, v142, v143]
+    apple-clang: &apple_clang
+        version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1", "10.0", "11.0", "12.0", "13", "13.0", "13.1", "14", "14.0", "15", "15.0"]
+        libcxx: [libstdc++, libc++]
+        cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
+    intel:
+        version: ["11", "12", "13", "14", "15", "16", "17", "18", "19", "19.1"]
+        update: [None, ANY]
+        base:
+            gcc:
+                <<: *gcc
+                threads: [None]
+                exception: [None]
+            Visual Studio:
+                <<: *visual_studio
+            apple-clang:
+                <<: *apple_clang
+    intel-cc:
+        version: ["2021.1", "2021.2", "2021.3"]
+        update: [None, ANY]
+        mode: ["icx", "classic", "dpcpp"]
+        libcxx: [None, libstdc++, libstdc++11, libc++]
+        cppstd: [None, 98, gnu98, 03, gnu03, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
+        runtime: [None, static, dynamic]
+        runtime_type: [None, Debug, Release]
+    qcc:
+        version: ["4.4", "5.4", "8.3"]
+        libcxx: [cxx, gpp, cpp, cpp-ne, accp, acpp-ne, ecpp, ecpp-ne]
+        cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17]
+    mcst-lcc:
+        version: ["1.19", "1.20", "1.21", "1.22", "1.23", "1.24", "1.25"]
+        base:
+            gcc:
+                <<: *gcc
+                threads: [None]
+                exceptions: [None]
+
+build_type: [None, Debug, Release, RelWithDebInfo, MinSizeRel]
+
+
+cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]  # Deprecated, use compiler.cppstd
+"""

--- a/conans/client/tools/apple.py
+++ b/conans/client/tools/apple.py
@@ -6,8 +6,8 @@ from conans.util.runners import check_output_runner
 
 
 def is_apple_os(os_):
-    """returns True if OS is Apple one (Macos, iOS, watchOS or tvOS"""
-    return str(os_) in ['Macos', 'iOS', 'watchOS', 'tvOS']
+    """returns True if OS is Apple one (Macos, iOS, watchOS, tvOS or visionOS)"""
+    return str(os_) in ['Macos', 'iOS', 'watchOS', 'tvOS', 'visionOS']
 
 
 def to_apple_arch(arch):
@@ -27,12 +27,14 @@ def _guess_apple_sdk_name(os_, arch):
         return {'Macos': 'macosx',
                 'iOS': 'iphonesimulator',
                 'watchOS': 'watchsimulator',
-                'tvOS': 'appletvsimulator'}.get(str(os_))
+                'tvOS': 'appletvsimulator',
+                'visionOS': 'xrsimulator'}.get(str(os_))
     else:
         return {'Macos': 'macosx',
                 'iOS': 'iphoneos',
                 'watchOS': 'watchos',
-                'tvOS': 'appletvos'}.get(str(os_), None)
+                'tvOS': 'appletvos',
+                'visionOS': 'xros'}.get(str(os_), None)
 
 
 def apple_sdk_name(settings):
@@ -49,7 +51,8 @@ def apple_deployment_target_env(os_, os_version):
     env_name = {'Macos': 'MACOSX_DEPLOYMENT_TARGET',
                 'iOS': 'IOS_DEPLOYMENT_TARGET',
                 'watchOS': 'WATCHOS_DEPLOYMENT_TARGET',
-                'tvOS': 'TVOS_DEPLOYMENT_TARGET'}.get(str(os_))
+                'tvOS': 'TVOS_DEPLOYMENT_TARGET',
+                'visionOS': 'XROS_DEPLOYMENT_TARGET'}.get(str(os_))
     if not env_name:
         return {}
     return {env_name: os_version}
@@ -64,7 +67,9 @@ def apple_deployment_target_flag(os_, os_version, os_sdk=None, os_subsystem=None
             'watchos': '-mwatchos-version-min',
             'watchsimulator': '-mwatchos-simulator-version-min',
             'appletvos': '-mtvos-version-min',
-            'appletvsimulator': '-mtvos-simulator-version-min'}.get(str(os_sdk))
+            'appletvsimulator': '-mtvos-simulator-version-min',
+            'xros': '-mxros-version-min',
+            'xrsimulator': '-mxros-simulator-version-min'}.get(str(os_sdk))
     if os_subsystem == 'catalyst':
         # especial case, despite Catalyst is macOS, it requires an iOS version argument
         flag = '-mios-version-min'

--- a/conans/client/tools/oss.py
+++ b/conans/client/tools/oss.py
@@ -589,6 +589,7 @@ def get_gnu_triplet(os_, arch, compiler=None):
                  "iOS": "apple-ios",
                  "watchOS": "apple-watchos",
                  "tvOS": "apple-tvos",
+                 "visionOS": "apple-xros",
                  # NOTE: it technically must be "asmjs-unknown-emscripten" or
                  # "wasm32-unknown-emscripten", but it's not recognized by old config.sub versions
                  "Emscripten": "local-emscripten",

--- a/conans/test/unittests/model/other_settings_test.py
+++ b/conans/test/unittests/model/other_settings_test.py
@@ -319,7 +319,7 @@ class SayConan(ConanFile):
         self.assertIn(bad_value_msg("settings.os", "ChromeOS",
                                     ['AIX', 'Android', 'Arduino', 'Emscripten', 'FreeBSD', 'Linux', 'Macos', 'Neutrino',
                                      'SunOS', 'VxWorks', 'Windows', 'WindowsCE', 'WindowsStore', 'baremetal', 'iOS', 'tvOS',
-                                     'watchOS']),
+                                     'visionOS', 'watchOS']),
                       client.out)
 
         # Now add new settings to config and try again

--- a/conans/test/unittests/model/transitive_reqs_test.py
+++ b/conans/test/unittests/model/transitive_reqs_test.py
@@ -1737,7 +1737,7 @@ class SayConan(ConanFile):
         self.assertIn(bad_value_msg("settings.os", "Linux",
                                     ['AIX', 'Android', 'Arduino', 'Emscripten', 'FreeBSD', 'Macos',
                                      'Neutrino', 'SunOS', 'VxWorks', 'Windows', 'WindowsCE',
-                                     'WindowsStore', 'baremetal', 'iOS', 'tvOS', 'watchOS']),
+                                     'WindowsStore', 'baremetal', 'iOS', 'tvOS', 'visionOS', 'watchOS']),
                       str(cm.exception))
 
     def test_config_remove2(self):


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix): Add support for Apple visionOS and apple-clang 15 (currently still beta).
Docs: https://github.com/conan-io/docs/pull/XXXX

Issue link:

https://github.com/conan-io/conan/issues/14496

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.

NOTICE:

- In some cases I am unsure whether to use "xros" or "visionos". I just tried CMake, I don't have resources to test other build systems. I tried to adjust the config scripts for the other build tools accordingly...
- I didn't write any tests.
- It works for me in visionOS 1 beta 2 simulator runtime.

The profile I used:

[settings]
os=visionOS
os.version=1.0
os.sdk=xrsimulator
os.sdk_version=1.0
os_build=Macos
arch=x86_64
arch_build=x86_64
compiler=apple-clang
compiler.version=15
compiler.libcxx=libc++
build_type=Release
[options]
[build_requires]
[env]