### PR TITLE
Add `tools.files.download:verify`

### DIFF
--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -193,6 +193,7 @@ def download(conanfile, url, filename, verify=True, retry=None, retry_wait=None,
     retry = config.get("tools.files.download:retry", check_type=int, default=retry)
     retry_wait = retry_wait if retry_wait is not None else 5
     retry_wait = config.get("tools.files.download:retry_wait", check_type=int, default=retry_wait)
+    verify = config.get("tools.files.download:verify", check_type=bool, default=verify)
 
     filename = os.path.abspath(filename)
     downloader = SourcesCachingDownloader(conanfile)

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -69,7 +69,7 @@ BUILT_IN_CONFS = {
     "tools.deployer:symlinks": "Set to False to disable deployers copying symlinks",
     "tools.files.download:retry": "Number of retries in case of failure when downloading",
     "tools.files.download:retry_wait": "Seconds to wait between download attempts",
-    "tools.files.download:verify": "Force enable/disable of verification checks for downloaded files",
+    "tools.files.download:verify": "If set, overrides recipes on whether to perform SSL verification for their downloaded files. Only recommended to be set while testing",
     "tools.gnu:make_program": "Indicate path to make program",
     "tools.gnu:define_libcxx11_abi": "Force definition of GLIBCXX_USE_CXX11_ABI=1 for libstdc++11",
     "tools.gnu:pkg_config": "Path to pkg-config executable used by PkgConfig build helper",

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -69,6 +69,7 @@ BUILT_IN_CONFS = {
     "tools.deployer:symlinks": "Set to False to disable deployers copying symlinks",
     "tools.files.download:retry": "Number of retries in case of failure when downloading",
     "tools.files.download:retry_wait": "Seconds to wait between download attempts",
+    "tools.files.download:verify": "Force enable/disable of verification checks for downloaded files",
     "tools.gnu:make_program": "Indicate path to make program",
     "tools.gnu:define_libcxx11_abi": "Force definition of GLIBCXX_USE_CXX11_ABI=1 for libstdc++11",
     "tools.gnu:pkg_config": "Path to pkg-config executable used by PkgConfig build helper",

--- a/conans/test/integration/command/download/download_test.py
+++ b/conans/test/integration/command/download/download_test.py
@@ -1,73 +1,114 @@
 import os
-import unittest
+import textwrap
 from collections import OrderedDict
+from unittest import mock
 
 from conans.model.recipe_ref import RecipeReference
 from conans.test.utils.tools import TestClient, TestServer, NO_SETTINGS_PACKAGE_ID, GenConanfile
 from conans.util.files import load
 
 
-class DownloadTest(unittest.TestCase):
+def test_download_with_sources():
+    client = TestClient(default_server_user=True)
+    client.save({"conanfile.py": GenConanfile("pkg", "0.1").with_exports_sources("*"),
+                 "file.h": "myfile.h",
+                 "otherfile.cpp": "C++code"})
+    client.run("export . --user=lasote --channel=stable")
 
-    def test_download_with_sources(self):
-        client = TestClient(default_server_user=True)
-        client.save({"conanfile.py": GenConanfile("pkg", "0.1").with_exports_sources("*"),
-                     "file.h": "myfile.h",
-                     "otherfile.cpp": "C++code"})
-        client.run("export . --user=lasote --channel=stable")
+    ref = RecipeReference.loads("pkg/0.1@lasote/stable")
+    client.run("upload pkg/0.1@lasote/stable -r default")
+    client.run("remove pkg/0.1@lasote/stable -c")
 
-        ref = RecipeReference.loads("pkg/0.1@lasote/stable")
-        client.run("upload pkg/0.1@lasote/stable -r default")
-        client.run("remove pkg/0.1@lasote/stable -c")
+    client.run("download pkg/0.1@lasote/stable -r default")
+    assert "Downloading 'pkg/0.1@lasote/stable' sources" in client.out
+    source = client.get_latest_ref_layout(ref).export_sources()
+    assert "myfile.h" == load(os.path.join(source, "file.h"))
+    assert "C++code" == load(os.path.join(source, "otherfile.cpp"))
 
-        client.run("download pkg/0.1@lasote/stable -r default")
-        self.assertIn("Downloading 'pkg/0.1@lasote/stable' sources", client.out)
-        source = client.get_latest_ref_layout(ref).export_sources()
-        self.assertEqual("myfile.h", load(os.path.join(source, "file.h")))
-        self.assertEqual("C++code", load(os.path.join(source, "otherfile.cpp")))
 
-    def test_no_user_channel(self):
-        # https://github.com/conan-io/conan/issues/6009
-        client = TestClient(default_server_user=True)
-        client.save({"conanfile.py": GenConanfile()})
-        client.run("create . --name=pkg --version=1.0")
-        client.run("upload * --confirm -r default")
-        client.run("remove * -c")
+def test_no_user_channel():
+    # https://github.com/conan-io/conan/issues/6009
+    client = TestClient(default_server_user=True)
+    client.save({"conanfile.py": GenConanfile()})
+    client.run("create . --name=pkg --version=1.0")
+    client.run("upload * --confirm -r default")
+    client.run("remove * -c")
 
-        client.run("download pkg/1.0:{} -r default".format(NO_SETTINGS_PACKAGE_ID))
-        self.assertIn("Downloading package 'pkg/1.0#4d670581ccb765839f2239cc8dff8fbd:%s" %
-                      NO_SETTINGS_PACKAGE_ID, client.out)
+    client.run("download pkg/1.0:{} -r default".format(NO_SETTINGS_PACKAGE_ID))
+    assert f"Downloading package 'pkg/1.0#4d670581ccb765839f2239cc8dff8fbd:{NO_SETTINGS_PACKAGE_ID}" in client.out
 
-        # All
-        client.run("remove * -c")
-        client.run("download pkg/1.0#*:* -r default")
-        self.assertIn("Downloading package 'pkg/1.0#4d670581ccb765839f2239cc8dff8fbd:%s" %
-                      NO_SETTINGS_PACKAGE_ID, client.out)
+    # All
+    client.run("remove * -c")
+    client.run("download pkg/1.0#*:* -r default")
+    assert f"Downloading package 'pkg/1.0#4d670581ccb765839f2239cc8dff8fbd:{NO_SETTINGS_PACKAGE_ID}" in client.out
 
-    def test_download_with_python_requires(self):
-        """ In the past,
-        when having a python_require in a different repo, it cannot be ``conan download``
-        as the download runs from a single repo.
 
-        Now, from https://github.com/conan-io/conan/issues/14260, "conan download" doesn't
-        really need to load conanfile, so it doesn't fail because of this.
-        """
-        # https://github.com/conan-io/conan/issues/9548
-        servers = OrderedDict([("tools", TestServer()),
-                               ("pkgs", TestServer())])
-        c = TestClient(servers=servers, inputs=["admin", "password", "admin", "password"])
+def test_download_with_python_requires():
+    """ In the past,
+    when having a python_require in a different repo, it cannot be ``conan download``
+    as the download runs from a single repo.
 
-        c.save({"tool/conanfile.py": GenConanfile("tool", "0.1"),
-                "pkg/conanfile.py": GenConanfile("pkg", "0.1").with_python_requires("tool/0.1")})
-        c.run("export tool")
-        c.run("create pkg")
-        c.run("upload tool* -r tools -c")
-        c.run("upload pkg* -r pkgs -c")
-        c.run("remove * -c")
+    Now, from https://github.com/conan-io/conan/issues/14260, "conan download" doesn't
+    really need to load conanfile, so it doesn't fail because of this.
+    """
+    # https://github.com/conan-io/conan/issues/9548
+    servers = OrderedDict([("tools", TestServer()),
+                           ("pkgs", TestServer())])
+    c = TestClient(servers=servers, inputs=["admin", "password", "admin", "password"])
 
-        c.run("install --requires=pkg/0.1 -r pkgs -r tools")
-        self.assertIn("Downloading", c.out)
-        c.run("remove * -c")
+    c.save({"tool/conanfile.py": GenConanfile("tool", "0.1"),
+            "pkg/conanfile.py": GenConanfile("pkg", "0.1").with_python_requires("tool/0.1")})
+    c.run("export tool")
+    c.run("create pkg")
+    c.run("upload tool* -r tools -c")
+    c.run("upload pkg* -r pkgs -c")
+    c.run("remove * -c")
 
-        c.run("download pkg/0.1 -r pkgs")
-        assert "pkg/0.1: Downloaded package revision" in c.out
+    c.run("install --requires=pkg/0.1 -r pkgs -r tools")
+    assert "Downloading" in c.out
+    c.run("remove * -c")
+
+    c.run("download pkg/0.1 -r pkgs")
+    assert "pkg/0.1: Downloaded package revision" in c.out
+
+
+def test_download_verify_ssl_conf():
+    client = TestClient()
+
+    client.save({"conanfile.py": textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.files import download
+
+        class Pkg(ConanFile):
+            name = "pkg"
+            version = "1.0"
+
+            def source(self):
+                download(self, "http://verify.true", "", verify=True)
+                download(self, "http://verify.false", "", verify=False)
+        """)})
+
+    did_verify = {}
+
+    def custom_download(this, url, filepath, *args, **kwargs):
+        did_verify[url] = args[2]
+
+    with mock.patch("conans.client.downloaders.file_downloader.FileDownloader.download",
+                    custom_download):
+        client.run("create . -c tools.files.download:verify=True")
+        assert did_verify["http://verify.true"]
+        assert did_verify["http://verify.false"]
+
+        did_verify.clear()
+        client.run("remove pkg/1.0 -c")
+
+        client.run("create . -c tools.files.download:verify=False")
+        assert not did_verify["http://verify.true"]
+        assert not did_verify["http://verify.false"]
+
+        did_verify.clear()
+        client.run("remove pkg/1.0 -c")
+
+        client.run("create .")
+        assert did_verify["http://verify.true"]
+        assert not did_verify["http://verify.false"]


### PR DESCRIPTION
Changelog: Feature: Add `tools.files.download:verify`.
Docs: https://github.com/conan-io/docs/pull/3341
As a look into to see if we event want this.

The motivation from this comes from trying to locally develop packages whose sources do not play nice with our JFrog VPN. This is usually `pkgconf` (For me and @jcar87 both at least), but I've seen it in a few others.

As editing the recipe is a pain in the neck, my usual go-to is changing Conan not to verify any download, which is not ideal either.

This would allow to do things such as
`conan create . --version=1.0.0 --build=missing -c:b "pkgconf/*:tools.files.download:verify=False"` and have finegrained control over the verification.


Another possible solution if this does not go thru is to use the backup of CCI sources. I'm not 100% sure that an exception on origin will trigger a check of the backups, it might be worth considering if not.


Also, tests are missing because I'm not quite sure how to properly test this. Mocking the downloader seems like the way to go, but I still need to check on that