### PR TITLE
allow python_requires download for upload command

### DIFF
--- a/conan/api/subapi/upload.py
+++ b/conan/api/subapi/upload.py
@@ -15,14 +15,14 @@ class UploadAPI:
     def __init__(self, conan_api):
         self.conan_api = conan_api
 
-    def check_upstream(self, package_list, remote, force=False):
+    def check_upstream(self, package_list, remote, enabled_remotes, force=False):
         """Check if the artifacts are already in the specified remote, skipping them from
         the package_list in that case"""
         app = ConanApp(self.conan_api.cache_folder)
         for ref, bundle in package_list.refs().items():
             layout = app.cache.recipe_layout(ref)
             conanfile_path = layout.conanfile()
-            conanfile = app.loader.load_basic(conanfile_path)
+            conanfile = app.loader.load_basic(conanfile_path, remotes=enabled_remotes)
             if conanfile.upload_policy == "skip":
                 ConanOutput().info(f"{ref}: Skipping upload of binaries, "
                                    "because upload_policy='skip'")

--- a/conan/cli/commands/upload.py
+++ b/conan/cli/commands/upload.py
@@ -85,7 +85,7 @@ def upload(conan_api: ConanAPI, parser, *args):
         if args.check:
             conan_api.cache.check_integrity(package_list)
         # Check if the recipes/packages are in the remote
-        conan_api.upload.check_upstream(package_list, remote, args.force)
+        conan_api.upload.check_upstream(package_list, remote, enabled_remotes, args.force)
 
         # If only if search with "*" we ask for confirmation
         if not args.list and not args.confirm and "*" in args.pattern:

--- a/conans/test/integration/command/upload/test_upload_bundle.py
+++ b/conans/test/integration/command/upload/test_upload_bundle.py
@@ -40,7 +40,7 @@ def test_upload_bundle():
                 raise ConanException("No recipes found matching pattern '{}'".format(args.reference))
 
             # Check if the recipes/packages are in the remote
-            conan_api.upload.check_upstream(package_list, remote)
+            conan_api.upload.check_upstream(package_list, remote, enabled_remotes)
             conan_api.upload.prepare(package_list, enabled_remotes)
             cli_out_write(json.dumps(package_list.serialize(), indent=4))
         """)

--- a/conans/test/integration/command/upload/upload_test.py
+++ b/conans/test/integration/command/upload/upload_test.py
@@ -513,3 +513,17 @@ def test_upload_only_without_user_channel():
     c.run("search * -r=default")
     assert "lib/1.0@user/channel" in c.out
     assert "lib/1.0" in c.out
+
+
+def test_upload_with_python_requires():
+    # https://github.com/conan-io/conan/issues/14503
+    c = TestClient(default_server_user=True)
+    c.save({"tool/conanfile.py": GenConanfile("tool", "0.1"),
+            "dep/conanfile.py": GenConanfile("dep", "0.1").with_python_requires("tool/[>=0.1]")})
+    c.run("create tool")
+    c.run("create dep")
+    c.run("upload tool* -c -r=default")
+    c.run("remove tool* -c")
+    c.run("upload dep* -c -r=default")
+    # This used to fail, but adding the enabled remotes to python_requires resolution, it works
+    assert "tool/0.1: Downloaded recipe" in c.out


### PR DESCRIPTION
Changelog: Fix: Avoid errors in ``conan upload`` when ``python_requires`` are not in the cache and need to be downloaded.
Docs: Omit

Close https://github.com/conan-io/conan/issues/14503
