### PR TITLE
Print only packages confirmed interactively in ``conan upload``

### DIFF
--- a/conan/cli/commands/upload.py
+++ b/conan/cli/commands/upload.py
@@ -14,15 +14,27 @@ def summary_upload_list(results):
     """
     cli_out_write("Upload summary:")
     info = results["results"]
-    result = {}
-    for remote, remote_info in info.items():
-        new_info = result.setdefault(remote, {})
-        for ref, content in remote_info.items():
-            for rev, rev_content in content["revisions"].items():
-                pkgids = rev_content.get('packages')
-                if pkgids:
-                    new_info.setdefault(f"{ref}:{rev}", list(pkgids))
-    print_serial(result)
+
+    def format_upload(item):
+        if isinstance(item, dict):
+            result = {}
+            for k, v in item.items():
+                if isinstance(v, dict):
+                    v.pop("info", None)
+                    v.pop("timestamp", None)
+                    v.pop("files", None)
+                    upload_value = v.pop("upload", None)
+                    if upload_value is not None:
+                        msg = "Uploaded" if upload_value else "Skipped, already in server"
+                        force_upload = v.pop("force_upload", None)
+                        if force_upload:
+                            msg += " - forced"
+                        k = f"{k} ({msg})"
+                result[k] = format_upload(v)
+            return result
+        return item
+    info = {remote: format_upload(values) for remote, values in info.items()}
+    print_serial(info)
 
 
 @conan_command(group="Creator", formatters={"text": summary_upload_list,
@@ -82,15 +94,14 @@ def upload(conan_api: ConanAPI, parser, *args):
         package_list = conan_api.list.select(ref_pattern, package_query=args.package_query)
 
     if package_list.recipes:
-        if args.check:
-            conan_api.cache.check_integrity(package_list)
-        # Check if the recipes/packages are in the remote
-        conan_api.upload.check_upstream(package_list, remote, args.force)
-
         # If only if search with "*" we ask for confirmation
         if not args.list and not args.confirm and "*" in args.pattern:
             _ask_confirm_upload(conan_api, package_list)
 
+        if args.check:
+            conan_api.cache.check_integrity(package_list)
+        # Check if the recipes/packages are in the remote
+        conan_api.upload.check_upstream(package_list, remote, args.force)
         conan_api.upload.prepare(package_list, enabled_remotes, args.metadata)
 
         if not args.dry_run:
@@ -111,17 +122,22 @@ def upload(conan_api: ConanAPI, parser, *args):
     }
 
 
-def _ask_confirm_upload(conan_api, upload_data):
+def _ask_confirm_upload(conan_api, package_list):
     ui = UserInput(conan_api.config.get("core:non_interactive"))
-    for ref, bundle in upload_data.refs().items():
+    for ref, bundle in package_list.refs().items():
         msg = "Are you sure you want to upload recipe '%s'?" % ref.repr_notime()
+        ref_dict = package_list.recipes[str(ref)]["revisions"]
         if not ui.request_boolean(msg):
-            bundle["upload"] = False
-            for _, prev_bundle in upload_data.prefs(ref, bundle).items():
-                prev_bundle["upload"] = False
-
+            ref_dict.pop(ref.revision)
+            # clean up empy refs
+            if not ref_dict:
+                package_list.recipes.pop(str(ref))
         else:
-            for pref, prev_bundle in upload_data.prefs(ref, bundle).items():
+            for pref, prev_bundle in package_list.prefs(ref, bundle).items():
                 msg = "Are you sure you want to upload package '%s'?" % pref.repr_notime()
+                pkgs_dict = ref_dict[ref.revision]["packages"]
                 if not ui.request_boolean(msg):
-                    prev_bundle["upload"] = False
+                    pref_dict = pkgs_dict[pref.package_id]["revisions"]
+                    pref_dict.pop(pref.revision)
+                    if not pref_dict:
+                        pkgs_dict.pop(pref.package_id)

--- a/conans/test/integration/command/upload/upload_complete_test.py
+++ b/conans/test/integration/command/upload/upload_complete_test.py
@@ -9,6 +9,7 @@ from requests import ConnectionError
 from conans.paths import CONAN_MANIFEST
 from conans.test.utils.tools import (NO_SETTINGS_PACKAGE_ID, TestClient, TestRequester, TestServer,
                                      GenConanfile)
+from conans.util.env import environment_update
 from conans.util.files import load
 
 
@@ -83,6 +84,23 @@ def test_check_upload_confirm_question():
     client.run("upload hello* -r default")
 
     assert "Uploading recipe 'hello2/1.2.1@frodo/stable" not in client.out
+
+
+def test_check_upload_confirm_question_yes():
+    server = TestServer()
+    client = TestClient(servers={"default": server},
+                        inputs=["yes", "yes", "yes", "yes", "yes", "admin", "password"])
+    client.save({"conanfile.py": GenConanfile("hello1", "1.2.1")})
+    client.run("create . ")
+    client.save({"conanfile.py": GenConanfile("hello1", "1.2.1").with_package_file("file.txt",
+                                                                                   env_var="MYVAR")})
+
+    with environment_update({"MYVAR": "0"}):
+        client.run("create . ")
+    with environment_update({"MYVAR": "1"}):
+        client.run("create . ")
+    client.run("upload hello*#*:*#* -r default")
+    assert str(client.out).count("(Uploaded)") == 5
 
 
 class UploadTest(unittest.TestCase):

--- a/conans/test/integration/command/upload/upload_complete_test.py
+++ b/conans/test/integration/command/upload/upload_complete_test.py
@@ -72,7 +72,8 @@ def test_upload_with_pattern():
 
 def test_check_upload_confirm_question():
     server = TestServer()
-    client = TestClient(servers={"default": server}, inputs=["yes", "admin", "password", "n", "n"])
+    client = TestClient(servers={"default": server},
+                        inputs=["yes", "admin", "password", "n", "n", "n"])
     client.save({"conanfile.py": GenConanfile("hello1", "1.2.1")})
     client.run("export . --user=frodo --channel=stable")
     client.run("upload hello* -r default")
@@ -80,7 +81,7 @@ def test_check_upload_confirm_question():
     assert "Uploading recipe 'hello1/1.2.1@frodo/stable" in client.out
 
     client.save({"conanfile.py": GenConanfile("hello2", "1.2.1")})
-    client.run("export . --user=frodo --channel=stable")
+    client.run("create . --user=frodo --channel=stable")
     client.run("upload hello* -r default")
 
     assert "Uploading recipe 'hello2/1.2.1@frodo/stable" not in client.out


### PR DESCRIPTION
Changelog: Bugfix: Print only packages confirmed interactively in ``conan upload``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/14490