### PR TITLE
Print exception stacktrace from command run into stderr

### DIFF
--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -173,7 +173,7 @@ class Cli:
         except Exception as e:
             # must be a local-import to get updated value
             if ConanOutput.level_allowed(LEVEL_TRACE):
-                print(traceback.format_exc())
+                print(traceback.format_exc(), file=sys.stderr)
             self._conan2_migrate_recipe_msg(e)
             raise
 


### PR DESCRIPTION
Changelog: Bugfix: Print exception stacktrace (when `-vtrace` is set) into stderr instead of stdout
Docs: Omit

Hi! A `ConanException` from some command like `conan <cmd> -v trace -f json > output.json` redirected my error into JSON file and didn't write anything into the console. I believe such output should be always written into stderr.

- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
