### PR TITLE
Fix/db error

### DIFF
--- a/conan/api/model.py
+++ b/conan/api/model.py
@@ -89,6 +89,7 @@ class MultiPackagesList:
 
             ref = node["ref"]
             ref = RecipeReference.loads(ref)
+            ref.timestamp = node["rrev_timestamp"]
             recipe = recipe.lower()
             if any(r == "*" or r == recipe for r in recipes):
                 cache_list.add_refs([ref])
@@ -97,7 +98,7 @@ class MultiPackagesList:
             if remote:
                 remote_list = pkglist.lists.setdefault(remote, PackagesList())
                 remote_list.add_refs([ref])
-            pref = PkgReference(ref, node["package_id"], node["prev"])
+            pref = PkgReference(ref, node["package_id"], node["prev"], node["prev_timestamp"])
             binary_remote = node["binary_remote"]
             if binary_remote:
                 remote_list = pkglist.lists.setdefault(binary_remote, PackagesList())

--- a/conan/internal/cache/db/cache_database.py
+++ b/conan/internal/cache/db/cache_database.py
@@ -5,8 +5,6 @@ from conan.internal.cache.db.recipes_table import RecipesDBTable
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
 
-CONNECTION_TIMEOUT_SECONDS = 1  # Time a connection will wait when the database is locked
-
 
 class CacheDatabase:
 

--- a/conan/internal/cache/db/recipes_table.py
+++ b/conan/internal/cache/db/recipes_table.py
@@ -36,6 +36,7 @@ class RecipesDBTable(BaseDbTable):
     def create(self, path, ref: RecipeReference):
         assert ref is not None
         assert ref.revision is not None
+        assert ref.timestamp is not None
         placeholders = ', '.join(['?' for _ in range(len(self.columns))])
         with self.db_connection() as conn:
             try:

--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -212,6 +212,9 @@ class Node(object):
         result["recipe"] = self.recipe
         result["package_id"] = self.package_id
         result["prev"] = self.prev
+        result["rrev"] = self.ref.revision if self.ref is not None else None
+        result["rrev_timestamp"] = self.ref.timestamp if self.ref is not None else None
+        result["prev_timestamp"] = self.pref_timestamp
         result["remote"] = self.remote.name if self.remote else None
         result["binary_remote"] = self.binary_remote.name if self.binary_remote else None
         from conans.client.installer import build_id

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -291,6 +291,7 @@ class GraphBinariesAnalyzer(object):
             node.binary = BINARY_CACHE
             node.binary_remote = None
             node.prev = cache_latest_prev.revision
+            node.pref_timestamp = cache_latest_prev.timestamp
             assert node.prev, "PREV for %s is None" % str(node.pref)
 
     def _evaluate_package_id(self, node):

--- a/conans/client/graph/proxy.py
+++ b/conans/client/graph/proxy.py
@@ -135,7 +135,7 @@ class ConanProxy:
 
     def _download(self, ref, remote):
         assert ref.revision
+        assert ref.timestamp
         self._remote_manager.get_recipe(ref, remote)
-        self._cache.update_recipe_timestamp(ref)
         output = ConanOutput(scope=str(ref))
         output.info("Downloaded recipe revision %s" % ref.revision)

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -41,6 +41,7 @@ class RemoteManager(object):
 
     def get_recipe(self, ref, remote, metadata=None):
         assert ref.revision, "get_recipe without revision specified"
+        assert ref.timestamp, "get_recipe without ref.timestamp specified"
 
         layout = self._cache.get_or_create_ref_layout(ref)
         layout.export_remove()

--- a/conans/test/integration/command_v2/test_combined_pkglist_flows.py
+++ b/conans/test/integration/command_v2/test_combined_pkglist_flows.py
@@ -91,8 +91,8 @@ class TestCreateGraphToPkgList:
         c.run("list --graph=graph.json --graph-recipes=* --format=json")
         pkglist = json.loads(c.stdout)["Local Cache"]
         assert len(pkglist) == 2
-        assert len(pkglist["app/1.0"]["revisions"]["0fa1ff1b90576bb782600e56df642e19"]) == 0
-        assert len(pkglist["zlib/1.0"]["revisions"]["c570d63921c5f2070567da4bf64ff261"]) == 0
+        assert "packages" not in pkglist["app/1.0"]["revisions"]["0fa1ff1b90576bb782600e56df642e19"]
+        assert "packages" not in pkglist["zlib/1.0"]["revisions"]["c570d63921c5f2070567da4bf64ff261"]
 
 
 class TestGraphInfoToPkgList:

--- a/conans/test/integration/test_db_error.py
+++ b/conans/test/integration/test_db_error.py
@@ -1,0 +1,22 @@
+import os
+import shutil
+
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.tools import TestClient
+
+
+def test_db_error():
+    # https://github.com/conan-io/conan/issues/14517
+    c = TestClient(default_server_user=True)
+    c.save({"liba/conanfile.py": GenConanfile("liba", "0.1")})
+    c.run("create liba")
+    c.run("install --requires=liba/0.1 --format=json", redirect_stdout="graph.json")
+    c.run("list --graph=graph.json --format=json", redirect_stdout="installed.json")
+    c.run("upload --list=installed.json -r=default --format=json -c", redirect_stdout="upload.json")
+
+    c2 = TestClient(servers=c.servers, inputs=["admin", "password"])
+    shutil.copy(os.path.join(c.current_folder, "upload.json"), c2.current_folder)
+    print(c2.load("upload.json"))
+    c2.run("download --list=upload.json -r=default --format=json")
+    print(c2.out)
+

--- a/conans/test/integration/test_db_error.py
+++ b/conans/test/integration/test_db_error.py
@@ -11,7 +11,9 @@ def test_db_error():
     c.save({"liba/conanfile.py": GenConanfile("liba", "0.1")})
     c.run("create liba")
     c.run("install --requires=liba/0.1 --format=json", redirect_stdout="graph.json")
+    print(c.load("graph.json"))
     c.run("list --graph=graph.json --format=json", redirect_stdout="installed.json")
+    print(c.load("installed.json"))
     c.run("upload --list=installed.json -r=default --format=json -c", redirect_stdout="upload.json")
 
     c2 = TestClient(servers=c.servers, inputs=["admin", "password"])

--- a/conans/test/integration/test_db_error.py
+++ b/conans/test/integration/test_db_error.py
@@ -11,14 +11,11 @@ def test_db_error():
     c.save({"liba/conanfile.py": GenConanfile("liba", "0.1")})
     c.run("create liba")
     c.run("install --requires=liba/0.1 --format=json", redirect_stdout="graph.json")
-    print(c.load("graph.json"))
     c.run("list --graph=graph.json --format=json", redirect_stdout="installed.json")
-    print(c.load("installed.json"))
     c.run("upload --list=installed.json -r=default --format=json -c", redirect_stdout="upload.json")
 
     c2 = TestClient(servers=c.servers, inputs=["admin", "password"])
     shutil.copy(os.path.join(c.current_folder, "upload.json"), c2.current_folder)
-    print(c2.load("upload.json"))
     c2.run("download --list=upload.json -r=default --format=json")
-    print(c2.out)
-
+    # This used to crash
+    assert "liba/0.1: Downloaded package revision" in c2.out


### PR DESCRIPTION
Changelog: Bugfix: Avoid DB errors when timestamp is not provided to ``conan download`` when using package lists.
Changelog: Feature: Add ``rrev``, ``rrev_timestamp`` and ``prev_timestamp`` to the graph json serialization.
Docs: Omit

Close https://github.com/conan-io/conan/issues/14517
