### PR TITLE
serialize and list python_requires

### DIFF
--- a/conan/api/model.py
+++ b/conan/api/model.py
@@ -93,6 +93,21 @@ class MultiPackagesList:
             if any(r == "*" or r == recipe for r in recipes):
                 cache_list.add_refs([ref])
 
+            # We need to add the python_requires too
+            python_requires = node["python_requires"]
+            if python_requires is not None:
+                for pyref, pyreq in python_requires.items():
+                    pyrecipe = pyreq["recipe"]
+                    if pyrecipe == RECIPE_EDITABLE:
+                        continue
+                    pyref = RecipeReference.loads(pyref)
+                    if any(r == "*" or r == pyrecipe for r in recipes):
+                        cache_list.add_refs([pyref])
+                    pyremote = pyreq["remote"]
+                    if pyremote:
+                        remote_list = pkglist.lists.setdefault(pyremote, PackagesList())
+                        remote_list.add_refs([pyref])
+
             remote = node["remote"]
             if remote:
                 remote_list = pkglist.lists.setdefault(remote, PackagesList())

--- a/conans/client/graph/python_requires.py
+++ b/conans/client/graph/python_requires.py
@@ -14,11 +14,18 @@ class PyRequire(object):
         self.recipe = recipe_status
         self.remote = remote
 
+    def serialize(self):
+        return {"remote": self.remote.name if self.remote is not None else None,
+                "recipe": self.recipe}
+
 
 class PyRequires(object):
     """ this is the object that replaces the declared conanfile.py_requires"""
     def __init__(self):
         self._pyrequires = {}  # {pkg-name: PythonRequire}
+
+    def serialize(self):
+        return {r.ref.repr_notime(): r.serialize() for r in self._pyrequires.values()}
 
     def all_refs(self):
         return [r.ref for r in self._pyrequires.values()]

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -149,8 +149,11 @@ class ConanFile:
             result["license"] = list(self.license) if not isinstance(self.license, str) else self.license
 
         result["requires"] = self.requires.serialize()
+
         if hasattr(self, "python_requires"):
-            result["python_requires"] = [r.repr_notime() for r in self.python_requires.all_refs()]
+            result["python_requires"] = self.python_requires.serialize()
+        else:
+            result["python_requires"] = None
         result["system_requires"] = self.system_requires
 
         result["recipe_folder"] = self.recipe_folder

--- a/conans/test/integration/command/info/info_test.py
+++ b/conans/test/integration/command/info/info_test.py
@@ -195,11 +195,11 @@ class TestAdvancedCliOutput:
         client.save({"conanfile.py": conanfile})
 
         client.run("graph info .")
-        assert "python_requires: ['tool/0.1#4d670581ccb765839f2239cc8dff8fbd']" in client.out
+        assert "python_requires:\n    tool/0.1#4d670581ccb765839f2239cc8dff8fbd" in client.out
 
         client.run("graph info . --format=json")
         info = json.loads(client.stdout)
-        assert info["graph"]["nodes"]["0"]["python_requires"] == ['tool/0.1#4d670581ccb765839f2239cc8dff8fbd']
+        assert "tool/0.1#4d670581ccb765839f2239cc8dff8fbd" in info["graph"]["nodes"]["0"]["python_requires"]
 
     def test_build_id_info(self):
         client = TestClient()

--- a/conans/test/integration/command_v2/test_combined_pkglist_flows.py
+++ b/conans/test/integration/command_v2/test_combined_pkglist_flows.py
@@ -94,6 +94,27 @@ class TestCreateGraphToPkgList:
         assert len(pkglist["app/1.0"]["revisions"]["0fa1ff1b90576bb782600e56df642e19"]) == 0
         assert len(pkglist["zlib/1.0"]["revisions"]["c570d63921c5f2070567da4bf64ff261"]) == 0
 
+    def test_graph_pkg_list_python_requires(self):
+        """
+        include python_requires too
+        """
+        c = TestClient(default_server_user=True)
+        c.save({"pytool/conanfile.py": GenConanfile("pytool", "0.1"),
+                "zlib/conanfile.py": GenConanfile("zlib", "1.0").with_python_requires("pytool/0.1"),
+                "app/conanfile.py": GenConanfile("app", "1.0").with_requires("zlib/1.0")})
+        c.run("create pytool")
+        c.run("create zlib")
+        c.run("upload * -c -r=default")
+        c.run("remove * -c")
+        c.run("create app --format=json", redirect_stdout="graph.json")
+        c.run("list --graph=graph.json --format=json")
+        pkglist = json.loads(c.stdout)["Local Cache"]
+        assert len(pkglist) == 3
+        assert "96aec08148a2392127462c800e1c8af6" in pkglist["pytool/0.1"]["revisions"]
+        pkglist = json.loads(c.stdout)["default"]
+        assert len(pkglist) == 2
+        assert "96aec08148a2392127462c800e1c8af6" in pkglist["pytool/0.1"]["revisions"]
+
 
 class TestGraphInfoToPkgList:
     def test_graph_pkg_list_only_built(self):


### PR DESCRIPTION
Changelog: Feature: Serialization of graph with ``--format=json`` adds information to ``python_requires`` so ``conan list --graph`` can list ``python_requires`` too.
Docs: Omit
