### PR TITLE
serialize booleans in ConanFileDependencies

### DIFF
--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -147,10 +147,13 @@ class Requirement:
         return "{}, Traits: {}".format(self.ref, traits)
 
     def serialize(self):
-        serializable = ("ref", "run", "libs", "skip", "test", "force", "direct", "build",
+        result = {"ref": str(self.ref)}
+        serializable = ("run", "libs", "skip", "test", "force", "direct", "build",
                         "transitive_headers", "transitive_libs", "headers",
                         "package_id_mode", "visible")
-        return {attribute: str(getattr(self, attribute)) for attribute in serializable}
+        for attribute in serializable:
+            result[attribute] = getattr(self, attribute)
+        return result
 
     def copy_requirement(self):
         return Requirement(self.ref, headers=self.headers, libs=self.libs, build=self.build,

--- a/conans/test/integration/command/create_test.py
+++ b/conans/test/integration/command/create_test.py
@@ -457,14 +457,14 @@ def test_create_format_json():
                                          'compiler.libcxx': 'libstdc++', 'compiler.version': '12',
                                          'os': 'Linux'}
     consumer_deps = {
-        '1': {'ref': 'hello/0.1', 'run': 'False', 'libs': 'True', 'skip': 'False',
-              'test': 'False', 'force': 'False', 'direct': 'True', 'build': 'False',
-              'transitive_headers': 'None', 'transitive_libs': 'None', 'headers': 'True',
-              'package_id_mode': 'None', 'visible': 'True'},
-        '2': {'ref': 'pkg/0.2', 'run': 'False', 'libs': 'True', 'skip': 'False', 'test': 'False',
-              'force': 'False', 'direct': 'False', 'build': 'False', 'transitive_headers': 'None',
-              'transitive_libs': 'None', 'headers': 'True', 'package_id_mode': 'None',
-              'visible': 'True'}
+        '1': {'ref': 'hello/0.1', 'run': False, 'libs': True, 'skip': False,
+              'test': False, 'force': False, 'direct': True, 'build': False,
+              'transitive_headers': None, 'transitive_libs': None, 'headers': True,
+              'package_id_mode': None, 'visible': True},
+        '2': {'ref': 'pkg/0.2', 'run': False, 'libs': True, 'skip': False, 'test': False,
+              'force': False, 'direct': False, 'build': False, 'transitive_headers': None,
+              'transitive_libs': None, 'headers': True, 'package_id_mode': None,
+              'visible': True}
     }
     assert consumer_info["dependencies"] == consumer_deps
     # hello/0.1 pkg information
@@ -474,10 +474,10 @@ def test_create_format_json():
     assert hello_pkg_info["options"] == {}
     hello_pkg_info_deps = {
         "2": {
-            "ref": "pkg/0.2", "run": "False", "libs": "True", "skip": "False", "test": "False",
-            "force": "False", "direct": "True", "build": "False", "transitive_headers": "None",
-            "transitive_libs": "None", "headers": "True", "package_id_mode": "semver_mode",
-            "visible": "True"
+            "ref": "pkg/0.2", "run": False, "libs": True, "skip": False, "test": False,
+            "force": False, "direct": True, "build": False, "transitive_headers": None,
+            "transitive_libs": None, "headers": True, "package_id_mode": "semver_mode",
+            "visible": True
         }
     }
     assert hello_pkg_info["dependencies"] == hello_pkg_info_deps

--- a/conans/test/integration/command_v2/test_inspect.py
+++ b/conans/test/integration/command_v2/test_inspect.py
@@ -130,10 +130,10 @@ def test_requiremens_inspect():
             'options:',
             'options_definitions:',
             'package_type: None',
-            "requires: [{'ref': 'zlib/1.2.13', 'run': 'False', 'libs': 'True', 'skip': "
-            "'False', 'test': 'False', 'force': 'False', 'direct': 'True', 'build': "
-            "'False', 'transitive_headers': 'None', 'transitive_libs': 'None', 'headers': "
-            "'True', 'package_id_mode': 'None', 'visible': 'True'}]",
+            "requires: [{'ref': 'zlib/1.2.13', 'run': False, 'libs': True, 'skip': "
+            "False, 'test': False, 'force': False, 'direct': True, 'build': "
+            "False, 'transitive_headers': None, 'transitive_libs': None, 'headers': "
+            "True, 'package_id_mode': None, 'visible': True}]",
             'revision_mode: hash'] == tc.out.splitlines()
 
 


### PR DESCRIPTION
Changelog: Fix: Serialize booleans of ``dependencies`` in ``--format=json`` for graphs as booleans, not strings.
Docs: https://github.com/conan-io/docs/pull/3334


