### PR TITLE
check and raise for wrong ConanCenter URL

### DIFF
--- a/conans/client/cache/remote_registry.py
+++ b/conans/client/cache/remote_registry.py
@@ -128,6 +128,10 @@ class RemoteRegistry(object):
         :param url: URL to be validated
         """
         if url:
+            if url.startswith("https://conan.io/center"):
+                raise ConanException("Wrong ConanCenter remote URL. You are adding the web "
+                                     "https://conan.io/center the correct remote API is "
+                                     "https://center.conan.io")
             address = urlparse(url)
             if not all([address.scheme, address.netloc]):
                 self._output.warning("The URL '%s' is invalid. It must contain scheme and hostname."

--- a/conans/test/integration/command/remote_test.py
+++ b/conans/test/integration/command/remote_test.py
@@ -326,3 +326,15 @@ def test_add_duplicated_name_url():
     assert "WARN: Remote 'remote1' already exists in remotes" in c.out
     c.run("remote list")
     assert 1 == str(c.out).count("remote1")
+
+
+def test_add_wrong_conancenter():
+    """ Avoid common error of adding the wrong ConanCenter URL
+    """
+    c = TestClient()
+    c.run("remote add whatever https://conan.io/center", assert_error=True)
+    assert "Wrong ConanCenter remote URL. You are adding the web https://conan.io/center" in c.out
+    assert "the correct remote API is https://center.conan.io" in c.out
+    c.run("remote update conancenter --url=https://conan.io/center", assert_error=True)
+    assert "Wrong ConanCenter remote URL. You are adding the web https://conan.io/center" in c.out
+    assert "the correct remote API is https://center.conan.io" in c.out


### PR DESCRIPTION
Changelog: Feature: Raise an error if users are adding incorrect ConanCenter web URL as remote.
Docs: Omit

Close https://github.com/conan-io/web/issues/86
(and avoid similar issues in the future)
