### PR TITLE
Allow settings_target across compatibility method

### DIFF
--- a/conans/client/graph/compatibility.py
+++ b/conans/client/graph/compatibility.py
@@ -122,6 +122,6 @@ class BinaryCompatibility:
                     compat_info.options.update(options_values=OrderedDict(options))
                 result.append(compat_info)
                 settings_target = elem.get("settings_target")
-                if settings_target:
+                if settings_target and compat_info.settings_target:
                     compat_info.settings_target.update_values(settings_target)
         return result

--- a/conans/client/graph/compatibility.py
+++ b/conans/client/graph/compatibility.py
@@ -96,6 +96,7 @@ class BinaryCompatibility:
             # use the compatible ones
             conanfile.info = c
             conanfile.settings = c.settings
+            conanfile.settings_target = c.settings_target
             conanfile.options = c.options
             run_validate_package_id(conanfile)
             pid = c.package_id()
@@ -120,4 +121,7 @@ class BinaryCompatibility:
                 if options:
                     compat_info.options.update(options_values=OrderedDict(options))
                 result.append(compat_info)
+                settings_target = elem.get("settings_target")
+                if settings_target:
+                    compat_info.settings_target.update_values(settings_target)
         return result

--- a/conans/client/graph/compute_pid.py
+++ b/conans/client/graph/compute_pid.py
@@ -63,6 +63,10 @@ def compute_package_id(node, new_config):
 
     run_validate_package_id(conanfile)
 
+    if (conanfile.info.settings_target):
+        # settings_target has beed added to conan package via package_id api
+        conanfile.original_info.settings_target = conanfile.info.settings_target
+
     info = conanfile.info
     node.package_id = info.package_id()
 

--- a/conans/client/graph/compute_pid.py
+++ b/conans/client/graph/compute_pid.py
@@ -63,7 +63,7 @@ def compute_package_id(node, new_config):
 
     run_validate_package_id(conanfile)
 
-    if (conanfile.info.settings_target):
+    if conanfile.info.settings_target:
         # settings_target has beed added to conan package via package_id api
         conanfile.original_info.settings_target = conanfile.info.settings_target
 

--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -325,6 +325,7 @@ class ConanInfo:
         result.build_requires = self.build_requires.copy()
         result.python_requires = self.python_requires.copy()
         result.conf = self.conf.copy()
+        result.settings_target = self.settings_target.copy() if self.settings_target else None
         return result
 
     def dumps(self):

--- a/conans/test/integration/package_id/test_validate.py
+++ b/conans/test/integration/package_id/test_validate.py
@@ -6,7 +6,7 @@ import unittest
 
 import pytest
 
-from conan.cli.exit_codes import ERROR_INVALID_CONFIGURATION
+from conan.cli.exit_codes import ERROR_INVALID_CONFIGURATION, ERROR_GENERAL
 from conans.client.graph.graph import BINARY_INVALID
 from conans.test.assets.genconanfile import GenConanfile
 from conans.util.files import save
@@ -661,13 +661,13 @@ class TestValidateCppstd:
                    assert_error=True)
         assert 'pkg/0.1: Invalid: I need at least cppstd=14 to be used' in client.out
 
-class TestCompatibleSettingsTarget:
+class TestCompatibleSettingsTarget(unittest.TestCase):
     """ aims to be a very close to real use case of tool being used across different settings_target
     """
-    def test_tool_compatibility_across_different_archs(self):
+    def test_settings_target_in_compatibility_method_within_recipe(self):
         client = TestClient()
         """
-        test a tool which is compatible with multiple target architectures
+        test setting_target in recipe's compatibility method
         """
         tool_conanfile = textwrap.dedent("""
             from conan import ConanFile
@@ -699,7 +699,187 @@ class TestCompatibleSettingsTarget:
                     self.tool_requires("tool/0.1")
             """)
 
-        client.run("create . --name=tool --version=0.1 -s os=Linux -s:h arch=armv6 --build-require")
         client.save({"conanfile.py": app_conanfile})
         client.run("create . --name=app --version=0.1 -s os=Linux -s:h arch=armv7")
-        assert f"Using compatible package '{package_id}'"
+        assert f"Using compatible package '{package_id}'" in client.out
+
+    def test_settings_target_in_compatibility_in_global_compatibility_py(self):
+        client = TestClient()
+        """
+        test setting_target in global compatibility method
+        """
+        compat = textwrap.dedent("""\
+            def compatibility(self):
+                if self.settings_target.arch == "armv7":
+                    return [{"settings_target": [("arch", "armv6")]}]
+            """)
+        save(os.path.join(client.cache.plugins_path, "compatibility/compatibility.py"), compat)
+
+        tool_conanfile = textwrap.dedent("""
+            from conan import ConanFile
+
+            class Pkg(ConanFile):
+                settings = "arch"
+
+                def package_id(self):
+                    self.info.settings_target = self.settings_target
+                    for field in self.info.settings_target.fields:
+                        if field != "arch":
+                            self.info.settings_target.rm_safe(field)
+            """)
+
+        client.save({"conanfile.py": tool_conanfile})
+        package_id = "44fbc30cf7c3dc16d6ebd6e6d2ef26dcba8e2712"
+        client.run("create . --name=tool --version=0.1 -s os=Linux -s:h arch=armv6 --build-require")
+        assert f"tool/0.1: Package '{package_id}' created" in client.out
+
+        app_conanfile = textwrap.dedent("""
+            from conan import ConanFile
+
+            class Pkg(ConanFile):
+                settings = "arch"
+                def requirements(self):
+                    self.tool_requires("tool/0.1")
+            """)
+
+        client.save({"conanfile.py": app_conanfile})
+        client.run("create . --name=app --version=0.1 -s os=Linux -s:h arch=armv7")
+        assert f"Using compatible package '{package_id}'" in client.out
+
+    def test_no_settings_target_in_recipe_but_in_compatibility_method(self):
+        client = TestClient()
+        """
+        test settings_target in compatibility method when recipe is not a build-require
+        this should not crash. When building down-stream package it should end up with
+        ERROR_GENERAL instead of crash
+        """
+
+        tool_conanfile = textwrap.dedent("""
+            from conan import ConanFile
+
+            class Pkg(ConanFile):
+                settings = "arch"
+                def compatibility(self):
+                    if self.settings_target.arch == "armv7":
+                        return [{"settings_target": [("arch", "armv6")]}]
+            """)
+
+        client.save({"conanfile.py": tool_conanfile})
+        package_id = "e0a05e2c5c453286adecbc0715588349557b4e88"
+        client.run("create . --name=tool --version=0.1 -s os=Linux -s:h arch=armv6")
+        assert f"tool/0.1: Package '{package_id}' created" in client.out
+
+        app_conanfile = textwrap.dedent("""
+            from conan import ConanFile
+
+            class Pkg(ConanFile):
+                settings = "arch"
+                def requirements(self):
+                    self.tool_requires("tool/0.1")
+            """)
+
+        client.save({"conanfile.py": app_conanfile})
+        error = client.run("create . --name=app --version=0.1 -s os=Linux -s:h arch=armv7", assert_error=True)
+        self.assertEqual(error, ERROR_GENERAL)
+        self.assertIn("ERROR: Missing prebuilt package for 'tool/0.1'", client.out)
+
+    def test_no_settings_target_in_recipe_but_in_global_compatibility(self):
+        client = TestClient()
+        """
+        test settings_target in global compatibility method when recipe is not a build-require
+        this should not crash. When building down-stream package it should end up with
+        ERROR_GENERAL instead of crash
+        """
+        compat = textwrap.dedent("""\
+            def compatibility(self):
+                if self.settings_target.arch == "armv7":
+                    return [{"settings_target": [("arch", "armv6")]}]
+            """)
+        save(os.path.join(client.cache.plugins_path, "compatibility/compatibility.py"), compat)
+
+        tool_conanfile = textwrap.dedent("""
+            from conan import ConanFile
+
+            class Pkg(ConanFile):
+                settings = "arch"
+            """)
+
+        client.save({"conanfile.py": tool_conanfile})
+        package_id = "e0a05e2c5c453286adecbc0715588349557b4e88"
+        client.run("create . --name=tool --version=0.1 -s os=Linux -s:h arch=armv6")
+        assert f"tool/0.1: Package '{package_id}' created" in client.out
+
+        app_conanfile = textwrap.dedent("""
+            from conan import ConanFile
+
+            class Pkg(ConanFile):
+                settings = "arch"
+                def requirements(self):
+                    self.tool_requires("tool/0.1")
+            """)
+
+        client.save({"conanfile.py": app_conanfile})
+        error = client.run("create . --name=app --version=0.1 -s os=Linux -s:h arch=armv7", assert_error=True)
+        self.assertEqual(error, ERROR_GENERAL)
+        self.assertIn("ERROR: Missing prebuilt package for 'tool/0.1'", client.out)
+
+
+    def test_three_packages_with_and_without_settings_target(self):
+        client = TestClient()
+        """
+        test 3 packages, tool_a and tool_b have a mutual downstream package (app), and when
+        build app it should find tool_a (a compatible version of it), and find tool_b,
+        and conan create should be successful.
+        """
+        compat = textwrap.dedent("""\
+            def compatibility(self):
+                if self.settings_target.arch == "armv7":
+                    return [{"settings_target": [("arch", "armv6")]}]
+            """)
+        save(os.path.join(client.cache.plugins_path, "compatibility/compatibility.py"), compat)
+
+        tool_a_conanfile = textwrap.dedent("""
+            from conan import ConanFile
+
+            class Pkg(ConanFile):
+                settings = "arch"
+
+                def package_id(self):
+                    self.info.settings_target = self.settings_target
+                    for field in self.info.settings_target.fields:
+                        if field != "arch":
+                            self.info.settings_target.rm_safe(field)
+            """)
+
+        client.save({"conanfile.py": tool_a_conanfile})
+        package_id_tool_a = "44fbc30cf7c3dc16d6ebd6e6d2ef26dcba8e2712"
+        client.run("create . --name=tool_a --version=0.1 -s os=Linux -s:h arch=armv6 --build-require")
+        assert f"tool_a/0.1: Package '{package_id_tool_a}' created" in client.out
+
+
+        tool_b_conanfile = textwrap.dedent("""
+            from conan import ConanFile
+
+            class Pkg(ConanFile):
+                settings = "arch"
+            """)
+
+        client.save({"conanfile.py": tool_b_conanfile})
+        package_id_tool_b = "62e589af96a19807968167026d906e63ed4de1f5"
+        client.run("create . --name=tool_b --version=0.1 -s os=Linux -s arch=x86_64")
+        assert f"tool_b/0.1: Package '{package_id_tool_b}' created" in client.out
+
+        app_conanfile = textwrap.dedent("""
+            from conan import ConanFile
+
+            class Pkg(ConanFile):
+                settings = "arch"
+                def requirements(self):
+                    self.tool_requires("tool_a/0.1")
+                    self.tool_requires("tool_b/0.1")
+            """)
+
+        client.save({"conanfile.py": app_conanfile})
+        client.run("create . --name=app --version=0.1 -s os=Linux -s:h arch=armv7 -s:b arch=x86_64")
+        assert f"Using compatible package '{package_id_tool_a}'" in client.out
+        assert package_id_tool_b in client.out


### PR DESCRIPTION
Changelog: Feature: Allow access to `settings_target` in compatibility method.
Docs: Omit

Closes #14527


In the info.py module, following the guidance provided in the comments for the settings_target property, this commit focuses on refining the handling of settings_target within various package methods.

When populating the settings_target property via the package_id() method, the adjustment guarantees that it remains accessible to both the info and original_info methods. By extending its accessibility to these methods, it allows for seamless utilization within the compatibility() method as well.


- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.

--- 
Test Case Result

Before
```
E
E           ======== Computing necessary packages ========
E           tool/0.1: Compatible package ID 30b28f4b57d074979ce37758614b0bd2ca007f31 equal to the default package ID
E           app/0.1: Forced build from source
E           Requirements
E               app/0.1#0a0d67a98e79b54a848dc56809f632a4:4acd47797ab70f037765f4aa81d97e141228872f - Build
E           Build requirements
E               tool/0.1#643d7250bb4082abb8ef774ceb2e720c:30b28f4b57d074979ce37758614b0bd2ca007f31 - Missing
E
E           ======== Installing packages ========
E           ERROR: Missing binary: tool/0.1:30b28f4b57d074979ce37758614b0bd2ca007f31
E
E           tool/0.1: WARN: Can't find a 'tool/0.1' package binary '30b28f4b57d074979ce37758614b0bd2ca007f31' for the configuration:
E           [settings]
E           arch=x86_64
E           [settings_target]
E           arch=armv7
```

After
```
====================================== test session starts ===========================
platform linux -- Python 3.10.6, pytest-6.2.5, py-1.11.0, pluggy-1.2.0
rootdir: /mnt/c/Users/AAli/Desktop/workspace/conan, configfile: pytest.ini
plugins: xdist-3.3.1
collected 1 item

conans/test/integration/package_id/test_validate.py .                                                                                                                                                       [100%]

====================================== 1 passed in 1.14s ==============================
```
