### PR TITLE
Make `conan inspect` use all remotes by default

### DIFF
--- a/conan/cli/commands/inspect.py
+++ b/conan/cli/commands/inspect.py
@@ -25,6 +25,8 @@ def inspect(conan_api, parser, *args):
     parser.add_argument("path", help="Path to a folder containing a recipe (conanfile.py)")
     parser.add_argument("-r", "--remote", default=None, action="append",
                         help="Remote names. Accepts wildcards ('*' means all the remotes available)")
+    group.add_argument("-nr", "--no-remote", action="store_true",
+                       help='Do not use remote, resolve exclusively in the cache')
     parser.add_argument("-l", "--lockfile", action=OnceArgument,
                         help="Path to a lockfile. Use --lockfile=\"\" to avoid automatic use of "
                              "existing 'conan.lock' file")
@@ -37,7 +39,7 @@ def inspect(conan_api, parser, *args):
                                                conanfile_path=path,
                                                cwd=os.getcwd(),
                                                partial=args.lockfile_partial)
-    remotes = conan_api.remotes.list(args.remote) if args.remote else []
+    remotes = conan_api.remotes.list(args.remote) if not args.no_remote else []
     conanfile = conan_api.local.inspect(path, remotes=remotes, lockfile=lockfile)
     result = conanfile.serialize()
     # Some of the serialization info is not initialized so it's pointless to show it to the user

--- a/conan/cli/commands/inspect.py
+++ b/conan/cli/commands/inspect.py
@@ -25,8 +25,8 @@ def inspect(conan_api, parser, *args):
     parser.add_argument("path", help="Path to a folder containing a recipe (conanfile.py)")
     parser.add_argument("-r", "--remote", default=None, action="append",
                         help="Remote names. Accepts wildcards ('*' means all the remotes available)")
-    group.add_argument("-nr", "--no-remote", action="store_true",
-                       help='Do not use remote, resolve exclusively in the cache')
+    parser.add_argument("-nr", "--no-remote", action="store_true",
+                        help='Do not use remote, resolve exclusively in the cache')
     parser.add_argument("-l", "--lockfile", action=OnceArgument,
                         help="Path to a lockfile. Use --lockfile=\"\" to avoid automatic use of "
                              "existing 'conan.lock' file")

--- a/conans/test/integration/command_v2/test_inspect.py
+++ b/conans/test/integration/command_v2/test_inspect.py
@@ -168,9 +168,20 @@ def test_pythonrequires_remote():
             self.version = "1.0"
     """)
     tc.save({"conanfile.py": conanfile})
-    tc.run("inspect . -r default")
+    # Not specifying the remote also works
+    tc.run("inspect .")
+    assert "pyreq/1.0: Downloaded recipe revision 0ca726ab0febe1100901fffb27dc421f" in tc.out
     assert "name: my_company_package" in tc.out
     assert "version: 1.0" in tc.out
+    # It now finds it on the cache, because it was downloaded
+    tc.run("inspect . -nr")
+    assert "name: my_company_package" in tc.out
+    assert "version: 1.0" in tc.out
+    assert "'recipe': 'Cache'" in tc.out
+    tc.run("remove pyreq/* -c")
+    # And now no remotes fails
+    tc.run("inspect . -nr", assert_error=True)
+    assert "Cannot resolve python_requires 'pyreq/1.0': No remote defined" in tc.out
 
 
 def test_serializable_inspect():


### PR DESCRIPTION
Changelog: Fix: Make `conan inspect` use all remotes by default.
Docs: https://github.com/conan-io/docs/pull/3340

This PR homogenizes remote selection behaviour

Close https://github.com/conan-io/conan/issues/14571