### PR TITLE
allow user patches in conandata

### DIFF
--- a/conan/tools/files/patches.py
+++ b/conan/tools/files/patches.py
@@ -28,13 +28,13 @@ def patch(conanfile, base_path=None, patch_file=None, patch_string=None, strip=0
     directory. The folder containing the sources can be customized with the self.folders attribute
     in the layout(self) method.
 
+    :param conanfile: the current recipe, always pass 'self'
     :param base_path: The path is a relative path to conanfile.export_sources_folder unless an
            absolute path is provided.
     :param patch_file: Patch file that should be applied. The path is relative to the
            conanfile.source_folder unless an absolute path is provided.
     :param patch_string: Patch string that should be applied.
     :param strip: Number of folders to be stripped from the path.
-    :param output: Stream object.
     :param fuzz: Should accept fuzzy patches.
     :param kwargs: Extra parameters that can be added and will contribute to output information
     """
@@ -98,11 +98,13 @@ def apply_conandata_patches(conanfile):
             entry = it.copy()
             patch_file = entry.pop("patch_file")
             patch_file_path = os.path.join(conanfile.export_sources_folder, patch_file)
-            if not "patch_description" in entry:
+            if "patch_description" not in entry:
                 entry["patch_description"] = patch_file
             patch(conanfile, patch_file=patch_file_path, **entry)
         elif "patch_string" in it:
             patch(conanfile, **it)
+        elif "patch_user" in it:
+            pass  # This will be managed directly by users, can be a command or a script execution
         else:
             raise ConanException("The 'conandata.yml' file needs a 'patch_file' or 'patch_string'"
                                  " entry for every patch to be applied")

--- a/conans/test/unittests/tools/files/test_patches.py
+++ b/conans/test/unittests/tools/files/test_patches.py
@@ -179,6 +179,19 @@ def test_multiple_no_version(mock_patch_ng):
            in output.getvalue()
 
 
+def test_patch_user(mock_patch_ng):
+    output = RedirectedTestOutput()
+    with redirect_output(output):
+        conanfile = ConanFileMock()
+        conanfile.display_name = 'mocked/ref'
+        conanfile.conan_data = {'patches': [
+            {'patch_user': 'some replace command, the user will handle',
+             'myuserthings': 'other things', },
+        ]}
+        apply_conandata_patches(conanfile)
+        # it doesn't do anything, but it doesn't crash
+
+
 def test_multiple_with_version(mock_patch_ng):
     output = RedirectedTestOutput()
     with redirect_output(output):


### PR DESCRIPTION
Changelog: Feature: Allow ``patch_user`` in ``conandata.yml`` definition for user patches, not handled by ``apply_conandata_patches()``.
Docs: https://github.com/conan-io/docs/pull/3332

Close https://github.com/conan-io/conan/issues/14481