### PR TITLE
fix: Remove conan v2 ready list link

### DIFF
--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -187,7 +187,7 @@ class Cli:
             error = "*********************************************************\n" \
                     f"Recipe '{pkg}' seems broken.\n" \
                     f"It is possible that this recipe is not Conan 2.0 ready\n"\
-                    "If the recipe comes from ConanCenter check: https://conan.io/cci-v2.html\n" \
+                    "If the recipe comes from ConanCenter, report it at https://github.com/conan-io/conan-center-index/issues\n" \
                     "If it is your recipe, check if it is updated to 2.0\n" \
                     "*********************************************************\n"
             ConanOutput().writeln(error, fg=Color.BRIGHT_MAGENTA)
@@ -197,7 +197,7 @@ class Cli:
             error = "*********************************************************\n" \
                     f"Recipe '{pkg}' cannot build its binary\n" \
                     f"It is possible that this recipe is not Conan 2.0 ready\n" \
-                    "If the recipe comes from ConanCenter check: https://conan.io/cci-v2.html\n" \
+                    "If the recipe comes from ConanCenter, report it at https://github.com/conan-io/conan-center-index/issues\n" \
                     "If it is your recipe, check if it is updated to 2.0\n" \
                     "*********************************************************\n"
             ConanOutput().writeln(error, fg=Color.BRIGHT_MAGENTA)


### PR DESCRIPTION
Changelog: Fix: Remove conan v2 ready conan-center link.
Docs: omit

I found this error at https://github.com/conan-io/conan-center-index/pull/18196#issuecomment-1680770672 and the url is not working anymore, so I removed it from the message and added the suggestion to open an issue in cci repo, as soon conan v2 support will be required for all recipes.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
