### PR TITLE
Allow `--format=json` in `conan create` for `python-requires`

### DIFF
--- a/conan/api/subapi/graph.py
+++ b/conan/api/subapi/graph.py
@@ -91,11 +91,10 @@ class GraphAPI:
         app = ConanApp(self.conan_api.cache_folder)
         conanfile = app.loader.load_virtual(requires=requires,
                                             tool_requires=tool_requires,
-                                            python_requires=python_requires)
-        if app.loader._pyreq_loader:
-            app.loader._pyreq_loader.load_py_requires(conanfile, app.loader,
-                                                      lockfile, remotes,
-                                                      update, check_updates)
+                                            python_requires=python_requires,
+                                            graph_lock=lockfile, remotes=remotes,
+                                            update=update, check_updates=check_updates)
+
         consumer_definer(conanfile, profile_host, profile_build)
         root_node = Node(ref=None, conanfile=conanfile, context=CONTEXT_HOST, recipe=RECIPE_VIRTUAL)
         return root_node

--- a/conan/api/subapi/graph.py
+++ b/conan/api/subapi/graph.py
@@ -84,11 +84,18 @@ class GraphAPI:
         root_node = Node(ref, conanfile, recipe=RECIPE_CONSUMER, context=CONTEXT_HOST, path=path)
         return root_node
 
-    def _load_root_virtual_conanfile(self, profile_host, profile_build, requires, tool_requires):
-        if not requires and not tool_requires:
+    def _load_root_virtual_conanfile(self, profile_host, profile_build, requires, tool_requires,
+                                     lockfile, remotes, update, check_updates=False, python_requires=None):
+        if not python_requires and not requires and not tool_requires:
             raise ConanException("Provide requires or tool_requires")
         app = ConanApp(self.conan_api.cache_folder)
-        conanfile = app.loader.load_virtual(requires=requires,  tool_requires=tool_requires)
+        conanfile = app.loader.load_virtual(requires=requires,
+                                            tool_requires=tool_requires,
+                                            python_requires=python_requires)
+        if app.loader._pyreq_loader:
+            app.loader._pyreq_loader.load_py_requires(conanfile, app.loader,
+                                                      lockfile, remotes,
+                                                      update, check_updates)
         consumer_definer(conanfile, profile_host, profile_build)
         root_node = Node(ref=None, conanfile=conanfile, context=CONTEXT_HOST, recipe=RECIPE_VIRTUAL)
         return root_node
@@ -107,7 +114,7 @@ class GraphAPI:
             profile.options.scope(tool_requires[0])
 
     def load_graph_requires(self, requires, tool_requires, profile_host, profile_build,
-                            lockfile, remotes, update, check_updates=False):
+                            lockfile, remotes, update, check_updates=False, python_requires=None):
         requires = [RecipeReference.loads(r) if isinstance(r, str) else r for r in requires] \
             if requires else None
         tool_requires = [RecipeReference.loads(r) if isinstance(r, str) else r
@@ -116,7 +123,10 @@ class GraphAPI:
         self._scope_options(profile_host, requires=requires, tool_requires=tool_requires)
         root_node = self._load_root_virtual_conanfile(requires=requires, tool_requires=tool_requires,
                                                       profile_host=profile_host,
-                                                      profile_build=profile_build)
+                                                      profile_build=profile_build,
+                                                      lockfile=lockfile, remotes=remotes,
+                                                      update=update,
+                                                      python_requires=python_requires)
 
         # check_updates = args.check_updates if "check_updates" in args else False
         deps_graph = self.load_graph(root_node, profile_host=profile_host,

--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -59,11 +59,12 @@ def create(conan_api, parser, *args):
         args.build_test = args.build
 
     if is_python_require:
-        deps_graph = conan_api.graph.load_graph_requires([ref], [],
+        deps_graph = conan_api.graph.load_graph_requires([], [],
                                                          profile_host=profile_host,
                                                          profile_build=profile_build,
                                                          lockfile=lockfile,
-                                                         remotes=remotes, update=args.update)
+                                                         remotes=remotes, update=args.update,
+                                                         python_requires=[ref])
     else:
         requires = [ref] if not args.build_require else None
         tool_requires = [ref] if args.build_require else None

--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -58,8 +58,13 @@ def create(conan_api, parser, *args):
     if args.build is not None and args.build_test is None:
         args.build_test = args.build
 
-    deps_graph = None
-    if not is_python_require:
+    if is_python_require:
+        deps_graph = conan_api.graph.load_graph_requires([ref], [],
+                                                         profile_host=profile_host,
+                                                         profile_build=profile_build,
+                                                         lockfile=lockfile,
+                                                         remotes=remotes, update=args.update)
+    else:
         requires = [ref] if not args.build_require else None
         tool_requires = [ref] if args.build_require else None
         # FIXME: Dirty: package type still raw, not processed yet

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -258,9 +258,7 @@ class ConanFileLoader:
                 conanfile.requires(repr(reference))
 
         if python_requires:
-            conanfile.python_requires = []
-            for python_require in python_requires:
-                conanfile.python_requires.append(python_require.repr_notime())
+            conanfile.python_requires = [pr.repr_notime() for pr in python_requires]
 
         if self._pyreq_loader:
             self._pyreq_loader.load_py_requires(conanfile, self, graph_lock, remotes,

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -244,7 +244,8 @@ class ConanFileLoader:
 
         return conanfile
 
-    def load_virtual(self, requires=None, tool_requires=None, python_requires=None):
+    def load_virtual(self, requires=None, tool_requires=None, python_requires=None, graph_lock=None,
+                     remotes=None, update=None, check_updates=None):
         # If user don't specify namespace in options, assume that it is
         # for the reference (keep compatibility)
         conanfile = ConanFile(display_name="cli")
@@ -259,7 +260,11 @@ class ConanFileLoader:
         if python_requires:
             conanfile.python_requires = []
             for python_require in python_requires:
-                conanfile.python_requires.append(repr(python_require))
+                conanfile.python_requires.append(python_require.repr_notime())
+
+        if self._pyreq_loader:
+            self._pyreq_loader.load_py_requires(conanfile, self, graph_lock, remotes,
+                                                update, check_updates)
 
         conanfile._conan_is_consumer = True
         conanfile.generators = []  # remove the default txt generator

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -244,7 +244,7 @@ class ConanFileLoader:
 
         return conanfile
 
-    def load_virtual(self, requires=None, tool_requires=None):
+    def load_virtual(self, requires=None, tool_requires=None, python_requires=None):
         # If user don't specify namespace in options, assume that it is
         # for the reference (keep compatibility)
         conanfile = ConanFile(display_name="cli")
@@ -255,6 +255,11 @@ class ConanFileLoader:
         if requires:
             for reference in requires:
                 conanfile.requires(repr(reference))
+
+        if python_requires:
+            conanfile.python_requires = []
+            for python_require in python_requires:
+                conanfile.python_requires.append(repr(python_require))
 
         conanfile._conan_is_consumer = True
         conanfile.generators = []  # remove the default txt generator

--- a/conans/test/integration/command/create_test.py
+++ b/conans/test/integration/command/create_test.py
@@ -780,10 +780,13 @@ def test_python_requires_json_format():
            .with_package_type("python-require")})
     c.run("create . --format=json", redirect_stdout="output.json")
     data = json.loads(load(os.path.join(c.current_folder, "output.json")))
+    # There's a graph and the python requires is there
+    assert len(data["graph"]["nodes"]["0"]["python_requires"]) == 1
 
 
 def test_python_requires_with_test_package():
     c = TestClient()
+    # Code comes from the docs
     conanfile = textwrap.dedent("""
     from conan import ConanFile
 
@@ -806,5 +809,5 @@ def test_python_requires_with_test_package():
     """)
     c.save({"conanfile.py": conanfile, "test_package/conanfile.py": test_conanfile})
     c.run("create .")
-    # Ensure that creating a deps graph does not break the testings
+    # Ensure that creating a deps graph does not break the testing
     assert "pyreq/1.0 (test package): 42!!!" in c.out


### PR DESCRIPTION
Changelog: Fix: Allow `--format=json` in `conan create` for `python-requires`
Docs: Omit

Couldn't find anything concrete when testing locally, but this now makes it so calling `conan create .` with `--update` flag for python-requires does _something_ (Updates the recipe times). 

BUT, it's not capable of using a newer recipe _version_