### PR TITLE
Mutually exclude `--remotes` and `--no-remotes` in `conan inspect`

### DIFF
--- a/conan/cli/commands/inspect.py
+++ b/conan/cli/commands/inspect.py
@@ -17,16 +17,18 @@ def inspect_text_formatter(data):
             cli_out_write("{}: {}".format(name, str(value)))
 
 
-@conan_command(group="Consumer", formatters={"text": inspect_text_formatter, "json": default_json_formatter})
+@conan_command(group="Consumer", formatters={"text": inspect_text_formatter,
+                                             "json": default_json_formatter})
 def inspect(conan_api, parser, *args):
     """
     Inspect a conanfile.py to return its public fields.
     """
     parser.add_argument("path", help="Path to a folder containing a recipe (conanfile.py)")
-    parser.add_argument("-r", "--remote", default=None, action="append",
-                        help="Remote names. Accepts wildcards ('*' means all the remotes available)")
-    parser.add_argument("-nr", "--no-remote", action="store_true",
-                        help='Do not use remote, resolve exclusively in the cache')
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("-r", "--remote", default=None, action="append",
+                       help="Remote names. Accepts wildcards ('*' means all the remotes available)")
+    group.add_argument("-nr", "--no-remote", action="store_true",
+                       help='Do not use remote, resolve exclusively in the cache')
     parser.add_argument("-l", "--lockfile", action=OnceArgument,
                         help="Path to a lockfile. Use --lockfile=\"\" to avoid automatic use of "
                              "existing 'conan.lock' file")


### PR DESCRIPTION
Changelog: Omit
Docs: https://github.com/conan-io/docs/pull/3344

Caught this just in time :)
