### PR TITLE
Fix `editable add` remote args

### DIFF
--- a/conan/cli/commands/editable.py
+++ b/conan/cli/commands/editable.py
@@ -23,7 +23,7 @@ def editable_add(conan_api, parser, subparser, *args):
     add_reference_args(subparser)
     subparser.add_argument("-of", "--output-folder",
                            help='The root output folder for generated and build files')
-    group = parser.add_mutually_exclusive_group()
+    group = subparser.add_mutually_exclusive_group()
     group.add_argument("-r", "--remote", action="append", default=None,
                        help='Look in the specified remote or remotes server')
     group.add_argument("-nr", "--no-remote", action="store_true",

--- a/conans/test/integration/editable/editable_add_test.py
+++ b/conans/test/integration/editable/editable_add_test.py
@@ -32,3 +32,15 @@ class TestEditablePackageTest:
         assert "Reference 'lib/version@user/name' in editable mode" in t.out
         t.run('install --requires=lib/version@user/name')
         t.assert_listed_require({"lib/version@user/name": "Editable"})
+
+    def test_pyrequires_remote(self):
+        t = TestClient(default_server_user=True)
+        t.save({"conanfile.py": GenConanfile("pyreq", "1.0")})
+        t.run("create .")
+        t.run("upload pyreq/1.0 -c -r=default")
+        t.run("remove pyreq/1.0 -c")
+        t.save({"conanfile.py": GenConanfile("pkg", "1.0").with_python_requires("pyreq/1.0")})
+        t.run("editable add . -nr", assert_error=True)
+        assert "Cannot resolve python_requires 'pyreq/1.0': No remote defined" in t.out
+        t.run("editable add .")
+        assert "Reference 'pkg/1.0' in editable mode" in t.out


### PR DESCRIPTION
Changelog: Omit
Docs: https://github.com/conan-io/docs/pull/3345

Fix `conan editable` remote args to now properly work - the group was being done in the wrong parser

Found that the new editable remote args were not properly passed. I've fixed it there and checked that the rest of the mutual exclusive groups in the code base is done properly