### PR TITLE
Prettier error on wrong version ranges

### DIFF
--- a/conans/model/version_range.py
+++ b/conans/model/version_range.py
@@ -25,6 +25,8 @@ class _ConditionSet:
     def _parse_expression(expression):
         if expression == "" or expression == "*":
             return [_Condition(">=", Version("0.0.0"))]
+        elif len(expression) == 1:
+            raise ConanException(f'Error parsing version range "{expression}"')
 
         operator = expression[0]
         if operator not in (">", "<", "^", "~", "="):
@@ -38,7 +40,7 @@ class _ConditionSet:
                 index = 2
         version = expression[index:]
         if version == "":
-            raise ConanException(f"Error parsing version range {expression}")
+            raise ConanException(f'Error parsing version range "{expression}"')
         if operator == "~":  # tilde minor
             v = Version(version)
             index = 1 if len(v.main) > 1 else 0

--- a/conans/test/integration/conanfile/required_conan_version_test.py
+++ b/conans/test/integration/conanfile/required_conan_version_test.py
@@ -7,139 +7,134 @@ from conans import __version__
 from conans.test.utils.tools import TestClient
 
 
-class RequiredConanVersionTest(unittest.TestCase):
+def test_required_conan_version():
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
 
-    def test_required_conan_version(self):
-        client = TestClient()
-        conanfile = textwrap.dedent("""
-            from conan import ConanFile
+        required_conan_version = ">=100.0"
 
-            required_conan_version = ">=100.0"
+        class Lib(ConanFile):
+            pass
+        """)
+    client.save({"conanfile.py": conanfile})
+    client.run("export . --name=pkg --version=1.0", assert_error=True)
+    assert f"Current Conan version ({__version__}) does not satisfy the defined one (>=100.0)" in client.out
+    client.run("source . ", assert_error=True)
+    assert f"Current Conan version ({__version__}) does not satisfy the defined one (>=100.0)" in client.out
 
-            class Lib(ConanFile):
-                pass
-            """)
-        client.save({"conanfile.py": conanfile})
-        client.run("export . --name=pkg --version=1.0", assert_error=True)
-        self.assertIn("Current Conan version (%s) does not satisfy the defined one (>=100.0)"
-                      % __version__, client.out)
-        client.run("source . ", assert_error=True)
-        self.assertIn("Current Conan version (%s) does not satisfy the defined one (>=100.0)"
-                      % __version__, client.out)
-        with mock.patch("conans.client.conf.required_version.client_version", "101.0"):
-            client.run("export . --name=pkg --version=1.0")
-
-        with mock.patch("conans.client.conf.required_version.client_version", "101.0-dev"):
-            client.run("export . --name=pkg --version=1.0")
-
-        client.run("install --requires=pkg/1.0@", assert_error=True)
-        self.assertIn("Current Conan version (%s) does not satisfy the defined one (>=100.0)"
-                      % __version__, client.out)
-
-    def test_required_conan_version_with_loading_issues(self):
-        # https://github.com/conan-io/conan/issues/11239
-        client = TestClient()
-        conanfile = textwrap.dedent("""
-                    from conan import missing_import
-
-                    required_conan_version = ">=100.0"
-
-                    class Lib(ConanFile):
-                        pass
-                    """)
-        client.save({"conanfile.py": conanfile})
-        client.run("export . --name=pkg --version=1.0", assert_error=True)
-        self.assertIn("Current Conan version (%s) does not satisfy the defined one (>=100.0)"
-                      % __version__, client.out)
-
-        # Assigning required_conan_version without spaces
-        conanfile = textwrap.dedent("""
-                            from conan import missing_import
-
-                            required_conan_version=">=100.0"
-
-                            class Lib(ConanFile):
-                                pass
-                            """)
-        client.save({"conanfile.py": conanfile})
-        client.run("export . --name=pkg --version=1.0", assert_error=True)
-        self.assertIn("Current Conan version (%s) does not satisfy the defined one (>=100.0)"
-                      % __version__, client.out)
-
-        # If the range is correct, everything works, of course
-        conanfile = textwrap.dedent("""
-                            from conan import ConanFile
-
-                            required_conan_version = ">1.0.0"
-
-                            class Lib(ConanFile):
-                                pass
-                            """)
-        client.save({"conanfile.py": conanfile})
+    with mock.patch("conans.client.conf.required_version.client_version", "101.0"):
         client.run("export . --name=pkg --version=1.0")
 
-    def test_comment_after_required_conan_version(self):
-        """
-        An error used to pop out if you tried to add a comment in the same line than
-        required_conan_version, as it was trying to compare against >=10.0 # This should work
-        instead of just >= 10.0
-        """
-        client = TestClient()
-        conanfile = textwrap.dedent("""
-                    from conan import ConanFile
-                    from LIB_THAT_DOES_NOT_EXIST import MADE_UP_NAME
-                    required_conan_version = ">=10.0" # This should work
-                    class Lib(ConanFile):
-                        pass
-                    """)
-        client.save({"conanfile.py": conanfile})
-        client.run("export . --name=pkg --version=1.0", assert_error=True)
-        self.assertIn("Current Conan version (%s) does not satisfy the defined one (>=10.0)"
-                      % __version__, client.out)
+    with mock.patch("conans.client.conf.required_version.client_version", "101.0-dev"):
+        client.run("export . --name=pkg --version=1.0")
 
-    def test_commented_out_required_conan_version(self):
-        """
-        Used to not be able to comment out required_conan_version if we had to fall back
-        to regex check because of an error importing the recipe
-        """
-        client = TestClient()
-        conanfile = textwrap.dedent("""
-                    from conan import ConanFile
-                    from LIB_THAT_DOES_NOT_EXIST import MADE_UP_NAME
-                    required_conan_version = ">=1.0" # required_conan_version = ">=100.0"
-                    class Lib(ConanFile):
-                        pass
-                    """)
-        client.save({"conanfile.py": conanfile})
-        client.run("export . --name=pkg --version=10.0", assert_error=True)
-        self.assertNotIn("Current Conan version (%s) does not satisfy the defined one (>=1.0)"
-                      % __version__, client.out)
+    client.run("install --requires=pkg/1.0@", assert_error=True)
+    assert f"Current Conan version ({__version__}) does not satisfy the defined one (>=100.0)" in client.out
 
-        client = TestClient()
-        conanfile = textwrap.dedent("""
-                    from conan import ConanFile
-                    from LIB_THAT_DOES_NOT_EXIST import MADE_UP_NAME
-                    # required_conan_version = ">=10.0"
-                    class Lib(ConanFile):
-                        pass
-                    """)
-        client.save({"conanfile.py": conanfile})
-        client.run("export . --name=pkg --version=1.0", assert_error=True)
-        self.assertNotIn("Current Conan version (%s) does not satisfy the defined one (>=10.0)"
-                         % __version__, client.out)
 
-    def test_required_conan_version_invalid_syntax(self):
-        """ required_conan_version used to warn of mismatching versions if spaces were present,
-         but now we have a nicer error"""
-        # https://github.com/conan-io/conan/issues/12692
-        client = TestClient()
-        conanfile = textwrap.dedent("""
-                    from conan import ConanFile
-                    required_conan_version = ">= 1.0"
-                    class Lib(ConanFile):
-                        pass""")
-        client.save({"conanfile.py": conanfile})
-        client.run("export . --name=pkg --version=1.0", assert_error=True)
-        self.assertNotIn(f"Current Conan version ({__version__}) does not satisfy the defined one "
-                        "(>= 1.0)", client.out)
-        self.assertIn("Error parsing version range >=", client.out)
+def test_required_conan_version_with_loading_issues():
+    # https://github.com/conan-io/conan/issues/11239
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+                from conan import missing_import
+
+                required_conan_version = ">=100.0"
+
+                class Lib(ConanFile):
+                    pass
+                """)
+    client.save({"conanfile.py": conanfile})
+    client.run("export . --name=pkg --version=1.0", assert_error=True)
+    assert f"Current Conan version ({__version__}) does not satisfy the defined one (>=100.0)" in client.out
+
+    # Assigning required_conan_version without spaces
+    conanfile = textwrap.dedent("""
+                        from conan import missing_import
+
+                        required_conan_version=">=100.0"
+
+                        class Lib(ConanFile):
+                            pass
+                        """)
+    client.save({"conanfile.py": conanfile})
+    client.run("export . --name=pkg --version=1.0", assert_error=True)
+    assert f"Current Conan version ({__version__}) does not satisfy the defined one (>=100.0)" in client.out
+
+    # If the range is correct, everything works, of course
+    conanfile = textwrap.dedent("""
+                        from conan import ConanFile
+
+                        required_conan_version = ">1.0.0"
+
+                        class Lib(ConanFile):
+                            pass
+                        """)
+    client.save({"conanfile.py": conanfile})
+    client.run("export . --name=pkg --version=1.0")
+    assert "pkg/1.0: Exported" in client.out
+
+
+def test_comment_after_required_conan_version():
+    """
+    An error used to pop out if you tried to add a comment in the same line than
+    required_conan_version, as it was trying to compare against >=10.0 # This should work
+    instead of just >= 10.0
+    """
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+                from conan import ConanFile
+                from LIB_THAT_DOES_NOT_EXIST import MADE_UP_NAME
+                required_conan_version = ">=10.0" # This should work
+                class Lib(ConanFile):
+                    pass
+                """)
+    client.save({"conanfile.py": conanfile})
+    client.run("export . --name=pkg --version=1.0", assert_error=True)
+    assert f"Current Conan version ({__version__}) does not satisfy the defined one (>=10.0)" in client.out
+
+
+def test_commented_out_required_conan_version():
+    """
+    Used to not be able to comment out required_conan_version if we had to fall back
+    to regex check because of an error importing the recipe
+    """
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+                from conan import ConanFile
+                from LIB_THAT_DOES_NOT_EXIST import MADE_UP_NAME
+                required_conan_version = ">=1.0" # required_conan_version = ">=100.0"
+                class Lib(ConanFile):
+                    pass
+                """)
+    client.save({"conanfile.py": conanfile})
+    client.run("export . --name=pkg --version=10.0", assert_error=True)
+    assert f"Current Conan version ({__version__}) does not satisfy the defined one (>=1.0)" not in client.out
+
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+                from conan import ConanFile
+                from LIB_THAT_DOES_NOT_EXIST import MADE_UP_NAME
+                # required_conan_version = ">=10.0"
+                class Lib(ConanFile):
+                    pass
+                """)
+    client.save({"conanfile.py": conanfile})
+    client.run("export . --name=pkg --version=1.0", assert_error=True)
+    assert f"Current Conan version ({__version__}) does not satisfy the defined one (>=10.0)" not in client.out
+
+
+def test_required_conan_version_invalid_syntax():
+    """ required_conan_version used to warn of mismatching versions if spaces were present,
+     but now we have a nicer error"""
+    # https://github.com/conan-io/conan/issues/12692
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+                from conan import ConanFile
+                required_conan_version = ">= 1.0"
+                class Lib(ConanFile):
+                    pass""")
+    client.save({"conanfile.py": conanfile})
+    client.run("export . --name=pkg --version=1.0", assert_error=True)
+    assert f"Current Conan version ({__version__}) does not satisfy the defined one (>= 1.0)" not in client.out
+    assert 'Error parsing version range ">="' in client.out

--- a/conans/test/unittests/model/version/test_version_range.py
+++ b/conans/test/unittests/model/version/test_version_range.py
@@ -87,8 +87,10 @@ def test_range_prereleases_conf(version_range, resolve_prereleases, versions_in,
     for v in versions_out:
         assert not r.contains(Version(v), resolve_prereleases), f"Expected '{version_range}' NOT to contain '{v}' (conf.ranges_resolve_prereleases={resolve_prereleases})"
 
-
-def test_wrong_range_syntax():
-    # https://github.com/conan-io/conan/issues/12692
+@pytest.mark.parametrize("version_range", [
+    ">= 1.0",  # https://github.com/conan-io/conan/issues/12692
+    ">=0.0.1 < 1.0"  # https://github.com/conan-io/conan/issues/14612
+])
+def test_wrong_range_syntax(version_range):
     with pytest.raises(ConanException):
-        VersionRange(">= 1.0")
+        VersionRange(version_range)


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Adds more checks to fail without a trace when a version range has an unexpected space

Closes #14612