### PR TITLE
allow regex pattern for conf tools.info.package_id:confs

### DIFF
--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -473,10 +473,12 @@ class Conf:
         # Reading the list of all the configurations selected by the user to use for the package_id
         package_id_confs = self.get("tools.info.package_id:confs", default=[], check_type=list)
         for conf_name in package_id_confs:
-            value = self.get(conf_name)
-            # Pruning any empty values, those should not affect package ID
-            if value:
-                result.define(conf_name, value)
+            matching_confs = [c for c in self._values if re.match(conf_name, c)] or [conf_name]
+            for name in matching_confs:
+                value = self.get(name)
+                # Pruning any empty values, those should not affect package ID
+                if value:
+                    result.define(name, value)
         return result
 
     def set_relative_base_folder(self, folder):

--- a/conans/test/integration/configuration/conf/test_conf_copy.py
+++ b/conans/test/integration/configuration/conf/test_conf_copy.py
@@ -1,0 +1,59 @@
+import os
+import platform
+import textwrap
+
+import pytest
+from mock import patch
+
+from conan import conan_version
+from conans.errors import ConanException
+from conans.util.files import save, load
+from conans.test.utils.tools import TestClient
+
+from conans.model.conf import Conf
+
+
+def test_copy_conaninfo_conf():
+    conf = Conf()
+
+    conf.define("core:non_interactive", True)
+    conf.define("tools.cmake.cmaketoolchain:generator", True)
+    conf.define("tools.deployer:symlinks", True)
+    conf.define("user.myconf:cmake-test", True)
+
+    pattern = [".*"]
+    conf.define("tools.info.package_id:confs", pattern)
+    result = conf.copy_conaninfo_conf().dumps()
+    assert "tools.info.package_id:confs=%s" % pattern in result
+    assert "core:non_interactive" in result
+    assert "tools.cmake.cmaketoolchain:generator=True" in result
+    assert "tools.deployer:symlinks" in result
+    assert "user.myconf:cmake-test" in result
+
+    pattern = ["tools\..*"]
+    conf.define("tools.info.package_id:confs", pattern)
+    result = conf.copy_conaninfo_conf().dumps()
+    assert "tools.info.package_id:confs=%s" % pattern in result
+    assert "core:non_interactive" not in result
+    assert "tools.cmake.cmaketoolchain:generator=True" in result
+    assert "tools.deployer:symlinks" in result
+    assert "user.myconf:cmake-test" not in result
+
+    pattern = [".*cmake"]
+    conf.define("tools.info.package_id:confs", pattern)
+    result = conf.copy_conaninfo_conf().dumps()
+    assert "tools.info.package_id:confs=%s" % pattern not in result
+    assert "core:non_interactive" not in result
+    assert "tools.cmake.cmaketoolchain:generator=True" in result
+    assert "tools.deployer:symlinks" not in result
+    assert "user.myconf:cmake-test" in result
+
+    pattern = ["(tools.deploy|core)"]
+    conf.define("tools.info.package_id:confs", pattern)
+    result = conf.copy_conaninfo_conf().dumps()
+    assert "tools.info.package_id:confs=%s" % pattern not in result
+    assert "core:non_interactive" in result
+    assert "tools.cmake.cmaketoolchain:generator=True" not in result
+    assert "tools.deployer:symlinks" in result
+    assert "user.myconf:cmake-test" not in result
+


### PR DESCRIPTION
Changelog: Feature: Supporting regex pattern for conf `tools.info.package_id:confs`
Docs: https://github.com/conan-io/docs/pull/3382

Ref: #14620 

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
