### PR TITLE
clear info.conf for header-only libraries

### DIFF
--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -271,6 +271,9 @@ class Conf:
         """
         return other._values == self._values
 
+    def clear(self):
+        self._values.clear()
+
     def validate(self):
         for conf in self._values:
             self._check_conf_name(conf)

--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -392,6 +392,7 @@ class ConanInfo:
         self.settings.clear()
         self.options.clear()
         self.requires.clear()
+        self.conf.clear()
 
     def validate(self):
         # If the options are not fully defined, this is also an invalid case


### PR DESCRIPTION
Changelog: Bugfix: ``tools.info.package_id:confs`` shouldn't affect header-only libraries.
Docs: Omit

