### PR TITLE
cli_out_write: don't decorate data if colors are not set

### DIFF
--- a/conan/api/output.py
+++ b/conan/api/output.py
@@ -227,7 +227,7 @@ def cli_out_write(data, fg=None, bg=None, endline="\n", indentation=0):
 
     fg_ = fg or ''
     bg_ = bg or ''
-    if color_enabled(sys.stdout):
+    if (fg or bg) and color_enabled(sys.stdout):
         data = f"{' ' * indentation}{fg_}{bg_}{data}{Style.RESET_ALL}{endline}"
     else:
         data = f"{' ' * indentation}{data}{endline}"


### PR DESCRIPTION
Changelog: Bugfix: Fix unnecessarily decorating command stdout with escape sequences.
Docs: omit

Fixes #14614.

- [x] Refer to the issue that supports this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
