### PR TITLE
fixing lock create --update

### DIFF
--- a/conan/cli/commands/lock.py
+++ b/conan/cli/commands/lock.py
@@ -43,12 +43,12 @@ def lock_create(conan_api, parser, subparser, *args):
         graph = conan_api.graph.load_graph_consumer(path, args.name, args.version,
                                                     args.user, args.channel,
                                                     profile_host, profile_build, lockfile,
-                                                    remotes, args.build, args.update,
+                                                    remotes, args.update,
                                                     is_build_require=args.build_require)
     else:
         graph = conan_api.graph.load_graph_requires(args.requires, args.tool_requires,
                                                     profile_host, profile_build, lockfile,
-                                                    remotes, args.build, args.update)
+                                                    remotes, args.update)
 
     print_graph_basic(graph)
     graph.report_graph_error()


### PR DESCRIPTION
Changelog: Bugfix: ``conan lock create --update`` now correctly updates references from servers if newer than cache ones.
Docs: Omit

Close https://github.com/conan-io/conan/issues/14631