### PR TITLE
 CMakeDeps: remove warning about existing alias

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/targets.py
+++ b/conan/tools/cmake/cmakedeps/templates/targets.py
@@ -80,8 +80,6 @@ class TargetsTemplate(CMakeDepsFileTemplate):
         if(NOT TARGET {{alias}})
             add_library({{alias}} INTERFACE IMPORTED)
             set_property(TARGET {{ alias }} PROPERTY INTERFACE_LINK_LIBRARIES {{target}})
-        else()
-            message(WARNING "Target name '{{alias}}' already exists.")
         endif()
 
         {%- endfor %}
@@ -93,8 +91,6 @@ class TargetsTemplate(CMakeDepsFileTemplate):
         if(NOT TARGET {{alias}})
             add_library({{alias}} INTERFACE IMPORTED)
             set_property(TARGET {{ alias }} PROPERTY INTERFACE_LINK_LIBRARIES {{target}})
-        else()
-            message(WARNING "Target name '{{alias}}' already exists.")
         endif()
 
             {%- endfor %}

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_aliases.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_aliases.py
@@ -126,6 +126,10 @@ def test_custom_name():
 
 @pytest.mark.tool("cmake")
 def test_collide_global_alias():
+    """
+    FIXME: right now, having multiple aliases with same name doesn't emit any warning/error.
+    Possible alias collisions should be checked in CMakeDeps generator
+    """
     conanfile = textwrap.dedent("""
     from conan import ConanFile
 
@@ -153,11 +157,15 @@ def test_collide_global_alias():
     client.save({"conanfile.py": consumer, "CMakeLists.txt": cmakelists})
     client.run("create .")
 
-    assert "Target name 'hello::hello' already exists." in client.out
+    # assert "Target name 'hello::hello' already exists." in client.out
 
 
 @pytest.mark.tool("cmake")
 def test_collide_component_alias():
+    """
+    FIXME: right now, having multiple aliases with same name doesn't emit any warning/error.
+    Possible alias collisions should be checked in CMakeDeps generator
+    """
     conanfile = textwrap.dedent("""
     from conan import ConanFile
 
@@ -184,4 +192,4 @@ def test_collide_component_alias():
     client.save({"conanfile.py": consumer, "CMakeLists.txt": cmakelists})
     client.run("create .")
 
-    assert "Target name 'hello::buy' already exists." in client.out
+    # assert "Target name 'hello::buy' already exists." in client.out


### PR DESCRIPTION
Changelog: Fix: CMakeDeps: Remove "Target name ... already exists" warning about duplicating aliases.
Docs: omit

This PR benefits #14560 (and #12958)

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
