### PR TITLE
Feature/set meson b_vscrt with clang-cl

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -124,11 +124,12 @@ class MesonToolchain(object):
         cppstd = self._conanfile.settings.get_safe("compiler.cppstd")
         self._cpp_std = to_cppstd_flag(compiler, compiler_version, cppstd)
 
-        if compiler == "msvc":
+        self._b_vscrt = None
+        if compiler in ("msvc", "clang"):
             vscrt = msvc_runtime_flag(self._conanfile)
-            self._b_vscrt = str(vscrt).lower()
-        else:
-            self._b_vscrt = None
+            if vscrt:
+                self._b_vscrt = str(vscrt).lower()
+
         #: Dict-like object that defines Meson``properties`` with ``key=value`` format
         self.properties = {}
         #: Dict-like object that defines Meson ``project options`` with ``key=value`` format

--- a/conans/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/conans/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -1,4 +1,7 @@
+import platform
 import textwrap
+
+import pytest
 
 from conan.tools.meson import MesonToolchain
 from conans.test.utils.tools import TestClient
@@ -165,3 +168,40 @@ def test_deactivate_nowrap():
     content = t.load(MesonToolchain.native_filename)
     assert "wrap_mode " not in content
     assert "nofallback" not in content
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="requires Win")
+# @pytest.mark.tool("visual_studio", "17")
+# @pytest.mark.tool("clang", "16")
+@pytest.mark.parametrize("build_type,runtime,vscrt", [
+    ("Debug", "dynamic", "mdd"),
+    ("Debug", "static", "mtd"),
+    ("Release", "dynamic", "md"),
+    ("Release", "static", "mt")
+])
+def test_clang_cl_vscrt(build_type, runtime, vscrt):
+    profile = textwrap.dedent(f"""
+        [settings]
+        os=Windows
+        arch=x86_64
+        build_type={build_type}
+        compiler=clang
+        compiler.runtime={runtime}
+        compiler.runtime_type={build_type}
+        compiler.runtime_version=v143
+        compiler.version=16
+
+        [conf]
+        tools.cmake.cmaketoolchain:generator=Visual Studio 17
+
+        [buildenv]
+        CC=clang-cl
+        CXX=clang-cl
+   """)
+    t = TestClient()
+    t.save({"conanfile.txt": "[generators]\nMesonToolchain",
+            "profile": profile})
+
+    t.run("install . -pr:h=profile -pr:b=profile")
+    content = t.load(MesonToolchain.native_filename)
+    assert f"b_vscrt = '{vscrt}'" in content


### PR DESCRIPTION
Changelog: Feature: Ensure meson toolchain sets `b_vscrt` with clang-cl.
Docs: Omit

This is a follow up to #https://github.com/conan-io/conan/issues/13424#issuecomment-1471974865, specifically item 3.

* The `if compiler in ("msvc", "clang")` is a bit ugly but as I mentioned in the issue, I couldn't see a way to see if the compiler is really `clang-cl` at that point. Safe enough given the `msvc_runtime_flag` implementation (note I changed it to return `None` for all non-`compiler.runtime` cases such that _b_vscrt is consistently `None`; all other usages seem OK with that).
* Given that, arguably the `if compiler in ("msvc", "clang")` test could be removed. Intel's cl-like frontend?
* In the tests I couldn't get the VS17/clang16 `pytest.mark.tool` working, so they are commented out. I'm sure I'm just missing some magic incantation somewhere despite VS2022 being enable in my env.
* VS 17.7 has bumped clang from 15 -> 16. So I guess if the test runners aren't updated, these tests may fail. I use a jinja profile for clang-cl with this hack: `compiler.version={{ os.popen("clang-cl --version").read().removeprefix("clang version ").split(".")[0] }}`. I guess this could do something similar if necessary?

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
