### PR TITLE
Fix architecture detection when running on native ARM64 windows

### DIFF
--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -331,6 +331,8 @@ def _detected_architecture():
         return "sparc"
     elif "aarch64" in machine:
         return "armv8"
+    elif "ARM64" in machine:
+        return "armv8"
     elif "arm64" in machine:
         return "armv8"
     elif "64" in machine:

--- a/conans/test/unittests/util/detected_architecture_test.py
+++ b/conans/test/unittests/util/detected_architecture_test.py
@@ -31,7 +31,9 @@ class DetectedArchitectureTest(unittest.TestCase):
         ['sparc64', 'sparcv9'],
         ['s390', 's390'],
         ['s390x', 's390x'],
-        ['arm64', "armv8"]
+        ['arm64', "armv8"],
+        ['aarch64', 'armv8'],
+        ['ARM64', 'armv8']
     ])
     def test_various(self, mocked_machine, expected_arch):
 


### PR DESCRIPTION
Changelog: Bugfix: Fix detected CPU architecture when running ``conan profile detect`` on native ARM64 Windows.
Docs: Omit

Close https://github.com/conan-io/conan/issues/14663