### PR TITLE
Add nobara distro -> dnf package manager mapping.

### DIFF
--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -43,7 +43,7 @@ class _SystemPackageManagerTool(object):
                            "apk": ["alpine"],
                            "yum": ["pidora", "scientific", "xenserver", "amazon", "oracle", "amzn",
                                    "almalinux", "rocky"],
-                           "dnf": ["fedora", "rhel", "centos", "mageia"],
+                           "dnf": ["fedora", "rhel", "centos", "mageia", "nobara"],
                            "brew": ["Darwin"],
                            "pacman": ["arch", "manjaro", "msys2", "endeavouros"],
                            "choco": ["Windows"],

--- a/conans/test/integration/tools/system/package_manager_test.py
+++ b/conans/test/integration/tools/system/package_manager_test.py
@@ -48,6 +48,7 @@ def test_msys2():
     ("pidora", "yum"),
     ("rocky", "yum"),
     ("fedora", "dnf"),
+    ("nobara", "dnf"),
     ("arch", "pacman"),
     ("opensuse", "zypper"),
     ("sles", "zypper"),


### PR DESCRIPTION
Changelog: Feature: Add `nobara` distro to `dnf` package manager mapping.
Docs: Omit

- [x] #14665
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
