### PR TITLE
error message for usages of package_folder in generate()

### DIFF
--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -4,7 +4,7 @@ import traceback
 import importlib
 
 from conans.client.subsystems import deduce_subsystem, subsystem_path
-from conans.errors import ConanException, conanfile_exception_formatter
+from conans.errors import ConanException, conanfile_exception_formatter, conanfile_remove_attr
 from conans.util.files import save, mkdir, chdir
 
 _generators = {"CMakeToolchain": "conan.tools.cmake", "CMakeDeps": "conan.tools.cmake",
@@ -106,7 +106,9 @@ def write_generators(conanfile, app):
         mkdir(new_gen_folder)
         with chdir(new_gen_folder):
             with conanfile_exception_formatter(conanfile, "generate"):
+                setattr(conanfile, "_conan_generate_package_folder", True)
                 conanfile.generate()
+                delattr(conanfile, "_conan_generate_package_folder")
 
     if conanfile.virtualbuildenv:
         mkdir(new_gen_folder)

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -301,6 +301,9 @@ class ConanFile:
 
         :return: A string with the path to the package folder.
         """
+        if hasattr(self, "_conan_generate_package_folder"):
+            self.output.error("'self.package_folder' can't be used in 'generate()', "
+                              "please remove it, use 'self.build_folder' instead")
         return self.folders.base_package
 
     @property

--- a/conans/test/integration/generators/generators_test.py
+++ b/conans/test/integration/generators/generators_test.py
@@ -1,3 +1,5 @@
+import textwrap
+
 from conans.test.utils.tools import TestClient
 
 
@@ -8,3 +10,15 @@ class TestGenerators:
         client.save({"conanfile.txt": "[generators]\nunknown"})
         client.run("install . --build=*", assert_error=True)
         assert "ERROR: Invalid generator 'unknown'. Available types:" in client.out
+
+    def test_generate_package_folder_deprecation(self):
+        c = TestClient()
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            class Pkg(ConanFile):
+                def generate(self):
+                    self.package_folder
+                """)
+        c.save({"conanfile.py": conanfile})
+        c.run("install .")
+        assert "ERROR: 'self.package_folder' can't be used in 'generate()'" in c.out


### PR DESCRIPTION
Changelog: Fix: Show error message if using ``self.package_folder`` in ``generate()`` method.
Docs: TODO

NOTE: The implementation is not great, but python magic to patch the conanfile was also not great, too complicated. We are already doing it in ``conanfile_remove_attr``, but a passthrough error msg was a bit more complicated. Open to suggestions and ideas.