### PR TITLE
Fix skipped binaries that depends on non-skipped binaries

### DIFF
--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -32,7 +32,7 @@ class Requirement:
         self.overriden_ref = None  # to store if the requirement has been overriden (store old ref)
         self.override_ref = None  # to store if the requirement has been overriden (store new ref)
         self.is_test = test  # to store that it was a test, even if used as regular requires too
-        self.skip = None
+        self.skip = False
 
     @property
     def files(self):  # require needs some files in dependency package

--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -32,10 +32,11 @@ class Requirement:
         self.overriden_ref = None  # to store if the requirement has been overriden (store old ref)
         self.override_ref = None  # to store if the requirement has been overriden (store new ref)
         self.is_test = test  # to store that it was a test, even if used as regular requires too
+        self.skip = None
 
     @property
-    def skip(self):
-        return not (self.headers or self.libs or self.run or self.build)
+    def files(self):  # require needs some files in dependency package
+        return self.headers or self.libs or self.run or self.build
 
     @staticmethod
     def _default_if_none(field, default_value):


### PR DESCRIPTION
Changelog: Bugfix: Do not binary-skip packages that have transitive dependencies that are not skipped, otherwise the build chain of build systems to those transitive dependencies like ``CMakeDeps`` generated files are broken.
Docs: Omit

Close https://github.com/conan-io/conan/issues/14541
