### PR TITLE
Support clang-cl in default profile plugin

### DIFF
--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -30,7 +30,7 @@ _default_profile_plugin = """\
 
 def profile_plugin(profile):
     settings = profile.settings
-    if settings.get("compiler") == "msvc" and settings.get("compiler.runtime"):
+    if settings.get("compiler") in ("msvc", "clang") and settings.get("compiler.runtime"):
         if settings.get("compiler.runtime_type") is None:
             runtime = "Debug" if settings.get("build_type") == "Debug" else "Release"
             try:

--- a/conans/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/conans/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -171,8 +171,6 @@ def test_deactivate_nowrap():
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="requires Win")
-# @pytest.mark.tool("visual_studio", "17")
-# @pytest.mark.tool("clang", "16")
 @pytest.mark.parametrize("build_type,runtime,vscrt", [
     ("Debug", "dynamic", "mdd"),
     ("Debug", "static", "mtd"),
@@ -187,7 +185,6 @@ def test_clang_cl_vscrt(build_type, runtime, vscrt):
         build_type={build_type}
         compiler=clang
         compiler.runtime={runtime}
-        compiler.runtime_type={build_type}
         compiler.runtime_version=v143
         compiler.version=16
 


### PR DESCRIPTION
Changelog: Feature: Support clang-cl in default profile plugin.
Docs: https://github.com/conan-io/docs/pull/3387

This is a follow up to #https://github.com/conan-io/conan/issues/13424#issuecomment-1471974865, item 2 this time.

It would be nice if `cl` and `clang-cl` were consistent wrt `runtime_type`, though since the profile can set the value explicitly, it's not the end of the world if you think this is a bad idea (as far as I've looked `runtime` would only be set with a `cl`-like compiler, so should be good?).

If it's viable:

* I suppose https://docs.conan.io/2/reference/extensions/profile_plugin.html could do with an update but I'm not sure where that lives (a quick check of the docs and web repos was unsuccessful).
* I've removed `runtime_type` from #14664 tests; the now fail without the plugin change and succeed with. Or maybe there should be a test both with and without?

Thanks

- [x] Refer to the issue that supports this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
