### PR TITLE
[MesonToolchain] Showing a warning message if raw options are used

### DIFF
--- a/conan/tools/meson/helpers.py
+++ b/conan/tools/meson/helpers.py
@@ -1,3 +1,4 @@
+from conan.api.output import ConanOutput
 from conan.tools.build.flags import cppstd_msvc_flag
 from conans.errors import ConanException
 from conans.model.options import _PackageOption
@@ -99,6 +100,10 @@ def to_meson_value(value):
         return 'true' if value else 'false'
     elif isinstance(value, list):
         return '[{}]'.format(', '.join([str(to_meson_value(val)) for val in value]))
+    elif isinstance(value, _PackageOption):
+        ConanOutput().warning(f"Please, do not use a Conan option value directly. "
+                              f"Convert 'options.{value.name}' into a valid Python"
+                              f"data type, e.g, bool(self.options.shared)", warn_tag="deprecated")
     return value
 
 

--- a/conan/tools/meson/helpers.py
+++ b/conan/tools/meson/helpers.py
@@ -99,9 +99,6 @@ def to_meson_value(value):
         return 'true' if value else 'false'
     elif isinstance(value, list):
         return '[{}]'.format(', '.join([str(to_meson_value(val)) for val in value]))
-    elif isinstance(value, _PackageOption):
-        raise ConanException("Conan options cannot be specified directly as a valid Meson data type."
-                             " Please, use another Python data type like int, str, list or boolean.")
     return value
 
 

--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -73,6 +73,10 @@ class _PackageOption:
         return other == self.__str__()
 
     @property
+    def name(self):
+        return self._name
+
+    @property
     def value(self):
         return self._value
 

--- a/conans/test/functional/toolchains/meson/test_meson.py
+++ b/conans/test/functional/toolchains/meson/test_meson.py
@@ -91,6 +91,10 @@ class MesonToolchainTest(TestMesonBase):
                      "main.cpp": app})
         self.t.run("build .", assert_error=True)
         # Using directly the options, the result is -> HELLO_MSG = Hi everyone, which is incorrect
+        assert "WARN: deprecated: Please, do not use a Conan option value directly. " \
+               "Convert 'options.shared' into" in self.t.out
+        assert "WARN: deprecated: Please, do not use a Conan option value directly. " \
+               "Convert 'options.msg' into" in self.t.out
         assert "ERROR: Malformed value in machine file variable 'HELLO_MSG'." in self.t.out
         # Let's transform the Conan option into other allowed data type to solve the issue
         self.t.save({"conanfile.py": conanfile_py.format(msg="str(self.options.msg)")})

--- a/conans/test/functional/toolchains/meson/test_meson.py
+++ b/conans/test/functional/toolchains/meson/test_meson.py
@@ -22,8 +22,8 @@ class MesonToolchainTest(TestMesonBase):
 
         class App(ConanFile):
             settings = "os", "arch", "compiler", "build_type"
-            options = {{"shared": [True, False], "fPIC": [True, False]}}
-            default_options = {{"shared": False, "fPIC": True}}
+            options = {{"shared": [True, False], "fPIC": [True, False], "msg": ["ANY"]}}
+            default_options = {{"shared": False, "fPIC": True, "msg": "Hi everyone!"}}
 
             def config_options(self):
                 if self.settings.os == "Windows":
@@ -44,7 +44,11 @@ class MesonToolchainTest(TestMesonBase):
                 tc.project_options["FALSE_DEFINITION"] = False
                 tc.project_options["INT_DEFINITION"] = 42
                 tc.project_options["ARRAY_DEFINITION"] = ["Text1", "Text2"]
-                tc.project_options["DYNAMIC"] = {dynamic}
+                # Meson converts True/False into true/false boolean values
+                tc.project_options["DYNAMIC"] = self.options.shared
+                # This one will fail because HELLO_MSG = Hi everyone is an invalid value
+                # The good one should be HELLO_MSG = "Hi everyone"
+                tc.project_options["HELLO_MSG"] = {msg}
                 tc.generate()
 
             def build(self):
@@ -79,25 +83,25 @@ class MesonToolchainTest(TestMesonBase):
 
         # Issue related: https://github.com/conan-io/conan/issues/14453
         # At first, let's add a raw option to see that it fails
-        self.t.save({"conanfile.py": conanfile_py.format(dynamic="self.options.shared"),
+        self.t.save({"conanfile.py": conanfile_py.format(msg="self.options.msg"),
                      "meson.build": meson_build,
                      "meson_options.txt": meson_options_txt,
                      "hello.h": hello_h,
                      "hello.cpp": hello_cpp,
                      "main.cpp": app})
         self.t.run("build .", assert_error=True)
-        assert "Conan options cannot be specified directly as a valid Meson data type. " \
-               "Please, use another Python data type like int, str, list or boolean." in self.t.out
+        # Using directly the options, the result is -> HELLO_MSG = Hi everyone, which is incorrect
+        assert "ERROR: Malformed value in machine file variable 'HELLO_MSG'." in self.t.out
         # Let's transform the Conan option into other allowed data type to solve the issue
-        self.t.save({"conanfile.py": conanfile_py.format(dynamic="True if self.options.shared "
-                                                                 "else False")})
+        self.t.save({"conanfile.py": conanfile_py.format(msg="str(self.options.msg)")})
         self.t.run("build .")
         content = self.t.load(os.path.join("build", "gen_folder", "conan_meson_native.ini"))
         self.assertIn("[project options]", content)
         self.assertIn("STRING_DEFINITION = 'Text'", content)
         self.assertIn("TRUE_DEFINITION = true", content)
         self.assertIn("FALSE_DEFINITION = false", content)
-        self.assertIn("DYNAMIC = false", content)
+        self.assertIn("DYNAMIC = False", content)  # Meson transforms correctly this value into bool
+        self.assertIn("HELLO_MSG = 'Hi everyone!'", content)
         self.assertIn("INT_DEFINITION = 42", content)
         self.assertIn("ARRAY_DEFINITION = ['Text1', 'Text2']", content)
         self.assertIn("[built-in options]", content)


### PR DESCRIPTION
Changelog: Feature: MesonToolchain shows a warning message if any options are used directly.
Docs: https://github.com/conan-io/docs/pull/3381
Closes: https://github.com/conan-io/conan/issues/14453