### PR TITLE
Handle the case where `remotes` is `None`.

### DIFF
--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -341,7 +341,7 @@ class GraphBinariesAnalyzer(object):
                     if locked_prev:
                         self._process_locked_node(node, build_mode, locked_prev)
                         continue
-                self._evaluate_node(node, build_mode, remotes, update)
+                self._evaluate_node(node, build_mode, remotes or [], update)
 
         self._skip_binaries(deps_graph)
 


### PR DESCRIPTION
Changelog: (Bugfix): Handle the case where `remotes` is `None` in `evaluate_graph()`

This fixes a regression in conan 2.0.10, introduced in #14467 .

The `remotes` argument to `evaluate_graph()` may be `None`, as is shown by the following stack trace from a `conan export-pkg` command:

```
   File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\conan\cli\commands\export_pkg.py", line 93, in export_pkg
    deps_graph = run_test(conan_api, test_conanfile_path, ref, profile_host, profile_build,
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\conan\cli\commands\test.py", line 70, in run_test
    conan_api.graph.analyze_binaries(deps_graph, build_modes, remotes=remotes, update=update,
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\conan\api\subapi\graph.py", line 201, in analyze_binaries
    binaries_analyzer.evaluate_graph(graph, build_mode, lockfile, remotes, update,
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\conans\client\graph\graph_binaries.py", line 344, in evaluate_graph
    self._evaluate_node(node, build_mode, remotes, update)
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\conans\client\graph\graph_binaries.py", line 137, in _evaluate_node
    self._process_node(node, build_mode, remotes, update)
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\conans\client\graph\graph_binaries.py", line 196, in _process_node
    self._evaluate_download(node, remotes, update)
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\conans\client\graph\graph_binaries.py", line 261, in _evaluate_download
    self._get_package_from_remotes(node, remotes, update)
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\conans\client\graph\graph_binaries.py", line 54, in _get_package_from_remotes
    for r in remotes:
TypeError: 'NoneType' object is not iterable
```

The above-mentioned PR removed handling of that case.
