### PR TITLE
Fix `<host_version>` for recipes that are required as build requirements

### DIFF
--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -410,11 +410,12 @@ class DepsGraphBuilder(object):
             if not requirement.build_require:
                 raise ConanException(f"{current_node.ref} uses '<host_version>' in requires, "
                                      "it is only allowed in tool_requires")
-            transitive = current_node._public_deps.get(ref.name, context="host")
+            transitive = next((dep for dep in current_node.dependencies if
+                  not dep.build_require and dep.require.ref.name == ref.name), None)
             if transitive is None:
                 raise ConanException(
                     f"{current_node.ref} require '{ref}': didn't find a matching host dependency")
-            requirement.ref = transitive.ref
+            requirement.ref = transitive.require.ref
 
         try:
             result = self._proxy.get_recipe(requirement.ref, check_updates, update,

--- a/conans/test/integration/build_requires/build_requires_test.py
+++ b/conans/test/integration/build_requires/build_requires_test.py
@@ -649,9 +649,9 @@ class TestBuildTrackHost:
         c.save({"protobuf/conanfile.py": GenConanfile("protobuf"),
                 "pkg/conanfile.py": pkg,
                 "pkg/test_package/conanfile.py": GenConanfile().with_test("pass")})
-        c.run("create protobuf 1.0@ -s compiler.version=14 -s:b compiler.version=14")
+        c.run("create protobuf 1.0@")
         build_profile = "-pr:b default" if build_profile else ""
-        c.run(f"create pkg {build_profile} -s compiler.version=14 -s:b compiler.version=14")
+        c.run(f"create pkg {build_profile}")
         # works without problem
 
         test = textwrap.dedent("""
@@ -665,7 +665,8 @@ class TestBuildTrackHost:
                         pass
                 """)
         c.save({"pkg/test_package/conanfile.py": test})
-        c.run("create protobuf 1.0@ -s compiler.version=14 -s:b compiler.version=14")
+        c.run("create protobuf 1.0@")
         build_profile = "-pr:b default" if build_profile else ""
-        c.run(f"create pkg {build_profile} -s compiler.version=14 -s:b compiler.version=14")
-        # works without problem
+        # This used to fail
+        c.run(f"create pkg {build_profile}")
+        assert "protobuf/1.0 from local cache - Cache" in c.out

--- a/conans/test/integration/build_requires/build_requires_test.py
+++ b/conans/test/integration/build_requires/build_requires_test.py
@@ -628,3 +628,44 @@ class TestBuildTrackHost:
         c.save({"conanfile.py": GenConanfile("pkg").with_requirement("protobuf/<host_version>")})
         c.run(f"install . {build_profile}", assert_error=True)
         assert "uses '<host_version>' in requires" in c.out
+
+    @pytest.mark.parametrize("build_profile", [False, True])
+    def test_host_version_test_package(self, build_profile):
+        """
+        https://github.com/conan-io/conan/issues/14704
+        """
+        c = TestClient()
+        pkg = textwrap.dedent("""
+                from conan import ConanFile
+                class ProtoBuf(ConanFile):
+                    name = "pkg"
+                    version = "0.1"
+                    def requirements(self):
+                        self.requires("protobuf/[>=1.0]")
+                    def build_requirements(self):
+                        self.tool_requires("protobuf/<host_version>")
+                """)
+        # regular requires test_package
+        c.save({"protobuf/conanfile.py": GenConanfile("protobuf"),
+                "pkg/conanfile.py": pkg,
+                "pkg/test_package/conanfile.py": GenConanfile().with_test("pass")})
+        c.run("create protobuf 1.0@ -s compiler.version=14 -s:b compiler.version=14")
+        build_profile = "-pr:b default" if build_profile else ""
+        c.run(f"create pkg {build_profile} -s compiler.version=14 -s:b compiler.version=14")
+        # works without problem
+
+        test = textwrap.dedent("""
+                from conan import ConanFile
+                class Test(ConanFile):
+                    test_type = "explicit"
+
+                    def build_requirements(self):
+                        self.tool_requires(self.tested_reference_str)
+                    def test(self):
+                        pass
+                """)
+        c.save({"pkg/test_package/conanfile.py": test})
+        c.run("create protobuf 1.0@ -s compiler.version=14 -s:b compiler.version=14")
+        build_profile = "-pr:b default" if build_profile else ""
+        c.run(f"create pkg {build_profile} -s compiler.version=14 -s:b compiler.version=14")
+        # works without problem


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

At the very least the dependency lookup is not correct, but the idea still comes across

Closes #14704 