### PR TITLE
Change the default check=False in conan.tools.system.package_manager.Apt  to True

### DIFF
--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -234,7 +234,7 @@ class Apt(_SystemPackageManagerTool):
 
         self._arch_separator = ":"
 
-    def install(self, packages, recommends=False, **kwargs):
+    def install(self, packages, update=False, check=True, recommends=False):
         """
         Will try to install the list of packages passed as a parameter. Its
         behaviour is affected by the value of ``tools.system.package_manager:mode``
@@ -248,7 +248,8 @@ class Apt(_SystemPackageManagerTool):
         :return: the return code of the executed apt command.
         """
         recommends_str = '' if recommends else '--no-install-recommends '
-        return super(Apt, self).install(packages, recommends=recommends_str, **kwargs)
+        return super(Apt, self).install(packages, update=update, check=check,
+                                        recommends=recommends_str)
 
 
 class Yum(_SystemPackageManagerTool):

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -234,7 +234,7 @@ class Apt(_SystemPackageManagerTool):
 
         self._arch_separator = ":"
 
-    def install(self, packages, update=False, check=False, recommends=False):
+    def install(self, packages, recommends=False, **kwargs):
         """
         Will try to install the list of packages passed as a parameter. Its
         behaviour is affected by the value of ``tools.system.package_manager:mode``
@@ -248,8 +248,7 @@ class Apt(_SystemPackageManagerTool):
         :return: the return code of the executed apt command.
         """
         recommends_str = '' if recommends else '--no-install-recommends '
-        return super(Apt, self).install(packages, update=update, check=check,
-                                        recommends=recommends_str)
+        return super(Apt, self).install(packages, recommends=recommends_str, **kwargs)
 
 
 class Yum(_SystemPackageManagerTool):

--- a/conans/test/integration/tools/system/package_manager_test.py
+++ b/conans/test/integration/tools/system/package_manager_test.py
@@ -100,7 +100,7 @@ def test_apt_install_recommends(recommends, recommends_str):
     with mock.patch('conan.ConanFile.context', new_callable=PropertyMock) as context_mock:
         context_mock.return_value = "host"
         apt = Apt(conanfile)
-        apt.install(["package1", "package2"], recommends=recommends)
+        apt.install(["package1", "package2"], recommends=recommends, check=False)
     assert apt._conanfile.command == "apt-get install -y {}package1 package2".format(recommends_str)
 
 


### PR DESCRIPTION
Changelog: Bugfix: Change the default `check=False` in `conan.tools.system.package_manager.Apt`  to `True` as the other package manager tools.
Docs: https://github.com/conan-io/docs/pull/3380

Closes: https://github.com/conan-io/conan/issues/14708

This PR is just to discuss the idea of changing the default in Apt for check, after the issue in https://github.com/conan-io/conan/issues/14708

I can't find any historical reasons for that change in the default, so it can probably be considered a bug. Apparently, the risk of breaking users who relied on the bug wouldn't be significant, as all existing uses of these tools in the Conan Center Index set the 'check' argument to 'True' explicitly.

