### PR TITLE
profile show --format=json

### DIFF
--- a/conan/cli/commands/profile.py
+++ b/conan/cli/commands/profile.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 from conan.api.output import ConanOutput, cli_out_write
@@ -22,7 +23,14 @@ def profiles_list_cli_output(profiles):
         cli_out_write(p)
 
 
-@conan_subcommand(formatters={"text": print_profiles})
+def json_profiles(profiles):
+    host, build = profiles
+    result = {"host": host.serialize(),
+              "build": build.serialize()}
+    cli_out_write(json.dumps(result))
+
+
+@conan_subcommand(formatters={"text": print_profiles, "json": json_profiles})
 def profile_show(conan_api, parser, subparser, *args):
     """
     Show aggregated profiles from the passed arguments.

--- a/conans/test/integration/command/test_profile.py
+++ b/conans/test/integration/command/test_profile.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 from conans.test.utils.tools import TestClient
@@ -28,3 +29,13 @@ def test_ignore_paths_when_listing_profiles():
     c.run("profile list")
 
     assert ignore_path not in c.out
+
+
+def test_profile_show_json():
+    c = TestClient()
+    c.save({"myprofilewin": "[settings]\nos=Windows",
+            "myprofilelinux": "[settings]\nos=Linux"})
+    c.run("profile show -pr:b=myprofilewin -pr:h=myprofilelinux --format=json")
+    profile = json.loads(c.stdout)
+    assert profile["build"]["settings"] ==  {"os": "Windows"}
+    assert profile["host"]["settings"] == {"os": "Linux"}


### PR DESCRIPTION
Changelog: Feature: Add ``--format=json`` formatter to ``conan profile show`` command
Docs: https://github.com/conan-io/docs/pull/3388

Implement https://github.com/conan-io/conan/issues/14742
