### PR TITLE
CMakeToolchain generator sets `CMAKE_FRAMEWORK_PATH`

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -461,7 +461,11 @@ class FindFiles(Block):
         list(PREPEND CMAKE_MODULE_PATH {{ generators_folder }})
         {% endif %}
 
-        # Definition of CMAKE_PREFIX_PATH, CMAKE_XXXXX_PATH
+        # Definition of CMAKE_PREFIX_PATH, CMAKE_FRAMEWORK_PATH, CMAKE_XXXXX_PATH
+        {% if host_build_paths_root %}
+        # The root dirs of all "host" context dependencies should be considered during find_package()
+        list(PREPEND CMAKE_FRAMEWORK_PATH {{ host_build_paths_root }})
+        {% endif %}
         {% if host_build_paths_noroot %}
         # The explicitly defined "builddirs" of "host" context dependencies must be in PREFIX_PATH
         list(PREPEND CMAKE_PREFIX_PATH {{ host_build_paths_noroot }})
@@ -476,7 +480,7 @@ class FindFiles(Block):
         {% if cmake_library_path %}
         list(PREPEND CMAKE_LIBRARY_PATH {{ cmake_library_path }})
         {% endif %}
-        {% if is_apple and cmake_framework_path %}
+        {% if cmake_framework_path %}
         list(PREPEND CMAKE_FRAMEWORK_PATH {{ cmake_framework_path }})
         {% endif %}
         {% if cmake_include_path %}
@@ -545,8 +549,7 @@ class FindFiles(Block):
                 host_build_paths_noroot.extend(p for p in cppinfo.builddirs)
             host_lib_paths.extend(cppinfo.libdirs)
             host_bin_paths.extend(cppinfo.bindirs)
-            if is_apple_:
-                host_framework_paths.extend(cppinfo.frameworkdirs)
+            host_framework_paths.extend(cppinfo.frameworkdirs)
             host_include_paths.extend(cppinfo.includedirs)
 
         # Read information from build context

--- a/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
+++ b/conans/test/functional/toolchains/cmake/test_cmaketoolchain_paths.py
@@ -75,8 +75,10 @@ def test_cmaketoolchain_path_find_package(package, find_package, settings, find_
             def package(self):
                 self.copy(pattern="*")
             def package_info(self):
-                self.cpp_info.builddirs.append("cmake")
-        """)
+                if "{find_package}" == "module":
+                    # only module paths must be explicitly specified
+                    self.cpp_info.builddirs.append("cmake")
+        """.format(find_package=find_package))
     find = textwrap.dedent("""
         SET({package}_FOUND 1)
         MESSAGE("HELLO FROM THE {package} FIND PACKAGE!")


### PR DESCRIPTION
Changelog: (Feature): CMakeToolchain generator sets CMAKE_FRAMEWORK_PATH to host package roots

Let cmake `find_package()` do its default search procedure instead of maintaining a list of directories as `cpp_info.builddirs`.

With this change users need to maintain only cmake module paths in `cpp_info.builddirs` (containing `FindXXX.cmake`).
cmake config paths (containing `XXX-Config.cmake`) do not need to be maintained anymore.
conan will add each host package root path automatically to `CMAKE_FRAMEWORK_PATH`, which allows cmake to find them automatically when doing its default search procedure 
(Ref: https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-search-procedure)

Statement from Kitware:
```
The CMAKE_FRAMEWORK_PATH variable will be used by find_* commands, on all platforms. 
The main difference is that by default, on non-Mac platforms, find_* will first look for 
CMAKE_PREFIX_PATH variable entries and then  CMAKE_FRAMEWORK_PATH. 
Order is inverted on Mac by default. 
```

Ref: #14334 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
