### PR TITLE
Feature/add an option to install pkgs method

### DIFF
--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -156,9 +156,6 @@ tools_locations = {
         "system": {"path": {'Windows': 'C:/bazel/bin',
                             "Darwin": '/Users/jenkins/bin'}},
     },
-    'scons': {
-        "default": "system"
-    },
     'premake': {
         "exe": "premake5",
         "default": "5.0.0",

--- a/conans/test/functional/toolchains/scons/test_sconsdeps.py
+++ b/conans/test/functional/toolchains/scons/test_sconsdeps.py
@@ -8,7 +8,7 @@ from conans.test.utils.tools import TestClient
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="SCons functional tests"
                                                          "only for Linux")
-@pytest.mark.tool("scons")
+@pytest.mark.tool_scons
 def test_sconsdeps():
     client = TestClient(path_with_spaces=False)
 


### PR DESCRIPTION
Changelog: (Feature): Add a bool qualifier to `install()` method in `package_manager` called `host_tool` that
    indicates whether the package is a host tool or a library.
    According to that the we will install a package for the needed arch (host arch or destination arch which can be different in case of cross building).

This option enables the user controls whether the installed package is for the host or needed for the destination arch, this is useful specifically when cross building and we want to avoid misunderstanding about what we want to install. 

Referred to issue https://github.com/conan-io/conan/issues/14567

Docs: https://github.com/conan-io/docs/pull/XXXX

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
