### PR TITLE
Feature/Add an option to install() method in package_manager

### DIFF
--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -62,9 +62,12 @@ class _SystemPackageManagerTool(object):
                 if d in os_name:
                     return tool
 
-    def get_package_name(self, package):
-        # TODO: should we only add the arch if cross-building?
-        if self._arch in self._arch_names and cross_building(self._conanfile):
+    def get_package_name(self, package, host_package=True):        
+        # Only if the package is for building, for example a library,
+        # we should add the host arch when cross building.
+        # If the package is a tool that should be installed on the current build 
+        # machine we should not add the arch.
+        if self._arch in self._arch_names and cross_building(self._conanfile) and host_package:
             return "{}{}{}".format(package, self._arch_separator,
                                    self._arch_names.get(self._arch))
         return package
@@ -149,7 +152,7 @@ class _SystemPackageManagerTool(object):
             self._conanfile.output.warning(str(error))
         raise ConanException("None of the installs for the package substitutes succeeded.")
 
-    def _install(self, packages, update=False, check=True, **kwargs):
+    def _install(self, packages, update=False, check=True, host_package=True, **kwargs):
         pkgs = self._conanfile.system_requires.setdefault(self._active_tool, {})
         install_pkgs = pkgs.setdefault("install", [])
         install_pkgs.extend(p for p in packages if p not in install_pkgs)
@@ -157,7 +160,7 @@ class _SystemPackageManagerTool(object):
             return
 
         if check or self._mode in (self.mode_check, self.mode_report_installed):
-            packages = self.check(packages)
+            packages = self.check(packages, host_package=host_package)
             missing_pkgs = pkgs.setdefault("missing", [])
             missing_pkgs.extend(p for p in packages if p not in missing_pkgs)
 
@@ -178,7 +181,7 @@ class _SystemPackageManagerTool(object):
             if update:
                 self.update()
 
-            packages_arch = [self.get_package_name(package) for package in packages]
+            packages_arch = [self.get_package_name(package, host_package=host_package) for package in packages]
             if packages_arch:
                 command = self.install_command.format(sudo=self.sudo_str,
                                                       tool=self.tool_name,
@@ -196,8 +199,8 @@ class _SystemPackageManagerTool(object):
             command = self.update_command.format(sudo=self.sudo_str, tool=self.tool_name)
             return self._conanfile_run(command, self.accepted_update_codes)
 
-    def _check(self, packages):
-        missing = [pkg for pkg in packages if self.check_package(self.get_package_name(pkg)) != 0]
+    def _check(self, packages, host_package=True):
+        missing = [pkg for pkg in packages if self.check_package(self.get_package_name(pkg, host_package=host_package)) != 0]
         return missing
 
     def check_package(self, package):
@@ -234,7 +237,7 @@ class Apt(_SystemPackageManagerTool):
 
         self._arch_separator = ":"
 
-    def install(self, packages, update=False, check=True, recommends=False):
+    def install(self, packages, update=False, check=True, host_package=True, recommends=False):
         """
         Will try to install the list of packages passed as a parameter. Its
         behaviour is affected by the value of ``tools.system.package_manager:mode``
@@ -243,13 +246,15 @@ class Apt(_SystemPackageManagerTool):
         :param packages: try to install the list of packages passed as a parameter.
         :param update: try to update the package manager database before checking and installing.
         :param check: check if the packages are already installed before installing them.
+        :param host_package: install the packages for the host machine architecture (the machine
+               that will run the software), it has an effect when cross building.
         :param recommends: if the parameter ``recommends`` is ``False`` it will add the
                ``'--no-install-recommends'`` argument to the *apt-get* command call.
         :return: the return code of the executed apt command.
         """
         recommends_str = '' if recommends else '--no-install-recommends '
         return super(Apt, self).install(packages, update=update, check=check,
-                                        recommends=recommends_str)
+                                        host_package=host_package, recommends=recommends_str)
 
 
 class Yum(_SystemPackageManagerTool):

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -237,7 +237,7 @@ class Apt(_SystemPackageManagerTool):
 
         self._arch_separator = ":"
 
-    def install(self, packages, update=False, check=True, host_package=True, recommends=False):
+    def install(self, packages, update=False, check=True, recommends=False, host_package=True):
         """
         Will try to install the list of packages passed as a parameter. Its
         behaviour is affected by the value of ``tools.system.package_manager:mode``

--- a/conans/test/functional/toolchains/scons/test_sconsdeps.py
+++ b/conans/test/functional/toolchains/scons/test_sconsdeps.py
@@ -8,7 +8,7 @@ from conans.test.utils.tools import TestClient
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="SCons functional tests"
                                                          "only for Linux")
-@pytest.mark.tool_scons
+@pytest.mark.tool("scons")
 def test_sconsdeps():
     client = TestClient(path_with_spaces=False)
 

--- a/conans/test/functional/toolchains/scons/test_sconsdeps.py
+++ b/conans/test/functional/toolchains/scons/test_sconsdeps.py
@@ -8,7 +8,7 @@ from conans.test.utils.tools import TestClient
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="SCons functional tests"
                                                          "only for Linux")
-@pytest.mark.tool("scons")
+@pytest.mark.tool_scons
 def test_sconsdeps():
     client = TestClient(path_with_spaces=False)
 

--- a/conans/test/integration/tools/system/package_manager_test.py
+++ b/conans/test/integration/tools/system/package_manager_test.py
@@ -229,7 +229,7 @@ def test_tools_install_mode_install_different_archs(tool_class, arch_host, resul
             return ["package1", "package2"]
         from conan.tools.system.package_manager import _SystemPackageManagerTool
         with patch.object(_SystemPackageManagerTool, 'check', MagicMock(side_effect=fake_check)):
-            tool.install(["package1", "package2"], host_package=True)
+            tool.install(["package1", "package2"])
 
     assert tool._conanfile.command == result
 

--- a/conans/test/integration/tools/system/package_manager_test.py
+++ b/conans/test/integration/tools/system/package_manager_test.py
@@ -193,7 +193,7 @@ def test_dnf_yum_return_code_100(tool_class, result):
 
 
 @pytest.mark.parametrize("tool_class, arch_host, result", [
-    # not cross-compile -> do not add host architecture
+    # Install host package and not cross-compile -> do not add host architecture
     (Apk, 'x86_64', 'apk add --no-cache package1 package2'),
     (Apt, 'x86_64', 'apt-get install -y --no-install-recommends package1 package2'),
     (Yum, 'x86_64', 'yum install -y package1 package2'),
@@ -204,7 +204,7 @@ def test_dnf_yum_return_code_100(tool_class, result):
     (Chocolatey, 'x86_64', 'choco install --yes package1 package2'),
     (PacMan, 'x86_64', 'pacman -S --noconfirm package1 package2'),
     (Zypper, 'x86_64', 'zypper --non-interactive in package1 package2'),
-    # cross-compile -> add host architecture https://github.com/conan-io/conan/issues/12320
+    # Install host package and cross-compile -> add host architecture
     (Apt, 'x86', 'apt-get install -y --no-install-recommends package1:i386 package2:i386'),
     (Yum, 'x86', 'yum install -y package1.i?86 package2.i?86'),
     (Dnf, 'x86', 'dnf install -y package1.i?86 package2.i?86'),
@@ -229,11 +229,51 @@ def test_tools_install_mode_install_different_archs(tool_class, arch_host, resul
             return ["package1", "package2"]
         from conan.tools.system.package_manager import _SystemPackageManagerTool
         with patch.object(_SystemPackageManagerTool, 'check', MagicMock(side_effect=fake_check)):
-            tool.install(["package1", "package2"])
+            tool.install(["package1", "package2"], host_package=True)
 
     assert tool._conanfile.command == result
 
+@pytest.mark.parametrize("tool_class, arch_host, result", [
+    # Install build machine package and not cross-compile -> do not add host architecture
+    (Apk, 'x86_64', 'apk add --no-cache package1 package2'),
+    (Apt, 'x86_64', 'apt-get install -y --no-install-recommends package1 package2'),
+    (Yum, 'x86_64', 'yum install -y package1 package2'),
+    (Dnf, 'x86_64', 'dnf install -y package1 package2'),
+    (Brew, 'x86_64', 'brew install package1 package2'),
+    (Pkg, 'x86_64', 'pkg install -y package1 package2'),
+    (PkgUtil, 'x86_64', 'pkgutil --install --yes package1 package2'),
+    (Chocolatey, 'x86_64', 'choco install --yes package1 package2'),
+    (PacMan, 'x86_64', 'pacman -S --noconfirm package1 package2'),
+    (Zypper, 'x86_64', 'zypper --non-interactive in package1 package2'),
+    # Install build machine package and cross-compile -> do not add host architecture
+    (Apt, 'x86', 'apt-get install -y --no-install-recommends package1 package2'),
+    (Yum, 'x86', 'yum install -y package1 package2'),
+    (Dnf, 'x86', 'dnf install -y package1 package2'),
+    (Brew, 'x86', 'brew install package1 package2'),
+    (Pkg, 'x86', 'pkg install -y package1 package2'),
+    (PkgUtil, 'x86', 'pkgutil --install --yes package1 package2'),
+    (Chocolatey, 'x86', 'choco install --yes package1 package2'),
+    (PacMan, 'x86', 'pacman -S --noconfirm package1 package2'),
+    (Zypper, 'x86', 'zypper --non-interactive in package1 package2'),
+])
+def test_tools_install_mode_install_to_build_machine_arch(tool_class, arch_host, result):
+    conanfile = ConanFileMock()
+    conanfile.settings = MockSettings({"arch": arch_host})
+    conanfile.settings_build = MockSettings({"arch": "x86_64"})
+    conanfile.conf.define("tools.system.package_manager:tool", tool_class.tool_name)
+    conanfile.conf.define("tools.system.package_manager:mode", "install")
+    with mock.patch('conan.ConanFile.context', new_callable=PropertyMock) as context_mock:
+        context_mock.return_value = "host"
+        tool = tool_class(conanfile)
 
+        def fake_check(*args, **kwargs):
+            return ["package1", "package2"]
+        from conan.tools.system.package_manager import _SystemPackageManagerTool
+        with patch.object(_SystemPackageManagerTool, 'check', MagicMock(side_effect=fake_check)):
+            tool.install(["package1", "package2"], host_package=False)
+
+    assert tool._conanfile.command == result
+    
 @pytest.mark.parametrize("tool_class, result", [
     # cross-compile but arch_names=None -> do not add host architecture
     # https://github.com/conan-io/conan/issues/12320 because the package is archless


### PR DESCRIPTION
Changelog: Feature: Add `host_tool` to `install()` method in `package_manager` to indicate whether the package is a host tool or a library.
Docs: https://github.com/conan-io/docs/pull/3401


According to that the we will install a package for the needed arch (host arch or destination arch which can be different in case of cross building)

This option enables the user controls whether the installed package is for the host or needed for the destination arch, this is useful specifically when cross building and we want to avoid misunderstanding about what we want to install. 

Closes https://github.com/conan-io/conan/issues/14567



- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
