### PR TITLE
Add `--dry-run` for `conan remove`

### DIFF
--- a/conan/cli/commands/remove.py
+++ b/conan/cli/commands/remove.py
@@ -67,7 +67,7 @@ def remove(conan_api: ConanAPI, parser, *args):
     cache_name = "Local Cache" if not remote else remote.name
 
     def confirmation(message):
-        return (args.confirm or ui.request_boolean(message)) and not args.dry_run
+        return args.confirm or ui.request_boolean(message)
 
     if args.list:
         listfile = make_abs_path(args.list)
@@ -90,8 +90,9 @@ def remove(conan_api: ConanAPI, parser, *args):
         packages = ref_bundle.get("packages")
         if packages is None:
             if confirmation(f"Remove the recipe and all the packages of '{ref.repr_notime()}'?"):
-                conan_api.remove.recipe(ref, remote=remote)
-            elif not args.dry_run:
+                if not args.dry_run:
+                    conan_api.remove.recipe(ref, remote=remote)
+            else:
                 ref_dict.pop(ref.revision)
                 if not ref_dict:
                     package_list.recipes.pop(str(ref))
@@ -106,8 +107,9 @@ def remove(conan_api: ConanAPI, parser, *args):
 
         for pref, _ in prefs.items():
             if confirmation(f"Remove the package '{pref.repr_notime()}'?"):
-                conan_api.remove.package(pref, remote=remote)
-            elif not args.dry_run:
+                if not args.dry_run:
+                    conan_api.remove.package(pref, remote=remote)
+            else:
                 pref_dict = packages[pref.package_id]["revisions"]
                 pref_dict.pop(pref.revision)
                 if not pref_dict:

--- a/conan/cli/commands/remove.py
+++ b/conan/cli/commands/remove.py
@@ -9,8 +9,8 @@ from conans.errors import ConanException
 
 
 def summary_remove_list(results):
-    """ Do litte format modification to serialized
-    list bundle so it looks prettier on text output
+    """ Do a little format modification to serialized
+    list bundle, so it looks prettier on text output
     """
     cli_out_write("Remove summary:")
     info = results["results"]
@@ -51,6 +51,8 @@ def remove(conan_api: ConanAPI, parser, *args):
     parser.add_argument('-r', '--remote', action=OnceArgument,
                         help='Will remove from the specified remote')
     parser.add_argument("-l", "--list", help="Package list file")
+    parser.add_argument("--dry-run", default=False, action="store_true",
+                        help="Do not remove any items, only print those which would be removed")
     args = parser.parse_args(*args)
 
     if args.pattern is None and args.list is None:
@@ -65,7 +67,7 @@ def remove(conan_api: ConanAPI, parser, *args):
     cache_name = "Local Cache" if not remote else remote.name
 
     def confirmation(message):
-        return args.confirm or ui.request_boolean(message)
+        return not args.dry_run and (args.confirm or ui.request_boolean(message))
 
     if args.list:
         listfile = make_abs_path(args.list)

--- a/conan/cli/commands/remove.py
+++ b/conan/cli/commands/remove.py
@@ -67,7 +67,7 @@ def remove(conan_api: ConanAPI, parser, *args):
     cache_name = "Local Cache" if not remote else remote.name
 
     def confirmation(message):
-        return not args.dry_run and (args.confirm or ui.request_boolean(message))
+        return (args.confirm or ui.request_boolean(message)) and not args.dry_run
 
     if args.list:
         listfile = make_abs_path(args.list)
@@ -91,7 +91,7 @@ def remove(conan_api: ConanAPI, parser, *args):
         if packages is None:
             if confirmation(f"Remove the recipe and all the packages of '{ref.repr_notime()}'?"):
                 conan_api.remove.recipe(ref, remote=remote)
-            else:
+            elif not args.dry_run:
                 ref_dict.pop(ref.revision)
                 if not ref_dict:
                     package_list.recipes.pop(str(ref))
@@ -107,7 +107,7 @@ def remove(conan_api: ConanAPI, parser, *args):
         for pref, _ in prefs.items():
             if confirmation(f"Remove the package '{pref.repr_notime()}'?"):
                 conan_api.remove.package(pref, remote=remote)
-            else:
+            elif not args.dry_run:
                 pref_dict = packages[pref.package_id]["revisions"]
                 pref_dict.pop(pref.revision)
                 if not pref_dict:

--- a/conans/test/utils/tools.py
+++ b/conans/test/utils/tools.py
@@ -417,7 +417,8 @@ class TestClient(object):
         self.out = ""
         self.stdout = RedirectedTestOutput()
         self.stderr = RedirectedTestOutput()
-        self.user_inputs = RedirectedInputStream(inputs)
+        self.user_inputs = RedirectedInputStream([])
+        self.inputs = inputs or []
 
         # create default profile
         text = default_profiles[platform.system()]
@@ -513,13 +514,14 @@ class TestClient(object):
         self._handle_cli_result(command_line, assert_error=assert_error, error=error, trace=trace)
         return error
 
-    def run(self, command_line, assert_error=False, redirect_stdout=None, redirect_stderr=None):
+    def run(self, command_line, assert_error=False, redirect_stdout=None, redirect_stderr=None, inputs=None):
         """ run a single command as in the command line.
             If user or password is filled, user_io will be mocked to return this
             tuple if required
         """
         from conans.test.utils.mocks import RedirectedTestOutput
         with environment_update({"NO_COLOR": "1"}):  # Not initialize colorama in testing
+            self.user_inputs = RedirectedInputStream(inputs or self.inputs)
             self.stdout = RedirectedTestOutput()  # Initialize each command
             self.stderr = RedirectedTestOutput()
             self.out = ""


### PR DESCRIPTION
Changelog: Feature: Add `--dry-run` for `conan remove`.
Docs: https://github.com/conan-io/docs/pull/3404

After discussing with the team, the deciding factor was the difference in defaults between the semantics of `conan list` selection pattern and that of `conan remove`, which might make the usage of the pkglist feature a bit suprising (Even if that's still the recommended method!)

Closes #14245
