### PR TITLE
Conan 1.x: Do not output error in case of empty build_type

### DIFF
--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -104,11 +104,10 @@ class CMake(object):
         bf = self._conanfile.build_folder
         is_multi = is_multi_configuration(self._generator)
         if build_type and not is_multi:
-            self._conanfile.output.error("Don't specify 'build_type' at build time for "
-                                         "single-config build systems")
-
+            self._conanfile.output.warning("Specifying 'build_type' does not have "
+                                           "any effect for single-config build systems")
         bt = build_type or self._conanfile.settings.get_safe("build_type")
-        if not bt:
+        if not bt and is_multi:
             raise ConanException("build_type setting should be defined.")
         build_config = "--config {}".format(bt) if bt and is_multi else ""
 
@@ -137,9 +136,9 @@ class CMake(object):
         mkdir(self._conanfile, self._conanfile.package_folder)
 
         bt = build_type or self._conanfile.settings.get_safe("build_type")
-        if not bt:
-            raise ConanException("build_type setting should be defined.")
         is_multi = is_multi_configuration(self._generator)
+        if not bt and is_multi:
+            raise ConanException("build_type setting should be defined.")
         build_config = "--config {}".format(bt) if bt and is_multi else ""
 
         pkg_folder = '"{}"'.format(self._conanfile.package_folder.replace("\\", "/"))

--- a/conans/test/integration/toolchains/cmake/test_cmake.py
+++ b/conans/test/integration/toolchains/cmake/test_cmake.py
@@ -32,3 +32,52 @@ def test_configure_args():
     assert "-something" in client.out
     assert "--testverbose" in client.out
     assert "-testok" in client.out
+
+def test_build_type_single_config_warn():
+    client = TestClient()
+
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.cmake import CMake
+        class Pkg(ConanFile):
+            name = "pkg"
+            version = "0.1"
+            settings = "os", "compiler", "arch"
+            generators = "CMakeToolchain"
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+                cmake.build(build_type="Release")
+
+            def run(self, *args, **kwargs):
+                self.output.info("MYRUN: {}".format(*args))
+            """)
+    client.save({"conanfile.py": conanfile})
+    client.run("create . ")
+    assert "Specifying 'build_type' does not have " + \
+           "any effect for single-config build systems" in client.out
+    assert "Created package" in client.out
+
+def test_build_type_empty():
+    client = TestClient()
+
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.cmake import CMake
+        class Pkg(ConanFile):
+            name = "pkg"
+            version = "0.1"
+            settings = "os", "compiler", "arch"
+            generators = "CMakeToolchain"
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+                cmake.build()
+                cmake.install()
+
+            def run(self, *args, **kwargs):
+                self.output.info("MYRUN: {}".format(*args))
+            """)
+    client.save({"conanfile.py": conanfile})
+    client.run("create . ")
+    assert "Created package" in client.out


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix): Remove error output in case of non existent build_type setting

If there is no `build_type` setting considered in conanfile.py, `CMake` will throw an exception during`build()` (Which is correct). This means we must explicitly specify the `build_type` argument when calling `build()`.

Use case: A build tool which should always be build with build type "Release".

Unfortunately we get some ugly error output when doing this:
```
    settings = "os", "compiler", "arch"
    def build(self):
        cmake = CMake(self)
        cmake.configure()
        cmake.build(build_type="Release")
```
output (Note: The build passes succesful):
```
ERROR: Don't specify 'build_type' at build time for single-config build systems
```



- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
