### PR TITLE
Fix min target flag for xros and xros-simulator

### DIFF
--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -79,9 +79,11 @@ def apple_min_version_flag(os_version, os_sdk, subsystem):
     elif 'appletvsimulator' in os_sdk:
         flag = '-mtvos-simulator-version-min'
     elif 'xros' in os_sdk:
-        flag = '-mxros-version-min'
+        # need early return as string did not fit into the "normal" schema
+        return f'--target arm64-apple-xros{os_version}'
     elif 'xrsimulator' in os_sdk:
-        flag = '-mxros-simulator-version-min'
+        # need early return as string did not fit into the "normal" schema
+        return f'-target arm64-apple-xros{os_version}-simulator'
 
     if subsystem == 'catalyst':
         # especial case, despite Catalyst is macOS, it requires an iOS version argument

--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -80,7 +80,7 @@ def apple_min_version_flag(os_version, os_sdk, subsystem):
         flag = '-mtvos-simulator-version-min'
     elif 'xros' in os_sdk:
         # need early return as string did not fit into the "normal" schema
-        return f'--target arm64-apple-xros{os_version}'
+        return f'-target arm64-apple-xros{os_version}'
     elif 'xrsimulator' in os_sdk:
         # need early return as string did not fit into the "normal" schema
         return f'-target arm64-apple-xros{os_version}-simulator'


### PR DESCRIPTION
Changelog: Fix: Fix min target flag for xros and xros-simulator.
Docs: omit

Apple changes the way the "min target os version" flag is created
see: https://developer.apple.com/forums/thread/737595

This fixes the generation of the min target version flag for visionsOS and visionsOS simulator