### PR TITLE
Add Clang 17 to `settings.yml`, support new C++23 flag

### DIFF
--- a/conan/tools/build/flags.py
+++ b/conan/tools/build/flags.py
@@ -309,6 +309,10 @@ def _cppstd_clang(clang_version, cppstd):
         v23 = "c++2b"
         vgnu23 = "gnu++2b"
 
+    if clang_version >= "17":
+        v23 = "c++23"
+        vgnu23 = "gnu++23"
+
     flag = {"98": v98, "gnu98": vgnu98,
             "11": v11, "gnu11": vgnu11,
             "14": v14, "gnu14": vgnu14,

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -105,7 +105,7 @@ compiler:
     clang:
         version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
                   "5.0", "6.0", "7.0", "7.1",
-                  "8", "9", "10", "11", "12", "13", "14", "15", "16"]
+                  "8", "9", "10", "11", "12", "13", "14", "15", "16", "17"]
         libcxx: [null, libstdc++, libstdc++11, libc++, c++_shared, c++_static]
         cppstd: [null, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
         runtime: [null, static, dynamic]

--- a/conans/test/unittests/client/build/cpp_std_flags_test.py
+++ b/conans/test/unittests/client/build/cpp_std_flags_test.py
@@ -128,6 +128,12 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(_make_cppstd_flag("clang", "12", "20"), '-std=c++20')
         self.assertEqual(_make_cppstd_flag("clang", "12", "23"), '-std=c++2b')
 
+        self.assertEqual(_make_cppstd_flag("clang", "17", "11"), '-std=c++11')
+        self.assertEqual(_make_cppstd_flag("clang", "17", "14"), '-std=c++14')
+        self.assertEqual(_make_cppstd_flag("clang", "17", "17"), '-std=c++17')
+        self.assertEqual(_make_cppstd_flag("clang", "17", "20"), '-std=c++20')
+        self.assertEqual(_make_cppstd_flag("clang", "17", "23"), '-std=c++23')
+
     def test_clang_cppstd_defaults(self):
         self.assertEqual(_make_cppstd_default("clang", "2"), "gnu98")
         self.assertEqual(_make_cppstd_default("clang", "2.1"), "gnu98")


### PR DESCRIPTION
Changelog: Feature: Add support for Clang 17.
Docs: https://github.com/conan-io/docs/pull/3398

Release notes at https://releases.llvm.org/17.0.1/tools/clang/docs/ReleaseNotes.html
(new flag documented in [this section](https://releases.llvm.org/17.0.1/tools/clang/docs/ReleaseNotes.html#new-compiler-flags))

I think I'm not forgetting anything :)