### PR TITLE
fix editables with components

### DIFF
--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -459,7 +459,8 @@ class CppInfo:
         self._package.sysroot = self._package.sysroot or other._package.sysroot
         # COMPONENTS
         for cname, c in other.components.items():
-            self.components[cname].merge(c, overwrite)
+            # Make sure each component created on the fly does not bring new defaults
+            self.components.setdefault(cname, _Component(set_defaults=False)).merge(c, overwrite)
 
     def set_relative_base_folder(self, folder):
         """Prepend the folder to all the directories definitions, that are relative"""


### PR DESCRIPTION
Changelog: Bugfix: Fix relative paths of ``editable`` packages when they have components partially defining directories.
Docs: Omit

Close https://github.com/conan-io/conan/issues/14777