### PR TITLE
fix conan build

### DIFF
--- a/conan/cli/commands/build.py
+++ b/conan/cli/commands/build.py
@@ -13,7 +13,7 @@ def build(conan_api, parser, *args):
     """
     Install dependencies and call the build() method.
     """
-    parser.add_argument("path", nargs="?",
+    parser.add_argument("path",
                         help='Path to a python-based recipe file or a folder '
                              'containing a conanfile.py recipe. conanfile.txt '
                              'cannot be used with conan build.')


### PR DESCRIPTION
Changelog: Fix: ``conan build`` command prettier error when <path> argument not provided.
Docs: Omit

Close https://github.com/conan-io/conan/issues/14785
