### PR TITLE
fix compatible packages cache priority for offline

### DIFF
--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -104,30 +104,48 @@ class GraphBinariesAnalyzer(object):
         existing = compatibles.pop(original_package_id, None)   # Skip main package_id
         if existing:  # Skip the check if same package_id
             conanfile.output.info(f"Compatible package ID {original_package_id} equal to "
-                                  "the default package ID")
+                                  "the default package ID: Skipping it.")
 
-        if compatibles:
-            conanfile.output.info(f"Checking {len(compatibles)} compatible configurations:")
+        if not compatibles:
+            return
+
+        def _compatible_found(pkg_id, compatible_pkg):
+            diff = conanfile.info.dump_diff(compatible_pkg)
+            conanfile.output.info(f"Main binary package '{original_package_id}' missing. Using "
+                                  f"compatible package '{pkg_id}': {diff}")
+            # So they are available in package_info() method
+            conanfile.info = compatible_pkg  # Redefine current
+            conanfile.settings.update_values(compatible_pkg.settings.values_list)
+            # Trick to allow mutating the options (they were freeze=True)
+            # TODO: Improve this interface
+            conanfile.options = conanfile.options.copy_conaninfo_options()
+            conanfile.options.update_options(compatible_pkg.options)
+
+        conanfile.output.info(f"Checking {len(compatibles)} compatible configurations")
         for package_id, compatible_package in compatibles.items():
-            conanfile.output.info(f"'{package_id}': "
-                                  f"{conanfile.info.dump_diff(compatible_package)}")
+            if update:
+                conanfile.output.info(f"'{package_id}': "
+                                      f"{conanfile.info.dump_diff(compatible_package)}")
             node._package_id = package_id  # Modifying package id under the hood, FIXME
             node.binary = None  # Invalidate it
-            self._process_compatible_node(node, remotes, update)
-            if node.binary in (BINARY_CACHE, BINARY_DOWNLOAD, BINARY_UPDATE):
-                conanfile.output.info("Main binary package '%s' missing. Using "
-                                      "compatible package '%s'" % (original_package_id, package_id))
-                # So they are available in package_info() method
-                conanfile.info = compatible_package  # Redefine current
-                conanfile.settings.update_values(compatible_package.settings.values_list)
-                # Trick to allow mutating the options (they were freeze=True)
-                # TODO: Improve this interface
-                conanfile.options = conanfile.options.copy_conaninfo_options()
-                conanfile.options.update_options(compatible_package.options)
-                break
-        else:  # If no compatible is found, restore original state
-            node.binary = original_binary
-            node._package_id = original_package_id
+            self._process_compatible_node(node, remotes, update)  # TODO: what if BINARY_BUILD
+            if node.binary in (BINARY_CACHE, BINARY_UPDATE, BINARY_DOWNLOAD):
+                _compatible_found(package_id, compatible_package)
+                return
+        if not update:
+            conanfile.output.info(f"Compatible configurations not found in cache, checking servers")
+            for package_id, compatible_package in compatibles.items():
+                conanfile.output.info(f"'{package_id}': "
+                                      f"{conanfile.info.dump_diff(compatible_package)}")
+                node._package_id = package_id  # Modifying package id under the hood, FIXME
+                node.binary = None  # Invalidate it
+                self._evaluate_download(node, remotes, update)
+                if node.binary == BINARY_DOWNLOAD:
+                    _compatible_found(package_id, compatible_package)
+                    return
+        # If no compatible is found, restore original state
+        node.binary = original_binary
+        node._package_id = original_package_id
 
     def _evaluate_node(self, node, build_mode, remotes, update):
         assert node.binary is None, "Node.binary should be None"
@@ -225,10 +243,11 @@ class GraphBinariesAnalyzer(object):
             if not self._evaluate_clean_pkg_folder_dirty(node, package_layout):
                 break
 
-        if cache_latest_prev is None:  # This binary does NOT exist in the cache
-            self._evaluate_download(node, remotes, update)
-        else:  # This binary already exists in the cache, maybe can be updated
+        if cache_latest_prev is not None:
+            # This binary already exists in the cache, maybe can be updated
             self._evaluate_in_cache(cache_latest_prev, node, remotes, update)
+        elif update:
+            self._evaluate_download(node, remotes, update)
 
     def _process_locked_node(self, node, build_mode, locked_prev):
         # Check that this same reference hasn't already been checked

--- a/conans/test/integration/package_id/test_cache_compatibles.py
+++ b/conans/test/integration/package_id/test_cache_compatibles.py
@@ -127,6 +127,59 @@ def test_cppstd_validated():
            in client.out
 
 
+def test_cppstd_server():
+    """ this test proves the order, first from cache
+    """
+    c = TestClient(default_server_user=True)
+    compatibles = textwrap.dedent("""\
+        def compatibility(conanfile):
+            return [{"settings": [("compiler.cppstd", v)]} for v in ("11", "14", "17", "20")]
+        """)
+    compatible_folder = os.path.join(c.cache.plugins_path, "compatibility")
+    save(os.path.join(compatible_folder, "compatibility.py"), compatibles)
+
+    conanfile = GenConanfile("dep", "0.1").with_settings("compiler")
+    c.save({"dep/conanfile.py": conanfile,
+            "consumer/conanfile.py": GenConanfile().with_requires("dep/0.1")})
+
+    base_settings = "-s compiler=gcc -s compiler.version=8 -s compiler.libcxx=libstdc++11"
+    c.run(f"create dep {base_settings} -s compiler.cppstd=20")
+    c.run("upload * -r=default -c")
+    c.run("remove * -c")
+
+    c.run(f"install consumer {base_settings} -s compiler.cppstd=17")
+    assert "dep/0.1: Checking 3 compatible configurations" in c.out
+    assert "dep/0.1: Compatible configurations not found in cache, checking servers" in c.out
+    assert "dep/0.1: Main binary package '6179018ccb6b15e6443829bf3640e25f2718b931' missing. " \
+           "Using compatible package '326c500588d969f55133fdda29506ef61ef03eee': " \
+           "compiler.cppstd=20" in c.out
+    c.assert_listed_binary({"dep/0.1": ("326c500588d969f55133fdda29506ef61ef03eee",
+                                        "Download (default)")})
+    # second time, not download, already in cache
+    c.run(f"install consumer {base_settings} -s compiler.cppstd=17")
+    assert "dep/0.1: Checking 3 compatible configurations" in c.out
+    assert "dep/0.1: Compatible configurations not found in cache, checking servers" not in c.out
+    assert "dep/0.1: Main binary package '6179018ccb6b15e6443829bf3640e25f2718b931' missing. " \
+           "Using compatible package '326c500588d969f55133fdda29506ef61ef03eee': " \
+           "compiler.cppstd=20" in c.out
+    c.assert_listed_binary({"dep/0.1": ("326c500588d969f55133fdda29506ef61ef03eee", "Cache")})
+
+    # update checks in servers
+    c2 = TestClient(servers=c.servers, inputs=["admin", "password"])
+    c2.save({"dep/conanfile.py": conanfile})
+    c2.run(f"create dep {base_settings} -s compiler.cppstd=14")
+    c2.run("upload * -r=default -c")
+
+    c.run(f"install consumer {base_settings} -s compiler.cppstd=17 --update")
+    assert "dep/0.1: Checking 3 compatible configurations" in c.out
+    assert "dep/0.1: Compatible configurations not found in cache, checking servers" not in c.out
+    assert "dep/0.1: Main binary package '6179018ccb6b15e6443829bf3640e25f2718b931' missing. " \
+           "Using compatible package 'ce92fac7c26ace631e30875ddbb3a58a190eb601': " \
+           "compiler.cppstd=14" in c.out
+    c.assert_listed_binary({"dep/0.1": ("ce92fac7c26ace631e30875ddbb3a58a190eb601",
+                                        "Download (default)")})
+
+
 class TestDefaultCompat:
 
     def test_default_cppstd_compatibility(self):


### PR DESCRIPTION
Changelog: Bugfix: ``compatible`` packages look first in the cache, and only if not found, the servers, to allow offline installs when there are compatible packages.
Docs: Omit

For https://github.com/conan-io/conan/issues/14799

