### PR TITLE
fix 'export-pkg' for 'python-require'

### DIFF
--- a/conan/cli/commands/export_pkg.py
+++ b/conan/cli/commands/export_pkg.py
@@ -7,6 +7,7 @@ from conan.cli.command import conan_command, OnceArgument
 from conan.cli.commands.create import _get_test_conanfile_path
 from conan.cli.formatters.graph import format_graph_json
 from conan.cli.printers.graph import print_graph_basic
+from conans.errors import ConanException
 
 
 @conan_command(group="Creator", formatters={"json": format_graph_json})
@@ -45,11 +46,13 @@ def export_pkg(conan_api, parser, *args):
     profile_host, profile_build = conan_api.profiles.get_profiles_from_args(args)
     remotes = conan_api.remotes.list(args.remote) if not args.no_remote else []
 
+    conanfile = conan_api.local.inspect(path, remotes, lockfile)
+    # The package_type is not fully processed at export
+    if conanfile.package_type == "python-require":
+        raise ConanException("export-pkg can only be used for binaries, not for 'python-require'")
     ref, conanfile = conan_api.export.export(path=path, name=args.name, version=args.version,
                                              user=args.user, channel=args.channel, lockfile=lockfile,
                                              remotes=remotes)
-    # The package_type is not fully processed at export
-    assert conanfile.package_type != "python-require", "A python-require cannot be export-pkg"
     lockfile = conan_api.lockfile.update_lockfile_export(lockfile, conanfile, ref,
                                                          args.build_require)
 

--- a/conans/test/integration/py_requires/python_requires_test.py
+++ b/conans/test/integration/py_requires/python_requires_test.py
@@ -1199,3 +1199,14 @@ def test_transitive_range_not_found_in_cache():
     c.run("create . ")
     c.assert_listed_require({"pr/1.0": "Cache"}, python=True)
     assert "pr/[>0]: pr/1.0" in c.out
+
+
+def test_export_pkg():
+    c = TestClient()
+    c.save({"conanfile.py": GenConanfile("pytool", "0.1").with_package_type("python-require")})
+    c.run("export-pkg .", assert_error=True)
+    assert "export-pkg can only be used for binaries, not for 'python-require'" in c.out
+    # Make sure nothing is exported
+    c.run("list *")
+    assert "WARN: There are no matching recipe references" in c.out
+    assert "pytool/0.1" not in c.out


### PR DESCRIPTION
Changelog: Fix: Better error message when trying to ``export-pkg`` a ``python-require`` package, and avoid it being exported and then failing.
Docs: Omit

Close https://github.com/conan-io/conan/issues/14818
