### PR TITLE
Add warning for suprising version range option behaviour

### DIFF
--- a/conans/model/version_range.py
+++ b/conans/model/version_range.py
@@ -94,6 +94,11 @@ class VersionRange:
         prereleases = False
         for t in tokens[1:]:
             if "include_prerelease" in t:
+                if "include_prerelease=" in t:
+                    from conan.api.output import ConanOutput
+                    ConanOutput().warning(
+                        f'include_prerelease version range option in "{expression}" does not take an attribute, '
+                        'its presence unconditionally enables prereleases')
                 prereleases = True
                 break
             else:

--- a/conans/test/unittests/model/version/test_version_range.py
+++ b/conans/test/unittests/model/version/test_version_range.py
@@ -94,3 +94,15 @@ def test_range_prereleases_conf(version_range, resolve_prereleases, versions_in,
 def test_wrong_range_syntax(version_range):
     with pytest.raises(ConanException):
         VersionRange(version_range)
+
+
+@pytest.mark.parametrize("version_range", [
+    ">=0.1, include_prerelease",
+    ">=0.1, include_prerelease=True",
+    ">=0.1, include_prerelease=False",
+])
+def test_wrong_range_option_syntax(version_range):
+    """We don't error out on bad options, maybe we should,
+    but for now this test ensures we don't change it without realizing"""
+    vr = VersionRange(version_range)
+    assert all(cs.prerelease for cs in vr.condition_sets)


### PR DESCRIPTION
Changelog: Omit
Docs: https://github.com/conan-io/docs/pull/3437

This warns on version ranegs like `[>=1 <2,include_prerelease=False]`, which does exactly the opposite of what the user wants.

We might want this as an error, or to listen to the value if assigned