### PR TITLE
Fix wrong cppstd detection for newer apple-clang compilers

### DIFF
--- a/conan/internal/api/detect_api.py
+++ b/conan/internal/api/detect_api.py
@@ -220,9 +220,12 @@ def default_cppstd(compiler, compiler_version):
     def _mcst_lcc_cppstd_default(version):
         return "gnu14" if version >= "1.24" else "gnu98"
 
+    def _apple_clang_cppstd_default(version):
+        return "gnu17" if version >= "11" else "gnu98"
+
     default = {"gcc": _gcc_cppstd_default(compiler_version),
                "clang": _clang_cppstd_default(compiler_version),
-               "apple-clang": "gnu98",
+               "apple-clang": _apple_clang_cppstd_default(compiler_version),
                "msvc": _visual_cppstd_default(compiler_version),
                "mcst-lcc": _mcst_lcc_cppstd_default(compiler_version)}.get(str(compiler), None)
     return default

--- a/conan/internal/api/detect_api.py
+++ b/conan/internal/api/detect_api.py
@@ -220,15 +220,22 @@ def default_cppstd(compiler, compiler_version):
     def _mcst_lcc_cppstd_default(version):
         return "gnu14" if version >= "1.24" else "gnu98"
 
-    def _apple_clang_cppstd_default(version):
-        return "gnu17" if version >= "11" else "gnu98"
-
     default = {"gcc": _gcc_cppstd_default(compiler_version),
                "clang": _clang_cppstd_default(compiler_version),
-               "apple-clang": _apple_clang_cppstd_default(compiler_version),
+               "apple-clang": "gnu98",
                "msvc": _visual_cppstd_default(compiler_version),
                "mcst-lcc": _mcst_lcc_cppstd_default(compiler_version)}.get(str(compiler), None)
     return default
+
+
+def detect_cppstd(compiler, compiler_version):
+    cppstd = default_cppstd(compiler, compiler_version)
+    if compiler == "apple-clang" and compiler_version >= "11":
+        # Conan does not detect the default cppstd for apple-clang,
+        # because it's still 98 for the compiler (eben though xcode uses newer in projects)
+        # and having it be so old would be annoying for users
+        cppstd = "gnu17"
+    return cppstd
 
 
 def detect_compiler():

--- a/conans/client/conf/detect.py
+++ b/conans/client/conf/detect.py
@@ -1,6 +1,6 @@
 from conan.api.output import ConanOutput
 from conan.internal.api.detect_api import detect_os, detect_arch, default_msvc_runtime, \
-    detect_libcxx, default_cppstd, detect_compiler, default_compiler_version
+    detect_libcxx, detect_cppstd, detect_compiler, default_compiler_version
 
 
 def detect_defaults_settings():
@@ -31,7 +31,7 @@ def detect_defaults_settings():
     libcxx = detect_libcxx(compiler, version)
     if libcxx:
         result.append(("compiler.libcxx", libcxx))
-    cppstd = default_cppstd(compiler, version)
+    cppstd = detect_cppstd(compiler, version)
     if cppstd:
         result.append(("compiler.cppstd", cppstd))
     result.append(("build_type", "Release"))

--- a/conans/test/unittests/client/build/cpp_std_flags_test.py
+++ b/conans/test/unittests/client/build/cpp_std_flags_test.py
@@ -237,11 +237,11 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(_make_cppstd_default("apple-clang", "8"), "gnu98")
         self.assertEqual(_make_cppstd_default("apple-clang", "9"), "gnu98")
         self.assertEqual(_make_cppstd_default("apple-clang", "10"), "gnu98")
-        self.assertEqual(_make_cppstd_default("apple-clang", "11"), "gnu98")
-        self.assertEqual(_make_cppstd_default("apple-clang", "12"), "gnu98")
-        self.assertEqual(_make_cppstd_default("apple-clang", "13"), "gnu98")
-        self.assertEqual(_make_cppstd_default("apple-clang", "14"), "gnu98")
-        self.assertEqual(_make_cppstd_default("apple-clang", "15"), "gnu98")
+        self.assertEqual(_make_cppstd_default("apple-clang", "11"), "gnu17")
+        self.assertEqual(_make_cppstd_default("apple-clang", "12"), "gnu17")
+        self.assertEqual(_make_cppstd_default("apple-clang", "13"), "gnu17")
+        self.assertEqual(_make_cppstd_default("apple-clang", "14"), "gnu17")
+        self.assertEqual(_make_cppstd_default("apple-clang", "15"), "gnu17")
 
     def test_visual_cppstd_flags(self):
         self.assertEqual(_make_cppstd_flag("msvc", "170", "11"), None)

--- a/conans/test/unittests/client/build/cpp_std_flags_test.py
+++ b/conans/test/unittests/client/build/cpp_std_flags_test.py
@@ -237,11 +237,11 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(_make_cppstd_default("apple-clang", "8"), "gnu98")
         self.assertEqual(_make_cppstd_default("apple-clang", "9"), "gnu98")
         self.assertEqual(_make_cppstd_default("apple-clang", "10"), "gnu98")
-        self.assertEqual(_make_cppstd_default("apple-clang", "11"), "gnu17")
-        self.assertEqual(_make_cppstd_default("apple-clang", "12"), "gnu17")
-        self.assertEqual(_make_cppstd_default("apple-clang", "13"), "gnu17")
-        self.assertEqual(_make_cppstd_default("apple-clang", "14"), "gnu17")
-        self.assertEqual(_make_cppstd_default("apple-clang", "15"), "gnu17")
+        self.assertEqual(_make_cppstd_default("apple-clang", "11"), "gnu98")
+        self.assertEqual(_make_cppstd_default("apple-clang", "12"), "gnu98")
+        self.assertEqual(_make_cppstd_default("apple-clang", "13"), "gnu98")
+        self.assertEqual(_make_cppstd_default("apple-clang", "14"), "gnu98")
+        self.assertEqual(_make_cppstd_default("apple-clang", "15"), "gnu98")
 
     def test_visual_cppstd_flags(self):
         self.assertEqual(_make_cppstd_flag("msvc", "170", "11"), None)

--- a/conans/test/unittests/tools/build/test_cppstd.py
+++ b/conans/test/unittests/tools/build/test_cppstd.py
@@ -1,7 +1,9 @@
 import pytest
 
+from conan.internal.api.detect_api import detect_cppstd
 from conan.tools.build import supported_cppstd, check_min_cppstd, valid_min_cppstd, default_cppstd
 from conans.errors import ConanException, ConanInvalidConfiguration
+from conans.model.version import Version
 from conans.test.utils.mocks import MockSettings, ConanFileMock
 
 
@@ -23,6 +25,23 @@ def test_supported_cppstd_clang(compiler, compiler_version, values):
     conanfile = ConanFileMock(settings)
     sot = supported_cppstd(conanfile)
     assert sot == values
+
+
+@pytest.mark.parametrize("compiler,compiler_version,result", [
+    ("gcc", "5", 'gnu98'),
+    ("gcc", "8", "gnu14"),
+    ("gcc", "12", "gnu17"),
+    ("msvc", "190", "14"),
+    ("apple-clang", "10.0", "gnu98"),
+    # We diverge from the default cppstd for apple-clang >= 11
+    ("apple-clang", "12.0", "gnu17"),
+    ("clang", "4", "gnu98"),
+    ("clang", "6", "gnu14"),
+    ("clang", "17", "gnu17")
+])
+def test_detected_cppstd(compiler, compiler_version, result):
+    sot = detect_cppstd(compiler, Version(compiler_version))
+    assert sot == result
 
 
 def test_supported_cppstd_with_specific_values():
@@ -115,21 +134,6 @@ def test_supported_cppstd_qcc(compiler, compiler_version, values):
     conanfile = ConanFileMock(settings)
     sot = supported_cppstd(conanfile)
     assert sot == values
-
-
-@pytest.mark.parametrize("compiler,compiler_version,result", [
-    ("gcc", "5", 'gnu98'),
-    ("gcc", "8", "gnu14"),
-    ("msvc", "190", "14"),
-    ("apple-clang", "10.0", "gnu98"),
-    ("apple-clang", "12.0", "gnu17"),
-    ("clang", "6", "gnu14"),
-])
-def test_default_cppstd(compiler, compiler_version, result):
-    settings = MockSettings({"compiler": compiler, "compiler.version": compiler_version})
-    conanfile = ConanFileMock(settings)
-    sot = default_cppstd(conanfile)
-    assert sot == result
 
 
 def test_check_cppstd_type():

--- a/conans/test/unittests/tools/build/test_cppstd.py
+++ b/conans/test/unittests/tools/build/test_cppstd.py
@@ -104,6 +104,7 @@ def test_supported_cppstd_mcst(compiler, compiler_version, values):
     sot = supported_cppstd(conanfile)
     assert sot == values
 
+
 @pytest.mark.parametrize("compiler,compiler_version,values", [
     ("qcc", "4.4", ['98', 'gnu98']),
     ("qcc", "5.4", ['98', 'gnu98', '11', 'gnu11', "14", "gnu14", "17", "gnu17"]),
@@ -120,10 +121,11 @@ def test_supported_cppstd_qcc(compiler, compiler_version, values):
     ("gcc", "5", 'gnu98'),
     ("gcc", "8", "gnu14"),
     ("msvc", "190", "14"),
-    ("apple-clang", "12.0", "gnu98"),
+    ("apple-clang", "10.0", "gnu98"),
+    ("apple-clang", "12.0", "gnu17"),
     ("clang", "6", "gnu14"),
 ])
-def test_default_cppstd_gcc(compiler, compiler_version, result):
+def test_default_cppstd(compiler, compiler_version, result):
     settings = MockSettings({"compiler": compiler, "compiler.version": compiler_version})
     conanfile = ConanFileMock(settings)
     sot = default_cppstd(conanfile)

--- a/conans/test/unittests/util/detect_test.py
+++ b/conans/test/unittests/util/detect_test.py
@@ -3,6 +3,7 @@ import unittest
 
 from parameterized import parameterized
 
+from conan.internal.api.detect_api import detect_cppstd
 from conans.client.conf.detect import detect_defaults_settings
 from conans.model.version import Version
 from conans.test.utils.mocks import RedirectedTestOutput


### PR DESCRIPTION
Changelog: Bugfix: Fix wrong cppstd detection for newer apple-clang versions introduced in 2.0.11.
Docs: Omit

Closes #14835
