### PR TITLE
Use importlib in Python >= 3.12, add Conan v1 deprecation message

### DIFF
--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -319,6 +319,7 @@ class Command(object):
         that the package has been created correctly. Check 'conan test' command
         to know more about 'test_folder' project.
         """
+        self._warn_conan_version()
         parser = argparse.ArgumentParser(description=self.create.__doc__,
                                          prog="conan create",
                                          formatter_class=SmartFormatter)
@@ -470,6 +471,7 @@ class Command(object):
         the package is installed, Conan will write the files for the specified
         generators.
         """
+        self._warn_conan_version()
         parser = argparse.ArgumentParser(description=self.install.__doc__,
                                          prog="conan install",
                                          formatter_class=SmartFormatter)
@@ -860,7 +862,7 @@ class Command(object):
         using a build helper, like CMake(), the --package-folder will be
         configured as the destination folder for the install step.
         """
-
+        self._warn_conan_version()
         parser = argparse.ArgumentParser(description=self.build.__doc__,
                                          prog="conan build",
                                          formatter_class=SmartFormatter)
@@ -2204,7 +2206,6 @@ class Command(object):
                     return False
 
                 self._warn_python_version()
-                self._warn_conan_version()
 
                 if command in ["-h", "--help"]:
                     self._show_help()

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -4,6 +4,7 @@ import json
 import os
 import signal
 import sys
+import textwrap
 from argparse import ArgumentError
 from difflib import get_close_matches
 
@@ -2177,6 +2178,12 @@ class Command(object):
                               front=Color.BRIGHT_RED)
             self._out.writeln("*"*width, front=Color.BRIGHT_RED)
 
+    def _warn_conan_version(self):
+        width = 70
+        self._out.writeln(textwrap.fill("Conan 1 is on a deprecation path, "
+                                        "please consider migrating to Conan 2", width),
+                          front=Color.BRIGHT_YELLOW)
+
     def run(self, *args):
         """HIDDEN: entry point for executing commands, dispatcher to class
         methods
@@ -2197,6 +2204,7 @@ class Command(object):
                     return False
 
                 self._warn_python_version()
+                self._warn_conan_version()
 
                 if command in ["-h", "--help"]:
                     self._show_help()


### PR DESCRIPTION
Changelog: Fix: Use importlib in Python >= 3.12
Docs: Omit

If using Python >= 3.12, use the same importlib mechanism than Conan 2. Note that this is not globally enabled for every Python version to avoid corner case differences between the two in all Python versions, ensuring nothing breaks for users stuck in older Python versions 

I've added the message to this same PR as discussed with the team, but happy to separate into a different one - I've chosen to show it for every command except `--version`, as the python_version message does

Closes #14801