### PR TITLE
Properly lock release candidates of python requires

### DIFF
--- a/conan/internal/conan_app.py
+++ b/conan/internal/conan_app.py
@@ -57,7 +57,7 @@ class ConanApp(object):
         self.proxy = ConanProxy(self)
         self.range_resolver = RangeResolver(self)
 
-        self.pyreq_loader = PyRequireLoader(self.proxy, self.range_resolver)
+        self.pyreq_loader = PyRequireLoader(self)
         cmd_wrap = CmdWrapper(self.cache)
         conanfile_helpers = ConanFileHelpers(self.requester, cmd_wrap, global_conf, self.cache)
         self.loader = ConanFileLoader(self.pyreq_loader, conanfile_helpers)

--- a/conans/client/graph/python_requires.py
+++ b/conans/client/graph/python_requires.py
@@ -60,10 +60,11 @@ class PyRequires(object):
 
 
 class PyRequireLoader(object):
-    def __init__(self, proxy, range_resolver):
-        self._proxy = proxy
-        self._range_resolver = range_resolver
+    def __init__(self, conan_app):
+        self._proxy = conan_app.proxy
+        self._range_resolver = conan_app.range_resolver
         self._cached_py_requires = {}
+        self._resolve_prereleases = conan_app.cache.new_config.get("core.version_ranges:resolve_prereleases")
 
     def load_py_requires(self, conanfile, loader, graph_lock, remotes, update, check_update):
         py_requires_refs = getattr(conanfile, "python_requires", None)
@@ -107,7 +108,7 @@ class PyRequireLoader(object):
             raise ConanException("python-requires 'alias' are not supported in Conan 2.0. "
                                  "Please use version ranges instead")
         if graph_lock:
-            graph_lock.resolve_locked_pyrequires(requirement)
+            graph_lock.resolve_locked_pyrequires(requirement, self._resolve_prereleases)
         # If the lock hasn't resolved the range, and it hasn't failed (it is partial), resolve it
         self._range_resolver.resolve(requirement, "python_requires", remotes, update)
         ref = requirement.ref

--- a/conans/test/integration/lockfile/test_lock_pyrequires.py
+++ b/conans/test/integration/lockfile/test_lock_pyrequires.py
@@ -95,6 +95,8 @@ def test_lock_pyrequires_prereleases():
     tc.run("export dep")
     dep_rrev = tc.exported_recipe_revision()
     tc.run("lock create app --lockfile-out=app.lock", assert_error=True)
+    # Makes sense, prereleases are not active
+    assert "Version range '>=0' from requirement 'dep/[>=0]' required by 'python_requires' could not be resolved"
 
     tc.save_home({"global.conf": "core.version_ranges:resolve_prereleases=True"})
     # This used to crash even with the conf activated

--- a/conans/test/integration/lockfile/test_lock_pyrequires.py
+++ b/conans/test/integration/lockfile/test_lock_pyrequires.py
@@ -4,6 +4,7 @@ import textwrap
 
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
+from conans.util.files import load
 
 
 def test_transitive_py_requires():
@@ -85,6 +86,21 @@ def test_transitive_matching_ranges():
     assert "pkga/0.2: dep: dep/0.1!!" in client.out
     assert "pkgb/0.2: tool: tool/0.3!!" in client.out
     assert "pkgb/0.2: dep: dep/0.2!!" in client.out
+
+
+def test_lock_pyrequires_prereleases():
+    tc = TestClient()
+    tc.save({"dep/conanfile.py": GenConanfile("dep", "1.0-0.1"),
+             "app/conanfile.py": GenConanfile("app", "1.0").with_python_requires("dep/[>=0]")})
+    tc.run("export dep")
+    dep_rrev = tc.exported_recipe_revision()
+    tc.run("lock create app --lockfile-out=app.lock", assert_error=True)
+
+    tc.save_home({"global.conf": "core.version_ranges:resolve_prereleases=True"})
+    # This used to crash even with the conf activated
+    tc.run("lock create app --lockfile-out=app.lock")
+    data = json.loads(load(os.path.join(tc.current_folder, "app.lock")))
+    assert data["python_requires"][0].startswith(f"dep/1.0-0.1#{dep_rrev}")
 
 
 def test_lock_pyrequires_create():


### PR DESCRIPTION
Changelog: Bugfix: Properly lock release candidates of python requires
Docs: Omit

The `core.version_ranges:resolve_prereleases` conf works fine for resolving python require prereleases, but a missing argument was not letting lockfiles to also work, this fixes it
