### PR TITLE
fix integrity-check when export_source not downloaded

### DIFF
--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -85,7 +85,7 @@ def cache_clean(conan_api: ConanAPI, parser, subparser, *args):
         conan_api.cache.clean(package_list)
 
 
-@conan_subcommand(formatters={"text": cli_out_write})
+@conan_subcommand()
 def cache_check_integrity(conan_api: ConanAPI, parser, subparser, *args):
     """
     Check the integrity of the local cache for the given references

--- a/conan/internal/integrity_check.py
+++ b/conan/internal/integrity_check.py
@@ -1,3 +1,5 @@
+import os
+
 from conan.api.output import ConanOutput
 from conans.errors import ConanException
 from conans.model.package_ref import PkgReference
@@ -31,6 +33,12 @@ class IntegrityChecker:
         layout = self._app.cache.recipe_layout(ref)
         output = ConanOutput()
         read_manifest, expected_manifest = layout.recipe_manifests()
+        # Filter exports_sources from read manifest if there are no exports_sources locally
+        # This happens when recipe is downloaded without sources (not built from source)
+        export_sources_folder = layout.export_sources()
+        if not os.path.exists(export_sources_folder):
+            read_manifest.file_sums = {k: v for k, v in read_manifest.file_sums.items()
+                                       if not k.startswith("export_source")}
 
         if read_manifest != expected_manifest:
             output.error(f"{ref}: Manifest mismatch")

--- a/conans/test/integration/lockfile/test_lock_requires.py
+++ b/conans/test/integration/lockfile/test_lock_requires.py
@@ -618,13 +618,3 @@ class TestLockfileUpdate:
         lock = c.load("consumer/conan.lock")
         assert "pkg/0.1" not in lock
         assert "pkg/0.2" in lock
-
-
-def test_error_test_explicit():
-    # https://github.com/conan-io/conan/issues/14833
-    client = TestClient()
-    test = GenConanfile().with_test("pass").with_class_attribute("test_type = 'explicit'")
-    client.save({"conanfile.py": GenConanfile("pkg", "0.1"),
-                 "test_package/conanfile.py": test})
-    client.run("lock create conanfile.py --lockfile-out=my.lock")
-    client.run("create . --lockfile=my.lock")

--- a/conans/test/integration/lockfile/test_lock_requires.py
+++ b/conans/test/integration/lockfile/test_lock_requires.py
@@ -618,3 +618,13 @@ class TestLockfileUpdate:
         lock = c.load("consumer/conan.lock")
         assert "pkg/0.1" not in lock
         assert "pkg/0.2" in lock
+
+
+def test_error_test_explicit():
+    # https://github.com/conan-io/conan/issues/14833
+    client = TestClient()
+    test = GenConanfile().with_test("pass").with_class_attribute("test_type = 'explicit'")
+    client.save({"conanfile.py": GenConanfile("pkg", "0.1"),
+                 "test_package/conanfile.py": test})
+    client.run("lock create conanfile.py --lockfile-out=my.lock")
+    client.run("create . --lockfile=my.lock")


### PR DESCRIPTION
Changelog: Bugfix: Fix integrity-check (``upload --check`` or ``cache check-integrity``) when the ``export_source`` has not been downloaded
Docs: Omit

Close https://github.com/conan-io/conan/issues/14840
