### PR TITLE
fix conan source with python_requires in remotes

### DIFF
--- a/conan/api/subapi/local.py
+++ b/conan/api/subapi/local.py
@@ -64,12 +64,13 @@ class LocalAPI:
         app = ConanApp(self._conan_api.cache_folder)
         return app.cache.editable_packages.edited_refs
 
-    def source(self, path, name=None, version=None, user=None, channel=None):
+    def source(self, path, name=None, version=None, user=None, channel=None, remotes=None):
         """ calls the 'source()' method of the current (user folder) conanfile.py
         """
         app = ConanApp(self._conan_api.cache_folder)
         conanfile = app.loader.load_consumer(path, name=name, version=version,
-                                             user=user, channel=channel, graph_lock=None)
+                                             user=user, channel=channel, graph_lock=None,
+                                             remotes=remotes)
         # This profile is empty, but with the conf from global.conf
         profile = self._conan_api.profiles.get_profile([])
         initialize_conanfile_profile(conanfile, profile, profile, CONTEXT_HOST, False)

--- a/conan/cli/commands/source.py
+++ b/conan/cli/commands/source.py
@@ -15,6 +15,7 @@ def source(conan_api, parser, *args):
 
     cwd = os.getcwd()
     path = conan_api.local.get_conanfile_path(args.path, cwd, py=True)
+    enabled_remotes = conan_api.remotes.list()  # for python_requires not local
     # TODO: Missing lockfile for python_requires
     conan_api.local.source(path, name=args.name, version=args.version, user=args.user,
-                           channel=args.channel)
+                           channel=args.channel, remotes=enabled_remotes)

--- a/conans/test/integration/command/source_test.py
+++ b/conans/test/integration/command/source_test.py
@@ -289,3 +289,4 @@ def test_source_python_requires():
     c.save({"conanfile.py": GenConanfile().with_python_requires("pytool/0.1")}, clean_first=True)
     c.run("source . ")
     assert "pytool/0.1: Not found in local cache, looking in remotes" in c.out
+    assert "pytool/0.1: Downloaded recipe" in c.out

--- a/conans/test/integration/command/source_test.py
+++ b/conans/test/integration/command/source_test.py
@@ -277,3 +277,15 @@ class TestSourceWithoutDefaultProfile:
         client.run("source .")
         assert "conanfile.py: Calling source()" in client.out
         assert "CACHE:MYCACHE!!" in client.out
+
+
+def test_source_python_requires():
+    c = TestClient(default_server_user=True)
+    c.save({"conanfile.py": GenConanfile("pytool", "0.1")})
+    c.run("export . ")
+    c.run("upload * -r=default -c")
+    c.run("remove * -c")
+
+    c.save({"conanfile.py": GenConanfile().with_python_requires("pytool/0.1")}, clean_first=True)
+    c.run("source . ")
+    assert "pytool/0.1: Not found in local cache, looking in remotes" in c.out


### PR DESCRIPTION
Changelog: Fix: Define remotes in ``conan source`` command in case recipe has ``python_requires`` that need to be downloaded from remotes.
Docs: Omit

Close https://github.com/conan-io/conan/issues/14848
