### PR TITLE
feat: Improve BUILD-file formatting

### DIFF
--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -56,53 +56,53 @@ class BazelDeps(object):
         return filegroup
 
     def _get_dependency_buildfile_content(self, dependency):
-        template = textwrap.dedent("""
+        template = textwrap.dedent("""\
             load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library")
 
-            {% for libname, filepath in libs.items() %}
+            {%- for libname, filepath in libs.items() %}
             cc_import(
                 name = "{{ libname }}_precompiled",
                 {{ library_type }} = "{{ filepath }}",
             )
-            {% endfor %}
+            {%- endfor %}
 
-            {% for libname, (lib_path, dll_path) in shared_with_interface_libs.items() %}
+            {%- for libname, (lib_path, dll_path) in shared_with_interface_libs.items() %}
             cc_import(
                 name = "{{ libname }}_precompiled",
                 interface_library = "{{ lib_path }}",
                 shared_library = "{{ dll_path }}",
             )
-            {% endfor %}
+            {%- endfor %}
 
             cc_library(
                 name = "{{ name }}",
-                {% if headers %}
+                {%- if headers %}
                 hdrs = glob([{{ headers }}]),
-                {% endif %}
-                {% if includes %}
+                {%- endif %}
+                {%- if includes %}
                 includes = [{{ includes }}],
-                {% endif %}
-                {% if defines %}
+                {%- endif %}
+                {%- if defines %}
                 defines = [{{ defines }}],
                 {% endif %}
-                {% if linkopts %}
+                {%- if linkopts %}
                 linkopts = [{{ linkopts }}],
-                {% endif %}
+                {%- endif %}
                 visibility = ["//visibility:public"],
-                {% if libs or shared_with_interface_libs %}
+                {%- if libs or shared_with_interface_libs %}
                 deps = [
                     # do not sort
-                {% for lib in libs %}
-                ":{{ lib }}_precompiled",
-                {% endfor %}
-                {% for lib in shared_with_interface_libs %}
-                ":{{ lib }}_precompiled",
-                {% endfor %}
-                {% for dep in dependencies %}
-                "@{{ dep }}",
-                {% endfor %}
+                    {%- for lib in libs %}
+                    ":{{ lib }}_precompiled",
+                    {%- endfor %}
+                    {%- for lib in shared_with_interface_libs %}
+                    ":{{ lib }}_precompiled",
+                    {%- endfor %}
+                    {%- for dep in dependencies %}
+                    "@{{ dep }}",
+                    {%- endfor %}
                 ],
-                {% endif %}
+                {%- endif %}
             )
 
         """)

--- a/conans/test/unittests/tools/google/test_bazeldeps.py
+++ b/conans/test/unittests/tools/google/test_bazeldeps.py
@@ -58,7 +58,9 @@ def test_bazeldeps_dependency_buildfiles():
                 assert 'linkopts = ["/DEFAULTLIB:system_lib1"]' in dependency_content
             else:
                 assert 'linkopts = ["-lsystem_lib1"],' in dependency_content
-            assert """deps = [\n        # do not sort\n    \n    ":lib1_precompiled",""" in dependency_content
+            assert "deps = [\n" in dependency_content
+            assert "# do not sort\n"
+            assert '":lib1_precompiled",' in dependency_content
 
 
 def test_bazeldeps_get_lib_file_path_by_basename():
@@ -79,7 +81,7 @@ def test_bazeldeps_get_lib_file_path_by_basename():
 
     # FIXME: This will run infinite loop if conanfile.dependencies.host.topological_sort.
     #  Move to integration test
-    with mock.patch('conans.ConanFile.dependencies', new_callable=mock.PropertyMock) as mock_deps:
+    with (mock.patch('conans.ConanFile.dependencies', new_callable=mock.PropertyMock) as mock_deps):
         req = Requirement(ConanFileReference.loads("OriginalDepName/1.0"))
         mock_deps.return_value = ConanFileDependencies({req: ConanFileInterface(conanfile_dep)})
 
@@ -93,7 +95,9 @@ def test_bazeldeps_get_lib_file_path_by_basename():
                 assert 'linkopts = ["/DEFAULTLIB:system_lib1"]' in dependency_content
             else:
                 assert 'linkopts = ["-lsystem_lib1"],' in dependency_content
-            assert 'deps = [\n        # do not sort\n    \n    ":liblib1.a_precompiled",' in dependency_content
+            assert 'deps = [' in dependency_content
+            assert '# do not sort'  in dependency_content
+            assert '":liblib1.a_precompiled"' in dependency_content
 
 
 def test_bazeldeps_dependency_transitive():

--- a/conans/test/unittests/tools/google/test_bazeldeps.py
+++ b/conans/test/unittests/tools/google/test_bazeldeps.py
@@ -81,7 +81,7 @@ def test_bazeldeps_get_lib_file_path_by_basename():
 
     # FIXME: This will run infinite loop if conanfile.dependencies.host.topological_sort.
     #  Move to integration test
-    with (mock.patch('conans.ConanFile.dependencies', new_callable=mock.PropertyMock) as mock_deps):
+    with mock.patch('conans.ConanFile.dependencies', new_callable=mock.PropertyMock) as mock_deps:
         req = Requirement(ConanFileReference.loads("OriginalDepName/1.0"))
         mock_deps.return_value = ConanFileDependencies({req: ConanFileInterface(conanfile_dep)})
 

--- a/conans/test/unittests/tools/google/test_bazeldeps.py
+++ b/conans/test/unittests/tools/google/test_bazeldeps.py
@@ -58,9 +58,7 @@ def test_bazeldeps_dependency_buildfiles():
                 assert 'linkopts = ["/DEFAULTLIB:system_lib1"]' in dependency_content
             else:
                 assert 'linkopts = ["-lsystem_lib1"],' in dependency_content
-            assert "deps = [\n" in dependency_content
-            assert "# do not sort\n"
-            assert '":lib1_precompiled",' in dependency_content
+            assert """deps = [\n        # do not sort\n        ":lib1_precompiled",""" in dependency_content
 
 
 def test_bazeldeps_get_lib_file_path_by_basename():
@@ -95,9 +93,7 @@ def test_bazeldeps_get_lib_file_path_by_basename():
                 assert 'linkopts = ["/DEFAULTLIB:system_lib1"]' in dependency_content
             else:
                 assert 'linkopts = ["-lsystem_lib1"],' in dependency_content
-            assert 'deps = [' in dependency_content
-            assert '# do not sort'  in dependency_content
-            assert '":liblib1.a_precompiled"' in dependency_content
+            assert 'deps = [\n        # do not sort\n        ":liblib1.a_precompiled",' in dependency_content
 
 
 def test_bazeldeps_dependency_transitive():


### PR DESCRIPTION
Changelog: Omit
Docs: Omit


This improves generated bazel BUILD files, as there have been not so nice spaces in the files.
See also the example below:

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.

Differences for an exemplary BUILD file:
**Old:**
```

load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library")


cc_import(
    name = "GLEW_precompiled",
    static_library = "lib/libGLEW.a",
)




cc_library(
    name = "glew",
    
    hdrs = glob(["include/**"]),
    
    
    includes = ["include"],
    
    
    
    visibility = ["//visibility:public"],
    
    deps = [
        # do not sort
    
    ":GLEW_precompiled",
    
    
    
    "@opengl",
    
    "@glu",
    
    ],
    
)

```

**New:**
```
load("@rules_cc//cc:defs.bzl", "cc_import", "cc_library")
cc_import(
    name = "GLEW_precompiled",
    static_library = "lib/libGLEW.a",
)

cc_library(
    name = "glew",
    hdrs = glob(["include/**"]),
    includes = ["include"],
    visibility = ["//visibility:public"],
    deps = [
        # do not sort
        ":GLEW_precompiled",
        "@opengl",
        "@glu",
    ],
)
```
