### PR TITLE
CMake use multiple targets in target argument

### DIFF
--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -128,7 +128,9 @@ class CMake(object):
 
         args = []
         if target is not None:
-            args = ["--target", target]
+            target_list = [target] if isinstance(target, str) else target
+            args.extend(["--target"] + target_list)
+
         if cli_args:
             args.extend(cli_args)
 

--- a/conans/test/integration/toolchains/cmake/test_cmake.py
+++ b/conans/test/integration/toolchains/cmake/test_cmake.py
@@ -55,7 +55,6 @@ def test_multiple_targets(argument, output_args):
             settings = "os", "compiler", "build_type", "arch"
             def build(self):
                 cmake = CMake(self)
-                cmake.configure()
                 cmake.build(target=${argument})
 
             def run(self, *args, **kwargs):

--- a/conans/test/integration/toolchains/cmake/test_cmake.py
+++ b/conans/test/integration/toolchains/cmake/test_cmake.py
@@ -1,4 +1,8 @@
 import textwrap
+from string import Template
+
+import pytest
+
 from conans.test.utils.tools import TestClient
 
 
@@ -31,3 +35,33 @@ def test_configure_args():
     assert "-something" in client.out
     assert "--testverbose" in client.out
     assert "-testok" in client.out
+
+
+@pytest.mark.parametrize("argument, output_args", [
+    ("'target'", "--target target"),
+    ("['target']", "--target target"),
+    ("['target1', 'target2']", "--target target1 target2"),
+])
+def test_multiple_targets(argument, output_args):
+    client = TestClient()
+
+    conanfile_template = Template(textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.cmake import CMake
+        class Pkg(ConanFile):
+            generators = "CMakeToolchain"
+            name = "pkg"
+            version = "0.1"
+            settings = "os", "compiler", "build_type", "arch"
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+                cmake.build(target=${argument})
+
+            def run(self, *args, **kwargs):
+                self.output.info("MYRUN: {}".format(*args))
+            """))
+    conanfile = conanfile_template.substitute(argument=argument)
+    client.save({"conanfile.py": conanfile})
+    client.run("create . ")
+    assert output_args in client.out


### PR DESCRIPTION
Changelog: Feature: CMake helper can use multiple targets in target argument.
Docs: omit

Documentation added in docstring for CMake helper https://github.com/conan-io/conan/pull/15066

Closes: https://github.com/conan-io/conan/issues/14878
