### PR TITLE
serialize pyrequires path, needed for buildinfo

### DIFF
--- a/conans/client/graph/python_requires.py
+++ b/conans/client/graph/python_requires.py
@@ -16,7 +16,8 @@ class PyRequire(object):
 
     def serialize(self):
         return {"remote": self.remote.name if self.remote is not None else None,
-                "recipe": self.recipe}
+                "recipe": self.recipe,
+                "path": self.path}
 
 
 class PyRequires(object):

--- a/conans/test/integration/command/info/info_test.py
+++ b/conans/test/integration/command/info/info_test.py
@@ -1,4 +1,5 @@
 import json
+import os
 import textwrap
 
 from conan.cli.exit_codes import ERROR_GENERAL
@@ -199,7 +200,12 @@ class TestAdvancedCliOutput:
 
         client.run("graph info . --format=json")
         info = json.loads(client.stdout)
-        assert "tool/0.1#4d670581ccb765839f2239cc8dff8fbd" in info["graph"]["nodes"]["0"]["python_requires"]
+        pyrequires = info["graph"]["nodes"]["0"]["python_requires"]
+        tool = pyrequires["tool/0.1#4d670581ccb765839f2239cc8dff8fbd"]
+        # lets make sure the path exists
+        assert tool["recipe"] == "Cache"
+        assert tool["remote"] is None
+        assert os.path.exists(tool["path"])
 
     def test_build_id_info(self):
         client = TestClient()


### PR DESCRIPTION
Changelog: Fix: Serialize the ``path`` information of ``python_requires``, necessary for computing buildinfo
Docs: Omit
