### PR TITLE
Add clang 17 to conan 1

### DIFF
--- a/conan/tools/_compilers.py
+++ b/conan/tools/_compilers.py
@@ -350,6 +350,10 @@ def _cppstd_clang(clang_version, cppstd):
         v23 = "c++2b"
         vgnu23 = "gnu++2b"
 
+    if clang_version >= "17":
+        v23 = "c++23"
+        vgnu23 = "gnu++23"
+
     flag = {"98": v98, "gnu98": vgnu98,
             "11": v11, "gnu11": vgnu11,
             "14": v14, "gnu14": vgnu14,

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -119,7 +119,7 @@ _t_default_settings_yml = Template(textwrap.dedent("""
         clang:
             version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
                       "5.0", "6.0", "7.0", "7.1",
-                      "8", "9", "10", "11", "12", "13", "14", "15", "16"]
+                      "8", "9", "10", "11", "12", "13", "14", "15", "16", "17"]
             libcxx: [None, libstdc++, libstdc++11, libc++, c++_shared, c++_static]
             cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
             runtime: [None, MD, MT, MTd, MDd, static, dynamic]

--- a/conans/client/migrations_settings.py
+++ b/conans/client/migrations_settings.py
@@ -4765,7 +4765,7 @@ compiler:
     clang:
         version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
                   "5.0", "6.0", "7.0", "7.1",
-                  "8", "9", "10", "11", "12", "13", "14", "15", "16"]
+                  "8", "9", "10", "11", "12", "13", "14", "15", "16", "17"]
         libcxx: [None, libstdc++, libstdc++11, libc++, c++_shared, c++_static]
         cppstd: [None, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
         runtime: [None, MD, MT, MTd, MDd, static, dynamic]

--- a/conans/test/unittests/client/build/cpp_std_flags_test.py
+++ b/conans/test/unittests/client/build/cpp_std_flags_test.py
@@ -131,6 +131,12 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(_make_cppstd_flag("clang", "12", "20"), '-std=c++20')
         self.assertEqual(_make_cppstd_flag("clang", "12", "23"), '-std=c++2b')
 
+        self.assertEqual(_make_cppstd_flag("clang", "17", "11"), '-std=c++11')
+        self.assertEqual(_make_cppstd_flag("clang", "17", "14"), '-std=c++14')
+        self.assertEqual(_make_cppstd_flag("clang", "17", "17"), '-std=c++17')
+        self.assertEqual(_make_cppstd_flag("clang", "17", "20"), '-std=c++20')
+        self.assertEqual(_make_cppstd_flag("clang", "17", "23"), '-std=c++2b')
+
     def test_clang_cppstd_defaults(self):
         self.assertEqual(_make_cppstd_default("clang", "2"), "gnu98")
         self.assertEqual(_make_cppstd_default("clang", "2.1"), "gnu98")


### PR DESCRIPTION
Changelog: Feature: Add clang-17 support to settings.
Docs: https://github.com/conan-io/docs/pull/3447


fixes #14914
See no need to modify docs here.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
