### PR TITLE
more quiet system packages

### DIFF
--- a/conan/tools/gnu/pkgconfig.py
+++ b/conan/tools/gnu/pkgconfig.py
@@ -31,7 +31,7 @@ class PkgConfig:
         with env.vars(self._conanfile).apply():
             # This way we get the environment from ConanFile, from profile (default buildenv)
             output = StringIO()
-            self._conanfile.run(command, stdout=output)
+            self._conanfile.run(command, stdout=output, quiet=True)
         value = output.getvalue().strip()
         return value
 
@@ -94,6 +94,7 @@ class PkgConfig:
         """
         if not self.provides:
             raise ConanException("PkgConfig error, '{}' files not available".format(self._library))
+        self._conanfile.output.verbose(f"PkgConfig fill cpp_info for {self._library}")
         if is_system:
             cpp_info.system_libs = self.libs
         else:

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -62,10 +62,10 @@ class _SystemPackageManagerTool(object):
                 if d in os_name:
                     return tool
 
-    def get_package_name(self, package, host_package=True):        
+    def get_package_name(self, package, host_package=True):
         # Only if the package is for building, for example a library,
         # we should add the host arch when cross building.
-        # If the package is a tool that should be installed on the current build 
+        # If the package is a tool that should be installed on the current build
         # machine we should not add the arch.
         if self._arch in self._arch_names and cross_building(self._conanfile) and host_package:
             return "{}{}{}".format(package, self._arch_separator,
@@ -83,7 +83,8 @@ class _SystemPackageManagerTool(object):
             return method(*args, **kwargs)
 
     def _conanfile_run(self, command, accepted_returns):
-        ret = self._conanfile.run(command, ignore_errors=True)
+        # When checking multiple packages, this is too noisy
+        ret = self._conanfile.run(command, ignore_errors=True, quiet=True)
         if ret not in accepted_returns:
             raise ConanException("Command '%s' failed" % command)
         return ret

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -333,7 +333,8 @@ class ConanFile:
         if not quiet:
             ConanOutput().writeln(f"{self.display_name}: RUN: {command}", fg=Color.BRIGHT_BLUE)
         retcode = conan_run(wrapped_cmd, cwd=cwd, stdout=stdout, shell=shell)
-        ConanOutput().writeln("")
+        if not quiet:
+            ConanOutput().writeln("")
 
         if not ignore_errors and retcode != 0:
             raise ConanException("Error %d while executing" % retcode)

--- a/conans/test/integration/tools/system/package_manager_test.py
+++ b/conans/test/integration/tools/system/package_manager_test.py
@@ -171,7 +171,8 @@ def test_dnf_yum_return_code_100(tool_class, result):
         context_mock.return_value = "host"
         tool = tool_class(conanfile)
 
-        def fake_run(command, win_bash=False, subsystem=None, env=None, ignore_errors=False):
+        def fake_run(command, win_bash=False, subsystem=None, env=None, ignore_errors=False,
+                     quiet=False):
             assert command == result
             return 100 if "check-update" in command else 0
 
@@ -183,7 +184,8 @@ def test_dnf_yum_return_code_100(tool_class, result):
         context_mock.return_value = "host"
         tool = tool_class(conanfile)
 
-        def fake_run(command, win_bash=False, subsystem=None, env=None, ignore_errors=False):
+        def fake_run(command, win_bash=False, subsystem=None, env=None, ignore_errors=False,
+                     quiet=False):
             return 55 if "check-update" in command else 0
 
         conanfile.run = fake_run
@@ -273,7 +275,7 @@ def test_tools_install_mode_install_to_build_machine_arch(tool_class, arch_host,
             tool.install(["package1", "package2"], host_package=False)
 
     assert tool._conanfile.command == result
-    
+
 @pytest.mark.parametrize("tool_class, result", [
     # cross-compile but arch_names=None -> do not add host architecture
     # https://github.com/conan-io/conan/issues/12320 because the package is archless


### PR DESCRIPTION
Changelog: Fix: The output of system packages via ``Apt.install()`` or ``PkgConfig.fill_cpp_info``, like ``xorg/system`` was very noisy to the Conan output, making it more quiet
Docs: Omit
