### PR TITLE
fix recreation of same package revision

### DIFF
--- a/conans/test/integration/cache/test_same_pref_removal.py
+++ b/conans/test/integration/cache/test_same_pref_removal.py
@@ -1,0 +1,21 @@
+import os
+
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.tools import TestClient
+
+
+def test_same_pref_removal():
+    c = TestClient()
+    c.save({"conanfile.py": GenConanfile("pkg", "0.1")})
+    c.run("export .")
+    c.run("install --requires=pkg/0.1 --build=pkg*")
+    layout = c.created_layout()
+    pkg_folder1 = layout.package()
+    assert os.path.exists(os.path.join(pkg_folder1, "conanmanifest.txt"))
+    assert os.path.exists(os.path.join(pkg_folder1, "conaninfo.txt"))
+    c.run("install --requires=pkg/0.1 --build=pkg*")
+    layout = c.created_layout()
+    pkg_folder2 = layout.package()
+    assert pkg_folder1 == pkg_folder2
+    assert os.path.exists(os.path.join(pkg_folder1, "conanmanifest.txt"))
+    assert os.path.exists(os.path.join(pkg_folder1, "conaninfo.txt"))

--- a/conans/test/integration/command_v2/test_cache_clean.py
+++ b/conans/test/integration/command_v2/test_cache_clean.py
@@ -60,8 +60,8 @@ def test_cache_clean_all():
 
 def test_cache_multiple_builds_same_prev_clean():
     """
-    Different consecutive builds will create different folders, even if for the
-    same exact prev, leaving trailing non-referenced folders
+    Different consecutive builds will create exactly the same folder, for the
+    same exact prev, not leaving trailing non-referenced folders
     """
     c = TestClient()
     c.save({"conanfile.py": GenConanfile("pkg", "0.1")})
@@ -75,7 +75,7 @@ def test_cache_multiple_builds_same_prev_clean():
     c.run("cache path pkg/0.1:da39a3ee5e6b4b0d3255bfef95601890afd80709")
     path2 = str(c.stdout)
     assert path2 in create_out
-    assert path1 != path2
+    assert path1 == path2
 
     builds_folder = os.path.join(c.cache_folder, "p", "b")
     assert len(os.listdir(builds_folder)) == 1  # only one build


### PR DESCRIPTION
Changelog: Fix: Solve re-build of an existing package revision (like forcing rebuild of a an existing header-only package), while previous folder was still used by other projects.
Docs: Omit

Close https://github.com/conan-io/conan/issues/14933