### PR TITLE
smart cache path

### DIFF
--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -37,6 +37,16 @@ class CacheAPI:
         ref_layout = app.cache.recipe_layout(ref)
         return ref_layout.source()
 
+    def unique_binary(self, ref:RecipeReference):
+        app = ConanApp(self.conan_api.cache_folder)
+        ref = _resolve_latest_ref(app, ref)
+        prefs = app.cache.get_package_references(ref, only_latest_prev=True)
+        if len(prefs) != 1:
+            raise ConanException(f"There are {len(prefs)} binaries for {ref}. "
+                                 f"This only works when there is exactly 1 binary. "
+                                 "Please specify the package_id too.")
+        return prefs[0]
+
     def build_path(self, pref: PkgReference):
         app = ConanApp(self.conan_api.cache_folder)
         pref = _resolve_latest_pref(app, pref)


### PR DESCRIPTION
Changelog: Feature: Smart ``conan cache path`` command that is able to deduce the ``package_id`` if it is a single one, and to retrieve recipe, export and source folders when providing a full package-reference
Docs: omit


Just a proof of concept, to discuss, not guaranteed that it will be moved forward.

Close https://github.com/conan-io/conan/issues/14828
