### PR TITLE
Add config passing to conan profile detect

### DIFF
--- a/conan/api/subapi/profiles.py
+++ b/conan/api/subapi/profiles.py
@@ -91,8 +91,7 @@ class ProfilesAPI:
 
     def _get_profile(self, profiles, settings, options, conf, cwd, cache_settings,
                      profile_plugin, global_conf):
-        loader = ProfileLoader(self._conan_api.cache_folder)
-        profile = loader.from_cli_args(profiles, settings, options, conf, cwd)
+        profile = self.load_profile(profiles, settings, options, conf, cwd)
         if profile_plugin is not None:
             try:
                 profile_plugin(profile)
@@ -105,6 +104,10 @@ class ProfilesAPI:
         # Apply the new_config to the profiles the global one, so recipes get it too
         profile.conf.rebase_conf_definition(global_conf)
         return profile
+
+    def load_profile(self, profiles, settings, options, conf, cwd):
+        loader = ProfileLoader(self._conan_api.cache_folder)
+        return loader.from_cli_args(profiles, settings, options, conf, cwd)
 
     def get_path(self, profile, cwd=None, exists=True):
         """

--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -71,19 +71,20 @@ def add_profiles_args(parser, multiple_contexts=True):
                 setattr(namespace, self.dest + "_" + context, items)
 
     def create_config(short, long, example=None):
+        help_message = f'Apply the specified {long}. '\
+                       f'By default, or if specifying -{short}:h (--{long}:host), '\
+                       f'it applies to the host context. '\
+                       f'Use -{short}:b (--{long}:build) to specify the build context, '\
+                       f'or -{short}:a (--{long}:all) to specify both contexts at once'\
+                       + ('' if not example else f". Example: {example}")
+
         parser.add_argument(f"-{short}", f"--{long}",
                             default=None,
                             action="append",
                             dest=f"{long}_host",
                             metavar=long.upper(),
-                            help=f'Apply the specified {long}. '
-                                 + ((
-                                         f'By default, or if specifying -{short}:h (--{long}:host), '
-                                         f'it applies to the host context. '
-                                         f'Use -{short}:b (--{long}:build) to specify the build context, '
-                                         f'or -{short}:a (--{long}:all) to specify both contexts at once'
-                                         + ('' if not example else f". Example: {example}"))
-                                     if multiple_contexts else ''))
+                            help=help_message if multiple_contexts else '')
+
         for context in contexts:
             parser.add_argument(f"-{short}:{context[0]}", f"--{long}:{context}",
                                 default=None,

--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -57,8 +57,8 @@ def add_common_install_arguments(parser):
     add_profiles_args(parser)
 
 
-def add_profiles_args(parser):
-    contexts = ["build", "host"]
+def add_profiles_args(parser, multiple_contexts=True):
+    contexts = ["build", "host"] if multiple_contexts else []
 
     # This comes from the _AppendAction code but modified to add to the contexts
     class ContextAllAction(argparse.Action):
@@ -77,23 +77,26 @@ def add_profiles_args(parser):
                             dest=f"{long}_host",
                             metavar=long.upper(),
                             help='Apply the specified profile. '
-                                 f'By default, or if specifying -{short}:h (--{long}:host), it applies to the host context. '
-                                 f'Use -{short}:b (--{long}:build) to specify the build context, '
-                                 f'or -{short}:a (--{long}:all) to specify both contexts at once'
-                                   + ('' if not example else f". Example: {example}"))
+                                 + ((
+                                         f'By default, or if specifying -{short}:h (--{long}:host), '
+                                         f'it applies to the host context. '
+                                         f'Use -{short}:b (--{long}:build) to specify the build context, '
+                                         f'or -{short}:a (--{long}:all) to specify both contexts at once'
+                                         + ('' if not example else f". Example: {example}"))
+                                     if multiple_contexts else ''))
         for context in contexts:
             parser.add_argument(f"-{short}:{context[0]}", f"--{long}:{context}",
                                 default=None,
                                 action="append",
                                 dest=f"{long}_{context}",
                                 help="")
-
-        parser.add_argument(f"-{short}:a", f"--{long}:all",
-                            default=None,
-                            action=ContextAllAction,
-                            dest=long,
-                            metavar=f"{long.upper()}_ALL",
-                            help="")
+        if multiple_contexts:
+            parser.add_argument(f"-{short}:a", f"--{long}:all",
+                                default=None,
+                                action=ContextAllAction,
+                                dest=long,
+                                metavar=f"{long.upper()}_ALL",
+                                help="")
 
     create_config("pr", "profile")
     create_config("o", "options", "-o pkg:with_qt=true")

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -3,8 +3,6 @@ import os
 import platform
 import subprocess
 import textwrap
-import unittest
-
 import pytest
 
 from conans.client.conf.detect import detect_defaults_settings

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -1,3 +1,4 @@
+import json
 import os
 import platform
 import subprocess
@@ -14,140 +15,152 @@ from conans.util.files import save
 from conans.util.runners import check_output_runner
 from conan.tools.microsoft.visual import vcvars_command
 
-class TestProfile(unittest.TestCase):
 
-    def test_list_empty(self):
-        client = TestClient()
-        client.run("profile list")
-        self.assertIn("Profiles found in the cache:", client.out)
-
-    def test_list(self):
-        client = TestClient()
-        profiles = ["default", "profile1", "profile2", "profile3",
-                    "nested" + os.path.sep + "profile4",
-                    "nested" + os.path.sep + "two" + os.path.sep + "profile5",
-                    "nested" + os.path.sep + "profile6"]
-        if platform.system() != "Windows":
-            profiles.append("symlink_me" + os.path.sep + "profile7")
-        for profile in profiles:
-            save(os.path.join(client.cache.profiles_path, profile), "")
-
-        if platform.system() != "Windows":
-            os.symlink(os.path.join(client.cache.profiles_path, 'symlink_me'),
-                       os.path.join(client.cache.profiles_path, 'link'))
-            # profile7 will be shown twice because it is symlinked.
-            profiles.append("link" + os.path.sep + "profile7")
-
-        # Make sure local folder doesn't interact with profiles
-        os.mkdir(os.path.join(client.current_folder, "profile3"))
-        client.run("profile list")
-        for p in profiles:
-            assert p in client.out
-
-        # Test profile list json file
-        # FIXME: Json cannot be captured from tests?
-        # client.run("profile list --format=json > profiles_list.json")
-        # json_content = client.load("profiles_list.json")
-        # json_obj = json.loads(json_content)
-        # self.assertEqual(list, type(json_obj))
-        # self.assertEqual(profiles, json_obj)
-
-    def test_show(self):
-        client = TestClient()
-        profile1 = textwrap.dedent("""
-            [settings]
-            os=Windows
-            [options]
-            MyOption=32
-            [conf]
-            tools.build:jobs=20
-            """)
-        save(os.path.join(client.cache.profiles_path, "profile1"), profile1)
-
-        client.run("profile show -pr=profile1")
-        self.assertIn("[settings]\nos=Windows", client.out)
-        self.assertIn("MyOption=32", client.out)
-        # self.assertIn("CC=/path/tomy/gcc_build", client.out)
-        # self.assertIn("CXX=/path/tomy/g++_build", client.out)
-        # self.assertIn("package:VAR=value", client.out)
-        self.assertIn("tools.build:jobs=20", client.out)
-
-    def test_missing_subarguments(self):
-        client = TestClient()
-        client.run("profile", assert_error=True)
-        self.assertIn("ERROR: Exiting with code: 2", client.out)
+def test_list_empty():
+    client = TestClient()
+    client.run("profile list")
+    assert "Profiles found in the cache:" in client.out
 
 
-class DetectCompilersTest(unittest.TestCase):
-    def test_detect_default_compilers(self):
-        platform_default_compilers = {
-            "Linux": "gcc",
-            "Darwin": "apple-clang",
-            "Windows": "msvc"
-        }
+def test_list():
+    client = TestClient()
+    profiles = ["default", "profile1", "profile2", "profile3",
+                "nested" + os.path.sep + "profile4",
+                "nested" + os.path.sep + "two" + os.path.sep + "profile5",
+                "nested" + os.path.sep + "profile6"]
+    if platform.system() != "Windows":
+        profiles.append("symlink_me" + os.path.sep + "profile7")
+    for profile in profiles:
+        save(os.path.join(client.cache.profiles_path, profile), "")
 
-        result = detect_defaults_settings()
-        # result is a list of tuples (name, value) so converting it to dict
-        result = dict(result)
-        platform_compiler = platform_default_compilers.get(platform.system(), None)
-        if platform_compiler is not None:
-            self.assertEqual(result.get("compiler", None), platform_compiler)
+    if platform.system() != "Windows":
+        os.symlink(os.path.join(client.cache.profiles_path, 'symlink_me'),
+                   os.path.join(client.cache.profiles_path, 'link'))
+        # profile7 will be shown twice because it is symlinked.
+        profiles.append("link" + os.path.sep + "profile7")
 
-    @pytest.mark.tool("gcc")
-    @pytest.mark.skipif(platform.system() != "Darwin", reason="only OSX test")
-    def test_detect_default_in_mac_os_using_gcc_as_default(self):
-        """
-        Test if gcc in Mac OS X is using apple-clang as frontend
-        """
-        # See: https://github.com/conan-io/conan/issues/2231
-        output = check_output_runner("gcc --version", stderr=subprocess.STDOUT)
+    # Make sure local folder doesn't interact with profiles
+    os.mkdir(os.path.join(client.current_folder, "profile3"))
+    client.run("profile list")
+    for p in profiles:
+        assert p in client.out
 
-        if "clang" not in output:
-            # Not test scenario gcc should display clang in output
-            # see: https://stackoverflow.com/questions/19535422/os-x-10-9-gcc-links-to-clang
-            raise Exception("Apple gcc doesn't point to clang with gcc frontend anymore!")
+    # Test profile list json file
+    client.run("profile list --format=json", redirect_stdout="profiles_list.json")
+    json_content = client.load("profiles_list.json")
+    json_obj = json.loads(json_content)
+    assert type(json_obj) == list
+    assert set(profiles) == set(json_obj)
 
-        output = RedirectedTestOutput()  # Initialize each command
+
+def test_show():
+    client = TestClient()
+    profile1 = textwrap.dedent("""
+        [settings]
+        os=Windows
+        [options]
+        MyOption=32
+        [conf]
+        tools.build:jobs=20
+        """)
+
+    client.save({"profile1": profile1})
+    client.run("profile show -pr=profile1")
+    assert "[settings]\nos=Windows" in client.out
+    assert "MyOption=32" in client.out
+    assert "tools.build:jobs=20" in client.out
+
+    client.run("profile show -pr=profile1 -pr:b=profile1 -f=json", redirect_stdout="profile1.json")
+    profile = json.loads(client.load("profile1.json"))
+    assert profile == {'host': {'settings': {'os': 'Windows'}, 'package_settings': {},
+                                'options': {'MyOption': '32'}, 'tool_requires': {},
+                                'conf': {'tools.build:jobs': 20}, 'build_env': ''},
+                       'build': {'settings': {'os': 'Windows'}, 'package_settings': {},
+                                 'options': {'MyOption': '32'}, 'tool_requires': {},
+                                 'conf': {'tools.build:jobs': 20}, 'build_env': ''}}
+
+
+def test_missing_subarguments():
+    client = TestClient()
+    client.run("profile", assert_error=True)
+    assert "ERROR: Exiting with code: 2" in client.out
+
+
+def test_detect_default_compilers():
+    platform_default_compilers = {
+        "Linux": "gcc",
+        "Darwin": "apple-clang",
+        "Windows": "msvc"
+    }
+
+    result = detect_defaults_settings()
+    # result is a list of tuples (name, value) so converting it to dict
+    result = dict(result)
+    platform_compiler = platform_default_compilers.get(platform.system(), None)
+    if platform_compiler is not None:
+        assert result.get("compiler", None) == platform_compiler
+
+
+@pytest.mark.tool("gcc")
+@pytest.mark.skipif(platform.system() != "Darwin", reason="only OSX test")
+def test_detect_default_in_mac_os_using_gcc_as_default(self):
+    """
+    Test if gcc in Mac OS X is using apple-clang as frontend
+    """
+    # See: https://github.com/conan-io/conan/issues/2231
+    output = check_output_runner("gcc --version", stderr=subprocess.STDOUT)
+
+    if "clang" not in output:
+        # Not test scenario gcc should display clang in output
+        # see: https://stackoverflow.com/questions/19535422/os-x-10-9-gcc-links-to-clang
+        raise Exception("Apple gcc doesn't point to clang with gcc frontend anymore!")
+
+    output = RedirectedTestOutput()  # Initialize each command
+    with redirect_output(output):
+        with environment_update({"CC": "gcc"}):
+            result = detect_defaults_settings()
+    # result is a list of tuples (name, value) so converting it to dict
+    result = dict(result)
+    # No compiler should be detected
+    assert result.get("compiler", None) is None
+    assert "gcc detected as a frontend using apple-clang" in output
+
+
+def test_profile_new():
+    c = TestClient()
+    c.run("profile detect --name=./MyProfile2")
+    assert "os=" in c.out
+    assert "compiler.runtime_type" not in c.out  # Even in Windows
+
+    c.run("profile detect --name=./MyProfile2", assert_error=True)
+    assert "MyProfile2' already exists" in c.out
+
+    c.run("profile detect --name=./MyProfile2 --force")  # will not raise error
+
+    c.run("profile detect --name=./MyProfile3 -o *:my_custom_option=42 -s compiler.cppstd=gnu98")
+    assert "*:my_custom_option=42" in c.out
+    assert "compiler.cppstd=gnu98" in c.out  # Override from default detected one
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows and msvc")
+def test_profile_new_msvc_vcvars():
+    c = TestClient()
+
+    # extract location of cl.exe from vcvars
+    vcvars = vcvars_command(version="15", architecture="x64")
+    ret = c.run_command(f"{vcvars} && where cl.exe")
+    assert ret == 0
+    cl_executable = c.out.splitlines()[-1]
+    assert os.path.isfile(cl_executable)
+    cl_location = os.path.dirname(cl_executable)
+
+    # Try different variations, including full path and full path with quotes
+    for var in ["cl", "cl.exe", cl_executable, f'"{cl_executable}"']:
+        output = RedirectedTestOutput()
         with redirect_output(output):
-            with environment_update({"CC": "gcc"}):
-                result = detect_defaults_settings()
-        # result is a list of tuples (name, value) so converting it to dict
-        result = dict(result)
-        # No compiler should be detected
-        self.assertIsNone(result.get("compiler", None))
-        self.assertIn("gcc detected as a frontend using apple-clang", output)
+            with environment_update({"CC": var, "PATH": cl_location}):
+                c.run("profile detect --name=./cl-profile --force")
 
-    def test_profile_new(self):
-        c = TestClient()
-        c.run("profile detect --name=./MyProfile2")
-        profile = c.load("MyProfile2")
-        assert "os=" in profile
-        assert "compiler.runtime_type" not in profile  # Even in Windows
-
-        c.run("profile detect --name=./MyProfile2", assert_error=True)
-        assert "MyProfile2' already exists" in c.out
-
-        c.run("profile detect --name=./MyProfile2 --force")  # will not raise error
-    
-    @pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows and msvc")
-    def test_profile_new_msvc_vcvars(self):
-        c = TestClient()
-
-        # extract location of cl.exe from vcvars
-        vcvars = vcvars_command(version="15", architecture="x64")
-        ret = c.run_command(f"{vcvars} && where cl.exe")
-        assert ret == 0
-        cl_executable = c.out.splitlines()[-1]
-        assert os.path.isfile(cl_executable)
-        cl_location = os.path.dirname(cl_executable)
-        
-        # Try different variations, including full path and full path with quotes 
-        for var in ["cl", "cl.exe", cl_executable, f'"{cl_executable}"']:
-            output = RedirectedTestOutput()
-            with redirect_output(output):
-                with environment_update({"CC": var, "PATH": cl_location}):
-                    c.run("profile detect --name=./cl-profile --force")
-
-            profile = c.load("cl-profile")
-            assert "compiler=msvc" in profile
-            assert "compiler.version=191" in profile
+        profile = c.load("cl-profile")
+        assert "compiler=msvc" in profile
+        assert "compiler.version=191" in profile

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -101,7 +101,7 @@ def test_detect_default_compilers():
 
 @pytest.mark.tool("gcc")
 @pytest.mark.skipif(platform.system() != "Darwin", reason="only OSX test")
-def test_detect_default_in_mac_os_using_gcc_as_default(self):
+def test_detect_default_in_mac_os_using_gcc_as_default():
     """
     Test if gcc in Mac OS X is using apple-clang as frontend
     """


### PR DESCRIPTION
Changelog: Feature: Add ability to pass configs to override results of `conan profile detect`
Docs: TODO

Besides the `multiple_contexts` change for the profile arg helper, my main concern is that this would be the first command to accept `-pr` etc, but not context specifiers, as they don't make any sense in this context