### PR TITLE
remove color from conan --version

### DIFF
--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -156,7 +156,7 @@ class Cli:
             command = self._commands[command_argument]
         except KeyError as exc:
             if command_argument in ["-v", "--version"]:
-                cli_out_write("Conan version %s" % client_version, fg=Color.BRIGHT_GREEN)
+                cli_out_write("Conan version %s" % client_version)
                 return
 
             if command_argument in ["-h", "--help"]:


### PR DESCRIPTION
Changelog: Fix: Remove colors from ``conan --version`` output
Docs: Omit

For https://github.com/conan-io/conan/issues/7658
