### PR TITLE
editable shouldn't download sources

### DIFF
--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -182,6 +182,9 @@ class BinaryInstaller:
             return
 
         conanfile = node.conanfile
+        if node.binary == BINARY_EDITABLE:
+            return
+
         recipe_layout = self._cache.recipe_layout(node.ref)
         export_source_folder = recipe_layout.export_sources()
         source_folder = recipe_layout.source()

--- a/conans/test/integration/command/test_forced_download_source.py
+++ b/conans/test/integration/command/test_forced_download_source.py
@@ -48,3 +48,27 @@ def test_info(client):
     assert "RUNNING SOURCE" in client.out
     client.run("graph info --requires=dep/0.1 -c tools.build:download_source=True")
     assert "RUNNING SOURCE" not in client.out
+
+
+def test_info_editable():
+    """ graph info for editable shouldn't crash, but it also shoudn't do anythin
+    # https://github.com/conan-io/conan/issues/15003
+    """
+    c = TestClient()
+    dep = textwrap.dedent("""
+        from conan import ConanFile
+
+        class Dep(ConanFile):
+            name = "dep"
+            version = "0.1"
+
+            def source(self):
+                self.output.info("RUNNING SOURCE!!")
+            """)
+
+    c.save({"conanfile.py": dep})
+    c.run("editable add .")
+    c.run("graph info --requires=dep/0.1")
+    assert "RUNNING SOURCE" not in c.out
+    c.run("graph info --requires=dep/0.1 -c tools.build:download_source=True")
+    assert "RUNNING SOURCE" not in c.out  # BUT it doesn't crash, it used to crash


### PR DESCRIPTION
Changelog: Bugfix: ``tools.build:download_source=True`` will not fail when there are editable packages.
Docs: https://github.com/conan-io/docs/pull/3448

Close https://github.com/conan-io/conan/issues/15003

Note I have opted for not trying to do the download. The download can be a destructive action, removing local changes, which defeats the purpose of editables. ``conan source`` must be manually called by users on the editable explicitly, but it will not be called by the consumers ``install`` even if ``tools.build:download_source=True``.