### PR TITLE
[upload] Ignore metadata when passing empty string

### DIFF
--- a/conan/api/subapi/upload.py
+++ b/conan/api/subapi/upload.py
@@ -38,11 +38,15 @@ class UploadAPI:
         :param package_list:
         :param enabled_remotes:
         :param metadata: A list of patterns of metadata that should be uploaded. Default None
-        means all metadata will be uploaded together with the pkg artifacts"""
+        means all metadata will be uploaded together with the pkg artifacts. If metadata is empty
+        string (""), it means that no metadata files should be uploaded."""
+        if metadata and metadata != [''] and '' in metadata:
+            raise ConanException("Empty string and patterns can not be mixed for metadata.")
         app = ConanApp(self.conan_api.cache_folder)
         preparator = PackagePreparator(app)
         preparator.prepare(package_list, enabled_remotes)
-        gather_metadata(package_list, app.cache, metadata)
+        if metadata != ['']:
+            gather_metadata(package_list, app.cache, metadata)
         signer = PkgSignaturesPlugin(app.cache)
         # This might add files entries to package_list with signatures
         signer.sign(package_list)

--- a/conan/internal/upload_metadata.py
+++ b/conan/internal/upload_metadata.py
@@ -2,6 +2,7 @@ import fnmatch
 import os
 
 from conan.api.output import ConanOutput
+from conan.errors import ConanException
 
 
 def _metadata_files(folder, metadata):
@@ -32,6 +33,8 @@ def gather_metadata(package_list, cache, metadata: list):
 
     if metadata == ['']:
         return
+    elif metadata and '' in metadata:
+        raise ConanException("Empty string is not a valid pattern for metadata upload")
 
     for rref, recipe_bundle in package_list.refs().items():
         if metadata or recipe_bundle["upload"]:

--- a/conan/internal/upload_metadata.py
+++ b/conan/internal/upload_metadata.py
@@ -18,7 +18,21 @@ def _metadata_files(folder, metadata):
     return result
 
 
-def gather_metadata(package_list, cache, metadata):
+def gather_metadata(package_list, cache, metadata: list):
+    """
+    List and configure the metadata files to be uploaded.
+    The metadata supports patterns, so it can be used to upload only a subset of the metadata files.
+    When metadata is not specified, all metadata files are uploaded.
+    But, when metadata is empty string (""), it means that no metadata files should be uploaded.
+
+    :param package_list: Package to be uploaded
+    :param cache: Conan client cache
+    :param metadata: A list of patterns of metadata that should be uploaded. Default None
+    """
+
+    if metadata == ['']:
+        return
+
     for rref, recipe_bundle in package_list.refs().items():
         if metadata or recipe_bundle["upload"]:
             metadata_folder = cache.recipe_layout(rref).metadata()

--- a/conan/internal/upload_metadata.py
+++ b/conan/internal/upload_metadata.py
@@ -2,7 +2,6 @@ import fnmatch
 import os
 
 from conan.api.output import ConanOutput
-from conan.errors import ConanException
 
 
 def _metadata_files(folder, metadata):
@@ -19,16 +18,7 @@ def _metadata_files(folder, metadata):
     return result
 
 
-def gather_metadata(package_list, cache, metadata: list):
-    """
-    List and configure the metadata files to be uploaded.
-    The metadata supports patterns, so it can be used to upload only a subset of the metadata files.
-    When metadata is not specified, all metadata files are uploaded.
-
-    :param package_list: Package to be uploaded
-    :param cache: Conan client cache
-    :param metadata: A list of patterns of metadata that should be uploaded. Default None
-    """
+def gather_metadata(package_list, cache, metadata):
     for rref, recipe_bundle in package_list.refs().items():
         if metadata or recipe_bundle["upload"]:
             metadata_folder = cache.recipe_layout(rref).metadata()

--- a/conan/internal/upload_metadata.py
+++ b/conan/internal/upload_metadata.py
@@ -24,18 +24,11 @@ def gather_metadata(package_list, cache, metadata: list):
     List and configure the metadata files to be uploaded.
     The metadata supports patterns, so it can be used to upload only a subset of the metadata files.
     When metadata is not specified, all metadata files are uploaded.
-    But, when metadata is empty string (""), it means that no metadata files should be uploaded.
 
     :param package_list: Package to be uploaded
     :param cache: Conan client cache
     :param metadata: A list of patterns of metadata that should be uploaded. Default None
     """
-
-    if metadata == ['']:
-        return
-    elif metadata and '' in metadata:
-        raise ConanException("Empty string is not a valid pattern for metadata upload")
-
     for rref, recipe_bundle in package_list.refs().items():
         if metadata or recipe_bundle["upload"]:
             metadata_folder = cache.recipe_layout(rref).metadata()

--- a/conans/test/integration/metadata/test_metadata_commands.py
+++ b/conans/test/integration/metadata/test_metadata_commands.py
@@ -235,4 +235,4 @@ class TestMetadataCommands:
         self._save_metadata_file(client, f"pkg/0.1:{pid}")
 
         client.run('upload * --confirm --remote=default --metadata="" --metadata="logs/*"', assert_error=True)
-        assert "ERROR: Empty string is not a valid pattern for metadata upload" in client.out
+        assert "ERROR: Empty string and patterns can not be mixed for metadata." in client.out

--- a/conans/test/integration/metadata/test_metadata_commands.py
+++ b/conans/test/integration/metadata/test_metadata_commands.py
@@ -195,10 +195,9 @@ class TestMetadataCommands:
         """
         Upload command should fail when passing --metadata="" and a pattern
         """
-        client, pid = create_conan_pkg
-
-        self.save_metadata_file(client, "pkg/0.1")
-        self.save_metadata_file(client, f"pkg/0.1:{pid}")
+        client = TestClient(default_server_user=True)
+        client.save({"conanfile.py": GenConanfile("pkg", "0.1")})
+        client.run("export .")
 
         client.run('upload * --confirm --remote=default --metadata="" --metadata="logs/*"', assert_error=True)
         assert "ERROR: Empty string and patterns can not be mixed for metadata." in client.out

--- a/conans/test/integration/metadata/test_metadata_commands.py
+++ b/conans/test/integration/metadata/test_metadata_commands.py
@@ -193,8 +193,7 @@ class TestMetadataCommands:
 
     def test_upload_ignored_metadata_with_pattern(self, create_conan_pkg):
         """
-        Upload command should ignore metadata files when passing --metadata="".
-        Even if a pattern is passed to the upload command.
+        Upload command should fail when passing --metadata="" and a pattern
         """
         client, pid = create_conan_pkg
 

--- a/conans/test/integration/metadata/test_metadata_commands.py
+++ b/conans/test/integration/metadata/test_metadata_commands.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.test_files import temp_folder
@@ -8,28 +9,27 @@ from conans.util.files import save, load
 
 class TestMetadataCommands:
 
-    def _save_metadata_file(self, client, pkg_ref, filename="somefile.log"):
+    @pytest.fixture
+    def create_conan_pkg(self):
+        client = TestClient(default_server_user=True)
+        client.save({"conanfile.py": GenConanfile("pkg", "0.1")})
+        client.run("create .")
+        pid = client.created_package_id("pkg/0.1")
+        return client, pid
+
+    def save_metadata_file(self, client, pkg_ref, filename="somefile.log"):
         client.run(f"cache path {pkg_ref} --folder=metadata")
         metadata_path = str(client.stdout).strip()
         myfile = os.path.join(metadata_path, "logs", filename)
-        save(myfile, pkg_ref)
+        save(myfile, f"{pkg_ref}!!!!")
+        return metadata_path, myfile
 
-    def test_upload(self):
-        c = TestClient(default_server_user=True)
-        c.save({"conanfile.py": GenConanfile("pkg", "0.1")})
-        c.run("create .")
-        pid = c.created_package_id("pkg/0.1")
+    def test_upload(self, create_conan_pkg):
+        c, pid = create_conan_pkg
 
         # Add some metadata
-        c.run("cache path pkg/0.1 --folder=metadata")
-        metadata_path = str(c.stdout).strip()
-        myfile = os.path.join(metadata_path, "logs", "mylogs.txt")
-        save(myfile, "mylogs!!!!")
-
-        c.run(f"cache path pkg/0.1:{pid} --folder=metadata")
-        pkg_metadata_path = str(c.stdout).strip()
-        myfile = os.path.join(pkg_metadata_path, "logs", "mybuildlogs.txt")
-        save(myfile, "mybuildlogs!!!!")
+        self.save_metadata_file(c, "pkg/0.1", "mylogs.txt")
+        self.save_metadata_file(c, f"pkg/0.1:{pid}", "mybuildlogs.txt")
 
         # Now upload everything
         c.run("upload * -c -r=default")
@@ -37,10 +37,8 @@ class TestMetadataCommands:
         assert "pkg/0.1:da39a3ee5e6b4b0d3255bfef95601890afd80709: Package metadata: 1 files" in c.out
 
         # Add new files to the metadata
-        myfile = os.path.join(metadata_path, "logs", "mylogs2.txt")
-        save(myfile, "mylogs2!!!!")
-        myfile = os.path.join(pkg_metadata_path, "logs", "mybuildlogs2.txt")
-        save(myfile, "mybuildlogs2!!!!")
+        self.save_metadata_file(c, "pkg/0.1", "mylogs2.txt")
+        self.save_metadata_file(c, f"pkg/0.1:{pid}", "mybuildlogs2.txt")
         # Upload the metadata, even if the revisions exist in the server
         # adding the new metadata logs files
         c.run("upload * -c -r=default --metadata=*")
@@ -69,10 +67,7 @@ class TestMetadataCommands:
         c.run("export .")
 
         # Add some metadata
-        c.run("cache path pkg/0.1 --folder=metadata")
-        metadata_path = str(c.stdout).strip()
-        myfile = os.path.join(metadata_path, "logs", "mylogs.txt")
-        save(myfile, "mylogs!!!!")
+        _, myfile = self.save_metadata_file(c, "pkg/0.1", "mylogs.txt")
 
         # Now upload everything
         c.run("upload * -c -r=default")
@@ -93,13 +88,11 @@ class TestMetadataCommands:
         content = load(os.path.join(metadata_path, "logs", "mylogs.txt"))
         assert "mylogs2!!!!" in content
 
-    def test_folder_exist(self):
+    def test_folder_exist(self, create_conan_pkg):
         """ so we can cp -R to the metadata folder, having to create the folder in the cache
         is weird
         """
-        c = TestClient(default_server_user=True)
-        c.save({"conanfile.py": GenConanfile("pkg", "0.1")})
-        c.run("create .")
+        c, _ = create_conan_pkg
         c.run("cache path pkg/0.1 --folder=metadata")
         metadata_path = str(c.stdout).strip()
         assert os.path.isdir(metadata_path)
@@ -107,27 +100,17 @@ class TestMetadataCommands:
         pkg_metadata_path = str(c.stdout).strip()
         assert os.path.isdir(pkg_metadata_path)
 
-    def test_direct_download_redownload(self):
+    def test_direct_download_redownload(self, create_conan_pkg):
         """ When we directly download things, without "conan install" first, it is also able
         to fetch the requested metadata
 
         Also, re-downloading same thing shouldn't fail
         """
-        c = TestClient(default_server_user=True)
-        c.save({"conanfile.py": GenConanfile("pkg", "0.1")})
-        c.run("create .")
-        pid = c.created_package_id("pkg/0.1")
+        c, pid = create_conan_pkg
 
         # Add some metadata
-        c.run("cache path pkg/0.1 --folder=metadata")
-        metadata_path = str(c.stdout).strip()
-        myfile = os.path.join(metadata_path, "logs", "mylogs.txt")
-        save(myfile, "mylogs!!!!")
-
-        c.run(f"cache path pkg/0.1:{pid} --folder=metadata")
-        pkg_metadata_path = str(c.stdout).strip()
-        myfile = os.path.join(pkg_metadata_path, "logs", "mybuildlogs.txt")
-        save(myfile, "mybuildlogs!!!!")
+        metadata_path, _ = self.save_metadata_file(c, "pkg/0.1", "mylogs.txt")
+        self.save_metadata_file(c, f"pkg/0.1:{pid}", "mybuildlogs.txt")
 
         # Now upload everything
         c.run("upload * -c -r=default")
@@ -150,24 +133,14 @@ class TestMetadataCommands:
         pkg_metadata_path = str(c.stdout).strip()
         assert os.path.isfile(os.path.join(pkg_metadata_path, "logs", "mybuildlogs.txt"))
 
-    def test_no_download_cached(self):
+    def test_no_download_cached(self, create_conan_pkg):
         """ as the metadata can change, no checksum, no revision, cannot be cached
         """
-        c = TestClient(default_server_user=True)
-        c.save({"conanfile.py": GenConanfile("pkg", "0.1")})
-        c.run("create .")
-        pid = c.created_package_id("pkg/0.1")
+        c, pid = create_conan_pkg
 
         # Add some metadata
-        c.run("cache path pkg/0.1 --folder=metadata")
-        metadata_path = str(c.stdout).strip()
-        myrecipefile = os.path.join(metadata_path, "logs", "mylogs.txt")
-        save(myrecipefile, "mylogs!!!!")
-
-        c.run(f"cache path pkg/0.1:{pid} --folder=metadata")
-        pkg_metadata_path = str(c.stdout).strip()
-        mypkgfile = os.path.join(pkg_metadata_path, "logs", "mybuildlogs.txt")
-        save(mypkgfile, "mybuildlogs!!!!")
+        _, myrecipefile = self.save_metadata_file(c, "pkg/0.1", "mylogs.txt")
+        _, mypkgfile = self.save_metadata_file(c, f"pkg/0.1:{pid}", "mybuildlogs.txt")
 
         # Now upload everything
         c.run("upload * -c -r=default")
@@ -184,11 +157,11 @@ class TestMetadataCommands:
         c2.run("cache path pkg/0.1 --folder=metadata")
         c2_metadata_path = str(c2.stdout).strip()
         mylogs = load(os.path.join(c2_metadata_path, "logs", "mylogs.txt"))
-        assert "mylogs!!!!" in mylogs
+        assert "pkg/0.1!!!!" in mylogs
         c2.run(f"cache path pkg/0.1:{pid} --folder=metadata")
         c2_pkg_metadata_path = str(c2.stdout).strip()
         mybuildlogs = load(os.path.join(c2_pkg_metadata_path, "logs", "mybuildlogs.txt"))
-        assert "mybuildlogs!!!!" in mybuildlogs
+        assert f"pkg/0.1:{pid}!!!!" in mybuildlogs
 
         # Now the other client will update the metadata
         save(myrecipefile, "mylogs2!!!!")
@@ -205,34 +178,28 @@ class TestMetadataCommands:
         mybuildlogs = load(os.path.join(c2_pkg_metadata_path, "logs", "mybuildlogs.txt"))
         assert "mybuildlogs2!!!!" in mybuildlogs
 
-    def test_upload_ignored_metadata(self):
+    def test_upload_ignored_metadata(self, create_conan_pkg):
         """
         Upload command should ignore metadata files when passing --metadata=""
         """
-        client = TestClient(default_server_user=True)
-        client.save({"conanfile.py": GenConanfile("pkg", "0.1")})
-        client.run("create .")
-        pid = client.created_package_id("pkg/0.1")
+        client, pid = create_conan_pkg
 
-        self._save_metadata_file(client, "pkg/0.1")
-        self._save_metadata_file(client, f"pkg/0.1:{pid}")
+        self.save_metadata_file(client, "pkg/0.1")
+        self.save_metadata_file(client, f"pkg/0.1:{pid}")
 
         client.run('upload * --confirm --remote=default --metadata=""')
         assert "Recipe metadata" not in client.out
         assert "Package metadata" not in client.out
 
-    def test_upload_ignored_metadata_with_pattern(self):
+    def test_upload_ignored_metadata_with_pattern(self, create_conan_pkg):
         """
         Upload command should ignore metadata files when passing --metadata="".
         Even if a pattern is passed to the upload command.
         """
-        client = TestClient(default_server_user=True)
-        client.save({"conanfile.py": GenConanfile("pkg", "0.1")})
-        client.run("create .")
-        pid = client.created_package_id("pkg/0.1")
+        client, pid = create_conan_pkg
 
-        self._save_metadata_file(client, "pkg/0.1")
-        self._save_metadata_file(client, f"pkg/0.1:{pid}")
+        self.save_metadata_file(client, "pkg/0.1")
+        self.save_metadata_file(client, f"pkg/0.1:{pid}")
 
         client.run('upload * --confirm --remote=default --metadata="" --metadata="logs/*"', assert_error=True)
         assert "ERROR: Empty string and patterns can not be mixed for metadata." in client.out


### PR DESCRIPTION
- Added the support to ignore metadata upload when passing `--metadata=""` to `conan upload` command.
- Mixing no upload for metadata with a pattern for upload is considered invalid and user error (e.g `--metadata="" --metadata="logs/*")
- Add 2 new tests to validate metadata ignored upload
- Replaced duplicated pattern for package create and metadata create by regular methods in metadata upload test file.


Changelog: Feature: Ignore metadata upload by passing --metadata=""
Docs: https://github.com/conan-io/docs/pull/3436

closes #15006 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
