### PR TITLE
Check commits even with shallow clone of tags

### DIFF
--- a/conan/tools/scm/git.py
+++ b/conan/tools/scm/git.py
@@ -91,15 +91,11 @@ class Git:
 
         try:
             # This will raise if commit not present.
-            self.run("fetch origin --dry-run --depth=1 {}".format(commit))
+            self.run("fetch {} --dry-run --depth=1 {}".format(remote, commit))
             return True
         except Exception as e:
-            # The error message contains the command and the commit if it can't find it.
-            if str(e).count(commit) == 2:
-                return False
-            else:
-                # Perhaps a connection error.
-                raise ConanException("Unable to check remote commit in '%s': %s" % (self.folder, str(e)))
+            # Don't raise an error because the fetch could fail for many more reasons than the branch.
+            return False
 
     def is_dirty(self):
         """

--- a/conans/test/functional/tools/scm/test_git.py
+++ b/conans/test/functional/tools/scm/test_git.py
@@ -921,7 +921,6 @@ class TestGitShallowTagClone:
         """
         a shallow cloned repo won't have the new commit locally, but can fetch it.
         """
-        return
         folder = temp_folder()
         url, commit = create_local_git_repo(files={"conanfile.py": self.conanfile}, folder=folder)
 


### PR DESCRIPTION
Changelog: Fix: Make ``Git()`` check commits in remote server even for shallow clones.
Docs: omit

Fixes https://github.com/conan-io/conan/issues/14928

When performing a shallow clone of a tag (e.g. `git clone https://github.com/conan-io/conan --depth=1 -b 2.0.13`) it does not copy and of the branches or history.  The `commit_in_remote` method of the `Git` class only checks local information.  This PR will additionally check the remote if needed.

I tested this by cloning a repo twice - one as a normal clone and the other with a shallow clone of a tag.  I created an additional commit in each repo.  I ran of total of 8 tests - checking all possibilities of:
1. Shallow vs Full clone
2. Commit in repo
3. Network connection available.

The `git fetch` performed requires a connection to the remote repo.  I wanted to make sure that it failed gracefully in an offline scenario.  The function performed as expected in all cases.

Without an internet connection, the function waits until the command times out and then throws an error (which is communicated to the user).

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
