### PR TITLE
package_manager: handle linux mint

### DIFF
--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -61,6 +61,11 @@ class _SystemPackageManagerTool(object):
             for d in distros:
                 if d in os_name:
                     return tool
+                
+        # No default package manager was found for the system,
+        # so notify the user
+        self._conanfile.output.info("A default system package manager couldn't be found for {}, "
+                                    "system packages will not be installed.".format(os_name))
 
     def get_package_name(self, package, host_package=True):
         # Only if the package is for building, for example a library,

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -39,7 +39,7 @@ class _SystemPackageManagerTool(object):
             os_name = distro.id() or os_name
         elif os_name == "Windows" and self._conanfile.conf.get("tools.microsoft.bash:subsystem") == "msys2":
             os_name = "msys2"
-        manager_mapping = {"apt-get": ["Linux", "ubuntu", "debian", "raspbian"],
+        manager_mapping = {"apt-get": ["Linux", "ubuntu", "debian", "raspbian", "linuxmint"],
                            "apk": ["alpine"],
                            "yum": ["pidora", "scientific", "xenserver", "amazon", "oracle", "amzn",
                                    "almalinux", "rocky"],

--- a/conans/test/integration/tools/system/package_manager_test.py
+++ b/conans/test/integration/tools/system/package_manager_test.py
@@ -45,6 +45,7 @@ def test_msys2():
 @pytest.mark.parametrize("distro, tool", [
     ("ubuntu", "apt-get"),
     ("debian", "apt-get"),
+    ("linuxmint", "apt-get"),
     ("pidora", "yum"),
     ("rocky", "yum"),
     ("fedora", "dnf"),


### PR DESCRIPTION
Changelog: Fix: Default to apt-get package manager in Linux Mint
Docs: https://github.com/conan-io/docs/pull/3441

- [ ] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [X] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.

Linux Mint, being based on Ubuntu, should default to using the apt-get package manager. Being a decently popular OS for Linux beginners, ideally Conan should work on it with as little configuration from the user as possible, and the tool name is one such configuration that can be preset.

Right now it fails to install system packages even with sudo=True and mode=install in the global.conf file, as it doesn't know which package manager to use.