### PR TITLE
Exclusive DB access

### DIFF
--- a/conan/internal/cache/db/table.py
+++ b/conan/internal/cache/db/table.py
@@ -11,18 +11,17 @@ class BaseDbTable:
     row_type: namedtuple = None
     columns: namedtuple = None
     unique_together: tuple = None
-    _connection_mutex: threading.Lock = None
+    _connection_mutex = threading.Lock()
 
     def __init__(self, filename):
         self.filename = filename
         column_names: List[str] = [it[0] for it in self.columns_description]
         self.row_type = namedtuple('_', column_names)
         self.columns = self.row_type(*column_names)
-        self._connection_mutex = threading.Lock()
 
     @contextmanager
     def db_connection(self):
-        with self._connection_mutex:
+        with type(self)._connection_mutex:
             connection = sqlite3.connect(self.filename, isolation_level=None, timeout=10)
             try:
                 yield connection

--- a/conan/internal/cache/db/table.py
+++ b/conan/internal/cache/db/table.py
@@ -21,7 +21,7 @@ class BaseDbTable:
 
     @contextmanager
     def db_connection(self):
-        with type(self)._connection_mutex:
+        with self._connection_mutex:
             connection = sqlite3.connect(self.filename, isolation_level=None, timeout=10)
             try:
                 yield connection

--- a/conan/internal/cache/db/table.py
+++ b/conan/internal/cache/db/table.py
@@ -23,7 +23,7 @@ class BaseDbTable:
 
     @contextmanager
     def db_connection(self):
-        assert self._lock.acquire(timeout=10)
+        assert self._lock.acquire(timeout=10), "Conan failed to acquire database lock"
         connection = sqlite3.connect(self.filename, isolation_level=None, timeout=10)
         try:
             yield connection

--- a/conan/internal/cache/db/table.py
+++ b/conan/internal/cache/db/table.py
@@ -23,7 +23,7 @@ class BaseDbTable:
 
     @contextmanager
     def db_connection(self):
-        assert self._lock.acquire(timeout=10)
+        assert self._lock.acquire()
         connection = sqlite3.connect(self.filename, isolation_level=None, timeout=10)
         try:
             yield connection

--- a/conan/internal/cache/db/table.py
+++ b/conan/internal/cache/db/table.py
@@ -23,13 +23,13 @@ class BaseDbTable:
 
     @contextmanager
     def db_connection(self):
-        assert self.lock.acquire(timeout=10)
+        assert self._lock.acquire(timeout=10)
         connection = sqlite3.connect(self.filename, isolation_level=None, timeout=10)
         try:
             yield connection
         finally:
             connection.close()
-            self.lock.release()
+            self._lock.release()
 
     def create_table(self):
         def field(name, typename, nullable=False, check_constraints: Optional[List] = None,

--- a/conan/internal/cache/db/table.py
+++ b/conan/internal/cache/db/table.py
@@ -11,25 +11,25 @@ class BaseDbTable:
     row_type: namedtuple = None
     columns: namedtuple = None
     unique_together: tuple = None
-    _lock: threading.Lock = None
-    _lock_storage = defaultdict(threading.Lock)
+    # _lock: threading.Lock = None
+    # _lock_storage = defaultdict(threading.Lock)
 
     def __init__(self, filename):
         self.filename = filename
         column_names: List[str] = [it[0] for it in self.columns_description]
         self.row_type = namedtuple('_', column_names)
         self.columns = self.row_type(*column_names)
-        self._lock = self._lock_storage[self.filename]
+        # self._lock = self._lock_storage[self.filename]
 
     @contextmanager
     def db_connection(self):
-        assert self._lock.acquire()
+        # assert self._lock.acquire(timeout=10)
         connection = sqlite3.connect(self.filename, isolation_level=None, timeout=10)
         try:
             yield connection
         finally:
             connection.close()
-            self._lock.release()
+            # self._lock.release()
 
     def create_table(self):
         def field(name, typename, nullable=False, check_constraints: Optional[List] = None,

--- a/conan/internal/cache/db/table.py
+++ b/conan/internal/cache/db/table.py
@@ -21,12 +21,13 @@ class BaseDbTable:
 
     @contextmanager
     def db_connection(self):
-        with self._connection_mutex:
-            connection = sqlite3.connect(self.filename, isolation_level=None, timeout=10)
-            try:
-                yield connection
-            finally:
-                connection.close()
+        assert self._connection_mutex.acquire(timeout=10)
+        connection = sqlite3.connect(self.filename, isolation_level=None, timeout=10)
+        try:
+            yield connection
+        finally:
+            connection.close()
+            self._connection_mutex.release()
 
     def create_table(self):
         def field(name, typename, nullable=False, check_constraints: Optional[List] = None,

--- a/conan/internal/cache/db/table.py
+++ b/conan/internal/cache/db/table.py
@@ -11,6 +11,7 @@ class BaseDbTable:
     row_type: namedtuple = None
     columns: namedtuple = None
     unique_together: tuple = None
+    _lock: threading.Lock = None
     _lock_storage = defaultdict(threading.Lock)
 
     def __init__(self, filename):
@@ -18,17 +19,17 @@ class BaseDbTable:
         column_names: List[str] = [it[0] for it in self.columns_description]
         self.row_type = namedtuple('_', column_names)
         self.columns = self.row_type(*column_names)
+        self._lock = self._lock_storage[self.filename]
 
     @contextmanager
     def db_connection(self):
-        lock = self._lock_storage[self.filename]
-        assert lock.acquire(timeout=10)
+        assert self.lock.acquire(timeout=10)
         connection = sqlite3.connect(self.filename, isolation_level=None, timeout=10)
         try:
             yield connection
         finally:
             connection.close()
-            lock.release()
+            self.lock.release()
 
     def create_table(self):
         def field(name, typename, nullable=False, check_constraints: Optional[List] = None,

--- a/conan/internal/cache/db/table.py
+++ b/conan/internal/cache/db/table.py
@@ -11,25 +11,25 @@ class BaseDbTable:
     row_type: namedtuple = None
     columns: namedtuple = None
     unique_together: tuple = None
-    # _lock: threading.Lock = None
-    # _lock_storage = defaultdict(threading.Lock)
+    _lock: threading.Lock = None
+    _lock_storage = defaultdict(threading.Lock)
 
     def __init__(self, filename):
         self.filename = filename
         column_names: List[str] = [it[0] for it in self.columns_description]
         self.row_type = namedtuple('_', column_names)
         self.columns = self.row_type(*column_names)
-        # self._lock = self._lock_storage[self.filename]
+        self._lock = self._lock_storage[self.filename]
 
     @contextmanager
     def db_connection(self):
-        # assert self._lock.acquire(timeout=10)
+        assert self._lock.acquire(timeout=10)
         connection = sqlite3.connect(self.filename, isolation_level=None, timeout=10)
         try:
             yield connection
         finally:
             connection.close()
-            # self._lock.release()
+            self._lock.release()
 
     def create_table(self):
         def field(name, typename, nullable=False, check_constraints: Optional[List] = None,


### PR DESCRIPTION
Changelog: Feature: Allow only one simultaneous database connection.
Docs: omit

Implementation of a [proposed solution](https://github.com/conan-io/conan/issues/13924#issuecomment-1784219584) for "database is locked" errors.

Fixes #13924 - I did not really check that this change fixes the error but it should