### PR TITLE
RISC-V

### DIFF
--- a/conan/internal/api/detect_api.py
+++ b/conan/internal/api/detect_api.py
@@ -50,6 +50,10 @@ def detect_arch():
         return "armv8"
     elif "ARM64" in machine:
         return "armv8"
+    elif 'riscv64' in machine:
+        return "riscv64"
+    elif "riscv32" in machine:
+        return 'riscv32'
     elif "64" in machine:
         return "x86_64"
     elif "86" in machine:

--- a/conan/tools/gnu/get_gnu_triplet.py
+++ b/conan/tools/gnu/get_gnu_triplet.py
@@ -58,6 +58,10 @@ def _get_gnu_triplet(os_, arch, compiler=None):
         elif "e2k" in arch:
             # https://lists.gnu.org/archive/html/config-patches/2015-03/msg00000.html
             machine = "e2k-unknown"
+        elif "riscv64" in arch:
+            machine = 'riscv64'
+        elif 'riscv32' in arch:
+            machine = "riscv32"
 
     if machine is None:
         raise ConanException("Unknown '%s' machine, Conan doesn't know how to "

--- a/conan/tools/meson/helpers.py
+++ b/conan/tools/meson/helpers.py
@@ -1,6 +1,5 @@
 from conan.api.output import ConanOutput
 from conan.tools.build.flags import cppstd_msvc_flag
-from conans.errors import ConanException
 from conans.model.options import _PackageOption
 
 __all__ = ["to_meson_machine", "to_meson_value", "to_cppstd_flag"]
@@ -50,7 +49,9 @@ _meson_cpu_family_map = {
     'sparcv9': ('sparc64', 'sparc64', 'big'),
     'wasm': ('wasm32', 'wasm32', 'little'),
     'x86': ('x86', 'x86', 'little'),
-    'x86_64': ('x86_64', 'x86_64', 'little')
+    'x86_64': ('x86_64', 'x86_64', 'little'),
+    'riscv32': ('riscv32', 'riscv32', 'little'),
+    'riscv64': ('riscv64', 'riscv32', 'little')
 }
 
 

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -77,6 +77,7 @@ arch: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64,
        sparc, sparcv9,
        mips, mips64, avr, s390, s390x, asm.js, wasm, sh4le,
        e2k-v2, e2k-v3, e2k-v4, e2k-v5, e2k-v6, e2k-v7,
+       riscv64, riscv32,
        xtensalx6, xtensalx106, xtensalx7]
 compiler:
     sun-cc:

--- a/conans/test/unittests/tools/gnu/test_triplets.py
+++ b/conans/test/unittests/tools/gnu/test_triplets.py
@@ -63,6 +63,8 @@ from conans.errors import ConanException
     ["Linux", "e2k-v5", None, "e2k-unknown-linux-gnu"],
     ["Linux", "e2k-v6", None, "e2k-unknown-linux-gnu"],
     ["Linux", "e2k-v7", None, "e2k-unknown-linux-gnu"],
+    ["Linux", "riscv32", None, "riscv32-linux-gnu"],
+    ["Linux", "riscv64", None, "riscv64-linux-gnu"],
 ])
 def test_get_gnu_triplet(os_, arch, compiler, expected_triplet):
     triplet = _get_gnu_triplet(os_, arch, compiler)

--- a/conans/test/unittests/util/detected_architecture_test.py
+++ b/conans/test/unittests/util/detected_architecture_test.py
@@ -28,7 +28,9 @@ class DetectedArchitectureTest(unittest.TestCase):
         ['s390x', 's390x'],
         ['arm64', "armv8"],
         ['aarch64', 'armv8'],
-        ['ARM64', 'armv8']
+        ['ARM64', 'armv8'],
+        ["riscv64", 'riscv64'],
+        ['riscv32', "riscv32"]
     ])
     def test_various(self, mocked_machine, expected_arch):
 


### PR DESCRIPTION
add some basic RISC-V support to the default conan settings.

I've tested a few popular recipes of different build systems, e.g.:
- custom (OpenSSL)
- CMake (JsonCpp, GTest)
- AutoTools (libxml2, libiconv)
- Meson (pixman)

and all were built successfully with no issues.

Changelog: Feature: Added ``riscv64, riscv32`` architectures to default ``settings.yml`` and management of them in Meson and Autotools.
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
