### PR TITLE
test for build-missing of transitive tool-requires

### DIFF
--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -65,6 +65,7 @@ class Node(object):
         self.error = None
         self.cant_build = False  # It will set to a str with a reason if the validate_build() fails
         self.should_build = False  # If the --build or policy wants to build this binary
+        self.build_allowed = False
 
     def __lt__(self, other):
         """

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -396,11 +396,11 @@ class GraphBinariesAnalyzer(object):
                 for dep in node.transitive_deps.values():
                     dep.require.skip = dep.node not in deps_required
 
-                # Finally accumulate for marking binaries as SKIP download
+                # Finally accumulate all needed nodes for marking binaries as SKIP download
                 news_req = [r for r in deps_required
-                            if r.binary in (BINARY_BUILD, BINARY_EDITABLE_BUILD, BINARY_EDITABLE)]
-                # TODO: Optimize not repeat expansions
-                new_root_nodes.update(news_req)
+                            if r.binary in (BINARY_BUILD, BINARY_EDITABLE_BUILD, BINARY_EDITABLE)
+                            if r not in required_nodes]  # Avoid already expanded before
+                new_root_nodes.update(news_req)  # For expanding the next iteration
                 required_nodes.update(deps_required)
 
             root_nodes = new_root_nodes

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -33,7 +33,6 @@ class GraphBinariesAnalyzer(object):
         if build_mode.forced(conanfile, ref, with_deps_to_build):
             node.should_build = True
             conanfile.output.info('Forced build from source')
-            print("FORCED!!!!!!!!!!!!!!!!!!!!!!!!!!!", node)
             node.binary = BINARY_BUILD if not node.cant_build else BINARY_INVALID
             node.prev = None
             return True
@@ -152,7 +151,6 @@ class GraphBinariesAnalyzer(object):
         node._package_id = original_package_id
 
     def _evaluate_node(self, node, build_mode, remotes, update):
-        ConanOutput().warning(f"EVALUAING NODE!!!!!!!!!!!!!!!!!!!!!!! {node}")
         assert node.binary is None, "Node.binary should be None"
         assert node.package_id is not None, "Node.package_id shouldn't be None"
         assert node.prev is None, "Node.prev should be None"
@@ -164,7 +162,7 @@ class GraphBinariesAnalyzer(object):
 
         if node.binary == BINARY_MISSING and build_mode.allowed(node.conanfile):
             node.should_build = True
-            ConanOutput().warning(f"ALLOWED!!!!!!!!!!!!!!!!!!!!!!! {node}")
+            node.build_allowed = True
             node.binary = BINARY_BUILD if not node.cant_build else BINARY_INVALID
 
         if (node.binary in (BINARY_BUILD, BINARY_MISSING) and node.conanfile.info.invalid and
@@ -213,7 +211,6 @@ class GraphBinariesAnalyzer(object):
                 node.prev = cache_latest_prev.revision
             elif build_mode.allowed(node.conanfile):
                 node.should_build = True
-                ConanOutput().warning(f"SKIP!!!!!!!!!!!!!!!!!!!!!!! {node}")
                 node.binary = BINARY_BUILD
             else:
                 node.binary = BINARY_MISSING
@@ -376,10 +373,10 @@ class GraphBinariesAnalyzer(object):
         required_nodes = set()
         required_nodes.add(graph.root)
         for node in graph.nodes:
-            ConanOutput().warning(f"..........CHECK IF SKIP {node}")
             if node.binary not in (BINARY_BUILD, BINARY_EDITABLE_BUILD, BINARY_EDITABLE) \
                     and node is not graph.root:
-                ConanOutput().warning(f"         CANNOT BE SKIPPED {node}")
+                continue
+            if node.binary is BINARY_BUILD and node.build_allowed:
                 continue
             # The nodes that are directly required by this one to build correctly
             deps_required = set(d.node for d in node.transitive_deps.values() if d.require.files)
@@ -395,15 +392,10 @@ class GraphBinariesAnalyzer(object):
             for dep in node.transitive_deps.values():
                 dep.require.skip = dep.node not in deps_required
 
-            ConanOutput().warning(f"DEPS REQUIRED BY {node} = {deps_required}")
             # Finally accumulate for marking binaries as SKIP download
             required_nodes.update(deps_required)
-            ConanOutput().warning(f"TOTAL DEPS {required_nodes}")
 
         for node in graph.nodes:
             if node not in required_nodes and node.conanfile.conf.get("tools.graph:skip_binaries",
                                                                       check_type=bool, default=True):
-                ConanOutput().warning(f"         SUCCESSFULLY SKIPPING! {node}")
                 node.binary = BINARY_SKIP
-            else:
-                ConanOutput().warning(f"         NOT SKIPPING {node}")

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -371,29 +371,39 @@ class GraphBinariesAnalyzer(object):
     @staticmethod
     def _skip_binaries(graph):
         required_nodes = set()
+        # Aggregate all necessary starting nodes
         required_nodes.add(graph.root)
         for node in graph.nodes:
-            if node.binary not in (BINARY_BUILD, BINARY_EDITABLE_BUILD, BINARY_EDITABLE) \
-                    and node is not graph.root:
-                continue
-            if node.binary is BINARY_BUILD and node.build_allowed:
-                continue
-            # The nodes that are directly required by this one to build correctly
-            deps_required = set(d.node for d in node.transitive_deps.values() if d.require.files)
+            if node.binary in (BINARY_BUILD, BINARY_EDITABLE_BUILD, BINARY_EDITABLE):
+                if not node.build_allowed:  # Only those that are forced to build, not only "missing"
+                    required_nodes.add(node)
 
-            # second pass, transitive affected. Packages that have some dependency that is required
-            # cannot be skipped either. In theory the binary could be skipped, but build system
-            # integrations like CMakeDeps rely on find_package() to correctly find transitive deps
-            indirect = (d.node for d in node.transitive_deps.values()
-                        if any(t.node in deps_required for t in d.node.transitive_deps.values()))
-            deps_required.update(indirect)
+        root_nodes = required_nodes.copy()
+        while root_nodes:
+            new_root_nodes = set()
+            for node in root_nodes:
+                # The nodes that are directly required by this one to build correctly
+                deps_required = set(d.node for d in node.transitive_deps.values() if d.require.files)
 
-            # Third pass, mark requires as skippeable
-            for dep in node.transitive_deps.values():
-                dep.require.skip = dep.node not in deps_required
+                # second pass, transitive affected. Packages that have some dependency that is required
+                # cannot be skipped either. In theory the binary could be skipped, but build system
+                # integrations like CMakeDeps rely on find_package() to correctly find transitive deps
+                indirect = (d.node for d in node.transitive_deps.values()
+                            if any(t.node in deps_required for t in d.node.transitive_deps.values()))
+                deps_required.update(indirect)
 
-            # Finally accumulate for marking binaries as SKIP download
-            required_nodes.update(deps_required)
+                # Third pass, mark requires as skippeable
+                for dep in node.transitive_deps.values():
+                    dep.require.skip = dep.node not in deps_required
+
+                # Finally accumulate for marking binaries as SKIP download
+                news_req = [r for r in deps_required
+                            if r.binary in (BINARY_BUILD, BINARY_EDITABLE_BUILD, BINARY_EDITABLE)]
+                # TODO: Optimize not repeat expansions
+                new_root_nodes.update(news_req)
+                required_nodes.update(deps_required)
+
+            root_nodes = new_root_nodes
 
         for node in graph.nodes:
             if node not in required_nodes and node.conanfile.conf.get("tools.graph:skip_binaries",

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -178,7 +178,7 @@ class BinaryInstaller:
     def _install_source(self, node, remotes):
         conanfile = node.conanfile
         download_source = conanfile.conf.get("tools.build:download_source", check_type=bool)
-        ConanOutput().warning(f"DOWNLAOD SOURCE {node}={download_source}. Binary {node.binary}")
+
         if not download_source and node.binary != BINARY_BUILD:
             return
 

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -178,7 +178,7 @@ class BinaryInstaller:
     def _install_source(self, node, remotes):
         conanfile = node.conanfile
         download_source = conanfile.conf.get("tools.build:download_source", check_type=bool)
-
+        ConanOutput().warning(f"DOWNLAOD SOURCE {node}={download_source}. Binary {node.binary}")
         if not download_source and node.binary != BINARY_BUILD:
             return
 

--- a/conans/test/integration/build_requires/build_requires_test.py
+++ b/conans/test/integration/build_requires/build_requires_test.py
@@ -1,6 +1,7 @@
 import json
 import os
 import platform
+import re
 import textwrap
 import unittest
 
@@ -969,3 +970,22 @@ class TestBuildTrackHost:
         # lock can be used
         c.run("install app --lockfile=app/conan.lock")
         c.assert_listed_require({"protobuf/1.1": "Cache"}, build=True)
+
+
+def test_build_missing_build_requires():
+    c = TestClient()
+    c.save({"tooldep/conanfile.py": GenConanfile("tooldep", "0.1"),
+            "tool/conanfile.py": GenConanfile("tool", "0.1").with_tool_requires("tooldep/0.1"),
+            "pkg/conanfile.py": GenConanfile("pkg", "0.1").with_tool_requires("tool/0.1"),
+            "app/conanfile.py": GenConanfile().with_requires("pkg/0.1")})
+    c.run("create tooldep")
+    c.run("create tool")
+    c.run("create pkg")
+    c.run("remove tool*:* -c")
+    print(c.out)
+    c.run("install app")
+    print(c.out)
+    c.run("install app --build=missing")
+    print(c.out)
+    assert "- Build" not in c.out
+    assert re.search(r"Skipped binaries(\s*)tool/0.1, tooldep/0.1", client.out)

--- a/conans/test/integration/build_requires/build_requires_test.py
+++ b/conans/test/integration/build_requires/build_requires_test.py
@@ -982,10 +982,9 @@ def test_build_missing_build_requires():
     c.run("create tool")
     c.run("create pkg")
     c.run("remove tool*:* -c")
-    print(c.out)
     c.run("install app")
-    print(c.out)
-    c.run("install app --build=missing")
-    print(c.out)
     assert "- Build" not in c.out
-    assert re.search(r"Skipped binaries(\s*)tool/0.1, tooldep/0.1", client.out)
+    assert re.search(r"Skipped binaries(\s*)tool/0.1, tooldep/0.1", c.out)
+    c.run("install app --build=missing")
+    assert "- Build" not in c.out
+    assert re.search(r"Skipped binaries(\s*)tool/0.1, tooldep/0.1", c.out)

--- a/conans/test/integration/build_requires/profile_build_requires_test.py
+++ b/conans/test/integration/build_requires/profile_build_requires_test.py
@@ -58,6 +58,10 @@ class BuildRequiresTest(unittest.TestCase):
         client.run("export . --user=lasote --channel=stable")
 
     def test_profile_requires(self):
+        """
+        cli -(tool-requires)-> tool/0.1
+          \\--(requires)->mylib/0.1 -(tool_requires)->tool/0.1 (skipped)
+        """
         client = TestClient()
         self._create(client)
 


### PR DESCRIPTION
Changelog: Bugfix: ``--build=missing`` was doing unnecessary builds of packages that were not needed and could be skipped, in the case of ``tool_requires`` having transitive dependencies.
Docs: Omit