### PR TITLE
CMP0091 should be only set on Windows

### DIFF
--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -170,8 +170,8 @@ def write_cmake_presets(conanfile, toolchain_file, generator, cache_variables,
             cmake_make_program = cmake_make_program.replace("\\", "/")
             cache_variables["CMAKE_MAKE_PROGRAM"] = cmake_make_program
 
-    if "CMAKE_POLICY_DEFAULT_CMP0091" not in cache_variables:
-        cache_variables["CMAKE_POLICY_DEFAULT_CMP0091"] = "NEW"
+        if "CMAKE_POLICY_DEFAULT_CMP0091" not in cache_variables:
+            cache_variables["CMAKE_POLICY_DEFAULT_CMP0091"] = "NEW"
 
     if "BUILD_TESTING" not in cache_variables:
         if conanfile.conf.get("tools.build:skip_test", check_type=bool):


### PR DESCRIPTION
CMP0091 should be only set on Windows, otherwise it will generate a warning on newer version of CMake (tested on 3.27.0)

CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_POLICY_DEFAULT_CMP0091

Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
