### PR TITLE
Fix default path fallack when `core.sources:download_cache` is not set

### DIFF
--- a/conans/client/downloaders/caching_file_downloader.py
+++ b/conans/client/downloaders/caching_file_downloader.py
@@ -24,7 +24,6 @@ class SourcesCachingDownloader:
         self._cache = helpers.cache
         self._output = conanfile.output
         self._conanfile = conanfile
-        self._cache_folder = helpers.cache.cache_folder
 
     def download(self, urls, file_path,
                  retry, retry_wait, verify_ssl, auth, headers, md5, sha1, sha256):
@@ -50,7 +49,7 @@ class SourcesCachingDownloader:
         something is found.
         """
         # We are going to use the download_urls definition for backups
-        download_cache_folder = download_cache_folder or HomePaths(self._cache_folder).default_sources_backup_folder
+        download_cache_folder = download_cache_folder or HomePaths(self._cache.cache_folder).default_sources_backup_folder
         # regular local shared download cache, not using Conan backup sources servers
         backups_urls = backups_urls or ["origin"]
         if download_cache_folder and not os.path.isabs(download_cache_folder):

--- a/conans/client/downloaders/caching_file_downloader.py
+++ b/conans/client/downloaders/caching_file_downloader.py
@@ -24,6 +24,7 @@ class SourcesCachingDownloader:
         self._cache = helpers.cache
         self._output = conanfile.output
         self._conanfile = conanfile
+        self._cache_folder = helpers.cache.cache_folder
 
     def download(self, urls, file_path,
                  retry, retry_wait, verify_ssl, auth, headers, md5, sha1, sha256):
@@ -49,7 +50,7 @@ class SourcesCachingDownloader:
         something is found.
         """
         # We are going to use the download_urls definition for backups
-        download_cache_folder = download_cache_folder or HomePaths(self.conan_api.cache_folder).default_sources_backup_folder
+        download_cache_folder = download_cache_folder or HomePaths(self._cache_folder).default_sources_backup_folder
         # regular local shared download cache, not using Conan backup sources servers
         backups_urls = backups_urls or ["origin"]
         if download_cache_folder and not os.path.isabs(download_cache_folder):

--- a/conans/test/integration/cache/backup_sources_test.py
+++ b/conans/test/integration/cache/backup_sources_test.py
@@ -185,7 +185,8 @@ class TestDownloadCacheBackupSources:
         assert f"Sources for {self.file_server.fake_url}/internet/myfile.txt found in remote backup" in self.client.out
         assert f"File {self.file_server.fake_url}/mycompanystorage/mycompanyfile.txt not found in {self.file_server.fake_url}/backups/" in self.client.out
 
-        # Ensure defaults backup folder works if nothing set in global.conf
+        # Ensure defaults backup folder works if it's not set in global.conf
+        # (The rest is needed to exercise the rest of the code)
         self.client.save(
             {"global.conf": f"core.sources:download_urls=['{self.file_server.fake_url}/backups/', 'origin']\n"
                             f"core.sources:exclude_urls=['{self.file_server.fake_url}/mycompanystorage/', '{self.file_server.fake_url}/mycompanystorage2/']"},

--- a/conans/test/integration/cache/backup_sources_test.py
+++ b/conans/test/integration/cache/backup_sources_test.py
@@ -185,6 +185,15 @@ class TestDownloadCacheBackupSources:
         assert f"Sources for {self.file_server.fake_url}/internet/myfile.txt found in remote backup" in self.client.out
         assert f"File {self.file_server.fake_url}/mycompanystorage/mycompanyfile.txt not found in {self.file_server.fake_url}/backups/" in self.client.out
 
+        # Ensure defaults backup folder works if nothing set in global.conf
+        self.client.save(
+            {"global.conf": f"core.sources:download_urls=['{self.file_server.fake_url}/backups/', 'origin']\n"
+                            f"core.sources:exclude_urls=['{self.file_server.fake_url}/mycompanystorage/', '{self.file_server.fake_url}/mycompanystorage2/']"},
+            path=self.client.cache.cache_folder)
+        self.client.run("source .")
+        assert f"Sources for {self.file_server.fake_url}/internet/myfile.txt found in remote backup" in self.client.out
+        assert f"File {self.file_server.fake_url}/mycompanystorage/mycompanyfile.txt not found in {self.file_server.fake_url}/backups/" in self.client.out
+
     def test_download_origin_first(self):
         http_server_base_folder_internet = os.path.join(self.file_server.store, "internet")
 


### PR DESCRIPTION
Changelog: Bugfix: Fix backup sources error when no `core.sources:download_cache` is set.
Docs: Omit

The tests were unfortunately not covering that case

Closes #15103 