### PR TITLE
Add `stderr` capture argument to conanfile's `run()` method

### DIFF
--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -318,7 +318,7 @@ class ConanFile:
         return Path(self.generators_folder)
 
     def run(self, command, stdout=None, cwd=None, ignore_errors=False, env="", quiet=False,
-            shell=True, scope="build"):
+            shell=True, scope="build", stderr=None):
         # NOTE: "self.win_bash" is the new parameter "win_bash" for Conan 2.0
         command = self._conan_helpers.cmd_wrapper.wrap(command, conanfile=self)
         if env == "":  # This default allows not breaking for users with ``env=None`` indicating
@@ -332,7 +332,7 @@ class ConanFile:
         from conans.util.runners import conan_run
         if not quiet:
             ConanOutput().writeln(f"{self.display_name}: RUN: {command}", fg=Color.BRIGHT_BLUE)
-        retcode = conan_run(wrapped_cmd, cwd=cwd, stdout=stdout, shell=shell)
+        retcode = conan_run(wrapped_cmd, cwd=cwd, stdout=stdout, stderr=stderr, shell=shell)
         if not quiet:
             ConanOutput().writeln("")
 

--- a/conans/test/functional/conanfile/runner_test.py
+++ b/conans/test/functional/conanfile/runner_test.py
@@ -56,3 +56,18 @@ class Pkg(ConanFile):
         client.save({"conanfile.py": conanfile})
         client.run("source .")
         self.assertIn('conanfile.py: Buffer got msgs Hello', client.out)
+
+    def test_custom_stream_stderr(self):
+        conanfile = textwrap.dedent("""
+            from io import StringIO
+            from conan import ConanFile
+            class Pkg(ConanFile):
+                def source(self):
+                    my_buf = StringIO()
+                    self.run('echo Hello 1>&2', stderr=my_buf)
+                    self.output.info("Buffer got stderr msgs {}".format(my_buf.getvalue()))
+            """)
+        client = TestClient()
+        client.save({"conanfile.py": conanfile})
+        client.run("source .")
+        self.assertIn('conanfile.py: Buffer got stderr msgs Hello', client.out)


### PR DESCRIPTION
Changelog: Feature: Add `stderr` capture argument to conanfile's `run()` method.
Docs: https://github.com/conan-io/docs/pull/3482

To discuss with the team if we want this feature, but it was so simple to implement that I decided to create the PR before discussing it (Not sold on the test, I would like a better method to test stderr that does not rely on descriptor copying)

Added as a last argument because I'm afraid some users are relying on the order of the parameters so it did not feel right to add it after stdout

Closes #15118 