### PR TITLE
avoid cmake warning due to policy var unused

### DIFF
--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -116,8 +116,7 @@ class CMakeToolchain(object):
         # Preprocessor definitions per configuration
         {{ iterate_configs(preprocessor_definitions_config, action='add_compile_definitions') }}
 
-        if(CMAKE_POLICY_DEFAULT_CMP0091)
-        set(_conan_avoid_unused_policy_warning "${CMAKE_POLICY_DEFAULT_CMP0091}")
+        if(CMAKE_POLICY_DEFAULT_CMP0091)  # Avoid unused and not-initialized warnings
         endif()
         """)
 

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -116,7 +116,9 @@ class CMakeToolchain(object):
         # Preprocessor definitions per configuration
         {{ iterate_configs(preprocessor_definitions_config, action='add_compile_definitions') }}
 
-        set(_conan_avoid_unused_policy_warning ${CMAKE_POLICY_DEFAULT_CMP0091})
+        if(CMAKE_POLICY_DEFAULT_CMP0091)
+        set(_conan_avoid_unused_policy_warning "${CMAKE_POLICY_DEFAULT_CMP0091}")
+        endif()
         """)
 
     def __init__(self, conanfile, generator=None):

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -115,6 +115,8 @@ class CMakeToolchain(object):
         {% endfor %}
         # Preprocessor definitions per configuration
         {{ iterate_configs(preprocessor_definitions_config, action='add_compile_definitions') }}
+
+        set(_conan_avoid_unused_policy_warning ${CMAKE_POLICY_DEFAULT_CMP0091})
         """)
 
     def __init__(self, conanfile, generator=None):

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -239,6 +239,7 @@ def test_cmake_toolchain_multiple_user_toolchain():
     client.run("create . --name=pkg --version=0.1")
     assert "mytoolchain1.cmake !!!running!!!" in client.out
     assert "mytoolchain2.cmake !!!running!!!" in client.out
+    assert "CMake Warning" not in client.out
 
 
 @pytest.mark.tool("cmake")


### PR DESCRIPTION
Changelog: Fix: Avoid warning in CMake output due to `CMAKE_POLICY_DEFAULT_CMP0091` unused variable.
Docs: Omit
