### PR TITLE
Fix `conan graph info --format=text` being printed to stderr

### DIFF
--- a/conan/cli/commands/list.py
+++ b/conan/cli/commands/list.py
@@ -47,8 +47,8 @@ def print_serial(item, indent=None, color_index=None):
 
 
 def print_list_text(results):
-    """ Do litte format modification to serialized
-    list bundle so it looks prettier on text output
+    """ Do a little format modification to serialized
+    list bundle, so it looks prettier on text output
     """
     info = results["results"]
 

--- a/conan/cli/commands/upload.py
+++ b/conan/cli/commands/upload.py
@@ -9,8 +9,8 @@ from conan.errors import ConanException
 
 
 def summary_upload_list(results):
-    """ Do litte format modification to serialized
-    list bundle so it looks prettier on text output
+    """ Do a little format modification to serialized
+    list bundle, so it looks prettier on text output
     """
     ConanOutput().subtitle("Upload summary")
     info = results["results"]

--- a/conan/cli/formatters/graph/graph_info_text.py
+++ b/conan/cli/formatters/graph/graph_info_text.py
@@ -1,7 +1,7 @@
 import fnmatch
 from collections import OrderedDict
 
-from conan.api.output import ConanOutput
+from conan.api.output import ConanOutput, cli_out_write
 
 
 def filter_graph(graph, package_filter=None, field_filter=None):
@@ -27,23 +27,21 @@ def format_graph_info(result):
     field_filter = result["field_filter"]
     package_filter = result["package_filter"]
 
-    out = ConanOutput()
-    out.title("Basic graph information")
+    ConanOutput().subtitle("Basic graph information")
     serial = graph.serialize()
     serial = filter_graph(serial, package_filter, field_filter)
     for n in serial["nodes"].values():
-        out.writeln(f"{n['ref']}:")  # FIXME: This can be empty for consumers and it is ugly ":"
+        cli_out_write(f"{n['ref']}:")  # FIXME: This can be empty for consumers and it is ugly ":"
         _serial_pretty_printer(n, indent="  ")
     if graph.error:
         raise graph.error
 
 
 def _serial_pretty_printer(data, indent=""):
-    out = ConanOutput()
     for k, v in data.items():
         if isinstance(v, dict):
-            out.writeln(f"{indent}{k}:")
+            cli_out_write(f"{indent}{k}:")
             # TODO: increment color too
             _serial_pretty_printer(v, indent=indent+"  ")
         else:
-            out.writeln(f"{indent}{k}: {v}")
+            cli_out_write(f"{indent}{k}: {v}")


### PR DESCRIPTION
Changelog: Fix: Make `conan graph info --format=text` print to stdout.
Docs: Omit

I've also taken the time to ensure that no other formatter has the same issue - this seems to have been the last remnant.

Closes #15162
