### PR TITLE
Removed conan migration compatibility warning

### DIFF
--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -191,16 +191,6 @@ class Cli:
                     "If it is your recipe, check if it is updated to 2.0\n" \
                     "*********************************************************\n"
             ConanOutput().writeln(error, fg=Color.BRIGHT_MAGENTA)
-        result = re.search(r"(.*): Error in build\(\) method, line", message)
-        if result:
-            pkg = result.group(1)
-            error = "*********************************************************\n" \
-                    f"Recipe '{pkg}' cannot build its binary\n" \
-                    f"It is possible that this recipe is not Conan 2.0 ready\n" \
-                    "If the recipe comes from ConanCenter, report it at https://github.com/conan-io/conan-center-index/issues\n" \
-                    "If it is your recipe, check if it is updated to 2.0\n" \
-                    "*********************************************************\n"
-            ConanOutput().writeln(error, fg=Color.BRIGHT_MAGENTA)
 
     @staticmethod
     def exception_exit_error(exception):

--- a/conans/test/integration/conan_v2/test_legacy_cpp_info.py
+++ b/conans/test/integration/conan_v2/test_legacy_cpp_info.py
@@ -65,20 +65,3 @@ class TestLegacy1XRecipes:
         assert "Recipe 'pkg/1.0' seems broken." in c.out
         assert "It is possible that this recipe is not Conan 2.0 ready" in c.out
 
-    def test_legacy_build(self):
-        c = TestClient()
-        conanfile = textwrap.dedent("""
-            from conan import ConanFile
-            class Pkg(ConanFile):
-                name = "pkg"
-                version = "1.0"
-
-                def build(self):
-                    raise Exception("Build broken")
-            """)
-        c.save({"pkg/conanfile.py": conanfile,
-                "app/conanfile.py": GenConanfile("app", "1.0").with_requires("pkg/1.0")})
-        c.run("export pkg")
-        c.run("install app --build=missing", assert_error=True)
-        assert "Recipe 'pkg/1.0' cannot build its binary" in c.out
-        assert "It is possible that this recipe is not Conan 2.0 ready" in c.out


### PR DESCRIPTION
Changelog: Feature: Removed a warning about a potential issue with conan migration that would print every time a build failed.
Docs: Omit

Removed the corresponding test that was checking that the error would print.

Closes #15161

