### PR TITLE
Fix serialization of tool_requires in `conan profile show --format=json`

### DIFF
--- a/conans/model/profile.py
+++ b/conans/model/profile.py
@@ -30,12 +30,14 @@ class Profile(object):
         return self.dumps()
 
     def serialize(self):
-        # TODO: Remove it seems dead
+        def _serialize_tool_requires():
+            return {pattern: [ref.serialize() for ref in refs]
+                    for pattern, refs in self.tool_requires.items()}
         return {
             "settings": self.settings,
             "package_settings": self.package_settings,
             "options": self.options.serialize(),
-            "tool_requires": self.tool_requires,
+            "tool_requires": _serialize_tool_requires(),
             "conf": self.conf.serialize(),
             # FIXME: Perform a serialize method for ProfileEnvironment
             "build_env": self.buildenv.dumps()

--- a/conans/model/profile.py
+++ b/conans/model/profile.py
@@ -31,7 +31,7 @@ class Profile(object):
 
     def serialize(self):
         def _serialize_tool_requires():
-            return {pattern: [ref.serialize() for ref in refs]
+            return {pattern: [repr(ref) for ref in refs]
                     for pattern, refs in self.tool_requires.items()}
         return {
             "settings": self.settings,

--- a/conans/model/recipe_ref.py
+++ b/conans/model/recipe_ref.py
@@ -182,6 +182,15 @@ class RecipeReference:
             return not condition
         return condition
 
+    def serialize(self):
+        result = {"name": self.name,
+                  "version": str(self.version),
+                  "user": self.user,
+                  "channel": self.channel,
+                  "revision": self.revision,
+                  "timestamp": self.timestamp}
+        return result
+
 
 def ref_matches(ref, pattern, is_consumer):
     if not ref or not str(ref):

--- a/conans/model/recipe_ref.py
+++ b/conans/model/recipe_ref.py
@@ -182,15 +182,6 @@ class RecipeReference:
             return not condition
         return condition
 
-    def serialize(self):
-        result = {"name": self.name,
-                  "version": str(self.version),
-                  "user": self.user,
-                  "channel": self.channel,
-                  "revision": self.revision,
-                  "timestamp": self.timestamp}
-        return result
-
 
 def ref_matches(ref, pattern, is_consumer):
     if not ref or not str(ref):

--- a/conans/test/integration/command/test_profile.py
+++ b/conans/test/integration/command/test_profile.py
@@ -133,9 +133,14 @@ def test_shorthand_syntax():
 
 def test_profile_show_json():
     c = TestClient()
-    c.save({"myprofilewin": "[settings]\nos=Windows",
+    c.save({"myprofilewin": "[settings]\nos=Windows\n[tool_requires]\nmytool/*:mytool/1.0",
             "myprofilelinux": "[settings]\nos=Linux"})
     c.run("profile show -pr:b=myprofilewin -pr:h=myprofilelinux --format=json")
     profile = json.loads(c.stdout)
-    assert profile["build"]["settings"] == {"os": "Windows"}
     assert profile["host"]["settings"] == {"os": "Linux"}
+
+    assert profile["build"]["settings"] == {"os": "Windows"}
+    # Check that tool_requires are properly serialized in json format
+    # https://github.com/conan-io/conan/issues/15183
+    result = {'mytool/*': [{'channel': None, 'name': 'mytool', 'revision': None, 'timestamp': None, 'user': None, 'version': '1.0'}]}
+    assert profile["build"]["tool_requires"] == result

--- a/conans/test/integration/command/test_profile.py
+++ b/conans/test/integration/command/test_profile.py
@@ -142,5 +142,4 @@ def test_profile_show_json():
     assert profile["build"]["settings"] == {"os": "Windows"}
     # Check that tool_requires are properly serialized in json format
     # https://github.com/conan-io/conan/issues/15183
-    result = {'mytool/*': [{'channel': None, 'name': 'mytool', 'revision': None, 'timestamp': None, 'user': None, 'version': '1.0'}]}
-    assert profile["build"]["tool_requires"] == result
+    assert profile["build"]["tool_requires"] == {'mytool/*': ["mytool/1.0"]}

--- a/conans/test/unittests/model/profile_test.py
+++ b/conans/test/unittests/model/profile_test.py
@@ -127,8 +127,9 @@ def test_profile_serialize():
     profile.settings["compiler.version"] = "12"
     profile.tool_requires["*"] = ["zlib/1.2.8"]
     profile.update_package_settings({"MyPackage": [("os", "Windows")]})
-    expected_json = '{"settings": {"arch": "x86_64", "compiler": "Visual Studio", "compiler.version": "12"}, ' \
-                    '"package_settings": {"MyPackage": {"os": "Windows"}}, ' \
-                    '"options": {}, "tool_requires": {"*": ["zlib/1.2.8"]}, ' \
-                    '"conf": {"user.myfield:value": "MyVal"}, "build_env": "VAR1=1\\nVAR2=2\\n"}'
-    assert expected_json == json.dumps(profile.serialize())
+    expected_json = {
+        "settings": {"arch": "x86_64", "compiler": "Visual Studio", "compiler.version": "12"},
+        "package_settings": {"MyPackage": {"os": "Windows"}}, "options": {},
+        "tool_requires": {"*": ["'zlib/1.2.8'"]}, "conf": {"user.myfield:value": "MyVal"},
+        "build_env": "VAR1=1\nVAR2=2\n"}
+    assert expected_json == profile.serialize()


### PR DESCRIPTION
Changelog: Bugfix: Fix serialization of tool_requires in `conan profile show --format=json`.
Docs: Omit

To check with the team if we want to fully serialize the reference, or if printing its str representation would be enough

Closes #15183 
