### PR TITLE
Fix `conan graph info --format=html` reporting misleading conflicting nodes

### DIFF
--- a/conan/cli/formatters/graph/graph.py
+++ b/conan/cli/formatters/graph/graph.py
@@ -54,7 +54,8 @@ class _PrinterGraphItem(object):
 class _Grapher(object):
     def __init__(self, deps_graph):
         self._deps_graph = deps_graph
-        self.nodes, self.edges, self.node_map = self._build_graph()
+        self.node_map, self.edges = self._build_graph()
+        self.nodes = self.node_map.values()
 
     def _build_graph(self):
         graph_nodes = self._deps_graph.by_levels()
@@ -73,7 +74,7 @@ class _Grapher(object):
                 dst = _node_map[node_to]
                 edges.append((src, dst))
 
-        return _node_map.values(), edges, _node_map
+        return _node_map, edges
 
     @staticmethod
     def binary_color(node):

--- a/conan/cli/formatters/graph/graph.py
+++ b/conan/cli/formatters/graph/graph.py
@@ -54,7 +54,7 @@ class _PrinterGraphItem(object):
 class _Grapher(object):
     def __init__(self, deps_graph):
         self._deps_graph = deps_graph
-        self.nodes, self.edges = self._build_graph()
+        self.nodes, self.edges, self.node_map = self._build_graph()
 
     def _build_graph(self):
         graph_nodes = self._deps_graph.by_levels()
@@ -73,7 +73,7 @@ class _Grapher(object):
                 dst = _node_map[node_to]
                 edges.append((src, dst))
 
-        return _node_map.values(), edges
+        return _node_map.values(), edges, _node_map
 
     @staticmethod
     def binary_color(node):

--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -56,7 +56,7 @@ graph_info_html = """
                         font: { color: "{% if highlight_node %}white{% else %}black{% endif %}" },
                         fulllabel: '<h3>{{ node.label }}</h3>' +
                                    '<ul>' +
-                                   '    <li><b>id</b>: {{ node.package_id }}</li>' +
+                                   '    <li><b>package id</b>: {{ node.package_id }}</li>' +
                                    {%- for key, value in node.data().items() %}
                                    {%- if value %}
                                         {%- if key in ['url', 'homepage'] %}
@@ -92,7 +92,7 @@ graph_info_html = """
 
                 {% if error["context"].node.id is not none %}
                     // Add edge from node that introduces the conflict to the new error node
-                    edges.push({from: {{ error["context"].node.id }},
+                    edges.push({from: {{ graph.node_map[error["context"].node].id }},
                                 to: "{{ error["type"] }}",
                                 color: "red",
                                 dashes: true,
@@ -104,7 +104,7 @@ graph_info_html = """
 
                 {% if error["context"].prev_node is none and error["context"].base_previous.id is not none %}
                     // Add edge from base node to the new error node
-                    edges.push({from: {{ error["context"].base_previous.id }},
+                    edges.push({from: {{ graph.node_map[error["context"].base_previous].id }},
                                 to: "{{ error["type"] }}",
                                 color: "red",
                                 dashes: true,
@@ -116,7 +116,7 @@ graph_info_html = """
 
                 {% if error["context"].prev_node is not none and error["context"].prev_node.id is not none %}
                     // Add edge from previous node that already had conflicting dependency
-                    edges.push({from: {{ error["context"].prev_node.id }},
+                    edges.push({from: {{ graph.node_map[error["context"].prev_node].id }},
                                 to: "{{ error["type"] }}",
                                 color: "red",
                                 dashes: true,

--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -95,11 +95,11 @@ graph_info_html = """
                     edges.push({from: {{ graph.node_map[error["context"].node].id }},
                                 to: "{{ error["type"] }}",
                                 color: "red",
-                                dashes: true,
+                                dashes: false,
                                 title: "Conflict",
                                 physics: false,
                                 color: "red",
-                                arrows: "to;from"})
+                                arrows: "to"})
                 {% endif %}
 
                 {% if error["context"].prev_node is none and error["context"].base_previous.id is not none %}
@@ -107,7 +107,7 @@ graph_info_html = """
                     edges.push({from: {{ graph.node_map[error["context"].base_previous].id }},
                                 to: "{{ error["type"] }}",
                                 color: "red",
-                                dashes: true,
+                                dashes: false,
                                 title: "Conflict",
                                 physics: false,
                                 color: "red",
@@ -122,7 +122,7 @@ graph_info_html = """
                                 dashes: true,
                                 title: "Conflict",
                                 physics: false,
-                                color: "red",
+                                color: "gray",
                                 arrows: "to;from"})
                 {% endif %}
 

--- a/conans/test/integration/command/info/test_graph_info_graphical.py
+++ b/conans/test/integration/command/info/test_graph_info_graphical.py
@@ -201,6 +201,9 @@ def test_graph_info_html_output():
     assert "// Add edge from base node to the new error node" not in tc.out
     assert "// Add edge from previous node that already had conflicting dependency" in tc.out
 
+    # Ensure mapping is preserved, ui is node id 3 before ordering, but 2 after
+    assert "id: 2,\n                        label: 'ui/1.0'" in tc.out
+
     tc.run("graph info openimageio/ --format=html", assert_error=True)
     assert "// Add error conflict node" in tc.out
     assert "// Add edge from node that introduces the conflict to the new error node" in tc.out


### PR DESCRIPTION
Changelog: Bugfix: Fix `conan graph info --format=html` reporting misleading conflicting nodes.
Docs: Omit


The tests didn't catch this because I only tested with one level, which left the ids the same!

Don't merge yet, will add a test to ensure this keeps working in the future