### PR TITLE
Fix `conan graph explain` binary distance calculation

### DIFF
--- a/conan/api/subapi/list.py
+++ b/conan/api/subapi/list.py
@@ -267,8 +267,10 @@ class _BinaryDistance:
 
     @property
     def distance(self):
-        return len(self.platform_diff), len(self.settings_diff), \
-               len(self.options_diff), len(self.deps_diff)
+        return (len(self.platform_diff.get("expected", [])),
+                len(self.settings_diff.get("expected", [])),
+                len(self.options_diff.get("expected", [])),
+                len(self.deps_diff.get("expected", [])))
 
     def serialize(self):
         return {"platform": self.platform_diff,


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

We were calculating the number of _keys_, which was either 2 or 0, not by how much it was different.
There might be a tad more elegant solution but I like this one being straightforward

Can add a test if the team thinks it's necessary
