### PR TITLE
Add `in` operator support for ConanFile's `self.dependencies`

### DIFF
--- a/conans/model/dependencies.py
+++ b/conans/model/dependencies.py
@@ -73,6 +73,17 @@ class UserRequirementsDict(object):
     def values(self):
         return self._data.values()
 
+    def __contains__(self, item):
+        try:
+            self.get(item)
+            return True
+        except KeyError:
+            return False
+        except ConanException:
+            # ConanException is raised when there are more than one matching the filters
+            # so it's definitely in the dict
+            return True
+
 
 class ConanFileDependencies(UserRequirementsDict):
 

--- a/conans/test/integration/graph/test_dependencies_visit.py
+++ b/conans/test/integration/graph/test_dependencies_visit.py
@@ -33,6 +33,12 @@ def test_dependencies_visit():
                 if "openssl" in self.dependencies:
                     self.output.info("OpenSSL found in deps")
 
+                if "cmake" in self.dependencies:
+                    self.output.info("cmake found in default deps")
+
+                if "cmake" in self.dependencies.build:
+                    self.output.info("cmake found in deps.build")
+
                 if "badlib" in self.dependencies:
                     self.output.info("badlib found in deps")
         """)
@@ -56,6 +62,9 @@ def test_dependencies_visit():
 
     assert "OpenSSL found in deps" in client.out
     assert "badlib found in deps" not in client.out
+
+    assert "cmake found in default deps" not in client.out
+    assert "cmake found in deps.build" in client.out
 
 
 def test_dependencies_visit_settings_options():
@@ -100,6 +109,7 @@ asserts = [
     ('self.dependencies["missing"]', True, "'missing' not found in the dependency set"),
     ('self.output.info("Missing in deps: " + str("missing" in self.dependencies))', False, "Missing in deps: False"),
     ('self.output.info("Zlib in deps: " + str("zlib" in self.dependencies))', False, "Zlib in deps: True"),
+    ('self.output.info("Zlib in deps.build: " + str("zlib" in self.dependencies.build))', False, "Zlib in deps.build: True"),
 ]
 
 

--- a/conans/test/integration/graph/test_dependencies_visit.py
+++ b/conans/test/integration/graph/test_dependencies_visit.py
@@ -29,6 +29,12 @@ def test_dependencies_visit():
                 self.output.info("DefPRefBuild: {}!!!".format(dep.pref.repr_notime()))
                 for r, d in self.dependencies.build.items():
                     self.output.info("DIRECTBUILD {}: {}".format(r.direct, d))
+
+                if "openssl" in self.dependencies:
+                    self.output.info("OpenSSL found in deps")
+
+                if "badlib" in self.dependencies:
+                    self.output.info("badlib found in deps")
         """)
     client.save({"conanfile.py": conanfile})
 
@@ -47,6 +53,9 @@ def test_dependencies_visit():
 
     assert "conanfile.py: DIRECTBUILD True: cmake/0.1" in client.out
     assert "conanfile.py: DIRECTBUILD False: openssl/0.2" in client.out
+
+    assert "OpenSSL found in deps" in client.out
+    assert "badlib found in deps" not in client.out
 
 
 def test_dependencies_visit_settings_options():
@@ -89,6 +98,8 @@ asserts = [
      '- cmake/0.2, Traits: build=True, headers=False, libs=False, run=False, visible=False'
      ),
     ('self.dependencies["missing"]', True, "'missing' not found in the dependency set"),
+    ('self.output.info("Missing in deps: " + str("missing" in self.dependencies))', False, "Missing in deps: False"),
+    ('self.output.info("Zlib in deps: " + str("zlib" in self.dependencies))', False, "Zlib in deps: True"),
 ]
 
 


### PR DESCRIPTION
Changelog: Feature: Add `in` operator support for ConanFile's `self.dependencies`.
Docs: https://github.com/conan-io/docs/pull/3481

Closes https://github.com/conan-io/conan/issues/12832

Found this in the wild as a leftover while going over my created issues :)