### PR TITLE
Fix range escaping in conflict reports involving ranges

### DIFF
--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -82,11 +82,13 @@ graph_info_html = """
                 // Add error conflict node
                 nodes.push({
                     id: "{{ error["type"] }}",
-                    label: "{{ error["context"].require.ref }}",
+                    label: {{ error["context"].require.ref|string|tojson }},
                     shape: "circle",
                     font: { color: "white" },
                     color: "red",
-                    fulllabel: '<h3>{{ error["context"].require.ref }}</h3><p>This node creates a conflict in the dependency graph</p>',
+                    fulllabel: '<h3>' +
+                               {{ error["context"].require.ref|string|tojson }} +
+                               '</h3><p>This node creates a conflict in the dependency graph</p>',
                     shapeProperties: { borderDashes: [5, 5] }
                 })
 

--- a/conans/test/integration/command/info/test_graph_info_graphical.py
+++ b/conans/test/integration/command/info/test_graph_info_graphical.py
@@ -224,4 +224,5 @@ def test_graph_info_html_error_range_quoting():
     tc.run("export libpng")
 
     tc.run("graph info --requires=zlib/0.1 --requires=libpng/1.0 --format=html", assert_error=True)
-    assert 'label: "zlib/[&gt;=1.0]"' not in tc.out
+    assert 'zlib/[&gt;=1.0]' not in tc.out
+    assert r'"zlib/[\u003e=1.0]"' in tc.out

--- a/conans/test/integration/command/info/test_graph_info_graphical.py
+++ b/conans/test/integration/command/info/test_graph_info_graphical.py
@@ -179,7 +179,7 @@ def test_user_templates():
     assert template_folder in c.stdout
 
 
-def test_graph_info_html_output():
+def test_graph_info_html_error_reporting_output():
     tc = TestClient()
     tc.save({"lib/conanfile.py": GenConanfile("lib"),
              "ui/conanfile.py": GenConanfile("ui", "1.0").with_requirement("lib/1.0"),
@@ -212,3 +212,16 @@ def test_graph_info_html_output():
     # There used to be a few bugs with weird graphs, check for regressions
     assert "jinja2.exceptions.UndefinedError" not in tc.out
     assert "from: ," not in tc.out
+
+
+def test_graph_info_html_error_range_quoting():
+    tc = TestClient()
+    tc.save({"zlib/conanfile.py": GenConanfile("zlib"),
+             "libpng/conanfile.py": GenConanfile("libpng", "1.0").with_requirement("zlib/[>=1.0]")})
+
+    tc.run("export zlib --version=1.0")
+    tc.run("export zlib --version=0.1")
+    tc.run("export libpng")
+
+    tc.run("graph info --requires=zlib/0.1 --requires=libpng/1.0 --format=html", assert_error=True)
+    assert 'label: "zlib/[&gt;=1.0]"' not in tc.out


### PR DESCRIPTION
Changelog: Fix: Fix range escaping in conflict reports involving ranges.
Docs: Omit

Closes https://github.com/conan-io/conan/issues/14793

This makes it so that the string is parsed to json which escapes the ranges to unicode codes before having a chance to be automatically HTML escaped by Jinja2.


<img width="394" alt="Captura de pantalla 2023-12-06 a las 0 05 15" src="https://github.com/conan-io/conan/assets/5364255/f3a2500e-e294-40e5-ad7f-ae07fb2a57b1">

