### PR TITLE
[command][cache path] Raising error if folder path does not exist

### DIFF
--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -25,43 +25,43 @@ class CacheAPI:
         app = ConanApp(self.conan_api.cache_folder, self.conan_api.config.global_conf)
         ref.revision = None if ref.revision == "latest" else ref.revision
         ref_layout = app.cache.recipe_layout(ref)
-        return ref_layout.export()
+        return _check_folder_existence(ref, "export", ref_layout.export())
 
     def recipe_metadata_path(self, ref: RecipeReference):
         app = ConanApp(self.conan_api.cache_folder, self.conan_api.config.global_conf)
         ref = _resolve_latest_ref(app, ref)
         ref_layout = app.cache.recipe_layout(ref)
-        return ref_layout.metadata()
+        return _check_folder_existence(ref, "metadata", ref_layout.metadata())
 
     def export_source_path(self, ref: RecipeReference):
         app = ConanApp(self.conan_api.cache_folder, self.conan_api.config.global_conf)
         ref.revision = None if ref.revision == "latest" else ref.revision
         ref_layout = app.cache.recipe_layout(ref)
-        return ref_layout.export_sources()
+        return _check_folder_existence(ref, "export_sources", ref_layout.export_sources())
 
     def source_path(self, ref: RecipeReference):
         app = ConanApp(self.conan_api.cache_folder, self.conan_api.config.global_conf)
         ref.revision = None if ref.revision == "latest" else ref.revision
         ref_layout = app.cache.recipe_layout(ref)
-        return ref_layout.source()
+        return _check_folder_existence(ref, "source", ref_layout.source())
 
     def build_path(self, pref: PkgReference):
         app = ConanApp(self.conan_api.cache_folder, self.conan_api.config.global_conf)
         pref = _resolve_latest_pref(app, pref)
         ref_layout = app.cache.pkg_layout(pref)
-        return ref_layout.build()
+        return _check_folder_existence(pref, "build", ref_layout.build())
 
     def package_metadata_path(self, pref: PkgReference):
         app = ConanApp(self.conan_api.cache_folder, self.conan_api.config.global_conf)
         pref = _resolve_latest_pref(app, pref)
         ref_layout = app.cache.pkg_layout(pref)
-        return ref_layout.metadata()
+        return _check_folder_existence(pref, "metadata", ref_layout.metadata())
 
     def package_path(self, pref: PkgReference):
         app = ConanApp(self.conan_api.cache_folder, self.conan_api.config.global_conf)
         pref = _resolve_latest_pref(app, pref)
         ref_layout = app.cache.pkg_layout(pref)
-        return ref_layout.package()
+        return _check_folder_existence(pref, "package", ref_layout.package())
 
     def check_integrity(self, package_list):
         """Check if the recipes and packages are corrupted (it will raise a ConanExcepcion)"""
@@ -202,3 +202,9 @@ def _resolve_latest_pref(app, pref):
             raise ConanException(f"'{pref.repr_notime()}' not found in cache")
         pref = result
     return pref
+
+
+def _check_folder_existence(ref, folder_name, folder_path):
+    if not os.path.exists(folder_path):
+        raise ConanException(f"'{folder_name}' folder does not exist for the reference {ref}")
+    return folder_path

--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -48,8 +48,6 @@ def cache_path(conan_api: ConanAPI, parser, subparser, *args):
             path = conan_api.cache.recipe_metadata_path(ref)
         else:
             raise ConanException(f"'--folder {args.folder}' requires a valid package reference")
-        if args.folder and not os.path.exists(path):
-            raise ConanException(f"'{args.folder}' folder does not exist for the reference {ref}")
     else:
         if args.folder is None:
             path = conan_api.cache.package_path(pref)
@@ -59,9 +57,6 @@ def cache_path(conan_api: ConanAPI, parser, subparser, *args):
             path = conan_api.cache.package_metadata_path(pref)
         else:
             raise ConanException(f"'--folder {args.folder}' requires a recipe reference")
-        if args.folder and not os.path.exists(path):
-            raise ConanException(f"'{args.folder}' folder does not exist for the package reference "
-                                 f"{pref}")
     return path
 
 

--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -1,3 +1,5 @@
+import os.path
+
 from conan.api.conan_api import ConanAPI
 from conan.api.model import ListPattern, MultiPackagesList
 from conan.api.output import cli_out_write
@@ -46,6 +48,8 @@ def cache_path(conan_api: ConanAPI, parser, subparser, *args):
             path = conan_api.cache.recipe_metadata_path(ref)
         else:
             raise ConanException(f"'--folder {args.folder}' requires a valid package reference")
+        if args.folder and not os.path.exists(path):
+            raise ConanException(f"'{args.folder}' folder does not exist for the {ref}")
     else:
         if args.folder is None:
             path = conan_api.cache.package_path(pref)
@@ -55,6 +59,8 @@ def cache_path(conan_api: ConanAPI, parser, subparser, *args):
             path = conan_api.cache.package_metadata_path(pref)
         else:
             raise ConanException(f"'--folder {args.folder}' requires a recipe reference")
+        if args.folder and not os.path.exists(path):
+            raise ConanException(f"'{args.folder}' folder does not exist for the {pref}")
     return path
 
 

--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -1,5 +1,3 @@
-import os.path
-
 from conan.api.conan_api import ConanAPI
 from conan.api.model import ListPattern, MultiPackagesList
 from conan.api.output import cli_out_write

--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -49,7 +49,7 @@ def cache_path(conan_api: ConanAPI, parser, subparser, *args):
         else:
             raise ConanException(f"'--folder {args.folder}' requires a valid package reference")
         if args.folder and not os.path.exists(path):
-            raise ConanException(f"'{args.folder}' folder does not exist for the {ref}")
+            raise ConanException(f"'{args.folder}' folder does not exist for the reference {ref}")
     else:
         if args.folder is None:
             path = conan_api.cache.package_path(pref)
@@ -60,7 +60,8 @@ def cache_path(conan_api: ConanAPI, parser, subparser, *args):
         else:
             raise ConanException(f"'--folder {args.folder}' requires a recipe reference")
         if args.folder and not os.path.exists(path):
-            raise ConanException(f"'{args.folder}' folder does not exist for the {pref}")
+            raise ConanException(f"'{args.folder}' folder does not exist for the package reference "
+                                 f"{pref}")
     return path
 
 

--- a/conans/test/integration/command_v2/test_cache_path.py
+++ b/conans/test/integration/command_v2/test_cache_path.py
@@ -97,3 +97,17 @@ def test_cache_path_arg_errors():
     # source, cannot obtain build without pref
     t.run("cache path foo/1.0:pid --folder source", assert_error=True)
     assert "ERROR: '--folder source' requires a recipe reference" in t.out
+
+
+def test_cache_path_does_not_exist_folder():
+    client = TestClient(default_server_user=True)
+    conanfile = GenConanfile()
+    client.save({"conanfile.py": conanfile})
+    client.run("create . --name=mypkg --version=0.1")
+    pref = client.created_package_reference("mypkg/0.1")
+    client.run("upload * --confirm -r default")
+    client.run("remove * -c")
+
+    client.run(f"install --requires mypkg/0.1")
+    client.run(f"cache path {pref} --folder build", assert_error=True)
+    assert f"ERROR: 'build' folder does not exist for the package reference {pref}" in client.out

--- a/conans/test/integration/command_v2/test_cache_path.py
+++ b/conans/test/integration/command_v2/test_cache_path.py
@@ -110,4 +110,4 @@ def test_cache_path_does_not_exist_folder():
 
     client.run(f"install --requires mypkg/0.1")
     client.run(f"cache path {pref} --folder build", assert_error=True)
-    assert f"ERROR: 'build' folder does not exist for the package reference {pref}" in client.out
+    assert f"ERROR: 'build' folder does not exist for the reference {pref}" in client.out

--- a/conans/test/integration/metadata/test_metadata_commands.py
+++ b/conans/test/integration/metadata/test_metadata_commands.py
@@ -47,9 +47,9 @@ class TestMetadataCommands:
         c.run("remove * -c")
         c.run("install --requires=pkg/0.1")  # wont install metadata by default
         c.run("cache path pkg/0.1 --folder=metadata", assert_error=True)
-        assert "'metadata' folder does not exist for the pkg/0.1" in c.out
+        assert "'metadata' folder does not exist for the reference pkg/0.1" in c.out
         c.run(f"cache path pkg/0.1:{pid} --folder=metadata", assert_error=True)
-        assert f"'metadata' folder does not exist for the pkg/0.1:{pid}" in c.out
+        assert f"'metadata' folder does not exist for the package reference pkg/0.1:{pid}" in c.out
 
         # Forcing the download of the metadata of cache-existing things with the "download" command
         c.run("download pkg/0.1 -r=default --metadata=*")

--- a/conans/test/integration/metadata/test_metadata_commands.py
+++ b/conans/test/integration/metadata/test_metadata_commands.py
@@ -49,7 +49,7 @@ class TestMetadataCommands:
         c.run("cache path pkg/0.1 --folder=metadata", assert_error=True)
         assert "'metadata' folder does not exist for the reference pkg/0.1" in c.out
         c.run(f"cache path pkg/0.1:{pid} --folder=metadata", assert_error=True)
-        assert f"'metadata' folder does not exist for the package reference pkg/0.1:{pid}" in c.out
+        assert f"'metadata' folder does not exist for the reference pkg/0.1:{pid}" in c.out
 
         # Forcing the download of the metadata of cache-existing things with the "download" command
         c.run("download pkg/0.1 -r=default --metadata=*")


### PR DESCRIPTION
Changelog: Feature: `conan cache path xxx --folder xxxx` raises an error if the folder requested does not exist.
Docs: omit
