### PR TITLE
Make paths format in layout consistent on Windows

### DIFF
--- a/conans/model/layout.py
+++ b/conans/model/layout.py
@@ -90,7 +90,7 @@ class Folders(object):
         if self._base_source is None:
             return None
         if not self.source:
-            return self._base_source
+            return os.path.normpath(self._base_source)
 
         return os.path.normpath(os.path.join(self._base_source, self.source))
 
@@ -106,7 +106,7 @@ class Folders(object):
         if self._base_build is None:
             return None
         if not self.build:
-            return self._base_build
+            return os.path.normpath(self._base_build)
         return os.path.normpath(os.path.join(self._base_build, self.build))
 
     @property
@@ -147,7 +147,7 @@ class Folders(object):
         if self._base_generators is None:
             return None
         if not self.generators:
-            return self._base_generators
+            return os.path.normpath(self._base_generators)
         return os.path.normpath(os.path.join(self._base_generators, self.generators))
 
     def set_base_generators(self, folder):


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

The paths in `source_folder`, `build_folder` and `generators_folder` can have different path formats depending on how they are set (layout, output-folder, etc). When accessing those values from the output json the resulting path would sometimes apply the `normpath` function. This would yield different results in Windows producing inconsistencies in the resulting paths. (This only happens in Windows because `normpath` trasforms all `/` to `\`)

For example, using `cmake_layout()` produced a path with `\`, while using `output-folder` or no setting produced a path with `/`.

This changes makes those paths to always use the `normpath` so the result is consistent (it should always be `\` on Windows). Note that the paths in the output json will still be either `\\` or `/ ` but when extracting the value it will always be `\`.


