### PR TITLE
allow to copy & paste from compact format into conan-lock-add

### DIFF
--- a/conan/cli/commands/list.py
+++ b/conan/cli/commands/list.py
@@ -79,7 +79,7 @@ def print_list_text(results):
             for k, v in item.items():
                 if isinstance(v, dict) and v.get("timestamp"):
                     timestamp = v.pop("timestamp")
-                    k = f"{k}%{timestamp} ({timestamp_to_str(timestamp)})"
+                    k = f"{k} ({timestamp_to_str(timestamp)})"
                 result[k] = format_timestamps(v)
             return result
         return item

--- a/conan/cli/commands/list.py
+++ b/conan/cli/commands/list.py
@@ -79,7 +79,7 @@ def print_list_text(results):
             for k, v in item.items():
                 if isinstance(v, dict) and v.get("timestamp"):
                     timestamp = v.pop("timestamp")
-                    k = f"{k} ({timestamp_to_str(timestamp)})"
+                    k = f"{k}%{timestamp} ({timestamp_to_str(timestamp)})"
                 result[k] = format_timestamps(v)
             return result
         return item
@@ -109,7 +109,7 @@ def prepare_pkglist_compact(pkglist):
             new_rrev = f"{ref}#{rrev}"
             timestamp = rrev_info.pop("timestamp", None)
             if timestamp:
-                new_rrev += f" ({timestamp_to_str(timestamp)})"
+                new_rrev += f"%{timestamp} ({timestamp_to_str(timestamp)})"
 
             packages = rrev_info.pop("packages", None)
             if packages:

--- a/conan/cli/commands/lock.py
+++ b/conan/cli/commands/lock.py
@@ -109,17 +109,8 @@ def lock_add(conan_api, parser, subparser, *args):
     allow_uppercase = global_conf.get("core:allow_uppercase_pkg_names", check_type=bool)
 
     def _parse_requires(reqs):
-        def convert_timestamp(ref):  # allows user to specify time copy&paste from compact format
-            tokens = ref.split(" ", 1)
-            if len(tokens) == 2:
-                ref, t = tokens
-                if t[0] == "(" and t[-1] == ")":
-                    import dateutil
-                    t = dateutil.parser.parse(t[1:-1]).timestamp()
-                    ref = f"{ref}%{t}"
-            return ref
         if reqs:
-            result = [RecipeReference.loads(convert_timestamp(r)) for r in reqs]
+            result = [RecipeReference.loads(r) for r in reqs]
             [r.validate_ref(allow_uppercase) for r in result]
             return result
 

--- a/conan/cli/commands/lock.py
+++ b/conan/cli/commands/lock.py
@@ -6,7 +6,6 @@ from conan.cli.command import conan_command, OnceArgument, conan_subcommand
 from conan.cli import make_abs_path
 from conan.cli.args import common_graph_args, validate_common_graph_args
 from conan.cli.printers.graph import print_graph_packages, print_graph_basic
-from conans.client.cache.cache import ClientCache
 from conans.model.graph_lock import Lockfile, LOCKFILE
 from conans.model.recipe_ref import RecipeReference
 
@@ -110,8 +109,17 @@ def lock_add(conan_api, parser, subparser, *args):
     allow_uppercase = global_conf.get("core:allow_uppercase_pkg_names", check_type=bool)
 
     def _parse_requires(reqs):
+        def convert_timestamp(ref):  # allows user to specify time copy&paste from compact format
+            tokens = ref.split(" ", 1)
+            if len(tokens) == 2:
+                ref, t = tokens
+                if t[0] == "(" and t[-1] == ")":
+                    import dateutil
+                    t = dateutil.parser.parse(t[1:-1]).timestamp()
+                    ref = f"{ref}%{t}"
+            return ref
         if reqs:
-            result = [RecipeReference.loads(r) for r in reqs]
+            result = [RecipeReference.loads(convert_timestamp(r)) for r in reqs]
             [r.validate_ref(allow_uppercase) for r in result]
             return result
 

--- a/conans/test/integration/command_v2/list_test.py
+++ b/conans/test/integration/command_v2/list_test.py
@@ -778,14 +778,16 @@ class TestListCompact:
         c.run("create pkg -s os=Windows -s arch=x86")
         c.run("create other")
         c.run("list *:* --format=compact")
-        expected_output = re.sub(r"\(.*\)", "(timestamp)", c.stdout)
+        expected_output = re.sub(r"%.* ", "%timestamp ",
+                                 re.sub(r"\(.*\)", "(timestamp)", c.stdout))
+
         expected = textwrap.dedent("""\
             Local Cache
               other/1.0
-                other/1.0#d3c8cc5e6d23ca8c6f0eaa6285c04cbd (timestamp)
+                other/1.0#d3c8cc5e6d23ca8c6f0eaa6285c04cbd%timestamp (timestamp)
                   other/1.0#d3c8cc5e6d23ca8c6f0eaa6285c04cbd:da39a3ee5e6b4b0d3255bfef95601890afd80709
               pkg/1.0
-                pkg/1.0#d24b74828b7681f08d8f5ba0e7fd791e (timestamp)
+                pkg/1.0#d24b74828b7681f08d8f5ba0e7fd791e%timestamp (timestamp)
                   pkg/1.0#d24b74828b7681f08d8f5ba0e7fd791e:c11e463c49652ba9c5adc62573ee49f966bd8417
                     settings: Windows, x86
             """)

--- a/conans/test/integration/lockfile/test_user_overrides.py
+++ b/conans/test/integration/lockfile/test_user_overrides.py
@@ -2,7 +2,6 @@ import json
 
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
-from conans.util.dates import timestamp_to_str
 
 
 def test_user_overrides():
@@ -205,22 +204,6 @@ def test_timestamps_are_updated():
     assert f" math/1.0#{rev} - Cache" in c.out
     new_lock = c.load("conan.lock")
     assert "%0.123" not in new_lock
-
-
-def test_timestamps_human_sorted():
-    """ we can add as copied from 'conan list --format=compact
-    """
-    c = TestClient()
-    t1 = timestamp_to_str(1)
-    t2 = timestamp_to_str(2)
-    t3 = timestamp_to_str(3)
-    c.run(f'lock add --requires="math/1.0#revZ ({t2})"')
-    c.run(f'lock add --requires="math/1.0#revX ({t1})"')
-    c.run(f'lock add --requires="math/1.0#revY ({t3})"')
-    new_lock = json.loads(c.load("conan.lock"))
-    assert new_lock["requires"] == ["math/1.0#revY%3.0",
-                                    "math/1.0#revZ%2.0",
-                                    "math/1.0#revX%1.0"]
 
 
 def test_lock_add_error():

--- a/conans/test/integration/lockfile/test_user_overrides.py
+++ b/conans/test/integration/lockfile/test_user_overrides.py
@@ -2,6 +2,7 @@ import json
 
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
+from conans.util.dates import timestamp_to_str
 
 
 def test_user_overrides():
@@ -204,6 +205,22 @@ def test_timestamps_are_updated():
     assert f" math/1.0#{rev} - Cache" in c.out
     new_lock = c.load("conan.lock")
     assert "%0.123" not in new_lock
+
+
+def test_timestamps_human_sorted():
+    """ we can add as copied from 'conan list --format=compact
+    """
+    c = TestClient()
+    t1 = timestamp_to_str(1)
+    t2 = timestamp_to_str(2)
+    t3 = timestamp_to_str(3)
+    c.run(f'lock add --requires="math/1.0#revZ ({t2})"')
+    c.run(f'lock add --requires="math/1.0#revX ({t1})"')
+    c.run(f'lock add --requires="math/1.0#revY ({t3})"')
+    new_lock = json.loads(c.load("conan.lock"))
+    assert new_lock["requires"] == ["math/1.0#revY%3.0",
+                                    "math/1.0#revZ%2.0",
+                                    "math/1.0#revX%1.0"]
 
 
 def test_lock_add_error():


### PR DESCRIPTION
Changelog: Feature: Allow copy&paste of recipe revisions with timestamps from ``--format=compact`` into ``conan lock add``.
Docs: https://github.com/conan-io/docs/pull/3533

