### PR TITLE
Add pkglist formatter for conan export command

### DIFF
--- a/conans/test/integration/command_v2/test_combined_pkglist_flows.py
+++ b/conans/test/integration/command_v2/test_combined_pkglist_flows.py
@@ -66,6 +66,15 @@ class TestGraphCreatedUpload:
         assert "Uploading package 'zlib" in c.out
 
 
+class TestExportUpload:
+    def test_export_upload(self):
+        c = TestClient(default_server_user=True)
+        c.save({"zlib/conanfile.py": GenConanfile("zlib", "1.0")})
+        c.run("export zlib --format=pkglist", redirect_stdout="pkglist.json")
+        c.run("upload --list=pkglist.json -r=default -c")
+        assert "Uploading recipe 'zlib/1.0#c570d63921c5f2070567da4bf64ff261'" in c.out
+
+
 class TestCreateGraphToPkgList:
     def test_graph_pkg_list_only_built(self):
         c = TestClient()


### PR DESCRIPTION
Changelog: Feature: Add `pkglist` formatter for conan export command.
Docs: https://github.com/conan-io/docs/pull/3483

Closes: https://github.com/conan-io/conan/issues/15228