### PR TITLE
Fix `Git.get_url_and_commit` raising for some Git configs

### DIFF
--- a/conan/tools/scm/git.py
+++ b/conan/tools/scm/git.py
@@ -103,7 +103,7 @@ class Git:
 
         :return: True, if the current folder is dirty. Otherwise, False.
         """
-        status = self.run(f"status . -s").strip()
+        status = self.run("status . --short --no-branch --untracked-files").strip()
         return bool(status)
 
     def get_url_and_commit(self, remote="origin"):

--- a/conans/test/functional/tools/scm/test_git.py
+++ b/conans/test/functional/tools/scm/test_git.py
@@ -179,6 +179,32 @@ class TestGitCaptureSCM:
             assert "pkg/0.1: SCM COMMIT: {}".format(new_commit) in c.out
             assert "pkg/0.1: SCM URL: {}".format(url) in c.out
 
+    def test_capture_commit_modified_config(self):
+        """
+        A clean repo with the status.branch git config set to on
+        Expected to not raise an error an return the commit and url
+        """
+        folder = temp_folder()
+        url, commit = create_local_git_repo(files={"conanfile.py": self.conanfile}, folder=folder)
+        c = TestClient()
+        with c.chdir(folder):
+            c.run_command("git config --local status.branch true")
+            c.run("export .")
+            assert "pkg/0.1: SCM COMMIT: {}".format(commit) in c.out
+            assert "pkg/0.1: SCM URL: {}".format(url) in c.out
+
+    def test_capture_commit_modified_config_untracked(self):
+        """
+        A dirty repo with the showUntrackedFiles git config set to off.
+        Expected to throw an exception
+        """
+        folder = temp_folder()
+        url, commit = create_local_git_repo(files={"conanfile.py": self.conanfile}, folder=folder)
+        c = TestClient()
+        with c.chdir(folder):
+            c.save(files={"some_header.h": "now the repo is dirty"})
+            c.run_command("git config --local status.showUntrackedFiles no")
+            c.run("export .", assert_error=True)
 
 @pytest.mark.tool("git")
 class TestGitBasicClone:


### PR DESCRIPTION
Changelog: Bugfix: Fix `Git.get_url_and_commit` raising for some Git configs.
Docs: Omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
