### PR TITLE
Add different ref tracking syntax for  `<host_version>`

### DIFF
--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -1,5 +1,6 @@
 import copy
 import os
+import re
 from collections import deque
 
 from conans.client.conanfile.configure import run_configure_method
@@ -13,6 +14,7 @@ from conans.client.graph.provides import check_graph_provides
 from conans.errors import ConanException
 from conans.model.conan_file import ConanFile
 from conans.model.options import Options
+from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference, ref_matches
 from conans.model.requires import Requirement
 
@@ -269,15 +271,23 @@ class DepsGraphBuilder(object):
             graph.replaced_requires[original_require] = repr(require.ref)
             break  # First match executes the alternative and finishes checking others
 
+    def _match_host_version_ref_track(self, require):
+        ref_track_re = re.compile("<host_version(?::(.+))?>")
+        return ref_track_re.match(str(require.ref.version))
+
     def _create_new_node(self, node, require, graph, profile_host, profile_build, graph_lock):
-        if require.ref.version == "<host_version>":
+        ref_track_match = self._match_host_version_ref_track(require)
+        if require.ref.version == "<host_version>" or ref_track_match:
             if not require.build or require.visible:
                 raise ConanException(f"{node.ref} require '{require.ref}': 'host_version' can only "
                                      "be used for non-visible tool_requires")
-            req = Requirement(require.ref, headers=True, libs=True, visible=True)
+            temp = RecipeReference.loads(str(node.ref))
+            temp.name = ref_track_match.group(1)
+            ref = temp if ref_track_match else require.ref
+            req = Requirement(ref, headers=True, libs=True, visible=True)
             transitive = node.transitive_deps.get(req)
             if transitive is None:
-                raise ConanException(f"{node.ref} require '{require.ref}': didn't find a matching "
+                raise ConanException(f"{node.ref} require '{ref}': didn't find a matching "
                                      "host dependency")
             require.ref.version = transitive.require.ref.version
 

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -273,7 +273,7 @@ class DepsGraphBuilder(object):
 
     def _create_new_node(self, node, require, graph, profile_host, profile_build, graph_lock):
         require_version = str(require.ref.version)
-        if require_version == "<host_version>" or require_version.startswith("<host_version") and require_version.endswith(">"):
+        if require_version.startswith("<host_version") and require_version.endswith(">"):
             if not require.build or require.visible:
                 raise ConanException(f"{node.ref} require '{require.ref}': 'host_version' can only "
                                      "be used for non-visible tool_requires")

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -277,7 +277,7 @@ class DepsGraphBuilder(object):
             if not require.build or require.visible:
                 raise ConanException(f"{node.ref} require '{require.ref}': 'host_version' can only "
                                      "be used for non-visible tool_requires")
-            tracking_ref = require_version.split(':')
+            tracking_ref = require_version.split(':', 1)
             ref = require.ref
             if len(tracking_ref) > 1:
                 temp = RecipeReference.loads(str(node.ref))

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -280,9 +280,8 @@ class DepsGraphBuilder(object):
             tracking_ref = require_version.split(':', 1)
             ref = require.ref
             if len(tracking_ref) > 1:
-                temp = RecipeReference.loads(str(node.ref))
-                temp.name = tracking_ref[1][:-1]  # Remove the trailing >
-                ref = temp
+                ref = RecipeReference.loads(str(node.ref))
+                ref.name = tracking_ref[1][:-1]  # Remove the trailing >
             req = Requirement(ref, headers=True, libs=True, visible=True)
             transitive = node.transitive_deps.get(req)
             if transitive is None:

--- a/conans/test/integration/build_requires/build_requires_test.py
+++ b/conans/test/integration/build_requires/build_requires_test.py
@@ -512,6 +512,25 @@ class TestBuildTrackHost:
         c.run("install app --lockfile=app/conan.lock")
         c.assert_listed_require({"protobuf/1.1": "Cache"}, build=True)
 
+    @pytest.mark.parametrize("host_version, assert_error", [
+        ("libgettext", False),
+        (":", True),
+        ("", True)
+    ])
+    def test_host_version_different_ref(self, host_version, assert_error):
+        tc = TestClient(light=True)
+        tc.save({"gettext/conanfile.py": GenConanfile("gettext"),
+                 "libgettext/conanfile.py": GenConanfile("libgettext"),
+                 "app/conanfile.py": GenConanfile("app", "1.0").with_requires("libgettext/[>0.1]")
+                                                   .with_tool_requirement(f"gettext/<host_version:{host_version}>")})
+        tc.run("create libgettext --version=0.2")
+        tc.run("create gettext --version=0.1 --build-require")
+        tc.run("create gettext --version=0.2 --build-require")
+
+        tc.run("create app", assert_error=assert_error)
+        if not assert_error:
+            assert "gettext/0.2#d9f9eaeac9b6e403b271f04e04149df2" in tc.out
+
 
 def test_build_missing_build_requires():
     c = TestClient(light=True)

--- a/conans/test/integration/build_requires/build_requires_test.py
+++ b/conans/test/integration/build_requires/build_requires_test.py
@@ -141,7 +141,7 @@ def test_complete(client):
 
 
 def test_dependents_new_buildenv():
-    client = TestClient()
+    client = TestClient(light=True)
     boost = textwrap.dedent("""
         from conan import ConanFile
         class Boost(ConanFile):
@@ -197,7 +197,7 @@ def test_dependents_new_buildenv():
 
 
 def test_tool_requires_conanfile_txt():
-    client = TestClient()
+    client = TestClient(light=True)
     client.save({"conanfile.py": GenConanfile()})
 
     build_req = textwrap.dedent("""
@@ -219,7 +219,7 @@ def test_tool_requires_conanfile_txt():
 
 
 def test_profile_override_conflict():
-    client = TestClient()
+    client = TestClient(light=True)
 
     test = textwrap.dedent("""
         from conan import ConanFile
@@ -273,7 +273,7 @@ def test_both_context_options_error():
 def test_conditional_require_context():
     """ test that we can condition on the context to define a dependency
     """
-    c = TestClient()
+    c = TestClient(light=True)
     pkg = textwrap.dedent("""
         from conan import ConanFile
         class Pkg(ConanFile):
@@ -301,7 +301,7 @@ class TestBuildTrackHost:
         will put ``protoc`` from it in the PATH. Not a problem in majority of cases, but not the
         cleanest
         """
-        c = TestClient()
+        c = TestClient(light=True)
         pkg = textwrap.dedent("""
             from conan import ConanFile
             class ProtoBuf(ConanFile):
@@ -329,7 +329,7 @@ class TestBuildTrackHost:
         """
         Make the tool_requires follow the regular require with the expression "<host_version>"
         """
-        c = TestClient()
+        c = TestClient(light=True)
         pkg = textwrap.dedent("""
             from conan import ConanFile
             class ProtoBuf(ConanFile):
@@ -365,7 +365,7 @@ class TestBuildTrackHost:
         """
         same as above, but using version ranges instead of overrides
         """
-        c = TestClient()
+        c = TestClient(light=True)
         pkg = textwrap.dedent("""
             from conan import ConanFile
             class ProtoBuf(ConanFile):
@@ -405,7 +405,7 @@ class TestBuildTrackHost:
         """
         if no host requirement is defined, it will be an error
         """
-        c = TestClient()
+        c = TestClient(light=True)
         pkg = textwrap.dedent("""
             from conan import ConanFile
             class ProtoBuf(ConanFile):
@@ -423,7 +423,7 @@ class TestBuildTrackHost:
         """
         It is not possible to make host_version visible too
         """
-        c = TestClient()
+        c = TestClient(light=True)
         pkg = textwrap.dedent("""
             from conan import ConanFile
             class ProtoBuf(ConanFile):
@@ -440,7 +440,7 @@ class TestBuildTrackHost:
         """
         it can only be used by tool_requires, not regular requires
         """
-        c = TestClient()
+        c = TestClient(light=True)
         c.save({"conanfile.py": GenConanfile("pkg").with_requirement("protobuf/<host_version>")})
         c.run(f"install .", assert_error=True)
         assert " 'host_version' can only be used for non-visible tool_requires" in c.out
@@ -449,7 +449,7 @@ class TestBuildTrackHost:
         """
         https://github.com/conan-io/conan/issues/14704
         """
-        c = TestClient()
+        c = TestClient(light=True)
         pkg = textwrap.dedent("""
                 from conan import ConanFile
                 class ProtoBuf(ConanFile):
@@ -491,7 +491,7 @@ class TestBuildTrackHost:
         """
         Make the tool_requires follow the regular require with the expression "<host_version>" for a transitive_deps
         """
-        c = TestClient()
+        c = TestClient(light=True)
         c.save({"protobuf/conanfile.py": GenConanfile("protobuf"),
                 "pkg/conanfile.py": GenConanfile("pkg", "0.1").with_requirement("protobuf/[>=1.0]"),
                 "app/conanfile.py": GenConanfile().with_requires("pkg/0.1").with_tool_requirement("protobuf/<host_version>")})
@@ -514,7 +514,7 @@ class TestBuildTrackHost:
 
 
 def test_build_missing_build_requires():
-    c = TestClient()
+    c = TestClient(light=True)
     c.save({"tooldep/conanfile.py": GenConanfile("tooldep", "0.1"),
             "tool/conanfile.py": GenConanfile("tool", "0.1").with_tool_requires("tooldep/0.1"),
             "pkg/conanfile.py": GenConanfile("pkg", "0.1").with_tool_requires("tool/0.1"),

--- a/conans/test/integration/build_requires/build_requires_test.py
+++ b/conans/test/integration/build_requires/build_requires_test.py
@@ -516,7 +516,7 @@ class TestBuildTrackHost:
         ("libgettext>", False, "gettext/0.2#d9f9eaeac9b6e403b271f04e04149df2"),
         # Error cases, just checking that we fail gracefully - no tracebacks
         ("libgettext", True, "Package 'gettext/<host_version:libgettext' not resolved"),
-        (":>", True, "app/1.0 require '/1.0': didn't find a matching host dependency"),
+        (":>", True, "app/1.0 require ':/1.0': didn't find a matching host dependency"),
         (">", True, "app/1.0 require '/1.0': didn't find a matching host dependency"),
         (":", True, " Package 'gettext/<host_version::' not resolved"),
         ("", True, "Package 'gettext/<host_version:' not resolved: No remote defined")

--- a/conans/test/integration/build_requires/build_requires_test.py
+++ b/conans/test/integration/build_requires/build_requires_test.py
@@ -141,7 +141,7 @@ def test_complete(client):
 
 
 def test_dependents_new_buildenv():
-    client = TestClient(light=True)
+    client = TestClient()
     boost = textwrap.dedent("""
         from conan import ConanFile
         class Boost(ConanFile):
@@ -197,7 +197,7 @@ def test_dependents_new_buildenv():
 
 
 def test_tool_requires_conanfile_txt():
-    client = TestClient(light=True)
+    client = TestClient()
     client.save({"conanfile.py": GenConanfile()})
 
     build_req = textwrap.dedent("""
@@ -219,7 +219,7 @@ def test_tool_requires_conanfile_txt():
 
 
 def test_profile_override_conflict():
-    client = TestClient(light=True)
+    client = TestClient()
 
     test = textwrap.dedent("""
         from conan import ConanFile
@@ -273,7 +273,7 @@ def test_both_context_options_error():
 def test_conditional_require_context():
     """ test that we can condition on the context to define a dependency
     """
-    c = TestClient(light=True)
+    c = TestClient()
     pkg = textwrap.dedent("""
         from conan import ConanFile
         class Pkg(ConanFile):
@@ -301,7 +301,7 @@ class TestBuildTrackHost:
         will put ``protoc`` from it in the PATH. Not a problem in majority of cases, but not the
         cleanest
         """
-        c = TestClient(light=True)
+        c = TestClient()
         pkg = textwrap.dedent("""
             from conan import ConanFile
             class ProtoBuf(ConanFile):
@@ -329,7 +329,7 @@ class TestBuildTrackHost:
         """
         Make the tool_requires follow the regular require with the expression "<host_version>"
         """
-        c = TestClient(light=True)
+        c = TestClient()
         pkg = textwrap.dedent("""
             from conan import ConanFile
             class ProtoBuf(ConanFile):
@@ -365,7 +365,7 @@ class TestBuildTrackHost:
         """
         same as above, but using version ranges instead of overrides
         """
-        c = TestClient(light=True)
+        c = TestClient()
         pkg = textwrap.dedent("""
             from conan import ConanFile
             class ProtoBuf(ConanFile):
@@ -405,7 +405,7 @@ class TestBuildTrackHost:
         """
         if no host requirement is defined, it will be an error
         """
-        c = TestClient(light=True)
+        c = TestClient()
         pkg = textwrap.dedent("""
             from conan import ConanFile
             class ProtoBuf(ConanFile):
@@ -423,7 +423,7 @@ class TestBuildTrackHost:
         """
         It is not possible to make host_version visible too
         """
-        c = TestClient(light=True)
+        c = TestClient()
         pkg = textwrap.dedent("""
             from conan import ConanFile
             class ProtoBuf(ConanFile):
@@ -440,7 +440,7 @@ class TestBuildTrackHost:
         """
         it can only be used by tool_requires, not regular requires
         """
-        c = TestClient(light=True)
+        c = TestClient()
         c.save({"conanfile.py": GenConanfile("pkg").with_requirement("protobuf/<host_version>")})
         c.run(f"install .", assert_error=True)
         assert " 'host_version' can only be used for non-visible tool_requires" in c.out
@@ -449,7 +449,7 @@ class TestBuildTrackHost:
         """
         https://github.com/conan-io/conan/issues/14704
         """
-        c = TestClient(light=True)
+        c = TestClient()
         pkg = textwrap.dedent("""
                 from conan import ConanFile
                 class ProtoBuf(ConanFile):
@@ -491,7 +491,7 @@ class TestBuildTrackHost:
         """
         Make the tool_requires follow the regular require with the expression "<host_version>" for a transitive_deps
         """
-        c = TestClient(light=True)
+        c = TestClient()
         c.save({"protobuf/conanfile.py": GenConanfile("protobuf"),
                 "pkg/conanfile.py": GenConanfile("pkg", "0.1").with_requirement("protobuf/[>=1.0]"),
                 "app/conanfile.py": GenConanfile().with_requires("pkg/0.1").with_tool_requirement("protobuf/<host_version>")})
@@ -512,28 +512,31 @@ class TestBuildTrackHost:
         c.run("install app --lockfile=app/conan.lock")
         c.assert_listed_require({"protobuf/1.1": "Cache"}, build=True)
 
-    @pytest.mark.parametrize("host_version, assert_error", [
-        ("libgettext", False),
-        (":", True),
-        ("", True)
+    @pytest.mark.parametrize("host_version, assert_error, assert_msg", [
+        ("libgettext>", False, "gettext/0.2#d9f9eaeac9b6e403b271f04e04149df2"),
+        # Error cases, just checking that we fail gracefully - no tracebacks
+        ("libgettext", True, "Package 'gettext/<host_version:libgettext' not resolved"),
+        (":>", True, "app/1.0 require '/1.0': didn't find a matching host dependency"),
+        (">", True, "app/1.0 require '/1.0': didn't find a matching host dependency"),
+        (":", True, " Package 'gettext/<host_version::' not resolved"),
+        ("", True, "Package 'gettext/<host_version:' not resolved: No remote defined")
     ])
-    def test_host_version_different_ref(self, host_version, assert_error):
+    def test_host_version_different_ref(self, host_version, assert_error, assert_msg):
         tc = TestClient(light=True)
         tc.save({"gettext/conanfile.py": GenConanfile("gettext"),
                  "libgettext/conanfile.py": GenConanfile("libgettext"),
                  "app/conanfile.py": GenConanfile("app", "1.0").with_requires("libgettext/[>0.1]")
-                                                   .with_tool_requirement(f"gettext/<host_version:{host_version}>")})
+                                                   .with_tool_requirement(f"gettext/<host_version:{host_version}")})
         tc.run("create libgettext --version=0.2")
         tc.run("create gettext --version=0.1 --build-require")
         tc.run("create gettext --version=0.2 --build-require")
 
         tc.run("create app", assert_error=assert_error)
-        if not assert_error:
-            assert "gettext/0.2#d9f9eaeac9b6e403b271f04e04149df2" in tc.out
+        assert assert_msg in tc.out
 
 
 def test_build_missing_build_requires():
-    c = TestClient(light=True)
+    c = TestClient()
     c.save({"tooldep/conanfile.py": GenConanfile("tooldep", "0.1"),
             "tool/conanfile.py": GenConanfile("tool", "0.1").with_tool_requires("tooldep/0.1"),
             "pkg/conanfile.py": GenConanfile("pkg", "0.1").with_tool_requires("tool/0.1"),


### PR DESCRIPTION
Changelog: Feature: Add tracking syntax in `<host_version>` for different references.
Docs: https://github.com/conan-io/docs/pull/3480

Close https://github.com/conan-io/conan/issues/15265

I don't like the current approach, so opening the PR so that I can get some ideas from the team
