### PR TITLE
new lock remove command

### DIFF
--- a/conan/api/subapi/lockfile.py
+++ b/conan/api/subapi/lockfile.py
@@ -89,6 +89,12 @@ class LockfileAPI:
         return lockfile
 
     @staticmethod
+    def remove_lockfile(lockfile, requires=None, build_requires=None, python_requires=None):
+        lockfile.remove(requires=requires, build_requires=build_requires,
+                        python_requires=python_requires)
+        return lockfile
+
+    @staticmethod
     def save_lockfile(lockfile, lockfile_out, path=None):
         if lockfile_out is not None:
             lockfile_out = make_abs_path(lockfile_out, path)

--- a/conan/cli/commands/lock.py
+++ b/conan/cli/commands/lock.py
@@ -6,7 +6,6 @@ from conan.cli.command import conan_command, OnceArgument, conan_subcommand
 from conan.cli import make_abs_path
 from conan.cli.args import common_graph_args, validate_common_graph_args
 from conan.cli.printers.graph import print_graph_packages, print_graph_basic
-from conans.client.cache.cache import ClientCache
 from conans.model.graph_lock import Lockfile, LOCKFILE
 from conans.model.recipe_ref import RecipeReference
 
@@ -123,4 +122,28 @@ def lock_add(conan_api, parser, subparser, *args):
                                                requires=requires,
                                                python_requires=python_requires,
                                                build_requires=build_requires)
+    conan_api.lockfile.save_lockfile(lockfile, args.lockfile_out)
+
+
+@conan_subcommand()
+def lock_remove(conan_api, parser, subparser, *args):
+    """
+    Remove requires, build-requires or python-requires from an existing or new lockfile.
+    References can be supplied with and without revisions like "--requires=pkg/version",
+    """
+    subparser.add_argument('--requires', action="append", help='Remove references to lockfile.')
+    subparser.add_argument('--build-requires', action="append",
+                           help='Remove build-requires from lockfile')
+    subparser.add_argument('--python-requires', action="append",
+                           help='Remove python-requires from lockfile')
+    subparser.add_argument("--lockfile-out", action=OnceArgument, default=LOCKFILE,
+                           help="Filename of the created lockfile")
+    subparser.add_argument("--lockfile", action=OnceArgument, help="Filename of the input lockfile")
+    args = parser.parse_args(*args)
+
+    lockfile = conan_api.lockfile.get_lockfile(lockfile=args.lockfile, partial=True)
+    lockfile = conan_api.lockfile.remove_lockfile(lockfile,
+                                                  requires=args.requires,
+                                                  python_requires=args.python_requires,
+                                                  build_requires=args.build_requires)
     conan_api.lockfile.save_lockfile(lockfile, args.lockfile_out)

--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -1,3 +1,4 @@
+import fnmatch
 import json
 import os
 from collections import OrderedDict
@@ -72,7 +73,7 @@ class _LockRequires:
         if version.startswith("[") and version.endswith("]"):
             version_range = VersionRange(version[1:-1])
             for k, v in self._requires.items():
-                if k.name == ref.name and version_range.contains(k.version, None):
+                if fnmatch.fnmatch(k.name, ref.name) and version_range.contains(k.version, None):
                     new_pattern = f"{k.name}/*@{ref.user or ''}"
                     new_pattern += f"/{ref.channel}" if ref.channel else ""
                     if k.matches(new_pattern, False):

--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -6,6 +6,7 @@ from conan.api.output import ConanOutput
 from conans.client.graph.graph import RECIPE_VIRTUAL, RECIPE_CONSUMER, CONTEXT_BUILD, Overrides
 from conans.errors import ConanException
 from conans.model.recipe_ref import RecipeReference
+from conans.model.version_range import VersionRange
 from conans.util.files import load, save
 
 LOCKFILE = "conan.lock"
@@ -63,6 +64,23 @@ class _LockRequires:
             if existing and existing.revision is not None:
                 raise ConanException(f"Cannot add {ref} to lockfile, already exists")
             self._requires[ref] = package_ids
+
+    def remove(self, pattern):
+        ref = RecipeReference.loads(pattern)
+        version = str(ref.version)
+        remove = []
+        if version.startswith("[") and version.endswith("]"):
+            version_range = VersionRange(version[1:-1])
+            for k, v in self._requires.items():
+                if k.name == ref.name and version_range.contains(k.version, None):
+                    new_pattern = f"{k.name}/*@{ref.user or ''}"
+                    new_pattern += f"/{ref.channel}" if ref.channel else ""
+                    if k.matches(new_pattern, False):
+                        remove.append(k)
+        else:
+            remove = [k for k in self._requires if k.matches(pattern, False)]
+        self._requires = OrderedDict((k, v) for k, v in self._requires.items() if k not in remove)
+        return remove
 
     def sort(self):
         self._requires = OrderedDict(reversed(sorted(self._requires.items())))
@@ -170,6 +188,19 @@ class Lockfile(object):
             for r in python_requires:
                 self._python_requires.add(r)
             self._python_requires.sort()
+
+    def remove(self, requires=None, build_requires=None, python_requires=None):
+        def _remove(reqs, self_reqs, name):
+            if reqs:
+                removed = []
+                for r in reqs:
+                    removed.extend(self_reqs.remove(r))
+                for d in removed:
+                    ConanOutput().info(f"Removed locked {name}: {d.repr_notime()}")
+
+        _remove(requires, self._requires, "require")
+        _remove(build_requires, self._build_requires, "build_require")
+        _remove(python_requires, self._python_requires, "python_require")
 
     @staticmethod
     def deserialize(data):

--- a/conans/test/integration/lockfile/test_user_overrides.py
+++ b/conans/test/integration/lockfile/test_user_overrides.py
@@ -1,4 +1,7 @@
 import json
+import textwrap
+
+import pytest
 
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
@@ -211,3 +214,105 @@ def test_lock_add_error():
     c = TestClient()
     c.run(f"lock add --requires=math/1.0:pid1", assert_error=True)
     assert "ERROR: Invalid recipe reference 'math/1.0:pid1' is a package reference" in c.out
+
+
+class TestLockRemove:
+    @pytest.mark.parametrize("args, removed", [
+        ("--requires=math/*", ["math"]),
+        ("--requires=math/2.0", []),
+        ("--build-requires=cmake/1.0", ["cmake"]),
+        # Not valid ("--build-requires=*", ["cmake", "ninja"]),
+        ("--build-requires=*/*", ["cmake", "ninja"]), # But this is valid
+        ("--python-requires=mytool/*", ["mytool"]),
+        ("--python-requires=*tool/*", ["mytool", "othertool"]),
+        # With version ranges
+        ('--requires="math/[>=1.0 <2]"', ["math"]),
+        ('--requires="math/[>1.0]"', []),
+    ])
+    def test_lock_remove(self, args, removed):
+        c = TestClient()
+        lock = textwrap.dedent("""\
+            {
+                "version": "0.5",
+                "requires": [
+                    "math/1.0#85d927a4a067a531b1a9c7619522c015%1702683583.3411012",
+                    "math/1.0#12345%1702683584.3411012",
+                    "engine/1.0#fd2b006646a54397c16a1478ac4111ac%1702683583.3544693"
+                ],
+                "build_requires": [
+                    "cmake/1.0#85d927a4a067a531b1a9c7619522c015%1702683583.3411012",
+                    "ninja/1.0#fd2b006646a54397c16a1478ac4111ac%1702683583.3544693"
+                ],
+                "python_requires": [
+                    "mytool/1.0#85d927a4a067a531b1a9c7619522c015%1702683583.3411012",
+                    "othertool/1.0#fd2b006646a54397c16a1478ac4111ac%1702683583.3544693"
+                ]
+            }
+            """)
+        c.save({"conan.lock": lock})
+        c.run(f"lock remove {args}")
+        lock = c.load("conan.lock")
+        for remove in removed:
+            assert remove not in lock
+        for pkg in {"math", "engine", "cmake", "ninja", "mytool", "othertool"}.difference(removed):
+            assert pkg in lock
+
+    @pytest.mark.parametrize("args, removed", [
+        ("--requires=math/1.0#12345*", ["math/1.0#123456789abcdef"]),
+        ("--requires=math/1.0#*", ["math/1.0#123456789abcdef",
+                                   "math/1.0#85d927a4a067a531b1a9c7619522c015"]),
+    ])
+    def test_lock_remove_revisions(self, args, removed):
+        c = TestClient()
+        lock = textwrap.dedent("""\
+            {
+                "version": "0.5",
+                "requires": [
+                    "math/1.0#123456789abcdef%1702683584.3411012",
+                    "math/1.0#85d927a4a067a531b1a9c7619522c015%1702683583.3411012",
+                    "engine/1.0#fd2b006646a54397c16a1478ac4111ac%1702683583.3544693"
+                ]
+            }
+            """)
+        c.save({"conan.lock": lock})
+        c.run(f"lock remove {args}")
+        lock = c.load("conan.lock")
+        for remove in removed:
+            assert remove not in lock
+        for pkg in {"math/1.0#123456789abcdef",
+                    "math/1.0#85d927a4a067a531b1a9c7619522c015",
+                    "engine/1.0#fd2b006646a54397c16a1478ac4111ac"}.difference(removed):
+            assert pkg in lock
+
+    @pytest.mark.parametrize("args, removed", [
+        ("--requires=*/*@team", ["pkg/1.0@team"]),
+        ("--requires=*/*@team*", ["pkg/1.0@team", "math/2.0@team/stable"]),
+        ("--requires=*/*@user", ["math/1.0@user", "other/1.0@user"]),
+        ("--requires=*/*@", ["engine/1.0"]),  # Remove those without user
+        # with version ranges
+        ("--requires=math/[*]@user", ["math/1.0@user"]),
+        ("--requires=math/[*]@team*", ["math/2.0@team/stable"]),
+    ])
+    def test_lock_remove_user_channel(self, args, removed):
+        c = TestClient()
+        lock = textwrap.dedent("""\
+            {
+                "version": "0.5",
+                "requires": [
+                    "math/1.0@user#123456789abcdef%1702683584.3411012",
+                    "math/2.0@team/stable#123456789abcdef%1702683584.3411012",
+                    "other/1.0@user#85d927a4a067a531b1a9c7619522c015%1702683583.3411012",
+                    "pkg/1.0@team#85d927a4a067a531b1a9c7619522c015%1702683583.3411012",
+                    "engine/1.0#fd2b006646a54397c16a1478ac4111ac%1702683583.3544693"
+                ]
+            }
+            """)
+        c.save({"conan.lock": lock})
+        c.run(f"lock remove {args}")
+        lock = c.load("conan.lock")
+        for remove in removed:
+            assert remove not in lock
+        rest = {"math/1.0@user", "math/2.0@team/stable",
+                "other/1.0@user", "pkg/1.0@team", "engine/1.0"}.difference(removed)
+        for pkg in rest:
+            assert pkg in lock

--- a/conans/test/integration/lockfile/test_user_overrides.py
+++ b/conans/test/integration/lockfile/test_user_overrides.py
@@ -222,12 +222,13 @@ class TestLockRemove:
         ("--requires=math/2.0", []),
         ("--build-requires=cmake/1.0", ["cmake"]),
         # Not valid ("--build-requires=*", ["cmake", "ninja"]),
-        ("--build-requires=*/*", ["cmake", "ninja"]), # But this is valid
+        ("--build-requires=*/*", ["cmake", "ninja"]),  # But this is valid
         ("--python-requires=mytool/*", ["mytool"]),
         ("--python-requires=*tool/*", ["mytool", "othertool"]),
         # With version ranges
         ('--requires="math/[>=1.0 <2]"', ["math"]),
         ('--requires="math/[>1.0]"', []),
+        ('--requires="*/[>=1.0 <2]"', ["math", "engine"])
     ])
     def test_lock_remove(self, args, removed):
         c = TestClient()


### PR DESCRIPTION
Changelog: Feature: New ``conan lock remove`` command to remove requires from lockfiles.
Docs: https://github.com/conan-io/docs/pull/3496

I am proposing this PR to close:

Close https://github.com/conan-io/conan/issues/14523
Close https://github.com/conan-io/conan/issues/14524

The idea is that updates are equivalent to something like:
```bash
$ conan remove --requires=zlib/* && conan add --requires=zlib/1.2.11
```
But it will allow us to first iterate and learn about the logic of removal of versions from lockfiles, because ``conan remove`` makes sense in isolation, even without ``lock update`` or ``lock add``, like for example using it before resolving it to latest with ``--lockfile-partial``. When we have clear what is the UX and UI for the removal, we can do a single command ``conan update`` or ``conan add`` with extra arguments



