### PR TITLE
fix self.info.clear() for python_requires and tool_requires

### DIFF
--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -394,6 +394,8 @@ class ConanInfo:
         self.options.clear()
         self.requires.clear()
         self.conf.clear()
+        self.build_requires.clear()
+        self.python_requires.clear()
 
     def validate(self):
         # If the options are not fully defined, this is also an invalid case

--- a/conans/test/integration/package_id/package_id_test.py
+++ b/conans/test/integration/package_id/package_id_test.py
@@ -2,7 +2,9 @@ import textwrap
 
 import pytest
 
+from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, TestServer
+from conans.util.files import save
 
 
 def test_double_package_id_call():
@@ -183,3 +185,47 @@ def test_package_id_validate_settings():
     c.save({"conanfile.py": conanfile})
     c.run("create . --name=pkg --version=0.1", assert_error=True)
     assert "ConanException: Invalid setting 'DONT_EXIST' is not a valid 'settings.os' value" in c.out
+
+
+class TestBuildRequiresHeaderOnly:
+    def test_header_only(self):
+        c = TestClient(light=True)
+        save(c.cache.global_conf_path, "core.package_id:default_build_mode=minor_mode")
+        pkg = textwrap.dedent("""\
+            from conan import ConanFile
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "0.1"
+                tool_requires = "tool/[*]"
+                def package_id(self):
+                    self.info.clear()
+                """)
+        c.save({"tool/conanfile.py": GenConanfile("tool"),
+                "pkg/conanfile.py": pkg})
+        c.run("create tool --version=1.0")
+        c.run("create pkg")
+        pkgid = c.created_package_id("pkg/0.1")
+        c.run("create tool --version=1.2")
+        c.run("install --requires=pkg/0.1")
+        c.assert_listed_binary({"pkg/0.1": (pkgid, "Cache")})
+
+    def test_header_only_implements(self):
+        c = TestClient(light=True)
+        save(c.cache.global_conf_path, "core.package_id:default_build_mode=minor_mode")
+        pkg = textwrap.dedent("""\
+            from conan import ConanFile
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "0.1"
+                tool_requires = "tool/[*]"
+                package_type = "header-library"
+                implements = ["auto_header_only"]
+                """)
+        c.save({"tool/conanfile.py": GenConanfile("tool"),
+                "pkg/conanfile.py": pkg})
+        c.run("create tool --version=1.0")
+        c.run("create pkg")
+        pkgid = c.created_package_id("pkg/0.1")
+        c.run("create tool --version=1.2")
+        c.run("install --requires=pkg/0.1")
+        c.assert_listed_binary({"pkg/0.1": (pkgid, "Cache")})


### PR DESCRIPTION
Changelog: Bugfix: Make ``self.info.clear()`` and header-only packages to remove ``python_requires`` and ``tool_requires``.
Docs: https://github.com/conan-io/docs/pull/3485


