### PR TITLE
fix git status path for is_dirty

### DIFF
--- a/conan/tools/scm/git.py
+++ b/conan/tools/scm/git.py
@@ -103,7 +103,7 @@ class Git:
 
         :return: True, if the current folder is dirty. Otherwise, False.
         """
-        status = self.run("status -s").strip()
+        status = self.run(f"status . -s").strip()
         return bool(status)
 
     def get_url_and_commit(self, remote="origin"):

--- a/conans/test/functional/tools/scm/test_git.py
+++ b/conans/test/functional/tools/scm/test_git.py
@@ -89,6 +89,22 @@ class TestGitBasicCapture:
             assert "pkg/0.1: COMMIT IN REMOTE: True" in c.out
             assert "pkg/0.1: DIRTY: False" in c.out
 
+    def test_capture_commit_local_subfolder(self):
+        """
+        A local repo, without remote, will have commit, but no URL, and sibling folders
+        can be dirty, no prob
+        """
+        c = TestClient()
+        c.save({"subfolder/conanfile.py": self.conanfile,
+                "other/myfile.txt": "content"})
+        commit = c.init_git_repo()
+        c.save({"other/myfile.txt": "change content"})
+        c.run("export subfolder")
+        assert "pkg/0.1: COMMIT: {}".format(commit) in c.out
+        assert "pkg/0.1: URL: None" in c.out
+        assert "pkg/0.1: COMMIT IN REMOTE: False" in c.out
+        assert "pkg/0.1: DIRTY: False" in c.out
+
 
 @pytest.mark.tool("git")
 class TestGitCaptureSCM:


### PR DESCRIPTION
Changelog: Bugfix: ``Git.is_dirty()`` will use ``git status . -s`` to make sure it only process the current path, not the whole repo, similarly to other ``Git`` methods.
Docs: Omit

This PR doesn't have docs, has ``Git`` docs is autogenerated from code, and docstrings are correct.

Fix for https://github.com/conan-io/conan/issues/14416#issuecomment-1723073845
