### PR TITLE
Make `core:warnings_as_errors` accept a list

### DIFF
--- a/conan/api/output.py
+++ b/conan/api/output.py
@@ -229,11 +229,10 @@ class ConanOutput:
         return self
 
     def error(self, msg, error_type=None):
+        if self._warnings_as_errors and error_type != "exception":
+            raise ConanException(msg)
         if self._conan_output_level <= LEVEL_ERROR:
-            if self._warnings_as_errors and error_type != "exception":
-                raise ConanException(msg)
-            else:
-                self._write_message("ERROR: {}".format(msg), Color.RED)
+            self._write_message("ERROR: {}".format(msg), Color.RED)
         return self
 
     def flush(self):

--- a/conan/internal/conan_app.py
+++ b/conan/internal/conan_app.py
@@ -64,6 +64,16 @@ class ConanApp(object):
 
     @staticmethod
     def _configure(global_conf):
-        ConanOutput.set_warnings_as_errors(global_conf.get("core:warnings_as_errors",
-                                                           default=False, check_type=bool))
-        ConanOutput.define_silence_warnings(global_conf.get("core:skip_warnings", check_type=list))
+        legacy_warnings_as_errors_bool = global_conf.get("core:warnings_as_errors", None, check_type=bool)
+        if legacy_warnings_as_errors_bool is not None:
+            # Print this before setting the warnings as errors,
+            # else only this will be printed and Conan will exit
+            ConanOutput().warning("Boolean 'core:warnings_as_errors' key is deprecated, "
+                                  "use a list of patterns instead, e.g. ['*'] to treat all warnings as errors",
+                                  warn_tag="deprecated")
+            ConanOutput.set_warnings_as_errors(["*"] if legacy_warnings_as_errors_bool else [])
+        else:
+            ConanOutput.set_warnings_as_errors(global_conf.get("core:warnings_as_errors",
+                                                               default=[], check_type=list))
+        ConanOutput.define_silence_warnings(global_conf.get("core:skip_warnings",
+                                                            default=[], check_type=list))

--- a/conan/internal/conan_app.py
+++ b/conan/internal/conan_app.py
@@ -64,16 +64,7 @@ class ConanApp(object):
 
     @staticmethod
     def _configure(global_conf):
-        legacy_warnings_as_errors_bool = global_conf.get("core:warnings_as_errors", None, check_type=bool)
-        if legacy_warnings_as_errors_bool is not None:
-            # Print this before setting the warnings as errors,
-            # else only this will be printed and Conan will exit
-            ConanOutput().warning("Boolean 'core:warnings_as_errors' key is deprecated, "
-                                  "use a list of patterns instead, e.g. ['*'] to treat all warnings as errors",
-                                  warn_tag="deprecated")
-            ConanOutput.set_warnings_as_errors(["*"] if legacy_warnings_as_errors_bool else [])
-        else:
-            ConanOutput.set_warnings_as_errors(global_conf.get("core:warnings_as_errors",
-                                                               default=[], check_type=list))
+        ConanOutput.set_warnings_as_errors(global_conf.get("core:warnings_as_errors",
+                                                           default=[], check_type=list))
         ConanOutput.define_silence_warnings(global_conf.get("core:skip_warnings",
                                                             default=[], check_type=list))

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -12,8 +12,8 @@ from conans.model.recipe_ref import ref_matches
 BUILT_IN_CONFS = {
     "core:required_conan_version": "Raise if current version does not match the defined range.",
     "core:non_interactive": "Disable interactive user input, raises error if input necessary",
-    "core:warnings_as_errors": "Treat warnings as errors",
-    "core:skip_warnings": "Do not show warnings in this list",
+    "core:warnings_as_errors": "Treat warnings matching any of the patterns in this list as errors",
+    "core:skip_warnings": "Do not show warnings matching any of the patterns in this list",
     "core:default_profile": "Defines the default host profile ('default' by default)",
     "core:default_build_profile": "Defines the default build profile ('default' by default)",
     "core:allow_uppercase_pkg_names": "Temporarily (will be removed in 2.X) allow uppercase names",

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -12,8 +12,10 @@ from conans.model.recipe_ref import ref_matches
 BUILT_IN_CONFS = {
     "core:required_conan_version": "Raise if current version does not match the defined range.",
     "core:non_interactive": "Disable interactive user input, raises error if input necessary",
-    "core:warnings_as_errors": "Treat warnings matching any of the patterns in this list as errors",
-    "core:skip_warnings": "Do not show warnings matching any of the patterns in this list",
+    "core:warnings_as_errors": "Treat warnings matching any of the patterns in this list as errors and then raise an exception. "
+                               "Current warning tags are 'network', 'deprecated'",
+    "core:skip_warnings": "Do not show warnings matching any of the patterns in this list. "
+                          "Current warning tags are 'network', 'deprecated'",
     "core:default_profile": "Defines the default host profile ('default' by default)",
     "core:default_build_profile": "Defines the default build profile ('default' by default)",
     "core:allow_uppercase_pkg_names": "Temporarily (will be removed in 2.X) allow uppercase names",

--- a/conans/test/integration/command_v2/test_output.py
+++ b/conans/test/integration/command_v2/test_output.py
@@ -186,7 +186,7 @@ def test_output_level_envvar():
 
 class TestWarningHandling:
     warning_lines = ("self.output.warning('Tagged warning', warn_tag='tag')",
-             "self.output.warning('Untagged warning')")
+                     "self.output.warning('Untagged warning')")
     error_lines = ("self.output.error('Tagged error', error_type='exception')",
                    "self.output.error('Untagged error')")
 
@@ -199,6 +199,7 @@ class TestWarningHandling:
         assert "WARN: Untagged warning" in t.out
         assert "WARN: tag: Tagged warning" in t.out
 
+        # Deprecated boolean, still works
         t.save_home({"global.conf": "core:warnings_as_errors=True"})
         t.run("create . -vwarning", assert_error=True)
         assert "ConanException: tag: Tagged warning" in t.out
@@ -243,12 +244,17 @@ class TestWarningHandling:
         t = TestClient(light=True)
         t.save({"conanfile.py": GenConanfile("foo", "1.0").with_package(*self.error_lines)})
 
-        t.save_home({"global.conf": "core:warnings_as_errors=False"})
-        t.run("create .")
-        assert "ERROR: Tagged error" in t.out
-        assert "ERROR: Untagged error" in t.out
+        # t.save_home({"global.conf": "core:warnings_as_errors=False"})
+        # t.run("create .")
+        # assert "ERROR: Tagged error" in t.out
+        # assert "ERROR: Untagged error" in t.out
+        #
+        # t.save_home({"global.conf": "core:warnings_as_errors=True"})
+        # t.run("create .", assert_error=True)
+        # assert "ERROR: Tagged error" in t.out
+        # assert "ConanException: Untagged error" in t.out
 
-        t.save_home({"global.conf": "core:warnings_as_errors=True"})
+        t.save_home({"global.conf": "core:warnings_as_errors=['*']"})
         t.run("create .", assert_error=True)
         assert "ERROR: Tagged error" in t.out
         assert "ConanException: Untagged error" in t.out

--- a/conans/test/integration/command_v2/test_output.py
+++ b/conans/test/integration/command_v2/test_output.py
@@ -190,28 +190,27 @@ class TestWarningHandling:
     error_lines = ("self.output.error('Tagged error', error_type='exception')",
                    "self.output.error('Untagged error')")
 
-    def test_warning_as_error(self):
+    def test_warning_as_error_deprecated_syntax(self):
         t = TestClient(light=True)
         t.save({"conanfile.py": GenConanfile("foo", "1.0").with_package(*self.warning_lines)})
 
-        t.save_home({"global.conf": "core:warnings_as_errors=False"})
+        t.save_home({"global.conf": "core:warnings_as_errors=[]"})
         t.run("create . -vwarning")
         assert "WARN: Untagged warning" in t.out
         assert "WARN: tag: Tagged warning" in t.out
 
-        # Deprecated boolean, still works
-        t.save_home({"global.conf": "core:warnings_as_errors=True"})
+        t.save_home({"global.conf": "core:warnings_as_errors=['*']"})
         t.run("create . -vwarning", assert_error=True)
         assert "ConanException: tag: Tagged warning" in t.out
         # We bailed early, didn't get a chance to print this one
         assert "Untagged warning" not in t.out
 
-        t.save_home({"global.conf": """core:warnings_as_errors=True\ncore:skip_warnings=["tag"]"""})
+        t.save_home({"global.conf": """core:warnings_as_errors=['*']\ncore:skip_warnings=["tag"]"""})
         t.run("create . -verror", assert_error=True)
         assert "ConanException: Untagged warning" in t.out
         assert "Tagged warning" not in t.out
 
-        t.save_home({"global.conf": "core:warnings_as_errors=False"})
+        t.save_home({"global.conf": "core:warnings_as_errors=[]"})
         t.run("create . -verror")
         assert "ERROR: Untagged warning" not in t.out
         assert "ERROR: tag: Tagged warning" not in t.out
@@ -244,15 +243,10 @@ class TestWarningHandling:
         t = TestClient(light=True)
         t.save({"conanfile.py": GenConanfile("foo", "1.0").with_package(*self.error_lines)})
 
-        # t.save_home({"global.conf": "core:warnings_as_errors=False"})
-        # t.run("create .")
-        # assert "ERROR: Tagged error" in t.out
-        # assert "ERROR: Untagged error" in t.out
-        #
-        # t.save_home({"global.conf": "core:warnings_as_errors=True"})
-        # t.run("create .", assert_error=True)
-        # assert "ERROR: Tagged error" in t.out
-        # assert "ConanException: Untagged error" in t.out
+        t.save_home({"global.conf": "core:warnings_as_errors=[]"})
+        t.run("create .")
+        assert "ERROR: Tagged error" in t.out
+        assert "ERROR: Untagged error" in t.out
 
         t.save_home({"global.conf": "core:warnings_as_errors=['*']"})
         t.run("create .", assert_error=True)

--- a/conans/test/integration/command_v2/test_output.py
+++ b/conans/test/integration/command_v2/test_output.py
@@ -252,3 +252,7 @@ class TestWarningHandling:
         t.run("create .", assert_error=True)
         assert "ERROR: Tagged error" in t.out
         assert "ConanException: Untagged error" in t.out
+
+        t.run("create . -vquiet", assert_error=True)
+        assert "ERROR: Tagged error" not in t.out
+        assert "ConanException: Untagged error" not in t.out


### PR DESCRIPTION
Changelog: Fix: Make `core:warnings_as_errors` accept a list
Docs: Omit

WIP, uploading to get it out as soon as it's done :)

