### PR TITLE
ensure --build=editable and --build=cascade works together

### DIFF
--- a/conans/client/graph/build_mode.py
+++ b/conans/client/graph/build_mode.py
@@ -89,7 +89,3 @@ class BuildMode:
         for pattern in self.build_missing_patterns:
             if ref_matches(conanfile.ref, pattern, is_consumer=False):
                 return True
-
-    def report_matches(self):
-        for pattern in self._unused_patterns:
-            ConanOutput().error(f"No package matching '{pattern}' pattern found.", error_type="context")

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -29,7 +29,8 @@ class GraphBinariesAnalyzer(object):
         with_deps_to_build = False
         # check dependencies, if they are being built, "cascade" will try to build this one too
         if build_mode.cascade:
-            with_deps_to_build = any(dep.dst.binary == BINARY_BUILD for dep in node.dependencies)
+            with_deps_to_build = any(dep.dst.binary in (BINARY_BUILD, BINARY_EDITABLE_BUILD)
+                                     for dep in node.dependencies)
         if build_mode.forced(conanfile, ref, with_deps_to_build):
             node.should_build = True
             conanfile.output.info('Forced build from source')

--- a/conans/test/integration/editable/transitive_editable_test.py
+++ b/conans/test/integration/editable/transitive_editable_test.py
@@ -155,3 +155,10 @@ def test_transitive_editable_control_package_id_cache_consumers():
     c.run("install app --build=editable --build=cascade")
     c.assert_listed_binary({"pkgb/1.0": (pkgb_id, "Build"),
                             "pkgc/1.0": (pkgc_id, "Build")})
+
+    # Changes in pkga are good, we export it
+    c.run("export pkga")
+    # Now we remove the editable
+    c.run("editable remove pkga")
+    c.run("install app", assert_error=True)
+    assert "ERROR: Missing prebuilt package for 'pkga/1.0'" in c.out


### PR DESCRIPTION
Changelog: Feature: Ensure ``--build=editable`` and ``--build=cascade`` works together.
Docs: https://github.com/conan-io/docs/pull/3550

Close https://github.com/conan-io/conan/issues/15292