### PR TITLE
Feature/get commit repo

### DIFF
--- a/conan/tools/scm/git.py
+++ b/conan/tools/scm/git.py
@@ -32,8 +32,8 @@ class Git:
 
     def get_commit(self, repo=False):
         """
-        :param repo: By default gets the commit of the folder, use repository=True to get
-                           the commit of the repository instead.
+        :param repo: By default gets the commit of the defined folder, use repo=True to get
+                     the commit of the repository instead.
         :return: The current commit, with ``git rev-list HEAD -n 1 -- <folder>``.
             The latest commit is returned, irrespective of local not committed changes.
         """
@@ -109,7 +109,7 @@ class Git:
         status = self.run(f"status . -s").strip()
         return bool(status)
 
-    def get_url_and_commit(self, remote="origin"):
+    def get_url_and_commit(self, remote="origin", repo=False):
         """
         This is an advanced method, that returns both the current commit, and the remote repository url.
         This method is intended to capture the current remote coordinates for a package creation,
@@ -134,13 +134,15 @@ class Git:
         to strip the credentials from the result.
 
         :param remote: Name of the remote git repository ('origin' by default).
+        :param repo: By default gets the commit of the defined folder, use repo=True to get
+                     the commit of the repository instead.
         :return: (url, commit) tuple
         """
         dirty = self.is_dirty()
         if dirty:
             raise ConanException("Repo is dirty, cannot capture url and commit: "
                                  "{}".format(self.folder))
-        commit = self.get_commit()
+        commit = self.get_commit(repo=repo)
         url = self.get_remote_url(remote=remote)
         in_remote = self.commit_in_remote(commit, remote=remote)
         if in_remote:

--- a/conan/tools/scm/git.py
+++ b/conan/tools/scm/git.py
@@ -30,8 +30,10 @@ class Git:
             #  - the ``conan source`` command, not passing profiles, buildenv not injected
             return check_output_runner("git {}".format(cmd)).strip()
 
-    def get_commit(self):
+    def get_commit(self, repo=False):
         """
+        :param repo: By default gets the commit of the folder, use repository=True to get
+                           the commit of the repository instead.
         :return: The current commit, with ``git rev-list HEAD -n 1 -- <folder>``.
             The latest commit is returned, irrespective of local not committed changes.
         """
@@ -41,7 +43,8 @@ class Git:
             # --full-history is needed to not avoid wrong commits:
             # https://github.com/conan-io/conan/issues/10971
             # https://git-scm.com/docs/git-rev-list#Documentation/git-rev-list.txt-Defaultmode
-            commit = self.run('rev-list HEAD -n 1 --full-history -- "."')
+            path = '' if repo else '-- "."'
+            commit = self.run(f'rev-list HEAD -n 1 --full-history {path}')
             return commit
         except Exception as e:
             raise ConanException("Unable to get git commit in '%s': %s" % (self.folder, str(e)))

--- a/conan/tools/scm/git.py
+++ b/conan/tools/scm/git.py
@@ -30,9 +30,9 @@ class Git:
             #  - the ``conan source`` command, not passing profiles, buildenv not injected
             return check_output_runner("git {}".format(cmd)).strip()
 
-    def get_commit(self, repo=False):
+    def get_commit(self, repository=False):
         """
-        :param repo: By default gets the commit of the defined folder, use repo=True to get
+        :param repository: By default gets the commit of the defined folder, use repo=True to get
                      the commit of the repository instead.
         :return: The current commit, with ``git rev-list HEAD -n 1 -- <folder>``.
             The latest commit is returned, irrespective of local not committed changes.
@@ -43,7 +43,7 @@ class Git:
             # --full-history is needed to not avoid wrong commits:
             # https://github.com/conan-io/conan/issues/10971
             # https://git-scm.com/docs/git-rev-list#Documentation/git-rev-list.txt-Defaultmode
-            path = '' if repo else '-- "."'
+            path = '' if repository else '-- "."'
             commit = self.run(f'rev-list HEAD -n 1 --full-history {path}')
             return commit
         except Exception as e:
@@ -109,7 +109,7 @@ class Git:
         status = self.run("status . --short --no-branch --untracked-files").strip()
         return bool(status)
 
-    def get_url_and_commit(self, remote="origin", repo=False):
+    def get_url_and_commit(self, remote="origin", repository=False):
         """
         This is an advanced method, that returns both the current commit, and the remote repository url.
         This method is intended to capture the current remote coordinates for a package creation,
@@ -134,7 +134,7 @@ class Git:
         to strip the credentials from the result.
 
         :param remote: Name of the remote git repository ('origin' by default).
-        :param repo: By default gets the commit of the defined folder, use repo=True to get
+        :param repository: By default gets the commit of the defined folder, use repo=True to get
                      the commit of the repository instead.
         :return: (url, commit) tuple
         """
@@ -142,7 +142,7 @@ class Git:
         if dirty:
             raise ConanException("Repo is dirty, cannot capture url and commit: "
                                  "{}".format(self.folder))
-        commit = self.get_commit(repo=repo)
+        commit = self.get_commit(repository=repository)
         url = self.get_remote_url(remote=remote)
         in_remote = self.commit_in_remote(commit, remote=remote)
         if in_remote:

--- a/conans/test/functional/tools/scm/test_git.py
+++ b/conans/test/functional/tools/scm/test_git.py
@@ -28,9 +28,11 @@ class TestGitBasicCapture:
             def export(self):
                 git = Git(self, self.recipe_folder)
                 commit = git.get_commit()
+                repo_commit = git.get_commit(repo=True)
                 url = git.get_remote_url()
                 self.output.info("URL: {}".format(url))
                 self.output.info("COMMIT: {}".format(commit))
+                self.output.info("REPO_COMMIT: {}".format(repo_commit))
                 in_remote = git.commit_in_remote(commit)
                 self.output.info("COMMIT IN REMOTE: {}".format(in_remote))
                 self.output.info("DIRTY: {}".format(git.is_dirty()))
@@ -61,6 +63,7 @@ class TestGitBasicCapture:
         with c.chdir("myclone"):
             c.run("export .")
             assert "pkg/0.1: COMMIT: {}".format(commit) in c.out
+            assert "pkg/0.1: REPO_COMMIT: {}".format(commit) in c.out
             assert "pkg/0.1: URL: {}".format(url) in c.out
             assert "pkg/0.1: COMMIT IN REMOTE: True" in c.out
             assert "pkg/0.1: DIRTY: False" in c.out
@@ -101,6 +104,14 @@ class TestGitBasicCapture:
         c.save({"other/myfile.txt": "change content"})
         c.run("export subfolder")
         assert "pkg/0.1: COMMIT: {}".format(commit) in c.out
+        assert "pkg/0.1: REPO_COMMIT: {}".format(commit) in c.out
+        assert "pkg/0.1: URL: None" in c.out
+        assert "pkg/0.1: COMMIT IN REMOTE: False" in c.out
+        assert "pkg/0.1: DIRTY: False" in c.out
+        commit2 = git_add_changes_commit(c.current_folder, msg="fix")
+        c.run("export subfolder")
+        assert "pkg/0.1: COMMIT: {}".format(commit) in c.out
+        assert "pkg/0.1: REPO_COMMIT: {}".format(commit2) in c.out
         assert "pkg/0.1: URL: None" in c.out
         assert "pkg/0.1: COMMIT IN REMOTE: False" in c.out
         assert "pkg/0.1: DIRTY: False" in c.out

--- a/conans/test/functional/tools/scm/test_git.py
+++ b/conans/test/functional/tools/scm/test_git.py
@@ -28,7 +28,7 @@ class TestGitBasicCapture:
             def export(self):
                 git = Git(self, self.recipe_folder)
                 commit = git.get_commit()
-                repo_commit = git.get_commit(repo=True)
+                repo_commit = git.get_commit(repository=True)
                 url = git.get_remote_url()
                 self.output.info("URL: {}".format(url))
                 self.output.info("COMMIT: {}".format(commit))


### PR DESCRIPTION
Changelog: Feature: Add ``Git.get_commit(..., repository=True)`` to obtain the repository commit, not the folder commit.
Docs: omit

Close https://github.com/conan-io/conan/issues/15259
