### PR TITLE
change default for source_buildenv, too risky

### DIFF
--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -2,4 +2,4 @@ CHECKSUM_DEPLOY = "checksum_deploy"  # Only when v2
 REVISIONS = "revisions"  # Only when enabled in config, not by default look at server_launcher.py
 OAUTH_TOKEN = "oauth_token"
 
-__version__ = '2.0.15'
+__version__ = '2.0.16'

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -68,7 +68,7 @@ def config_source(export_source_folder, conanfile, hook_manager):
             # First of all get the exported scm sources (if auto) or clone (if fixed)
             # Now move the export-sources to the right location
             merge_directories(export_source_folder, conanfile.folders.base_source)
-            if getattr(conanfile, "source_buildenv", True):
+            if getattr(conanfile, "source_buildenv", False):
                 with VirtualBuildEnv(conanfile, auto_generate=True).vars().apply():
                     run_source_method(conanfile, hook_manager)
             else:

--- a/conans/test/integration/build_requires/test_build_requires_source_method.py
+++ b/conans/test/integration/build_requires/test_build_requires_source_method.py
@@ -39,6 +39,8 @@ class TestBuildEnvSource:
                 version = "0.1"
                 tool_requires = "tool/0.1"
 
+                source_buildenv = True
+
                 def source(self):
                     cmd = "mytool.bat" if platform.system() == "Windows" else "mytool.sh"
                     self.run(cmd)
@@ -62,6 +64,8 @@ class TestBuildEnvSource:
                 version = "0.1"
                 tool_requires = "tool/0.1"
                 settings = "build_type"
+
+                source_buildenv = True
 
                 def layout(self):
                     self.folders.source = "mysrc"
@@ -101,6 +105,8 @@ class TestBuildEnvSource:
                 tool_requires = "tool/0.1"
                 settings = "build_type"
 
+                source_buildenv = True
+
                 def layout(self):
                     cmake_layout(self)
                     bt = self.settings.get_safe("build_type") or "Release"
@@ -118,7 +124,7 @@ class TestBuildEnvSource:
         c.run("source .")
         assert "MY-TOOL! tool/0.1" in c.out
 
-    def test_source_buildenv_optout(self, client):
+    def test_source_buildenv_default_fail(self, client):
         c = client
 
         pkg = textwrap.dedent("""
@@ -130,15 +136,13 @@ class TestBuildEnvSource:
                 version = "0.1"
                 tool_requires = "tool/0.1"
 
-                source_buildenv = False
-
                 def source(self):
                     cmd = "mytool.bat" if platform.system() == "Windows" else "mytool.sh"
                     self.run(cmd)
             """)
         c.save({"conanfile.py": pkg})
         c.run("create .", assert_error=True)
-        assert "ERROR: pkg/0.1: Error in source() method, line 14" in c.out
+        assert "ERROR: pkg/0.1: Error in source() method, line 12" in c.out
 
         # Local will still work, because ``install`` generates env-scripts and no layout
         c.run("install .")


### PR DESCRIPTION
Changelog: Bugfix: Revert the default of ``source_buildenv``, make it ``False`` by default.
Docs: https://github.com/conan-io/docs/pull/3501

Close https://github.com/conan-io/conan/issues/15317

It might require future work to correctly propagate ``conf`` to the ``source()`` step too