### PR TITLE
[1.x][bugfix] Skipped binaries do not appear on requires

### DIFF
--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -288,10 +288,10 @@ class _PCGenerator:
         requires = self._get_cpp_info_requires_names(self._dep.cpp_info)
         # If we have found some component requires it would be enough
         if not requires:
-            # If no requires were found, let's try to get all the direct dependencies,
+            # If no requires were found, let's try to get all the direct visible dependencies,
             # e.g., requires = "other_pkg/1.0"
             requires = [_get_package_name(req, self._build_context_suffix)
-                        for req in self._dep.dependencies.direct_host.values()]
+                        for dep, req in self._dep.dependencies.direct_host.items() if dep.visible]
         description = "Conan package: %s" % pkg_name
         aliases = _get_package_aliases(self._dep)
         cpp_info = self._dep.cpp_info

--- a/conans/model/new_build_info.py
+++ b/conans/model/new_build_info.py
@@ -263,7 +263,8 @@ class NewCppInfo(object):
 
 def from_old_cppinfo(old):
     ret = NewCppInfo()
-    ret.merge(old)
+    if old is not None:
+        ret.merge(old)
     ret.clear_none()
     return ret
 

--- a/conans/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -795,9 +795,6 @@ def test_pkg_config_deps_and_private_deps():
             self.requires("pkg/0.1")
     """)
     client.save({"conanfile.py": conanfile}, clean_first=True)
-    # Now, it passes and creates the pc files correctly
+    # Now, it passes and creates the pc files correctly (the skipped one is not created)
     client.run("install .")
-    # bug???? private dependency is skipped so PC file is not created
-    # assert client.load("private.pc)
-    # But pkg still depends on it!!
-    assert "Requires: private" in get_requires_from_content(client.load("pkg.pc"))
+    assert "Requires:" not in client.load("pkg.pc")


### PR DESCRIPTION
Changelog: Bugfix: Non-visible transitive dependencies are not included in the requires (PkgConfigDeps).
Changelog: Bugfix: `from_old_cppinfo` helper checks if the old cpp_info is not `None` before merging.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/15311

