### PR TITLE
Disable creating editables without name and version

### DIFF
--- a/conan/api/subapi/local.py
+++ b/conan/api/subapi/local.py
@@ -46,6 +46,8 @@ class LocalAPI:
         path = self._conan_api.local.get_conanfile_path(path, cwd, py=True)
         app = ConanApp(self._conan_api.cache_folder, self._conan_api.config.global_conf)
         conanfile = app.loader.load_named(path, name, version, user, channel, remotes=remotes)
+        if conanfile.name is None or conanfile.version is None:
+            raise ConanException("Editable package recipe should declare its name and version")
         ref = RecipeReference(conanfile.name, conanfile.version, conanfile.user, conanfile.channel)
         # Retrieve conanfile.py from target_path
         target_path = self._conan_api.local.get_conanfile_path(path=path, cwd=cwd, py=True)

--- a/conans/test/integration/editable/editable_add_test.py
+++ b/conans/test/integration/editable/editable_add_test.py
@@ -44,3 +44,19 @@ class TestEditablePackageTest:
         assert "Cannot resolve python_requires 'pyreq/1.0': No remote defined" in t.out
         t.run("editable add .")
         assert "Reference 'pkg/1.0' in editable mode" in t.out
+
+
+def test_editable_no_name_version_test_package():
+    tc = TestClient()
+    tc.save({"conanfile.py": GenConanfile(),
+             "test_package/conanfile.py": GenConanfile("test_package")
+             .with_class_attribute("test_type = 'explicit'")
+            .with_test("self.output.info('Testing the package')")})
+    tc.run("editable add . --name=foo", assert_error=True)
+    assert "ERROR: Editable package recipe should declare its name and version" in tc.out
+
+    tc.run("editable add . --version=1.0", assert_error=True)
+    assert "ERROR: Editable package recipe should declare its name and version" in tc.out
+
+    tc.run("editable add .", assert_error=True)
+    assert "ERROR: Editable package recipe should declare its name and version" in tc.out

--- a/conans/test/integration/editable/test_editables_layout.py
+++ b/conans/test/integration/editable/test_editables_layout.py
@@ -317,3 +317,14 @@ def test_editable_components_absolute_paths():
     c.run("create .")
     # This used to crash due to "include" is not absolute path, now it works
     assert "Testing the package" in c.out
+
+
+def test_editable_no_version_test_package():
+    tc = TestClient()
+    tc.save({"conanfile.py": GenConanfile("app"),
+             "test_package/conanfile.py": GenConanfile("test_package")
+             .with_class_attribute("test_type = 'explicit'")
+            .with_test("self.output.info('Testing the package')")})
+    tc.run("editable add .")
+    tc.run("test test_package app/None")
+    assert "app/None (test package): Testing the package" in tc.out

--- a/conans/test/integration/editable/test_editables_layout.py
+++ b/conans/test/integration/editable/test_editables_layout.py
@@ -317,14 +317,3 @@ def test_editable_components_absolute_paths():
     c.run("create .")
     # This used to crash due to "include" is not absolute path, now it works
     assert "Testing the package" in c.out
-
-
-def test_editable_no_version_test_package():
-    tc = TestClient()
-    tc.save({"conanfile.py": GenConanfile("app"),
-             "test_package/conanfile.py": GenConanfile("test_package")
-             .with_class_attribute("test_type = 'explicit'")
-            .with_test("self.output.info('Testing the package')")})
-    tc.run("editable add .")
-    tc.run("test test_package app/None")
-    assert "app/None (test package): Testing the package" in tc.out


### PR DESCRIPTION
Changelog: Bugfix: Disable creating editables without name and version.
Docs: Omit

After looking into it with the team, we have decided that creating editables without specifying a name and version is an anti-pattern