### PR TITLE
Don't take `.` folder into consideration for `tools.files.copy()` `excludes` patterns

### DIFF
--- a/conan/tools/files/copy_pattern.py
+++ b/conan/tools/files/copy_pattern.py
@@ -69,11 +69,13 @@ def _filter_files(src, pattern, excludes, ignore_case, excluded_folder):
 
         relative_path = os.path.relpath(root, src)
         compare_relative_path = relative_path.lower() if ignore_case else relative_path
-        for exclude in excludes:
-            if fnmatch.fnmatch(compare_relative_path, exclude):
-                subfolders[:] = []
-                files = []
-                break
+        # Don't try to exclude the start folder, it conflicts with excluding names starting with dots
+        if not compare_relative_path == ".":
+            for exclude in excludes:
+                if fnmatch.fnmatch(compare_relative_path, exclude):
+                    subfolders[:] = []
+                    files = []
+                    break
         for f in files:
             relative_name = os.path.normpath(os.path.join(relative_path, f))
             filenames.append(relative_name)

--- a/conans/test/unittests/tools/files/test_tool_copy.py
+++ b/conans/test/unittests/tools/files/test_tool_copy.py
@@ -161,6 +161,7 @@ class ToolCopyTest(unittest.TestCase):
         save(os.path.join(folder1, "MyLib.txt"), "")
         save(os.path.join(folder1, "MyLibImpl.txt"), "")
         save(os.path.join(folder1, "MyLibTests.txt"), "")
+
         folder2 = temp_folder()
         copy(None, "*.txt", folder1, folder2, excludes="*Test*.txt")
         self.assertEqual({'MyLib.txt', 'MyLibImpl.txt'}, set(os.listdir(folder2)))
@@ -168,6 +169,29 @@ class ToolCopyTest(unittest.TestCase):
         folder2 = temp_folder()
         copy(None, "*.txt", folder1, folder2, excludes=("*Test*.txt", "*Impl*"))
         self.assertEqual(['MyLib.txt'], os.listdir(folder2))
+
+    def test_excludes_hidden_files(self):
+        folder1 = temp_folder()
+        folder_foo = os.path.join(folder1, "foo")
+        folder_foo_bar = os.path.join(folder_foo, "bar")
+        folder_hidden = os.path.join(folder1, ".hiddenfolder")
+        mkdir(folder_foo)
+        mkdir(folder_foo_bar)
+        mkdir(folder_hidden)
+
+        save(os.path.join(folder1, "file1.txt"), "")
+        save(os.path.join(folder1, ".hiddenfile"), "")
+        save(os.path.join(folder_foo, "file2.txt"), "")
+        save(os.path.join(folder_foo, ".hiddenfile2"), "")
+        save(os.path.join(folder_hidden, "file3.txt"), "")
+        save(os.path.join(folder_foo_bar, "file4.txt"), "")
+
+        folder2 = temp_folder()
+        copy(None, "*", folder1, folder2, excludes=(".*", "*/.*"))
+        assert os.listdir(folder2) == ['file1.txt', 'foo']
+        assert os.listdir(os.path.join(folder2, "foo")) == ['file2.txt', 'bar']
+        assert not os.path.exists(os.path.join(folder2, ".hiddenfolder"))
+        assert os.listdir(os.path.join(folder2, "foo", "bar")) == ['file4.txt']
 
     def test_excludes_camelcase_folder(self):
         # https://github.com/conan-io/conan/issues/8153

--- a/conans/test/unittests/tools/files/test_tool_copy.py
+++ b/conans/test/unittests/tools/files/test_tool_copy.py
@@ -7,7 +7,7 @@ import pytest
 
 from conan.tools.files import copy
 from conans.test.utils.test_files import temp_folder
-from conans.util.files import load, save, mkdir
+from conans.util.files import load, save, mkdir, save_files
 
 
 class ToolCopyTest(unittest.TestCase):
@@ -172,19 +172,14 @@ class ToolCopyTest(unittest.TestCase):
 
     def test_excludes_hidden_files(self):
         folder1 = temp_folder()
-        folder_foo = os.path.join(folder1, "foo")
-        folder_foo_bar = os.path.join(folder_foo, "bar")
-        folder_hidden = os.path.join(folder1, ".hiddenfolder")
-        mkdir(folder_foo)
-        mkdir(folder_foo_bar)
-        mkdir(folder_hidden)
-
-        save(os.path.join(folder1, "file1.txt"), "")
-        save(os.path.join(folder1, ".hiddenfile"), "")
-        save(os.path.join(folder_foo, "file2.txt"), "")
-        save(os.path.join(folder_foo, ".hiddenfile2"), "")
-        save(os.path.join(folder_hidden, "file3.txt"), "")
-        save(os.path.join(folder_foo_bar, "file4.txt"), "")
+        save_files(folder1, {
+            "file1.txt": "",
+            ".hiddenfile": "",
+            "foo/file2.txt": "",
+            "foo/.hiddenfile2": "",
+            ".hiddenfolder/file3.txt": "",
+            "foo/bar/file4.txt": ""
+        })
 
         folder2 = temp_folder()
         copy(None, "*", folder1, folder2, excludes=(".*", "*/.*"))


### PR DESCRIPTION
Changelog: Bugfix: Don't take `.` folder into consideration for `tools.files.copy()` `excludes` patterns.
Docs: Omit

Closes https://github.com/conan-io/conan/issues/9208

As per https://docs.python.org/3/library/os.path.html#os.path.relpath and my own testing, `relpath` folders do not start with a `./` from the source