### PR TITLE
output for long waiting conan-list commands

### DIFF
--- a/conan/api/output.py
+++ b/conan/api/output.py
@@ -1,5 +1,6 @@
 import fnmatch
 import sys
+import time
 
 from colorama import Fore, Style
 
@@ -252,3 +253,19 @@ def cli_out_write(data, fg=None, bg=None, endline="\n", indentation=0):
         data = f"{' ' * indentation}{data}{endline}"
 
     sys.stdout.write(data)
+
+
+class TimedOutput:
+    def __init__(self, interval, out=None, msg_format=None):
+        self._interval = interval
+        self._msg_format = msg_format
+        self._t = time.time()
+        self._out = out or ConanOutput()
+
+    def info(self, msg, *args, **kwargs):
+        t = time.time()
+        if t - self._t > self._interval:
+            self._t = t
+            if self._msg_format:
+                msg = self._msg_format(msg, *args, **kwargs)
+            self._out.info(msg)

--- a/conans/test/integration/command_v2/list_test.py
+++ b/conans/test/integration/command_v2/list_test.py
@@ -100,7 +100,7 @@ class TestListRefs:
         expected_output = f"{r_msg}\n" + expected
         expected_output = re.sub(r"\(.*\)", "", expected_output)
         output = re.sub(r"\(.*\)", "", str(client.out))
-        assert expected_output == output
+        assert expected_output in output
 
     @staticmethod
     def check_json(client, pattern, remote, expected):
@@ -293,7 +293,7 @@ class TestListPrefs:
         expected_output = f"{r_msg}\n" + expected
         expected_output = re.sub(r"\(.*\)", "", expected_output)
         output = re.sub(r"\(.*\)", "", str(client.out))
-        assert expected_output == output
+        assert expected_output in output
 
     @staticmethod
     def check_json(client, pattern, remote, expected):

--- a/conans/test/integration/command_v2/search_test.py
+++ b/conans/test/integration/command_v2/search_test.py
@@ -113,7 +113,7 @@ class TestRemotes:
             "    {}\n".format(recipe_name)
         )
 
-        assert expected_output == self.client.out
+        assert expected_output in self.client.out
 
     def test_search_in_all_remotes(self):
         remote1 = "remote1"
@@ -144,7 +144,7 @@ class TestRemotes:
         self._add_recipe(remote2, remote2_recipe2)
 
         self.client.run("search test_recipe")
-        assert expected_output == self.client.out
+        assert expected_output in self.client.out
 
     def test_search_in_one_remote(self):
         remote1 = "remote1"
@@ -201,7 +201,7 @@ class TestRemotes:
         self._add_recipe(remote2, remote2_recipe2)
 
         self.client.run("search test_recipe")
-        assert expected_output == self.client.out
+        assert expected_output in self.client.out
 
     def test_search_in_missing_remote(self):
         remote1 = "remote1"


### PR DESCRIPTION
Changelog: Feature: Display progress for long ``conan list`` commands.
Docs: Omit


Will display something like this, displaying something every 5 seconds:
```
(conan2_36) λ conan list z*#*:* -r=conancenter
Found 84 pkg/version recipes matching z* in conancenter
Listing revisions of z3/4.11.2 in conancenter (3/84)
Listing binaries of zbar/0.10#3c8869d4c554b578e2b67afeb1813028 in conancenter (6/8)
Listing revisions of zbar/0.23.92 in conancenter (7/84)
Listing binaries of zbar/0.23.92#19b32916172bc37203cadf4b85f94735 in conancenter (3/5)
Listing binaries of zbar/0.23.92#17419480121dda01c64e7bf8b2f0d086 in conancenter (4/5)
Listing revisions of zeromq/4.3.2 in conancenter (8/84)
Listing binaries of zeromq/4.3.2#9b754f566bf3108bba0deda1bcba3d3f in conancenter (4/15)
Listing binaries of zeromq/4.3.2#4ecc885cfac2e1da8da551dfc36c2712 in conancenter (6/15)
```