### PR TITLE
Order `conf` items when dumping them

### DIFF
--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -347,7 +347,7 @@ class Conf:
         """
         Returns a string with the format ``name=conf-value``
         """
-        return "\n".join([v.dumps() for v in reversed(self._values.values())])
+        return "\n".join([v.dumps() for v in sorted(self._values.values(), key=lambda x: x._name)])
 
     def serialize(self):
         """

--- a/conans/test/integration/package_id/package_id_and_confs_test.py
+++ b/conans/test/integration/package_id/package_id_and_confs_test.py
@@ -7,7 +7,7 @@ from conans.test.utils.tools import GenConanfile, TestClient, NO_SETTINGS_PACKAG
 PKG_ID_NO_CONF = "ebec3dc6d7f6b907b3ada0c3d3cdc83613a2b715"
 PKG_ID_1 = "89d32f25195a77f4ae2e77414b870781853bdbc1"
 PKG_ID_2 = "7f9ed92704709f56ecc7b133322479caf3ffd7ad"
-PKG_ID_3 = "45b796ec237c7e2399944e79bee49b56fd022067"
+PKG_ID_3 = "a9f917f3bad3b48b5bceae70214764274ccd6337"
 
 
 @pytest.mark.parametrize("package_id_confs, package_id", [

--- a/conans/test/unittests/model/test_conf.py
+++ b/conans/test/unittests/model/test_conf.py
@@ -187,8 +187,8 @@ def test_compose_conf_complex():
     c2.loads(text)
     c.update_conf_definition(c2)
     expected_text = textwrap.dedent("""\
-        user.company.cpu:jobs=5
         user.company.build:ccflags=--m otherflag
+        user.company.cpu:jobs=5
         user.company.list:objs=[0, 1, 2, 3, 4, 'mystr', {'a': 1}, 5, 6, {'b': 2}]
         user.company.network:proxies={'url': 'http://api.site.com/apiv2'}
         zlib:user.company.check:shared=!


### PR DESCRIPTION
Changelog: Bugfix: Fix `package_id` calculation when including conf values thru `tools.info.package_id:confs`.
Changelog: Bugfix: Order `conf` items when dumping them to allow reproducible `package_id` independent of the order the confs were declared.
Docs: Omit

This bugfix will generate new package ids for the corner cases where two different orders of the same set of confs were used in `tools.info.package_id:confs`, making the lex sort order only possible one 