### PR TITLE
Improve the error message when trying to use a `build-scripts` package as a regular requirement

### DIFF
--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -289,6 +289,8 @@ class Requirement:
                 downstream_require = Requirement(require.ref, headers=False, libs=False, run=require.run)
             elif pkg_type is PackageType.HEADER:
                 downstream_require = Requirement(require.ref, headers=require.headers, libs=require.libs, run=require.run)
+            elif pkg_type is PackageType.BUILD_SCRIPTS:
+                raise ConanError("build-scripts package must be used as a tool_requires(), not a regular requirement")
             else:
                 assert pkg_type == PackageType.UNKNOWN
                 # TODO: This is undertested, changing it did not break tests


### PR DESCRIPTION
It currently fails on an assert with no further context provided in the stack trace. There might be a better place to do this check, though. 

Also, might want to add a check for `PackageType.PYTHON` as well.

Changelog: Fix: Improve the error message when trying to use a `build-scripts` package as a regular requirement
Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
