### PR TITLE
refactor: move editables to local api

### DIFF
--- a/conan/api/subapi/install.py
+++ b/conan/api/subapi/install.py
@@ -16,7 +16,8 @@ class InstallAPI:
         :param remotes:
         """
         app = ConanApp(self.conan_api)
-        installer = BinaryInstaller(app, self.conan_api.config.global_conf)
+        installer = BinaryInstaller(app, self.conan_api.config.global_conf,
+                                    self.conan_api.local.editable_packages)
         installer.install_system_requires(deps_graph)  # TODO: Optimize InstallGraph computation
         installer.install(deps_graph, remotes)
 
@@ -26,7 +27,8 @@ class InstallAPI:
         :param graph: Dependency graph to intall packages for
         """
         app = ConanApp(self.conan_api)
-        installer = BinaryInstaller(app, self.conan_api.config.global_conf)
+        installer = BinaryInstaller(app, self.conan_api.config.global_conf,
+                                    self.conan_api.local.editable_packages)
         installer.install_system_requires(graph, only_info)
 
     def install_sources(self, graph, remotes):
@@ -35,7 +37,8 @@ class InstallAPI:
         :param graph: Dependency graph to install packages for
         """
         app = ConanApp(self.conan_api)
-        installer = BinaryInstaller(app, self.conan_api.config.global_conf)
+        installer = BinaryInstaller(app, self.conan_api.config.global_conf,
+                                    self.conan_api.local.editable_packages)
         installer.install_sources(graph, remotes)
 
     # TODO: Look for a better name

--- a/conan/api/subapi/local.py
+++ b/conan/api/subapi/local.py
@@ -2,6 +2,7 @@ import os
 
 from conan.cli import make_abs_path
 from conan.internal.conan_app import ConanApp
+from conans.client.cache.editable import EditablePackages
 from conans.client.conanfile.build import run_build_method
 from conans.client.graph.graph import CONTEXT_HOST
 from conans.client.graph.profile_node_definer import initialize_conanfile_profile
@@ -15,6 +16,7 @@ class LocalAPI:
 
     def __init__(self, conan_api):
         self._conan_api = conan_api
+        self.editable_packages = EditablePackages(conan_api.home_folder)
 
     @staticmethod
     def get_conanfile_path(path, cwd, py):
@@ -53,18 +55,16 @@ class LocalAPI:
         target_path = self._conan_api.local.get_conanfile_path(path=path, cwd=cwd, py=True)
         output_folder = make_abs_path(output_folder) if output_folder else None
         # Check the conanfile is there, and name/version matches
-        app.cache.editable_packages.add(ref, target_path, output_folder=output_folder)
+        self.editable_packages.add(ref, target_path, output_folder=output_folder)
         return ref
 
     def editable_remove(self, path=None, requires=None, cwd=None):
-        app = ConanApp(self._conan_api)
         if path:
             path = self._conan_api.local.get_conanfile_path(path, cwd, py=True)
-        return app.cache.editable_packages.remove(path, requires)
+        return self.editable_packages.remove(path, requires)
 
     def editable_list(self):
-        app = ConanApp(self._conan_api)
-        return app.cache.editable_packages.edited_refs
+        return self.editable_packages.edited_refs
 
     def source(self, path, name=None, version=None, user=None, channel=None, remotes=None):
         """ calls the 'source()' method of the current (user folder) conanfile.py

--- a/conan/internal/conan_app.py
+++ b/conan/internal/conan_app.py
@@ -56,8 +56,8 @@ class ConanApp:
         # Handle remote connections
         self.remote_manager = RemoteManager(self.cache, auth_manager)
 
-        self.proxy = ConanProxy(self)
-        self.range_resolver = RangeResolver(self, global_conf)
+        self.proxy = ConanProxy(self, conan_api.local.editable_packages)
+        self.range_resolver = RangeResolver(self, global_conf, conan_api.local.editable_packages)
 
         self.pyreq_loader = PyRequireLoader(self, global_conf)
         cmd_wrap = CmdWrapper(home_paths.wrapper_path)

--- a/conans/client/cache/cache.py
+++ b/conans/client/cache/cache.py
@@ -2,7 +2,6 @@ import os
 from typing import List
 
 from conan.internal.cache.cache import DataCache, RecipeLayout, PackageLayout
-from conans.client.cache.editable import EditablePackages
 from conans.client.store.localdb import LocalDB
 from conans.errors import ConanException
 from conans.model.package_ref import PkgReference
@@ -20,7 +19,6 @@ class ClientCache(object):
 
     def __init__(self, cache_folder, global_conf):
         self.cache_folder = cache_folder
-        self.editable_packages = EditablePackages(self.cache_folder)
         # paths
         self._store_folder = global_conf.get("core.cache:storage_path") or \
                              os.path.join(self.cache_folder, "p")

--- a/conans/client/graph/proxy.py
+++ b/conans/client/graph/proxy.py
@@ -1,5 +1,3 @@
-import os.path
-
 from conan.api.output import ConanOutput
 from conan.internal.cache.conan_reference_layout import BasicLayout
 from conans.client.graph.graph import (RECIPE_DOWNLOADED, RECIPE_INCACHE, RECIPE_NEWER,
@@ -9,8 +7,9 @@ from conans.errors import ConanException, NotFoundException
 
 
 class ConanProxy:
-    def __init__(self, conan_app):
+    def __init__(self, conan_app, editable_packages):
         # collaborators
+        self._editable_packages = editable_packages
         self._cache = conan_app.cache
         self._remote_manager = conan_app.remote_manager
         self._resolved = {}  # Cache of the requested recipes to optimize calls
@@ -31,7 +30,7 @@ class ConanProxy:
     def _get_recipe(self, reference, remotes, update, check_update):
         output = ConanOutput(scope=str(reference))
 
-        conanfile_path = self._cache.editable_packages.get_path(reference)
+        conanfile_path = self._editable_packages.get_path(reference)
         if conanfile_path is not None:
             return BasicLayout(reference, conanfile_path), RECIPE_EDITABLE, None
 

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -6,8 +6,9 @@ from conans.search.search import search_recipes
 
 class RangeResolver:
 
-    def __init__(self, conan_app, global_conf):
+    def __init__(self, conan_app, global_conf, editable_packages):
         self._cache = conan_app.cache
+        self._editable_packages = editable_packages
         self._remote_manager = conan_app.remote_manager
         self._cached_cache = {}  # Cache caching of search result, so invariant wrt installations
         self._cached_remote_found = {}  # dict {ref (pkg/*): {remote_name: results (pkg/1, pkg/2)}}
@@ -54,7 +55,7 @@ class RangeResolver:
             # TODO: This is still necessary to filter user/channel, until search_recipes is fixed
             local_found = [ref for ref in local_found if ref.user == search_ref.user
                            and ref.channel == search_ref.channel]
-            local_found.extend(r for r in self._cache.editable_packages.edited_refs
+            local_found.extend(r for r in self._editable_packages.edited_refs
                                if r.name == search_ref.name and r.user == search_ref.user
                                and r.channel == search_ref.channel)
             self._cached_cache[pattern] = local_found

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -168,8 +168,9 @@ class BinaryInstaller:
     locally in case they are not found in remotes
     """
 
-    def __init__(self, app, global_conf):
+    def __init__(self, app, global_conf, editable_packages):
         self._app = app
+        self._editable_packages = editable_packages
         self._cache = app.cache
         self._remote_manager = app.remote_manager
         self._hook_manager = app.hook_manager
@@ -348,7 +349,7 @@ class BinaryInstaller:
         node = install_node.nodes[0]
         conanfile = node.conanfile
         ref = node.ref
-        editable = self._cache.editable_packages.get(ref)
+        editable = self._editable_packages.get(ref)
         conanfile_path = editable["path"]
         output_folder = editable.get("output_folder")
 


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

This is a refactor, similar movement that we did with ``global_conf``, from the ``ClientCache`` to the ``ConfigAPI``, giving it an entry point with memory, so it will be possible to implement workspaces (and also avoids re-loading the ``editable_packages.json`` file several times)
