### PR TITLE
MesonToolchain: add `pkg-config` entry to generated machine file

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -53,6 +53,7 @@ class MesonToolchain(object):
     {% if as %}as = '{{as}}'{% endif %}
     {% if windres %}windres = '{{windres}}'{% endif %}
     {% if pkgconfig %}pkgconfig = '{{pkgconfig}}'{% endif %}
+    {% if pkgconfig %}pkg-config = '{{pkgconfig}}'{% endif %}
 
     [built-in options]
     {% if buildtype %}buildtype = '{{buildtype}}'{% endif %}

--- a/conans/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/conans/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -254,6 +254,7 @@ def test_env_vars_from_build_require():
     assert "as = 'AS_VALUE'" in content
     assert "windres = 'WINDRES_VALUE'" in content
     assert "pkgconfig = 'PKG_CONFIG_VALUE'" in content
+    assert "pkg-config = 'PKG_CONFIG_VALUE'" in content
 
 
 def test_check_c_cpp_ld_list_formats():


### PR DESCRIPTION
Changelog: Fix: Add `pkg-config` entry to machine file generated by MesonToolchain, due to `pkgconfig` entry being deprecated since Meson 1.3.0.
Docs: Omit

closes https://github.com/conan-io/conan/issues/15190

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.