### PR TITLE
fix winsdk_version bug

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -826,7 +826,7 @@ class GenericSystemBlock(Block):
         cmake_sysroot = self._conanfile.conf.get("tools.build:sysroot")
         cmake_sysroot = cmake_sysroot.replace("\\", "/") if cmake_sysroot is not None else None
 
-        result = self._get_winsdk_version(system_version, generator)
+        result = self._get_winsdk_version(system_version, generator_platform)
         system_version, winsdk_version, gen_platform_sdk_version = result
 
         return {"toolset": toolset,

--- a/conans/test/conftest.py
+++ b/conans/test/conftest.py
@@ -91,6 +91,9 @@ tools_locations = {
             "path": {'Windows': 'C:/cmake/cmake-3.23.1-win64-x64/bin',
                      'Darwin': '/Users/jenkins/cmake/cmake-3.23.1/bin',
                      'Linux': "/usr/share/cmake-3.23.5/bin"}
+        },
+        "3.28": {
+            "disabled": True  # TODO: Still not in CI
         }
     },
     'ninja': {

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -556,21 +556,39 @@ def test_cmake_toolchain_runtime_types_cmake_older_than_3_15():
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
-# @pytest.mark.tool("cmake", "3.28")
-def test_cmake_toolchain_winsdk_version():
-    client = TestClient(path_with_spaces=False)
-    client.run("new cmake_lib -d name=hello -d version=0.1")
-    cmake = client.load("CMakeLists.txt")
-    # TODO: when we have CMake 3.27 in CI
-    # cmake = cmake.replace("cmake_minimum_required(VERSION 3.15)",
-    #                       "cmake_minimum_required(VERSION 3.27)")
-    cmake += 'message(STATUS "CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION = ' \
-             '${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")'
-    client.save({"CMakeLists.txt": cmake})
-    client.run("create . -s arch=x86_64 -s compiler.version=193 "
-               "-c tools.microsoft:winsdk_version=8.1")
-    assert "CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION = 8.1" in client.out
-    assert "Conan toolchain: CMAKE_GENERATOR_PLATFORM=x64" in client.out
+class TestWinSDKVersion:
+    def test_cmake_toolchain_winsdk_version(self):
+        # This test passes also with CMake 3.28, as long as cmake_minimum_required(VERSION 3.27)
+        # is not defined
+        client = TestClient(path_with_spaces=False)
+        client.run("new cmake_lib -d name=hello -d version=0.1")
+        cmake = client.load("CMakeLists.txt")
+        cmake += 'message(STATUS "CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION = ' \
+                 '${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")'
+        client.save({"CMakeLists.txt": cmake})
+        client.run("create . -s arch=x86_64 -s compiler.version=193 "
+                   "-c tools.microsoft:winsdk_version=8.1")
+        assert "CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION = 8.1" in client.out
+        assert "Conan toolchain: CMAKE_GENERATOR_PLATFORM=x64" in client.out
+        assert "Conan toolchain: CMAKE_GENERATOR_PLATFORM=x64,version" not in client.out
+
+    @pytest.mark.tool("cmake", "3.28")
+    @pytest.mark.tool("visual_studio", "17")
+    def test_cmake_toolchain_winsdk_version2(self):
+        # https://github.com/conan-io/conan/issues/15372
+        client = TestClient(path_with_spaces=False)
+        client.run("new cmake_lib -d name=hello -d version=0.1")
+        cmake = client.load("CMakeLists.txt")
+        cmake = cmake.replace("cmake_minimum_required(VERSION 3.15)",
+                              "cmake_minimum_required(VERSION 3.27)")
+        cmake += 'message(STATUS "CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION = ' \
+                 '${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}")'
+        client.save({"CMakeLists.txt": cmake})
+        client.run("create . -s arch=x86_64 -s compiler.version=193 "
+                   "-c tools.microsoft:winsdk_version=8.1 "
+                   '-c tools.cmake.cmaketoolchain:generator="Visual Studio 17"')
+        assert "CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION = 8.1" in client.out
+        assert "Conan toolchain: CMAKE_GENERATOR_PLATFORM=x64,version=8.1" in client.out
 
 
 @pytest.mark.tool("cmake", "3.23")


### PR DESCRIPTION
Changelog: Bugfix: Solve ``winsdk_version`` bug in ``CMakeToolchain`` generator for ``cmake_minimum_required(3.27)``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/15372
