### PR TITLE
Raise error if `check_type=int` and conf value is set to `bool`

### DIFF
--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -313,7 +313,8 @@ class Conf:
                 return str(v)
             elif v is None:  # value was unset
                 return default
-            elif check_type is not None and not isinstance(v, check_type):
+            elif (check_type is not None and not isinstance(v, check_type) or
+                  check_type is int and isinstance(v, bool)):
                 raise ConanException(f"[conf] {conf_name} must be a "
                                      f"{check_type.__name__}-like object. The value '{v}' "
                                      f"introduced is a {type(v).__name__} object")

--- a/conans/test/unittests/model/test_conf.py
+++ b/conans/test/unittests/model/test_conf.py
@@ -220,6 +220,7 @@ def test_conf_get_check_type_and_default():
         zlib:user.company.check:shared_str="False"
         zlib:user.company.check:static_str=off
         user.company.list:newnames+=myname
+        core.download:parallel=True
     """)
     c = ConfDefinition()
     c.loads(text)
@@ -238,6 +239,10 @@ def test_conf_get_check_type_and_default():
     assert c.get("zlib:user.company.check:static_str") == "off"
     assert c.get("zlib:user.company.check:static_str", check_type=bool) is False  # smart conversion
     assert c.get("user.company.list:newnames") == ["myname"]  # Placeholder is removed
+    with pytest.raises(ConanException) as exc_info:
+        c.get("core.download:parallel", check_type=int)
+    assert ("[conf] core.download:parallel must be a int-like object. "
+            "The value 'True' introduced is a bool object") in str(exc_info.value)
 
 
 def test_conf_pop():


### PR DESCRIPTION
Changelog: Fix: Raise if `check_type=int` and conf value is set to `bool`.
Docs: Omit

I just realized reviewing this https://github.com/conan-io/conan/pull/15360 that as `bool` is instance of `int` we allow these cases but I think that for these cases it may be more correct to fail (not in the opposite that you may use 0 or 1 to set a bool value)