### PR TITLE
Fix getting environment variable CONAN_LOGIN_USERNAME_<REMOTE>

### DIFF
--- a/conan/api/subapi/remotes.py
+++ b/conan/api/subapi/remotes.py
@@ -101,7 +101,7 @@ class RemotesAPI:
         if with_user:
             user, token, _ = app.cache.localdb.get_login(remote.url)
             if not user:
-                var_name = f"CONAN_LOGIN_USERNAME_{remote.name.upper()}"
+                var_name = f"CONAN_LOGIN_USERNAME_{remote.name.replace('-', '_').upper()}"
                 user = os.getenv(var_name, None) or os.getenv("CONAN_LOGIN_USERNAME", None)
             if not user:
                 return


### PR DESCRIPTION
Trying to fix the ci for artifactory custom command in conan-extensions I found out that the authentication for certain commands is not managed correctly when using environment variables with the remote names in the end like `CONAN_LOGIN_USERNAME_EXTENSIONS_PROD`. This changes the environment variable management in `conan auth` but the problem is not solved with this. I still need to investigate it more in deep, leaving this PR here so we don't forget. 

I had to change to conan remote login: https://github.com/conan-io/conan-extensions/pull/95#discussion_r1441675667

Changelog: Bugfix: Fix getting environment variable CONAN_LOGIN_USERNAME_REMOTE.
Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
