### PR TITLE
MesonToolchain: respect can_run when deciding to cross compile

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -7,7 +7,7 @@ from conan.errors import ConanException
 from conan.internal import check_duplicated_generator
 from conan.tools.apple.apple import to_apple_arch, is_apple_os, apple_min_version_flag, \
     apple_sdk_path
-from conan.tools.build.cross_building import cross_building
+from conan.tools.build.cross_building import can_run
 from conan.tools.build.flags import libcxx_flags
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.meson.helpers import *
@@ -152,7 +152,7 @@ class MesonToolchain(object):
         self.cross_build = {}
         default_comp = ""
         default_comp_cpp = ""
-        if cross_building(conanfile, skip_x64_x86=True):
+        if not can_run(conanfile):
             os_host = conanfile.settings.get_safe("os")
             arch_host = conanfile.settings.get_safe("arch")
             os_build = conanfile.settings_build.get_safe('os')


### PR DESCRIPTION
Changelog: Bugfix: MesonToolchain: respect can_run when deciding to cross compile
Docs: (trivial bugfix to correct behaviour to better match documentation - no documentation change required)

* #15392: MesonToolchain was only using the cross_building test and not using can_run (which respects the conf value).  Fix this so we can force cross-compilation where the host cannot run the binary despite it seeming like it should be able to.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
