### PR TITLE
Fix/cache save create folder

### DIFF
--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -13,7 +13,7 @@ from conans.errors import ConanException
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
 from conans.util.dates import revision_timestamp_now
-from conans.util.files import rmdir, gzopen_without_timestamps
+from conans.util.files import rmdir, gzopen_without_timestamps, mkdir
 
 
 class CacheAPI:
@@ -113,6 +113,7 @@ class CacheAPI:
         cache_folder = self.conan_api.cache_folder
         app = ConanApp(cache_folder, self.conan_api.config.global_conf)
         out = ConanOutput()
+        mkdir(os.path.dirname(tgz_path))
         name = os.path.basename(tgz_path)
         with open(tgz_path, "wb") as tgz_handle:
             tgz = gzopen_without_timestamps(name, mode="w", fileobj=tgz_handle)

--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -130,7 +130,6 @@ def cache_save(conan_api: ConanAPI, parser, subparser, *args):
         ref_pattern = ListPattern(args.pattern)
         package_list = conan_api.list.select(ref_pattern)
     tgz_path = make_abs_path(args.file or "conan_cache_save.tgz")
-
     conan_api.cache.save(package_list, tgz_path)
     return {"results": {"Local Cache": package_list.serialize()}}
 

--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -130,6 +130,7 @@ def cache_save(conan_api: ConanAPI, parser, subparser, *args):
         ref_pattern = ListPattern(args.pattern)
         package_list = conan_api.list.select(ref_pattern)
     tgz_path = make_abs_path(args.file or "conan_cache_save.tgz")
+
     conan_api.cache.save(package_list, tgz_path)
     return {"results": {"Local Cache": package_list.serialize()}}
 

--- a/conans/test/integration/command_v2/test_cache_save_restore.py
+++ b/conans/test/integration/command_v2/test_cache_save_restore.py
@@ -155,3 +155,14 @@ def test_cache_save_restore_graph():
     c2.run("list *:*#*")
     assert "pkg/0.1" in c2.out
     assert "dep/0.1" in c2.out
+
+
+def test_cache_save_subfolder():
+    """ It is possible to save package list in subfolder that doesn't exist
+    https://github.com/conan-io/conan/issues/15362
+    """
+    c = TestClient()
+    c.save({"conanfile.py": GenConanfile("dep", "0.1")})
+    c.run("export .")
+    c.run("cache save * --file=subfolder/cache.tgz")
+    assert os.path.exists(os.path.join(c.current_folder, "subfolder", "cache.tgz"))


### PR DESCRIPTION
Changelog: Fix: Automatically create folder if ``conan cache save --file=subfolder/file.tgz`` subfolder doesn't exist.
Docs: Omit

Close https://github.com/conan-io/conan/issues/15362