### PR TITLE
[BazelDeps][bugfix] Avoid getting binaries in `_get_libs`

### DIFF
--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -118,15 +118,10 @@ def _get_libs(dep, cpp_info=None) -> list:
             full_path = os.path.join(libdir, f)
             if not os.path.isfile(full_path):  # Make sure that directories are excluded
                 continue
-            # Users may not name their libraries in a conventional way. For example, directly
-            # use the basename of the lib file as lib name.
-            if f in libs:
-                _save_lib_path(f, full_path)
-                continue
             name, ext = os.path.splitext(f)
             if name not in libs and name.startswith("lib"):
                 name = name[3:]  # libpkg -> pkg
-             # FIXME: Should it read a conf variable to know unexpected extensions?
+            # FIXME: Should it read a conf variable to know unexpected extensions?
             if (is_shared and ext in (".so", ".dylib", ".lib", ".dll")) or \
                (not is_shared and ext in (".a", ".lib")):
                 if name in libs:

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -119,6 +119,12 @@ def _get_libs(dep, cpp_info=None) -> list:
             if not os.path.isfile(full_path):  # Make sure that directories are excluded
                 continue
             name, ext = os.path.splitext(f)
+            # Users may not name their libraries in a conventional way. For example, directly
+            # use the basename of the lib file as lib name, e.g., cpp_info.libs = ["liblib1.a"]
+            # Issue related: https://github.com/conan-io/conan/issues/11331
+            if ext and f in libs:  # let's ensure that it has any extension
+                _save_lib_path(f, full_path)
+                continue
             if name not in libs and name.startswith("lib"):
                 name = name[3:]  # libpkg -> pkg
             # FIXME: Should it read a conf variable to know unexpected extensions?

--- a/conans/test/unittests/tools/google/test_bazel.py
+++ b/conans/test/unittests/tools/google/test_bazel.py
@@ -20,6 +20,7 @@ def cpp_info():
     save(ConanFileMock(), os.path.join(bindirs, "mylibwin2.dll"), "")
     save(ConanFileMock(), os.path.join(bindirs, "myliblin.so"), "")
     save(ConanFileMock(), os.path.join(bindirs, "mylibmac.dylib"), "")
+    save(ConanFileMock(), os.path.join(bindirs, "protoc"), "")  # binary
     save(ConanFileMock(), os.path.join(libdirs, "myliblin.a"), "")
     save(ConanFileMock(), os.path.join(libdirs, "mylibmac.a"), "")
     save(ConanFileMock(), os.path.join(libdirs, "mylibwin.lib"), "")
@@ -101,6 +102,8 @@ def test_bazeldeps_relativize_path(path, pattern, expected):
     (["noexist"], False, []),
     # no lib matching + Win + static
     (["noexist", "mylibwin"], False, [('mylibwin', False, '{base_folder}/lib/mylibwin.lib', None)]),
+    # protobuf (Issue related https://github.com/conan-io/conan/issues/15390)
+    (["protoc"], True, [])
 ])
 def test_bazeldeps_get_libs(cpp_info, libs, is_shared, expected):
     cpp_info.libs = libs

--- a/conans/test/unittests/tools/google/test_bazel.py
+++ b/conans/test/unittests/tools/google/test_bazel.py
@@ -103,7 +103,9 @@ def test_bazeldeps_relativize_path(path, pattern, expected):
     # no lib matching + Win + static
     (["noexist", "mylibwin"], False, [('mylibwin', False, '{base_folder}/lib/mylibwin.lib', None)]),
     # protobuf (Issue related https://github.com/conan-io/conan/issues/15390)
-    (["protoc"], True, [])
+    (["protoc"], True, []),
+    # non-conventional library name (Issue related https://github.com/conan-io/conan/pull/11343)
+    (["libmylib.so"], True, [('libmylib.so', True, '{base_folder}/lib/libmylib.so', None)]),
 ])
 def test_bazeldeps_get_libs(cpp_info, libs, is_shared, expected):
     cpp_info.libs = libs


### PR DESCRIPTION
Changelog: Bugfix: `BazelDeps._get_libs()` was gathering binary names.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/15390
