### PR TITLE
explore nested ANY settings.yml

### DIFF
--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -106,6 +106,11 @@ class SettingsItem(object):
             raise undefined_field(self._name, item, None, self._value)
         if self._value is None:
             raise ConanException("'%s' value not defined" % self._name)
+        return self._get_definition()
+
+    def _get_definition(self):
+        if self._value not in self._definition and "ANY" in self._definition:
+            return self._definition["ANY"]
         return self._definition[self._value]
 
     def __getattr__(self, item):
@@ -142,7 +147,7 @@ class SettingsItem(object):
         partial_name = ".".join(self._name.split(".")[1:])
         result.append((partial_name, self._value))
         if isinstance(self._definition, dict):
-            sub_config_dict = self._definition[self._value]
+            sub_config_dict = self._get_definition()
             result.extend(sub_config_dict.values_list)
         return result
 
@@ -150,7 +155,7 @@ class SettingsItem(object):
         if self._value is None and None not in self._definition:
             raise ConanException("'%s' value not defined" % self._name)
         if isinstance(self._definition, dict):
-            self._definition[self._value].validate()
+            self._get_definition().validate()
 
     def possible_values(self):
         if isinstance(self._definition, list):

--- a/conans/test/unittests/model/settings_test.py
+++ b/conans/test/unittests/model/settings_test.py
@@ -1,3 +1,4 @@
+import textwrap
 import unittest
 
 import pytest
@@ -47,6 +48,32 @@ class SettingsLoadsTest(unittest.TestCase):
         settings.os = "Windows"
         self.assertTrue(settings.os == "Windows")
         self.assertEqual("os=Windows", settings.dumps())
+
+    def test_nested_any(self):
+        yml = textwrap.dedent("""\
+            os:
+                ANY:
+                    version: [null, ANY]
+                Ubuntu:
+                    version: ["18.04", "20.04"]
+            """)
+        settings = Settings.loads(yml)
+        settings.os = "Windows"
+        settings.validate()
+        self.assertTrue(settings.os == "Windows")
+        self.assertIn("os=Windows", settings.dumps())
+        settings.os.version = 2
+        self.assertTrue(settings.os == "Windows")
+        self.assertEqual("os=Windows\nos.version=2", settings.dumps())
+        settings.os = "Ubuntu"
+        with self.assertRaisesRegex(ConanException, "'settings.os.version' value not defined"):
+            settings.validate()
+        with self.assertRaisesRegex(ConanException,
+                                    "Invalid setting '3' is not a valid 'settings.os.version'"):
+            settings.os.version = 3
+        settings.os.version = "20.04"
+        self.assertEqual("os=Ubuntu\nos.version=20.04", settings.dumps())
+        self.assertTrue(settings.os.version == "20.04")
 
     def test_getattr_none(self):
         yml = "os: [None, Windows]"


### PR DESCRIPTION
Changelog: Feature: Allow nested "ANY" definitions in ``settings.yml``.
Docs: https://github.com/conan-io/docs/pull/3546

Close https://github.com/conan-io/conan/issues/15414

