### PR TITLE
set jobs parameter in cmake build presets(#15419)

### DIFF
--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -6,7 +6,7 @@ from conan.api.output import ConanOutput
 from conan.tools.cmake.layout import get_build_folder_custom_vars
 from conan.tools.cmake.toolchain.blocks import GenericSystemBlock
 from conan.tools.cmake.utils import is_multi_configuration
-import conan.tools.build as build
+from conan.tools.build import build_jobs
 from conan.tools.microsoft import is_msvc
 from conans.client.graph.graph import RECIPE_CONSUMER
 from conan.errors import ConanException
@@ -190,7 +190,7 @@ class _CMakePresets:
     @staticmethod
     def _build_preset_fields(conanfile, multiconfig, preset_prefix):
         ret = _CMakePresets._common_preset_fields(conanfile, multiconfig, preset_prefix)
-        build_preset_jobs = build.build_jobs(conanfile)
+        build_preset_jobs = build_jobs(conanfile)
         ret["jobs"] = build_preset_jobs
         return ret
 

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -185,13 +185,13 @@ class _CMakePresets:
         ret = {"name": build_preset_name, "configurePreset": configure_preset_name}
         if multiconfig:
             ret["configuration"] = build_type
-        build_preset_jobs = build_jobs(conanfile)
-        ret["jobs"] = build_preset_jobs
         return ret
 
     @staticmethod
     def _build_preset_fields(conanfile, multiconfig, preset_prefix):
         ret = _CMakePresets._common_preset_fields(conanfile, multiconfig, preset_prefix)
+        build_preset_jobs = build_jobs(conanfile)
+        ret["jobs"] = build_preset_jobs
         return ret
 
     @staticmethod

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -6,6 +6,7 @@ from conan.api.output import ConanOutput
 from conan.tools.cmake.layout import get_build_folder_custom_vars
 from conan.tools.cmake.toolchain.blocks import GenericSystemBlock
 from conan.tools.cmake.utils import is_multi_configuration
+import conan.tools.build as build
 from conan.tools.microsoft import is_msvc
 from conans.client.graph.graph import RECIPE_CONSUMER
 from conan.errors import ConanException
@@ -189,6 +190,8 @@ class _CMakePresets:
     @staticmethod
     def _build_preset_fields(conanfile, multiconfig, preset_prefix):
         ret = _CMakePresets._common_preset_fields(conanfile, multiconfig, preset_prefix)
+        build_preset_jobs = build.build_jobs(conanfile)
+        ret["jobs"] = build_preset_jobs
         return ret
 
     @staticmethod

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -185,13 +185,13 @@ class _CMakePresets:
         ret = {"name": build_preset_name, "configurePreset": configure_preset_name}
         if multiconfig:
             ret["configuration"] = build_type
+        build_preset_jobs = build_jobs(conanfile)
+        ret["jobs"] = build_preset_jobs
         return ret
 
     @staticmethod
     def _build_preset_fields(conanfile, multiconfig, preset_prefix):
         ret = _CMakePresets._common_preset_fields(conanfile, multiconfig, preset_prefix)
-        build_preset_jobs = build_jobs(conanfile)
-        ret["jobs"] = build_preset_jobs
         return ret
 
     @staticmethod

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -1222,4 +1222,3 @@ def test_presets_njobs():
     c.run('install . -g CMakeToolchain -c tools.build:jobs=42')
     presets = json.loads(c.load("CMakePresets.json"))
     assert presets["buildPresets"][0]["jobs"] == 42
-    assert presets["testPresets"][0]["jobs"] == 42

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -1214,3 +1214,12 @@ def test_avoid_ovewrite_user_cmakepresets():
     c.run('install . -g CMakeToolchain', assert_error=True)
     assert "Error in generator 'CMakeToolchain': Existing CMakePresets.json not generated" in c.out
     assert "Use --output-folder or define a 'layout' to avoid collision" in c.out
+
+
+def test_presets_njobs():
+    c = TestClient()
+    c.save({"conanfile.txt": ""})
+    c.run('install . -g CMakeToolchain -c tools.build:jobs=42')
+    presets = json.loads(c.load("CMakePresets.json"))
+    assert presets["buildPresets"][0]["jobs"] == 42
+    assert presets["testPresets"][0]["jobs"] == 42


### PR DESCRIPTION
Changelog: Feature: ``CMakeToolchain`` defines ``jobs`` in generated ``CMakePresets.json`` buildPresets.
Docs: Omit

this should be seen as a proof of concept for the feature request to have conan generate CMakePresets.json with jobs parameter set.

closes #15419

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [?] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
