### PR TITLE
2.0.14 LRU migration: do not fail if cache.sqlite3 is missing

### DIFF
--- a/conans/client/migrations.py
+++ b/conans/client/migrations.py
@@ -58,11 +58,13 @@ class ClientMigrator(Migrator):
 
 
 def _migrate_pkg_db_lru(cache_folder, old_version):
-    ConanOutput().warning(f"Upgrade cache from Conan version '{old_version}'")
-    ConanOutput().warning("Running 2.0.14 Cache DB migration to add LRU column")
     config = ConfigAPI.load_config(cache_folder)
     storage = config.get("core.cache:storage_path") or os.path.join(cache_folder, "p")
     db_filename = os.path.join(storage, 'cache.sqlite3')
+    if not os.path.exists(db_filename):
+        return
+    ConanOutput().warning(f"Upgrade cache from Conan version '{old_version}'")
+    ConanOutput().warning("Running 2.0.14 Cache DB migration to add LRU column")
     connection = sqlite3.connect(db_filename, isolation_level=None,
                                  timeout=1, check_same_thread=False)
     try:


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

The migration fails with an "ERROR: unable to open database file" if the `p/cache.sqlite3` file is missing. This causes all Conan commands to re-attempt the migration and always fail.

Prior to the introduction of the LRU I have resorted to removing the `p` directory and the DB file to reclaim the disk space used by the cache, so this is likely not an uncommon scenario.

---

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
