### PR TITLE
Fix ``build_id()`` and ``package_id()`` modification settings with nested subsettings

### DIFF
--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -72,7 +72,7 @@ class SettingsItem(object):
         else:
             result._definition = {k: v.copy_conaninfo_settings()
                                   for k, v in self._definition.items()}
-            result._definition["ANY"] = SettingsItem([], "ANY")
+            result._definition["ANY"] = Settings()
         return result
 
     def __bool__(self):

--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -72,6 +72,7 @@ class SettingsItem(object):
         else:
             result._definition = {k: v.copy_conaninfo_settings()
                                   for k, v in self._definition.items()}
+            result._definition["ANY"] = SettingsItem([], "ANY")
         return result
 
     def __bool__(self):

--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -106,6 +106,11 @@ class SettingsItem(object):
             raise undefined_field(self._name, item, None, self._value)
         if self._value is None:
             raise ConanException("'%s' value not defined" % self._name)
+        return self._get_definition()
+
+    def _get_definition(self):
+        if self._value not in self._definition and "ANY" in self._definition:
+            return self._definition["ANY"]
         return self._definition[self._value]
 
     def __getattr__(self, item):
@@ -142,7 +147,7 @@ class SettingsItem(object):
         partial_name = ".".join(self._name.split(".")[1:])
         result.append((partial_name, self._value))
         if isinstance(self._definition, dict):
-            sub_config_dict = self._definition[self._value]
+            sub_config_dict = self._get_definition()
             result.extend(sub_config_dict.values_list)
         return result
 
@@ -150,7 +155,7 @@ class SettingsItem(object):
         if self._value is None and None not in self._definition:
             raise ConanException("'%s' value not defined" % self._name)
         if isinstance(self._definition, dict):
-            self._definition[self._value].validate()
+            self._get_definition().validate()
 
     def possible_values(self):
         if isinstance(self._definition, list):

--- a/conans/test/integration/package_id/build_id_test.py
+++ b/conans/test/integration/package_id/build_id_test.py
@@ -159,24 +159,14 @@ class TestBuildIdTest:
         client = TestClient()
         client.save({"conanfile.py": conanfile_os})
         client.run("create .  -s os=Windows -s arch=x86_64 -s build_type=Release")
-        print(client.out)
         assert "pkg/0.1: Calling build()" in client.out
         assert "Building my code!" in client.out
-        assert "Packaging Release!" in client.out
-        # Debug must not build
-        client.run("create .  -s os=Windows -s build_type=Debug")
+        assert "Packaging Windows-x86_64!" in client.out
+        # Others must not build
+        client.run("create .  -s os=Linux -s arch=x86 -s build_type=Debug")
         assert "pkg/0.1: Calling build()" not in client.out
         assert "Building my code!" not in client.out
-        assert "Packaging Debug!" in client.out
-
-        client.run("create . -s os=Linux -s build_type=Release")
-        assert "pkg/0.1: Calling build()" in client.out
-        assert "Building my code!" in client.out
-        assert "Packaging Release!" in client.out
-        client.run("create .  -s os=Linux -s build_type=Debug")
-        assert "Building my code!" in client.out
-        assert "pkg/0.1: Calling build()" in client.out
-        assert "Packaging Debug!" in client.out
+        assert "Packaging Linux-x86!" in client.out
 
 
 def test_remove_require():

--- a/conans/test/integration/package_id/build_id_test.py
+++ b/conans/test/integration/package_id/build_id_test.py
@@ -142,12 +142,13 @@ class TestBuildIdTest:
             class MyTest(ConanFile):
                 name = "pkg"
                 version = "0.1"
-                settings = "os", "arch", "build_type"
+                settings = "os", "arch", "build_type", "compiler"
 
                 def build_id(self):
-                    self.info_build.settings.build_type = "Any"
-                    self.info_build.settings.os = "Any"
-                    self.info_build.settings.arch = "Any"
+                    self.info_build.settings.build_type = "AnyValue"
+                    self.info_build.settings.os = "AnyValue"
+                    self.info_build.settings.arch = "AnyValue"
+                    self.info_build.settings.compiler = "AnyValue"
 
                 def build(self):
                     self.output.info("Building my code!")

--- a/conans/test/integration/package_id/package_id_test.py
+++ b/conans/test/integration/package_id/package_id_test.py
@@ -59,6 +59,7 @@ def test_value_parse():
 
             def package_id(self):
                 self.info.settings.arch = "kk=kk"
+                self.info.settings.os = "yy=yy"
         """)
 
     client = TestClient(default_server_user=True)

--- a/conans/test/integration/package_id/package_id_test.py
+++ b/conans/test/integration/package_id/package_id_test.py
@@ -159,8 +159,7 @@ def test_package_id_requires_info():
 
 
 def test_package_id_validate_settings():
-    """ ``self.info`` has some validation, the first time it executes
-    https://github.com/conan-io/conan/issues/12693
+    """ ``self.info`` has no validation, as it allows to be mutated
     """
     conanfile = textwrap.dedent("""
         from conan import ConanFile
@@ -173,8 +172,8 @@ def test_package_id_validate_settings():
         """)
     c = TestClient()
     c.save({"conanfile.py": conanfile})
-    c.run("create . --name=pkg --version=0.1", assert_error=True)
-    assert "ConanException: Invalid setting 'DONT_EXIST' is not a valid 'settings.os' value" in c.out
+    c.run("create . --name=pkg --version=0.1")
+    # It used to fail,
 
 
 class TestBuildRequiresHeaderOnly:

--- a/conans/test/unittests/model/settings_test.py
+++ b/conans/test/unittests/model/settings_test.py
@@ -1,3 +1,4 @@
+import textwrap
 import unittest
 
 import pytest
@@ -47,6 +48,32 @@ class SettingsLoadsTest(unittest.TestCase):
         settings.os = "Windows"
         self.assertTrue(settings.os == "Windows")
         self.assertEqual("os=Windows", settings.dumps())
+
+    def test_nested_any(self):
+        yml = textwrap.dedent("""\
+            os:
+                ANY:
+                    version: [null, ANY]
+                Ubuntu:
+                    version: ["18.04", "20.04"]
+            """)
+        settings = Settings.loads(yml)
+        settings.os = "Windows"
+        settings.validate()
+        self.assertTrue(settings.os == "Windows")
+        self.assertIn("os=Windows", settings.dumps())
+        settings.os.version = 2
+        self.assertTrue(settings.os == "Windows")
+        self.assertEqual("os=Windows\nos.version=2", settings.dumps())
+        settings.os = "Ubuntu"
+        with self.assertRaisesRegex(ConanException, "'settings.os.version' value not defined"):
+            settings.validate()
+        with self.assertRaisesRegex(ConanException,
+                                    "Invalid setting '3' is not a valid 'settings.os.version'"):
+            settings.os.version = 3
+        settings.os.version = "20.04"
+        self.assertEqual("os=Ubuntu\nos.version=20.04", settings.dumps())
+        self.assertTrue(settings.os.version == "20.04")
 
     def test_getattr_none(self):
         yml = "os: [None, Windows]"


### PR DESCRIPTION
Changelog: Bugfix: Allow to limit ``os``, ``compiler`` and other settings with subsettings in ``build_id()`` and ``package_id()`` methods.
Docs: Omit

Close https://github.com/conan-io/conan/issues/15437
