### PR TITLE
Add `--allowed-packges` to remotes to limit what references a remote can supply

### DIFF
--- a/conan/api/model.py
+++ b/conan/api/model.py
@@ -12,12 +12,12 @@ from conans.model.version_range import VersionRange
 
 class Remote:
 
-    def __init__(self, name, url, verify_ssl=True, disabled=False, filters=None):
+    def __init__(self, name, url, verify_ssl=True, disabled=False, allowed_packages=None):
         self._name = name  # Read only, is the key
         self.url = url
         self.verify_ssl = verify_ssl
         self.disabled = disabled
-        self.filters = filters
+        self.allowed_packages = allowed_packages
 
     @property
     def name(self):
@@ -30,11 +30,11 @@ class Remote:
                 self.verify_ssl == other.verify_ssl and self.disabled == other.disabled)
 
     def __str__(self):
-        filtered_msg = ""
-        if self.filters:
-            filtered_msg = ", Filtered: {}".format(", ".join(self.filters))
+        allowed_msg = ""
+        if self.allowed_packages:
+            allowed_msg = ", Allowed packages: {}".format(", ".join(self.allowed_packages))
         return "{}: {} [Verify SSL: {}, Enabled: {}{}]".format(self.name, self.url, self.verify_ssl,
-                                                               not self.disabled, filtered_msg)
+                                                               not self.disabled, allowed_msg)
 
     def __repr__(self):
         return str(self)

--- a/conan/api/model.py
+++ b/conan/api/model.py
@@ -30,8 +30,11 @@ class Remote:
                 self.verify_ssl == other.verify_ssl and self.disabled == other.disabled)
 
     def __str__(self):
-        return "{}: {} [Verify SSL: {}, Enabled: {}]".format(self.name, self.url, self.verify_ssl,
-                                                             not self.disabled)
+        filtered_msg = ""
+        if self.filters:
+            filtered_msg = ", Filtered: {}".format(", ".join(self.filters))
+        return "{}: {} [Verify SSL: {}, Enabled: {}{}]".format(self.name, self.url, self.verify_ssl,
+                                                               not self.disabled, filtered_msg)
 
     def __repr__(self):
         return str(self)

--- a/conan/api/model.py
+++ b/conan/api/model.py
@@ -12,11 +12,12 @@ from conans.model.version_range import VersionRange
 
 class Remote:
 
-    def __init__(self, name, url, verify_ssl=True, disabled=False):
+    def __init__(self, name, url, verify_ssl=True, disabled=False, filters=None):
         self._name = name  # Read only, is the key
         self.url = url
         self.verify_ssl = verify_ssl
         self.disabled = disabled
+        self.filters = filters
 
     @property
     def name(self):

--- a/conan/api/subapi/remotes.py
+++ b/conan/api/subapi/remotes.py
@@ -72,9 +72,9 @@ class RemotesAPI:
             RemoteRegistry(self._remotes_file).remove(remote.name)
             users_clean(app.cache.localdb, remote.url)
 
-    def update(self, remote_name, url=None, secure=None, disabled=None, index=None, filters=None):
+    def update(self, remote_name, url=None, secure=None, disabled=None, index=None, allowed_packages=None):
         RemoteRegistry(self._remotes_file).update(remote_name, url, secure, disabled=disabled,
-                                                  index=index, filters=filters)
+                                                  index=index, allowed_packages=allowed_packages)
 
     def rename(self, remote_name: str, new_name: str):
         RemoteRegistry(self._remotes_file).rename(remote_name, new_name)

--- a/conan/api/subapi/remotes.py
+++ b/conan/api/subapi/remotes.py
@@ -72,9 +72,9 @@ class RemotesAPI:
             RemoteRegistry(self._remotes_file).remove(remote.name)
             users_clean(app.cache.localdb, remote.url)
 
-    def update(self, remote_name, url=None, secure=None, disabled=None, index=None):
+    def update(self, remote_name, url=None, secure=None, disabled=None, index=None, filters=None):
         RemoteRegistry(self._remotes_file).update(remote_name, url, secure, disabled=disabled,
-                                                  index=index)
+                                                  index=index, filters=filters)
 
     def rename(self, remote_name: str, new_name: str):
         RemoteRegistry(self._remotes_file).rename(remote_name, new_name)

--- a/conan/cli/commands/remote.py
+++ b/conan/cli/commands/remote.py
@@ -72,9 +72,11 @@ def remote_add(conan_api, parser, subparser, *args):
                            help="Insert the remote at a specific position in the remote list")
     subparser.add_argument("-f", "--force", action='store_true',
                            help="Force the definition of the remote even if duplicated")
+    subparser.add_argument("--filter", action="append", default=None,
+                           help="Add recipe reference pattern filter to this remote")
     subparser.set_defaults(secure=True)
     args = parser.parse_args(*args)
-    r = Remote(args.name, args.url, args.secure, disabled=False)
+    r = Remote(args.name, args.url, args.secure, disabled=False, filters=args.filter)
     conan_api.remotes.add(r, force=args.force, index=args.index)
 
 
@@ -102,11 +104,12 @@ def remote_update(conan_api, parser, subparser, *args):
                            help="Allow insecure server connections when using SSL")
     subparser.add_argument("--index", action=OnceArgument, type=int,
                            help="Insert the remote at a specific position in the remote list")
+    subparser.add_argument("--filter", action="append", default=None, help="Add recipe reference pattern filter to this remote")
     subparser.set_defaults(secure=None)
     args = parser.parse_args(*args)
-    if args.url is None and args.secure is None and args.index is None:
+    if args.url is None and args.secure is None and args.index is None and args.filter is None:
         subparser.error("Please add at least one argument to update")
-    conan_api.remotes.update(args.remote, args.url, args.secure, index=args.index)
+    conan_api.remotes.update(args.remote, args.url, args.secure, index=args.index, filters=args.filter)
 
 
 @conan_subcommand()

--- a/conan/cli/commands/remote.py
+++ b/conan/cli/commands/remote.py
@@ -72,11 +72,11 @@ def remote_add(conan_api, parser, subparser, *args):
                            help="Insert the remote at a specific position in the remote list")
     subparser.add_argument("-f", "--force", action='store_true',
                            help="Force the definition of the remote even if duplicated")
-    subparser.add_argument("--filter", action="append", default=None,
-                           help="Add recipe reference pattern filter to this remote")
+    subparser.add_argument("--allowed-packages", action="append", default=None,
+                           help="Add recipe reference pattern to list of allowed packages for this remote")
     subparser.set_defaults(secure=True)
     args = parser.parse_args(*args)
-    r = Remote(args.name, args.url, args.secure, disabled=False, filters=args.filter)
+    r = Remote(args.name, args.url, args.secure, disabled=False, allowed_packages=args.allowed_packages)
     conan_api.remotes.add(r, force=args.force, index=args.index)
 
 
@@ -104,12 +104,13 @@ def remote_update(conan_api, parser, subparser, *args):
                            help="Allow insecure server connections when using SSL")
     subparser.add_argument("--index", action=OnceArgument, type=int,
                            help="Insert the remote at a specific position in the remote list")
-    subparser.add_argument("--filter", action="append", default=None, help="Add recipe reference pattern filter to this remote")
+    subparser.add_argument("--allowed-packages", action="append", default=None,
+                           help="Add recipe reference pattern to list of allowed packages for this remote")
     subparser.set_defaults(secure=None)
     args = parser.parse_args(*args)
-    if args.url is None and args.secure is None and args.index is None and args.filter is None:
+    if args.url is None and args.secure is None and args.index is None and args.allowed_packages is None:
         subparser.error("Please add at least one argument to update")
-    conan_api.remotes.update(args.remote, args.url, args.secure, index=args.index, filters=args.filter)
+    conan_api.remotes.update(args.remote, args.url, args.secure, index=args.index, allowed_packages=args.allowed_packages)
 
 
 @conan_subcommand()

--- a/conan/cli/commands/remote.py
+++ b/conan/cli/commands/remote.py
@@ -72,7 +72,7 @@ def remote_add(conan_api, parser, subparser, *args):
                            help="Insert the remote at a specific position in the remote list")
     subparser.add_argument("-f", "--force", action='store_true',
                            help="Force the definition of the remote even if duplicated")
-    subparser.add_argument("--allowed-packages", action="append", default=None,
+    subparser.add_argument("-ap", "--allowed-packages", action="append", default=None,
                            help="Add recipe reference pattern to list of allowed packages for this remote")
     subparser.set_defaults(secure=True)
     args = parser.parse_args(*args)
@@ -104,7 +104,7 @@ def remote_update(conan_api, parser, subparser, *args):
                            help="Allow insecure server connections when using SSL")
     subparser.add_argument("--index", action=OnceArgument, type=int,
                            help="Insert the remote at a specific position in the remote list")
-    subparser.add_argument("--allowed-packages", action="append", default=None,
+    subparser.add_argument("-ap", "--allowed-packages", action="append", default=None,
                            help="Add recipe reference pattern to list of allowed packages for this remote")
     subparser.set_defaults(secure=None)
     args = parser.parse_args(*args)

--- a/conans/client/cache/remote_registry.py
+++ b/conans/client/cache/remote_registry.py
@@ -33,9 +33,9 @@ class _Remotes:
         data = json.loads(text)
         for r in data.get("remotes", []):
             disabled = r.get("disabled", False)
-            filters = r.get("filters", None)
+            allowed_packages = r.get("allowed_packages", None)
             # TODO: Remote.serialize/deserialize
-            remote = Remote(r["name"], r["url"], r["verify_ssl"], disabled, filters)
+            remote = Remote(r["name"], r["url"], r["verify_ssl"], disabled, allowed_packages)
             result._remotes[r["name"]] = remote
         return result
 
@@ -45,8 +45,8 @@ class _Remotes:
             remote = {"name": r.name, "url": r.url, "verify_ssl": r.verify_ssl}
             if r.disabled:
                 remote["disabled"] = True
-            if r.filters:
-                remote["filters"] = r.filters
+            if r.allowed_packages:
+                remote["allowed_packages"] = r.allowed_packages
             remote_list.append(remote)
         ret = {"remotes": remote_list}
         return json.dumps(ret, indent=True)
@@ -97,7 +97,7 @@ class _Remotes:
                 else:
                     ConanOutput().warning(msg + " Adding duplicated remote url because '--force'.")
 
-    def update(self, remote_name, url=None, secure=None, disabled=None, index=None, force=False, filters=None):
+    def update(self, remote_name, url=None, secure=None, disabled=None, index=None, force=False, allowed_packages=None):
         remote = self[remote_name]
         if url is not None:
             self._check_urls(url, force, remote)
@@ -113,8 +113,8 @@ class _Remotes:
             remotes.insert(index, remote)
             self._remotes = {r.name: r for r in remotes}
 
-        if filters is not None:
-            remote.filters = filters
+        if allowed_packages is not None:
+            remote.allowed_packages = allowed_packages
 
     def items(self):
         return list(self._remotes.values())
@@ -176,11 +176,11 @@ class RemoteRegistry(object):
         remotes.remove(remote_name)
         self.save_remotes(remotes)
 
-    def update(self, remote_name, url, secure, disabled, index, filters):
+    def update(self, remote_name, url, secure, disabled, index, allowed_packages):
         if url is not None:
             self._validate_url(url)
         remotes = self._load_remotes()
-        remotes.update(remote_name, url, secure, disabled, index, filters=filters)
+        remotes.update(remote_name, url, secure, disabled, index, allowed_packages=allowed_packages)
         self.save_remotes(remotes)
 
     def rename(self, remote, new_name):

--- a/conans/client/cache/remote_registry.py
+++ b/conans/client/cache/remote_registry.py
@@ -114,8 +114,7 @@ class _Remotes:
             self._remotes = {r.name: r for r in remotes}
 
         if filters is not None:
-            remote.filters = remote.filters or []
-            remote.filters.extend(filters)
+            remote.filters = filters
 
     def items(self):
         return list(self._remotes.values())

--- a/conans/client/cache/remote_registry.py
+++ b/conans/client/cache/remote_registry.py
@@ -33,8 +33,9 @@ class _Remotes:
         data = json.loads(text)
         for r in data.get("remotes", []):
             disabled = r.get("disabled", False)
+            filters = r.get("filters", None)
             # TODO: Remote.serialize/deserialize
-            remote = Remote(r["name"], r["url"], r["verify_ssl"], disabled)
+            remote = Remote(r["name"], r["url"], r["verify_ssl"], disabled, filters)
             result._remotes[r["name"]] = remote
         return result
 
@@ -44,6 +45,8 @@ class _Remotes:
             remote = {"name": r.name, "url": r.url, "verify_ssl": r.verify_ssl}
             if r.disabled:
                 remote["disabled"] = True
+            if r.filters:
+                remote["filters"] = r.filters
             remote_list.append(remote)
         ret = {"remotes": remote_list}
         return json.dumps(ret, indent=True)
@@ -94,7 +97,7 @@ class _Remotes:
                 else:
                     ConanOutput().warning(msg + " Adding duplicated remote url because '--force'.")
 
-    def update(self, remote_name, url=None, secure=None, disabled=None, index=None, force=False):
+    def update(self, remote_name, url=None, secure=None, disabled=None, index=None, force=False, filters=None):
         remote = self[remote_name]
         if url is not None:
             self._check_urls(url, force, remote)
@@ -109,6 +112,10 @@ class _Remotes:
             remotes = list(self._remotes.values())
             remotes.insert(index, remote)
             self._remotes = {r.name: r for r in remotes}
+
+        if filters is not None:
+            remote.filters = remote.filters or []
+            remote.filters.extend(filters)
 
     def items(self):
         return list(self._remotes.values())
@@ -170,11 +177,11 @@ class RemoteRegistry(object):
         remotes.remove(remote_name)
         self.save_remotes(remotes)
 
-    def update(self, remote_name, url, secure, disabled, index):
+    def update(self, remote_name, url, secure, disabled, index, filters):
         if url is not None:
             self._validate_url(url)
         remotes = self._load_remotes()
-        remotes.update(remote_name, url, secure, disabled, index)
+        remotes.update(remote_name, url, secure, disabled, index, filters=filters)
         self.save_remotes(remotes)
 
     def rename(self, remote, new_name):

--- a/conans/client/graph/proxy.py
+++ b/conans/client/graph/proxy.py
@@ -97,6 +97,9 @@ class ConanProxy:
 
         results = []
         for remote in remotes:
+            if remote.filters and not any(reference.matches(f, is_consumer=False) for f in remote.filters):
+                output.info(f"Excluding remote {remote.name} because recipe is filtered out")
+                continue
             output.info(f"Checking remote: {remote.name}")
             try:
                 if not reference.revision:

--- a/conans/client/graph/proxy.py
+++ b/conans/client/graph/proxy.py
@@ -97,7 +97,8 @@ class ConanProxy:
 
         results = []
         for remote in remotes:
-            if remote.filters and not any(reference.matches(f, is_consumer=False) for f in remote.filters):
+            if remote.allowed_packages and not any(reference.matches(f, is_consumer=False)
+                                                   for f in remote.allowed_packages):
                 output.debug(f"Excluding remote {remote.name} because recipe is filtered out")
                 continue
             output.info(f"Checking remote: {remote.name}")

--- a/conans/client/graph/proxy.py
+++ b/conans/client/graph/proxy.py
@@ -98,7 +98,7 @@ class ConanProxy:
         results = []
         for remote in remotes:
             if remote.filters and not any(reference.matches(f, is_consumer=False) for f in remote.filters):
-                output.info(f"Excluding remote {remote.name} because recipe is filtered out")
+                output.debug(f"Excluding remote {remote.name} because recipe is filtered out")
                 continue
             output.info(f"Checking remote: {remote.name}")
             try:

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -64,9 +64,6 @@ class RangeResolver:
             return self._resolve_version(version_range, local_found, self._resolve_prereleases)
 
     def _search_remote_recipes(self, remote, search_ref):
-        (ConanOutput()
-         .info("Searching remote recipe: %s" % search_ref)
-         .info("For filters: %s" % remote.filters))
         if remote.filters and not any(search_ref.matches(f, is_consumer=False) for f in remote.filters):
             return []
         pattern = str(search_ref)

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -64,7 +64,8 @@ class RangeResolver:
             return self._resolve_version(version_range, local_found, self._resolve_prereleases)
 
     def _search_remote_recipes(self, remote, search_ref):
-        if remote.filters and not any(search_ref.matches(f, is_consumer=False) for f in remote.filters):
+        if remote.allowed_packages and not any(search_ref.matches(f, is_consumer=False)
+                                               for f in remote.allowed_packages):
             return []
         pattern = str(search_ref)
         pattern_cached = self._cached_remote_found.setdefault(pattern, {})

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -1,3 +1,4 @@
+from conan.api.output import ConanOutput
 from conans.errors import ConanException
 from conans.model.recipe_ref import RecipeReference
 from conans.model.version_range import VersionRange
@@ -63,6 +64,11 @@ class RangeResolver:
             return self._resolve_version(version_range, local_found, self._resolve_prereleases)
 
     def _search_remote_recipes(self, remote, search_ref):
+        (ConanOutput()
+         .info("Searching remote recipe: %s" % search_ref)
+         .info("For filters: %s" % remote.filters))
+        if remote.filters and not any(search_ref.matches(f, is_consumer=False) for f in remote.filters):
+            return []
         pattern = str(search_ref)
         pattern_cached = self._cached_remote_found.setdefault(pattern, {})
         results = pattern_cached.get(remote.name)

--- a/conans/test/integration/command/remote_test.py
+++ b/conans/test/integration/command/remote_test.py
@@ -372,9 +372,7 @@ class TestRemoteRecipeFilter(unittest.TestCase):
         assert "ERROR: Package 'lib/1.0' not resolved: Unable to find 'lib/1.0' in remotes" in self.client.out
         self.client.run("remove * -c")
 
-        self.client.run('remote update default --filter="lib/*"')
+        self.client.run('remote update default --filter="lib/*" --filter="app/*"')
         self.client.run("install --requires=app/1.0 -r=default")
         assert "app/1.0: Downloaded recipe revision 6d87b1d33fd24eba1f2f71124fd07f9c" in self.client.out
         assert "lib/1.0: Downloaded recipe revision 5abc78f3a076cc58852154c7546ff7e5" in self.client.out
-        self.client.run("remove * -c")
-

--- a/conans/test/integration/command/remote_test.py
+++ b/conans/test/integration/command/remote_test.py
@@ -395,6 +395,6 @@ def test_allowed_packages_remotes():
 def test_remote_allowed_packages_new():
     """Test that the allowed packages are saved in the remotes.json file when adding a new remote"""
     tc = TestClient(light=True)
-    tc.run("remote add foo https://foo --allowed-packages='liba/*'")
+    tc.run("remote add foo https://foo -ap='liba/*'")
     remotes = json.loads(load(os.path.join(tc.cache_folder, "remotes.json")))
     assert remotes["remotes"][0]["allowed_packages"] == ["liba/*"]

--- a/conans/test/integration/command/remote_test.py
+++ b/conans/test/integration/command/remote_test.py
@@ -397,4 +397,4 @@ def test_remote_allowed_packages_new():
     tc = TestClient(light=True)
     tc.run("remote add foo https://foo --allowed-packages='liba/*'")
     remotes = json.loads(load(os.path.join(tc.cache_folder, "remotes.json")))
-    assert remotes[0]["allowed_packages"] == ["liba/*"]
+    assert remotes["remotes"][0]["allowed_packages"] == ["liba/*"]

--- a/conans/test/integration/command/remote_test.py
+++ b/conans/test/integration/command/remote_test.py
@@ -2,12 +2,14 @@ import json
 import unittest
 from collections import OrderedDict
 
+import pytest
+
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient, TestServer
 from conans.util.files import load
 
 
-class RemoteTest(unittest.TestCase):
+class RemoteServerTest(unittest.TestCase):
 
     def setUp(self):
         self.servers = OrderedDict()
@@ -15,7 +17,7 @@ class RemoteTest(unittest.TestCase):
             test_server = TestServer()
             self.servers["remote%d" % i] = test_server
 
-        self.client = TestClient(servers=self.servers, inputs=3*["admin", "password"])
+        self.client = TestClient(servers=self.servers, inputs=3*["admin", "password"], light=True)
 
     def test_list_json(self):
         self.client.run("remote list --format=json")
@@ -84,24 +86,6 @@ class RemoteTest(unittest.TestCase):
         self.client.run("remote list")
         self.assertNotIn("remote0", self.client.out)
 
-    def test_rename(self):
-        client = TestClient()
-        client.save({"conanfile.py": GenConanfile()})
-        client.run("export . --name=hello --version=0.1 --user=user --channel=testing")
-        client.run("remote add r1 https://r1")
-        client.run("remote add r2 https://r2")
-        client.run("remote add r3 https://r3")
-        client.run("remote rename r2 mynewr2")
-        client.run("remote list")
-        lines = str(client.out).splitlines()
-        self.assertIn("r1: https://r1", lines[0])
-        self.assertIn("mynewr2: https://r2", lines[1])
-        self.assertIn("r3: https://r3", lines[2])
-
-        # Rename to an existing one
-        client.run("remote rename mynewr2 r1", assert_error=True)
-        self.assertIn("Remote 'r1' already exists", client.out)
-
     def test_insert(self):
         self.client.run("remote add origin https://myurl --index", assert_error=True)
 
@@ -119,8 +103,69 @@ class RemoteTest(unittest.TestCase):
         self.assertIn("origin3: https://myurl3", lines[1])
         self.assertIn("origin: https://myurl", lines[2])
 
+    def test_duplicated_error(self):
+        """ check remote name are not duplicated
+        """
+        self.client.run("remote add remote1 http://otherurl", assert_error=True)
+        self.assertIn("ERROR: Remote 'remote1' already exists in remotes (use --force to continue)",
+                      self.client.out)
+
+        self.client.run("remote list")
+        assert "otherurl" not in self.client.out
+        self.client.run("remote add remote1 http://otherurl --force")
+        self.assertIn("WARN: Remote 'remote1' already exists in remotes", self.client.out)
+
+        self.client.run("remote list")
+        assert "remote1: http://otherurl" in self.client.out
+
+    def test_missing_subarguments(self):
+        self.client.run("remote", assert_error=True)
+        self.assertIn("ERROR: Exiting with code: 2", self.client.out)
+
+    def test_invalid_url(self):
+        self.client.run("remote add foobar foobar.com")
+        self.assertIn("WARN: The URL 'foobar.com' is invalid. It must contain scheme and hostname.",
+                      self.client.out)
+        self.client.run("remote list")
+        self.assertIn("foobar.com", self.client.out)
+
+        self.client.run("remote update foobar --url pepe.org")
+        self.assertIn("WARN: The URL 'pepe.org' is invalid. It must contain scheme and hostname.",
+                      self.client.out)
+        self.client.run("remote list")
+        self.assertIn("pepe.org", self.client.out)
+
+    def test_errors(self):
+        self.client.run("remote update origin --url http://foo.com", assert_error=True)
+        self.assertIn("ERROR: Remote 'origin' doesn't exist", self.client.out)
+
+        self.client.run("remote remove origin", assert_error=True)
+        self.assertIn("ERROR: Remote 'origin' can't be found or is disabled", self.client.out)
+
+
+
+
+class RemoteModificationTest(unittest.TestCase):
+    def test_rename(self):
+        client = TestClient(light=True)
+        client.save({"conanfile.py": GenConanfile()})
+        client.run("export . --name=hello --version=0.1 --user=user --channel=testing")
+        client.run("remote add r1 https://r1")
+        client.run("remote add r2 https://r2")
+        client.run("remote add r3 https://r3")
+        client.run("remote rename r2 mynewr2")
+        client.run("remote list")
+        lines = str(client.out).splitlines()
+        self.assertIn("r1: https://r1", lines[0])
+        self.assertIn("mynewr2: https://r2", lines[1])
+        self.assertIn("r3: https://r3", lines[2])
+
+        # Rename to an existing one
+        client.run("remote rename mynewr2 r1", assert_error=True)
+        self.assertIn("Remote 'r1' already exists", client.out)
+
     def test_update_insert(self):
-        client = TestClient()
+        client = TestClient(light=True)
         client.run("remote add r1 https://r1")
         client.run("remote add r2 https://r2")
         client.run("remote add r3 https://r3")
@@ -142,7 +187,7 @@ class RemoteTest(unittest.TestCase):
 
     def test_update_insert_same_url(self):
         # https://github.com/conan-io/conan/issues/5107
-        client = TestClient()
+        client = TestClient(light=True)
         client.run("remote add r1 https://r1")
         client.run("remote add r2 https://r2")
         client.run("remote add r3 https://r3")
@@ -153,7 +198,7 @@ class RemoteTest(unittest.TestCase):
         self.assertLess(str(client.out).find("r1"), str(client.out).find("r3"))
 
     def test_verify_ssl(self):
-        client = TestClient()
+        client = TestClient(light=True)
         client.run("remote add my-remote http://someurl")
         client.run("remote add my-remote2 http://someurl2 --insecure")
         client.run("remote add my-remote3 http://someurl3")
@@ -173,7 +218,7 @@ class RemoteTest(unittest.TestCase):
         self.assertEqual(data["remotes"][2]["verify_ssl"], True)
 
     def test_remote_disable(self):
-        client = TestClient()
+        client = TestClient(light=True)
         client.run("remote add my-remote0 http://someurl0")
         client.run("remote add my-remote1 http://someurl1")
         client.run("remote add my-remote2 http://someurl2")
@@ -221,7 +266,7 @@ class RemoteTest(unittest.TestCase):
         assert "Enabled: False" not in client.out
 
     def test_invalid_remote_disable(self):
-        client = TestClient()
+        client = TestClient(light=True)
 
         client.run("remote disable invalid_remote", assert_error=True)
         msg = "ERROR: Remote 'invalid_remote' can't be found or is disabled"
@@ -236,7 +281,7 @@ class RemoteTest(unittest.TestCase):
         """
         Check that we don't raise an error if the remote is already in the required state
         """
-        client = TestClient()
+        client = TestClient(light=True)
 
         client.run("remote add my-remote0 http://someurl0")
         client.run("remote enable my-remote0")
@@ -246,57 +291,18 @@ class RemoteTest(unittest.TestCase):
         client.run("remote disable my-remote0")
 
     def test_verify_ssl_error(self):
-        client = TestClient()
+        client = TestClient(light=True)
         client.run("remote add my-remote http://someurl some_invalid_option=foo", assert_error=True)
 
         self.assertIn("unrecognized arguments: some_invalid_option=foo", client.out)
         data = json.loads(load(client.cache.remotes_path))
         self.assertEqual(data["remotes"], [])
 
-    def test_errors(self):
-        self.client.run("remote update origin --url http://foo.com", assert_error=True)
-        self.assertIn("ERROR: Remote 'origin' doesn't exist", self.client.out)
-
-        self.client.run("remote remove origin", assert_error=True)
-        self.assertIn("ERROR: Remote 'origin' can't be found or is disabled", self.client.out)
-
-    def test_duplicated_error(self):
-        """ check remote name are not duplicated
-        """
-        self.client.run("remote add remote1 http://otherurl", assert_error=True)
-        self.assertIn("ERROR: Remote 'remote1' already exists in remotes (use --force to continue)",
-                      self.client.out)
-
-        self.client.run("remote list")
-        assert "otherurl" not in self.client.out
-        self.client.run("remote add remote1 http://otherurl --force")
-        self.assertIn("WARN: Remote 'remote1' already exists in remotes", self.client.out)
-
-        self.client.run("remote list")
-        assert "remote1: http://otherurl" in self.client.out
-
-    def test_missing_subarguments(self):
-        self.client.run("remote", assert_error=True)
-        self.assertIn("ERROR: Exiting with code: 2", self.client.out)
-
-    def test_invalid_url(self):
-        self.client.run("remote add foobar foobar.com")
-        self.assertIn("WARN: The URL 'foobar.com' is invalid. It must contain scheme and hostname.",
-                      self.client.out)
-        self.client.run("remote list")
-        self.assertIn("foobar.com", self.client.out)
-
-        self.client.run("remote update foobar --url pepe.org")
-        self.assertIn("WARN: The URL 'pepe.org' is invalid. It must contain scheme and hostname.",
-                      self.client.out)
-        self.client.run("remote list")
-        self.assertIn("pepe.org", self.client.out)
-
 
 def test_add_duplicated_url():
     """ allow duplicated URL with --force
     """
-    c = TestClient()
+    c = TestClient(light=True)
     c.run("remote add remote1 http://url")
     c.run("remote add remote2 http://url", assert_error=True)
     assert "ERROR: Remote url already existing in remote 'remote1'" in c.out
@@ -320,7 +326,7 @@ def test_add_duplicated_name_url():
     """ do not add extra remote with same name and same url
         # https://github.com/conan-io/conan/issues/13569
     """
-    c = TestClient()
+    c = TestClient(light=True)
     c.run("remote add remote1 http://url")
     c.run("remote add remote1 http://url --force")
     assert "WARN: Remote 'remote1' already exists in remotes" in c.out
@@ -331,10 +337,44 @@ def test_add_duplicated_name_url():
 def test_add_wrong_conancenter():
     """ Avoid common error of adding the wrong ConanCenter URL
     """
-    c = TestClient()
+    c = TestClient(light=True)
     c.run("remote add whatever https://conan.io/center", assert_error=True)
     assert "Wrong ConanCenter remote URL. You are adding the web https://conan.io/center" in c.out
     assert "the correct remote API is https://center.conan.io" in c.out
     c.run("remote update conancenter --url=https://conan.io/center", assert_error=True)
     assert "Wrong ConanCenter remote URL. You are adding the web https://conan.io/center" in c.out
     assert "the correct remote API is https://center.conan.io" in c.out
+
+
+class TestRemoteRecipeFilter(unittest.TestCase):
+    def setUp(self):
+        self.client = TestClient(light=True, default_server_user=True)
+        self.client.save({"lib/conanfile.py": GenConanfile("lib", "1.0"),
+                          "app/conanfile.py": GenConanfile("app", "1.0")
+                         .with_requires("lib/1.0")})
+        self.client.run("create lib")
+        self.client.run("create app")
+        self.client.run("upload * -r=default -c")
+        self.client.run("remove * -c")
+
+    def test_filter_remotes(self):
+        self.client.run("install --requires=app/1.0 -r=default")
+        assert "app/1.0: Downloaded recipe revision 6d87b1d33fd24eba1f2f71124fd07f9c" in self.client.out
+        assert "lib/1.0: Downloaded recipe revision 5abc78f3a076cc58852154c7546ff7e5" in self.client.out
+        self.client.run("remove * -c")
+
+        # lib/2.* pattern does not match the one being required by app, should not be found
+        self.client.run('remote update default --filter="app/*" --filter="lib/2.*"')
+
+        self.client.run("install --requires=app/1.0 -r=default", assert_error=True)
+        assert "app/1.0: Downloaded recipe revision 6d87b1d33fd24eba1f2f71124fd07f9c" in self.client.out
+        assert "lib/1.0: Downloaded recipe revision 5abc78f3a076cc58852154c7546ff7e5" not in self.client.out
+        assert "ERROR: Package 'lib/1.0' not resolved: Unable to find 'lib/1.0' in remotes" in self.client.out
+        self.client.run("remove * -c")
+
+        self.client.run('remote update default --filter="lib/*"')
+        self.client.run("install --requires=app/1.0 -r=default")
+        assert "app/1.0: Downloaded recipe revision 6d87b1d33fd24eba1f2f71124fd07f9c" in self.client.out
+        assert "lib/1.0: Downloaded recipe revision 5abc78f3a076cc58852154c7546ff7e5" in self.client.out
+        self.client.run("remove * -c")
+


### PR DESCRIPTION
Changelog: Feature: Add `--allowed-packges` to remotes to limit what references a remote can supply.
Docs: https://github.com/conan-io/docs/pull/3534

