### PR TITLE
[MesonToolchain] Using `get_apple_sdk_fullname` to avoid empty apple minimum version flag

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -6,7 +6,7 @@ from jinja2 import Template
 from conan.errors import ConanException
 from conan.internal import check_duplicated_generator
 from conan.tools.apple.apple import to_apple_arch, is_apple_os, apple_min_version_flag, \
-    apple_sdk_path
+    apple_sdk_path, get_apple_sdk_fullname
 from conan.tools.build.cross_building import cross_building
 from conan.tools.build.flags import libcxx_flags
 from conan.tools.env import VirtualBuildEnv
@@ -296,13 +296,8 @@ class MesonToolchain(object):
                 "Apple SDK path not found. For cross-compilation, you must "
                 "provide a valid SDK path in 'tools.apple:sdk_path' config."
             )
-
-        # TODO: Delete this os_sdk check whenever the _guess_apple_sdk_name() function disappears
-        os_sdk = self._conanfile.settings.get_safe('os.sdk')
-        if not os_sdk and self._os != "Macos":
-            raise ConanException("Please, specify a suitable value for os.sdk.")
-
         # Calculating the main Apple flags
+        os_sdk = get_apple_sdk_fullname(self._conanfile)
         arch = to_apple_arch(self._conanfile)
         self.apple_arch_flag = ["-arch", arch] if arch else []
         self.apple_isysroot_flag = ["-isysroot", sdk_path] if sdk_path else []

--- a/conans/test/functional/toolchains/meson/test_cross_compilation.py
+++ b/conans/test/functional/toolchains/meson/test_cross_compilation.py
@@ -56,19 +56,18 @@ option('STRING_DEFINITION', type : 'string', description : 'a string option')
 
 
 @pytest.mark.tool("meson")
-@pytest.mark.skipif(sys.version_info.major == 2, reason="Meson not supported in Py2")
 @pytest.mark.skipif(platform.system() != "Darwin", reason="requires Xcode")
-@pytest.mark.parametrize("arch, os_, os_version, os_sdk", [
-    ('armv8', 'iOS', '10.0', 'iphoneos'),
-    ('armv7', 'iOS', '10.0', 'iphoneos'),
-    ('x86', 'iOS', '10.0', 'iphonesimulator'),
-    ('x86_64', 'iOS', '10.0', 'iphonesimulator'),
-    ('armv8', 'Macos', None, None)  # MacOS M1
+@pytest.mark.parametrize("arch, os_, os_version, os_sdk, platform_assertion", [
+    ('armv8', 'watchOS', '10.1', 'watchos', "platform 4"),
+    ('armv8', 'iOS', '17.1', 'iphoneos', "platform 2"),
+    ('armv7', 'iOS', '10.0', 'iphoneos', "cmd LC_VERSION_MIN_IPHONEOS"),  # "platform" is missing!
+    ('x86', 'iOS', '10.0', 'iphonesimulator', "cmd LC_VERSION_MIN_IPHONEOS"),  # "platform" is missing!
+    ('x86_64', 'iOS', '10.0', 'iphonesimulator', "cmd LC_VERSION_MIN_IPHONEOS"),  # "platform" is missing!
+    ('armv8', 'Macos', None, None, "platform 1"),  # MacOS M1
+    ('armv8', 'Macos', '10.11', None, "platform 1"),  # MacOS M1
 ])
-def test_apple_meson_toolchain_cross_compiling(arch, os_, os_version, os_sdk):
+def test_apple_meson_toolchain_cross_compiling(arch, os_, os_version, os_sdk, platform_assertion):
     profile = textwrap.dedent("""
-    include(default)
-
     [settings]
     os = {os}
     {os_version}
@@ -97,8 +96,7 @@ def test_apple_meson_toolchain_cross_compiling(arch, os_, os_version, os_sdk):
             "main.cpp": app,
             "profile_host": profile})
 
-    t.run("install . --profile:build=default --profile:host=profile_host")
-    t.run("build .")
+    t.run("build . --profile:build=default --profile:host=profile_host")
 
     libhello = os.path.join(t.current_folder, "build", "libhello.a")
     assert os.path.isfile(libhello) is True
@@ -115,10 +113,21 @@ def test_apple_meson_toolchain_cross_compiling(arch, os_, os_version, os_sdk):
     t.run_command('"%s" -info "%s"' % (lipo, demo))
     assert "architecture: %s" % _to_apple_arch(arch) in t.out
 
-    # only check for iOS because one of the macos build variants is usually native
+    # Extra check to ensure the host platform
+    t.run_command(f'otool -l "{libhello}"')
+    assert platform_assertion in t.out
+
     if os_ == "iOS":
+        # only check for iOS because one of the macos build variants is usually native
         content = t.load("conan_meson_cross.ini")
         assert "needs_exe_wrapper = true" in content
+    elif os_ == "Macos" and not os_version:
+        content = t.load("conan_meson_cross.ini")
+        assert "'-mmacosx-version-min=" not in content
+    elif os_ == "Macos" and os_version:
+        # Issue related: https://github.com/conan-io/conan/issues/15459
+        content = t.load("conan_meson_cross.ini")
+        assert f"'-mmacosx-version-min={os_version}'" in content
 
 
 @pytest.mark.tool("meson")
@@ -157,7 +166,6 @@ def test_windows_cross_compiling_x86():
 @pytest.mark.tool("meson")
 @pytest.mark.tool("android_ndk")
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Android NDK only tested in MacOS for now")
-@pytest.mark.skipif(sys.version_info.major == 2, reason="Meson not supported in Py2")
 def test_android_meson_toolchain_cross_compiling(arch, expected_arch):
     profile_host = textwrap.dedent("""
     include(default)
@@ -187,8 +195,7 @@ def test_android_meson_toolchain_cross_compiling(arch, expected_arch):
                  "main.cpp": app,
                  "profile_host": profile_host})
 
-    client.run("install . --profile:build=default --profile:host=profile_host")
-    client.run("build .")
+    client.run("build . --profile:build=default --profile:host=profile_host")
     content = client.load(os.path.join("conan_meson_cross.ini"))
     assert "needs_exe_wrapper = true" in content
     assert "Target machine cpu family: {}".format(expected_arch if expected_arch != "i386" else "x86") in client.out

--- a/conans/test/functional/toolchains/meson/test_cross_compilation.py
+++ b/conans/test/functional/toolchains/meson/test_cross_compilation.py
@@ -58,6 +58,7 @@ option('STRING_DEFINITION', type : 'string', description : 'a string option')
 @pytest.mark.tool("meson")
 @pytest.mark.skipif(platform.system() != "Darwin", reason="requires Xcode")
 @pytest.mark.parametrize("arch, os_, os_version, os_sdk, platform_assertion", [
+    # platform_assertion -> https://stackoverflow.com/questions/44188023/how-to-check-a-lib-static-or-dynamic-is-built-for-ios-simulator-or-mac-osx
     ('armv8', 'watchOS', '10.1', 'watchos', "platform 4"),
     ('armv8', 'iOS', '17.1', 'iphoneos', "platform 2"),
     ('armv7', 'iOS', '10.0', 'iphoneos', "cmd LC_VERSION_MIN_IPHONEOS"),  # "platform" is missing!

--- a/conans/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/conans/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -281,38 +281,3 @@ def test_check_c_cpp_ld_list_formats():
     assert "c = ['aarch64-poky-linux-gcc', '-mcpu=cortex-a53', '-march=armv8-a+crc+crypto']" in content
     assert "cpp = ['aarch64-poky-linux-g++', '-mcpu=cortex-a53', '-march=armv8-a+crc+crypto']" in content
     assert "ld = ['aarch64-poky-linux-ld', '--sysroot=/opt/sysroots/cortexa53-crypto-poky-linux']" in content
-
-
-@pytest.mark.skipif(platform.system() != "Darwin", reason="Requires OSX")
-def test_apple_meson_add_min_version_flag():
-    default = textwrap.dedent("""
-    [settings]
-    os=Macos
-    os.version=10.11
-    arch=x86_64
-    compiler=apple-clang
-    compiler.version=12.0
-    compiler.libcxx=libc++
-    build_type=Release
-    """)
-
-    cross = textwrap.dedent("""
-    [settings]
-    os=Macos
-    os.version=10.11
-    arch=armv8
-    compiler=apple-clang
-    compiler.version=12.0
-    compiler.libcxx=libc++
-    build_type=Release
-    """)
-
-    t = TestClient()
-    t.save({"conanfile.py": GenConanfile(name="app", version="1.0").with_generator("MesonToolchain")
-           .with_settings("arch", "os", "build_type", "compiler"),
-            "build_prof": default,
-            "host_prof": cross})
-
-    t.run("install . -pr:h host_prof -pr:b build_prof")
-    content = t.load(MesonToolchain.cross_filename)
-    assert "'-mmacosx-version-min=10.11'" in content

--- a/conans/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/conans/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -281,3 +281,37 @@ def test_check_c_cpp_ld_list_formats():
     assert "c = ['aarch64-poky-linux-gcc', '-mcpu=cortex-a53', '-march=armv8-a+crc+crypto']" in content
     assert "cpp = ['aarch64-poky-linux-g++', '-mcpu=cortex-a53', '-march=armv8-a+crc+crypto']" in content
     assert "ld = ['aarch64-poky-linux-ld', '--sysroot=/opt/sysroots/cortexa53-crypto-poky-linux']" in content
+
+
+def test_apple_meson_add_min_version_flag():
+    default = textwrap.dedent("""
+    [settings]
+    os=Macos
+    os.version=10.11
+    arch=x86_64
+    compiler=apple-clang
+    compiler.version=12.0
+    compiler.libcxx=libc++
+    build_type=Release
+    """)
+
+    cross = textwrap.dedent("""
+    [settings]
+    os=Macos
+    os.version=10.11
+    arch=armv8
+    compiler=apple-clang
+    compiler.version=12.0
+    compiler.libcxx=libc++
+    build_type=Release
+    """)
+
+    t = TestClient()
+    t.save({"conanfile.py": GenConanfile(name="app", version="1.0").with_generator("MesonToolchain")
+           .with_settings("arch", "os", "build_type", "compiler"),
+            "build_prof": default,
+            "host_prof": cross})
+
+    t.run("install . -pr:h host_prof -pr:b build_prof")
+    content = t.load(MesonToolchain.cross_filename)
+    assert "'-mmacosx-version-min=10.11'" in content

--- a/conans/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/conans/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -283,6 +283,7 @@ def test_check_c_cpp_ld_list_formats():
     assert "ld = ['aarch64-poky-linux-ld', '--sysroot=/opt/sysroots/cortexa53-crypto-poky-linux']" in content
 
 
+@pytest.mark.skipif(platform.system() != "Darwin", reason="Requires OSX")
 def test_apple_meson_add_min_version_flag():
     default = textwrap.dedent("""
     [settings]


### PR DESCRIPTION
Changelog: Bugfix: MesonToolchain calculates a valid `apple_min_version_flag`.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/15459
