### PR TITLE
Ability to use modified environment in generate() method in CMakePresets

### DIFF
--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -160,6 +160,8 @@ class CMakeToolchain(object):
         self.find_builddirs = True
         self.user_presets_path = "CMakeUserPresets.json"
         self.presets_prefix = "conan"
+        self.presets_build_environment = None
+        self.presets_run_environment = None
 
     def _context(self):
         """ Returns dict, the context for the template
@@ -220,11 +222,8 @@ class CMakeToolchain(object):
         if self._conanfile.conf.get("tools.cmake.cmaketoolchain:presets_environment", default="",
                                     check_type=str, choices=("disabled", "")) != "disabled":
 
-            benv = self._conanfile.buildenv
-            renv = self._conanfile.runenv
-
-            build_env = VirtualBuildEnv(self._conanfile, auto_generate=True).vars()
-            run_env = VirtualRunEnv(self._conanfile, auto_generate=True).vars()
+            build_env = self.presets_build_environment.vars() if self.presets_build_environment else VirtualBuildEnv(self._conanfile, auto_generate=True).vars()
+            run_env = self.presets_run_environment.vars() if self.presets_run_environment else VirtualRunEnv(self._conanfile, auto_generate=True).vars()
 
             buildenv = {name: value for name, value in
                         build_env.items(variable_reference="$penv{{{name}}}")}

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -222,8 +222,8 @@ class CMakeToolchain(object):
         if self._conanfile.conf.get("tools.cmake.cmaketoolchain:presets_environment", default="",
                                     check_type=str, choices=("disabled", "")) != "disabled":
 
-            build_env = self.presets_build_environment.vars() if self.presets_build_environment else VirtualBuildEnv(self._conanfile, auto_generate=True).vars()
-            run_env = self.presets_run_environment.vars() if self.presets_run_environment else VirtualRunEnv(self._conanfile, auto_generate=True).vars()
+            build_env = self.presets_build_environment.vars(self._conanfile) if self.presets_build_environment else VirtualBuildEnv(self._conanfile, auto_generate=True).vars()
+            run_env = self.presets_run_environment.vars(self._conanfile) if self.presets_run_environment else VirtualRunEnv(self._conanfile, auto_generate=True).vars()
 
             buildenv = {name: value for name, value in
                         build_env.items(variable_reference="$penv{{{name}}}")}

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -220,6 +220,9 @@ class CMakeToolchain(object):
         if self._conanfile.conf.get("tools.cmake.cmaketoolchain:presets_environment", default="",
                                     check_type=str, choices=("disabled", "")) != "disabled":
 
+            benv = self._conanfile.buildenv
+            renv = self._conanfile.runenv
+
             build_env = VirtualBuildEnv(self._conanfile, auto_generate=True).vars()
             run_env = VirtualRunEnv(self._conanfile, auto_generate=True).vars()
 

--- a/conan/tools/env/virtualbuildenv.py
+++ b/conan/tools/env/virtualbuildenv.py
@@ -9,6 +9,7 @@ class VirtualBuildEnv:
     """
 
     def __init__(self, conanfile, auto_generate=False):
+        self._buildenv = None
         self._conanfile = conanfile
         if not auto_generate:
             self._conanfile.virtualbuildenv = False
@@ -42,33 +43,36 @@ class VirtualBuildEnv:
 
         :return: an ``Environment`` object instance containing the obtained variables.
         """
-        # FIXME: Cache value?
-        build_env = Environment()
+
+        if self._buildenv is None:
+            self._buildenv = Environment()
+        else:
+            return self._buildenv
 
         # Top priority: profile
         profile_env = self._conanfile.buildenv
-        build_env.compose_env(profile_env)
+        self._buildenv.compose_env(profile_env)
 
         build_requires = self._conanfile.dependencies.build.topological_sort
         for require, build_require in reversed(build_requires.items()):
             if require.direct:  # Only buildenv_info from direct deps is propagated
                 # higher priority, explicit buildenv_info
                 if build_require.buildenv_info:
-                    build_env.compose_env(build_require.buildenv_info)
+                    self._buildenv.compose_env(build_require.buildenv_info)
             # Lower priority, the runenv of all transitive "requires" of the build requires
             if build_require.runenv_info:
-                build_env.compose_env(build_require.runenv_info)
+                self._buildenv.compose_env(build_require.runenv_info)
             # Then the implicit
             os_name = self._conanfile.settings_build.get_safe("os")
-            build_env.compose_env(runenv_from_cpp_info(build_require, os_name))
+            self._buildenv.compose_env(runenv_from_cpp_info(build_require, os_name))
 
         # Requires in host context can also bring some direct buildenv_info
         host_requires = self._conanfile.dependencies.host.topological_sort
         for require in reversed(host_requires.values()):
             if require.buildenv_info:
-                build_env.compose_env(require.buildenv_info)
+                self._buildenv.compose_env(require.buildenv_info)
 
-        return build_env
+        return self._buildenv
 
     def vars(self, scope="build"):
         """

--- a/conan/tools/env/virtualrunenv.py
+++ b/conan/tools/env/virtualrunenv.py
@@ -34,6 +34,7 @@ class VirtualRunEnv:
 
         :param conanfile:  The current recipe object. Always use ``self``.
         """
+        self._runenv = None
         self._conanfile = conanfile
         if not auto_generate:
             self._conanfile.virtualrunenv = False
@@ -60,23 +61,27 @@ class VirtualRunEnv:
 
         :return: an ``Environment`` object instance containing the obtained variables.
         """
-        runenv = Environment()
+
+        if self._runenv is None:
+            self._runenv = Environment()
+        else:
+            return self._runenv
 
         # Top priority: profile
         profile_env = self._conanfile.runenv
-        runenv.compose_env(profile_env)
+        self._runenv.compose_env(profile_env)
         # FIXME: Cache value?
 
         host_req = self._conanfile.dependencies.host
         test_req = self._conanfile.dependencies.test
         for require, dep in list(host_req.items()) + list(test_req.items()):
             if dep.runenv_info:
-                runenv.compose_env(dep.runenv_info)
+                self._runenv.compose_env(dep.runenv_info)
             if require.run:  # Only if the require is run (shared or application to be run)
                 _os = self._conanfile.settings.get_safe("os")
-                runenv.compose_env(runenv_from_cpp_info(dep, _os))
+                self._runenv.compose_env(runenv_from_cpp_info(dep, _os))
 
-        return runenv
+        return self._runenv
 
     def vars(self, scope="run"):
         """

--- a/conan/tools/env/virtualrunenv.py
+++ b/conan/tools/env/virtualrunenv.py
@@ -70,7 +70,6 @@ class VirtualRunEnv:
         # Top priority: profile
         profile_env = self._conanfile.runenv
         self._runenv.compose_env(profile_env)
-        # FIXME: Cache value?
 
         host_req = self._conanfile.dependencies.host
         test_req = self._conanfile.dependencies.test

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1704,5 +1704,5 @@ def test_add_generate_env_to_presets():
     assert "MY_BUILD_VAR:MY_BUILDVAR_VALUE_OVERRIDEN" in c.out
     assert "MY_ENV_VAR:MY_ENV_VAR_VALUE" in c.out
 
-    c.run_command(f"ctest --preset {preset} --verbose")
+    c.run_command(f"ctest --preset conan-release --verbose")
     assert "MY_RUNVAR_SET_IN_GENERATE" in c.out

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1681,7 +1681,7 @@ def test_add_generate_env_to_presets():
         enable_testing()
 
         if(WIN32)
-            set(ENV_CHECK_COMMAND set)
+            set(ENV_CHECK_COMMAND set.exe)
         else()
             set(ENV_CHECK_COMMAND env)
         endif()

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1495,7 +1495,7 @@ def test_redirect_stdout():
     assert re.search("Install stderr: ''", client.out)
 
 
-#@pytest.mark.tool("cmake", "3.23")
+@pytest.mark.tool("cmake", "3.23")
 class TestEnvironmentInPresets:
     @pytest.fixture(scope="class")
     def _init_client(self):

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1649,7 +1649,7 @@ def test_add_generate_env_to_presets():
                 #envvars = buildenv.environment()
                 #envvars.define("MY_BUILD_VAR", "MY_BUILDVAR_VALUE_OVERRIDEN")
                 #envvarsbuild = envvars.vars(self, scope="run")
-                #envvarsbuild.save_script("myproject-run-{}".format(str(self.settings.build_type).lower()))
+                #envvarsbuild.save_script("myproject-build-{}".format(str(self.settings.build_type).lower()))
 
 
                 deps = CMakeDeps(self)

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1609,7 +1609,7 @@ def test_add_env_to_presets():
     assert "tests passed" in c.out
 
 
-#@pytest.mark.tool("cmake", "3.23")
+@pytest.mark.tool("cmake", "3.23")
 def test_add_generate_env_to_presets():
     c = TestClient()
 

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1655,6 +1655,8 @@ def test_add_generate_env_to_presets():
                 deps = CMakeDeps(self)
                 deps.generate()
                 tc = CMakeToolchain(self)
+                tc.presets_build_environment = buildenv
+                tc.presets_run_environment = runenv
                 tc.generate()
     """)
 

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1607,3 +1607,79 @@ def test_add_env_to_presets():
 
     c.run_command("ctest --preset conan-debug")
     assert "tests passed" in c.out
+
+
+#@pytest.mark.tool("cmake", "3.23")
+def test_add_generate_env_to_presets():
+    c = TestClient()
+
+    tool = textwrap.dedent(r"""
+        import os
+        from conan import ConanFile
+        from conan.tools.files import chdir, save
+        class Tool(ConanFile):
+            version = "0.1"
+            name = "tool"
+            settings = "os", "compiler", "arch", "build_type"
+            def package_info(self):
+                self.buildenv_info.define("MY_BUILD_VAR", "MY_BUILDVAR_VALUE")
+        """)
+
+    consumer = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+        from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
+        from conan.tools.env import VirtualBuildEnv
+        class mypkgRecipe(ConanFile):
+            name = "mypkg"
+            version = "1.0"
+            settings = "os", "compiler", "build_type", "arch"
+            tool_requires = "tool/0.1"
+            #generators = "CMakeDeps", "CMakeToolchain"
+            def layout(self):
+                cmake_layout(self)
+
+            def generate(self):
+                buildenv = VirtualBuildEnv(self)
+                buildenv.environment().define("MY_BUILD_VAR", "MY_BUILDVAR_VALUE_OVERRIDEN")
+                buildenv.environment().define("MY_ADDED_BUILD_VAR", "MY_ADDED_BUILD_VAR_VALUE")
+                buildenv.generate()
+
+                #buildenv = VirtualBuildEnv(self)
+                #envvars = buildenv.environment()
+                #envvars.define("MY_BUILD_VAR", "MY_BUILDVAR_VALUE_OVERRIDEN")
+                #envvarsbuild = envvars.vars(self, scope="run")
+                #envvarsbuild.save_script("myproject-run-{}".format(str(self.settings.build_type).lower()))
+
+
+                deps = CMakeDeps(self)
+                deps.generate()
+                tc = CMakeToolchain(self)
+                tc.generate()
+    """)
+
+    cmakelists = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.15)
+        project(MyProject)
+        # build var should be available at configure
+        set(MY_BUILD_VAR $ENV{MY_BUILD_VAR})
+        set(MY_ADDED_BUILD_VAR $ENV{MY_BUILD_VAR})
+        if (MY_BUILD_VAR)
+            message("MY_BUILD_VAR:${MY_BUILD_VAR}")
+        else()
+            message("MY_BUILD_VAR NOT FOUND")
+        endif()
+    """)
+
+    c.save({"tool.py": tool,
+            "conanfile.py": consumer,
+            "CMakeLists.txt": cmakelists})
+
+    c.run("create tool.py")
+
+    c.run("install .")
+
+    preset = "conan-default" if platform.system() == "Windows" else "conan-release"
+
+    c.run_command(f"cmake --preset {preset}")
+    assert "MY_BUILD_VAR:MY_BUILDVAR_VALUE" in c.out

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1674,7 +1674,6 @@ def test_add_generate_env_to_presets():
 
         check_and_report_variable("MY_BUILD_VAR")
         check_and_report_variable("MY_ADDED_BUILD_VAR")
-        check_and_report_variable("PATH_VAR")
     """)
 
     c.save({"tool.py": tool,


### PR DESCRIPTION
Changelog: Feature: Adding `CMakeToolchain.presets_build/run_environment` to modify `CMakePresets` environment in `generate()` method.
Docs: https://github.com/conan-io/docs/pull/3547

Closes: https://github.com/conan-io/conan/issues/15342