### PR TITLE
proposal for testing python_requires explicitly

### DIFF
--- a/conan/api/subapi/graph.py
+++ b/conan/api/subapi/graph.py
@@ -73,7 +73,8 @@ class GraphAPI:
                                          channel=tested_reference.channel,
                                          graph_lock=lockfile, remotes=remotes,
                                          tested_python_requires=tested_python_requires,
-                                         update=update)
+                                         update=update,
+                                         tested_python_require_ref=str(tested_reference))
         initialize_conanfile_profile(conanfile, profile_build, profile_host, CONTEXT_HOST, False)
         conanfile.display_name = "%s (test package)" % str(tested_reference)
         conanfile.output.scope = conanfile.display_name

--- a/conan/api/subapi/graph.py
+++ b/conan/api/subapi/graph.py
@@ -73,8 +73,7 @@ class GraphAPI:
                                          channel=tested_reference.channel,
                                          graph_lock=lockfile, remotes=remotes,
                                          tested_python_requires=tested_python_requires,
-                                         update=update,
-                                         tested_python_require_ref=str(tested_reference))
+                                         update=update)
         initialize_conanfile_profile(conanfile, profile_build, profile_host, CONTEXT_HOST, False)
         conanfile.display_name = "%s (test package)" % str(tested_reference)
         conanfile.output.scope = conanfile.display_name

--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -128,12 +128,12 @@ def test_package(conan_api, deps_graph, test_conanfile_path, tested_python_requi
     out = ConanOutput()
     out.title("Testing the package")
     # TODO: Better modeling when we are testing a python_requires
-    if len(deps_graph.nodes) == 1 and not tested_python_requires:
+    conanfile = deps_graph.root.conanfile
+    if len(deps_graph.nodes) == 1 and not hasattr(conanfile, "python_requires"):
         raise ConanException("The conanfile at '{}' doesn't declare any requirement, "
                              "use `self.tested_reference_str` to require the "
                              "package being created.".format(test_conanfile_path))
     conanfile_folder = os.path.dirname(test_conanfile_path)
-    conanfile = deps_graph.root.conanfile
     # To make sure the folders are correct
     conanfile.folders.set_base_folders(conanfile_folder, output_folder=None)
     if conanfile.build_folder and conanfile.build_folder != conanfile.source_folder:

--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -9,7 +9,7 @@ from conan.cli.formatters.graph import format_graph_json
 from conan.cli.printers import print_profiles
 from conan.cli.printers.graph import print_graph_packages, print_graph_basic
 from conan.errors import ConanException
-from conans.util.files import mkdir
+from conans.util.files import mkdir, load
 
 
 @conan_command(group="Creator", formatters={"json": format_graph_json})
@@ -107,6 +107,11 @@ def create(conan_api, parser, *args):
         run_test(conan_api, test_conanfile_path, ref, profile_host, profile_build, remotes, lockfile,
                  update=False, build_modes=args.build, build_modes_test=args.build_test,
                  tested_python_requires=tested_python_requires, tested_graph=deps_graph)
+        if is_python_require:
+            if 'python_requires = "tested_reference_str"' not in load(test_conanfile_path):
+                ConanOutput().warning("test_package/conanfile.py should declare "
+                                      "'python_requires = \"tested_reference_str\"'",
+                                      warn_tag="deprecated")
 
     conan_api.lockfile.save_lockfile(lockfile, args.lockfile_out, cwd)
     return {"graph": deps_graph,

--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -98,7 +98,9 @@ def create(conan_api, parser, *args):
     if test_conanfile_path:
         # TODO: We need arguments for:
         #  - decide update policy "--test_package_update"
-        tested_python_requires = ref.repr_notime() if is_python_require else None
+        # If it is a string, it will be injected always, if it is a RecipeReference, then it will
+        # be replaced only if ``python_requires = "tested_reference_str"``
+        tested_python_requires = ref.repr_notime() if is_python_require else ref
         from conan.cli.commands.test import run_test
         # The test_package do not make the "conan create" command return a different graph or
         # produce a different lockfile. The result is always the same, irrespective of test_package
@@ -124,7 +126,7 @@ def _check_tested_reference_matches(deps_graph, tested_ref, out):
                     "tested is '{}'".format(missmatch[0], tested_ref))
 
 
-def test_package(conan_api, deps_graph, test_conanfile_path, tested_python_requires=None):
+def test_package(conan_api, deps_graph, test_conanfile_path):
     out = ConanOutput()
     out.title("Testing the package")
     # TODO: Better modeling when we are testing a python_requires

--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -107,11 +107,6 @@ def create(conan_api, parser, *args):
         run_test(conan_api, test_conanfile_path, ref, profile_host, profile_build, remotes, lockfile,
                  update=False, build_modes=args.build, build_modes_test=args.build_test,
                  tested_python_requires=tested_python_requires, tested_graph=deps_graph)
-        if is_python_require:
-            if 'python_requires = "tested_reference_str"' not in load(test_conanfile_path):
-                ConanOutput().warning("test_package/conanfile.py should declare "
-                                      "'python_requires = \"tested_reference_str\"'",
-                                      warn_tag="deprecated")
 
     conan_api.lockfile.save_lockfile(lockfile, args.lockfile_out, cwd)
     return {"graph": deps_graph,

--- a/conan/cli/commands/test.py
+++ b/conan/cli/commands/test.py
@@ -38,7 +38,7 @@ def test(conan_api, parser, *args):
     print_profiles(profile_host, profile_build)
 
     deps_graph = run_test(conan_api, path, ref, profile_host, profile_build, remotes, lockfile,
-                          args.update, build_modes=args.build)
+                          args.update, build_modes=args.build, tested_python_requires=ref)
     lockfile = conan_api.lockfile.update_lockfile(lockfile, deps_graph, args.lockfile_packages,
                                                   clean=args.lockfile_clean)
     conan_api.lockfile.save_lockfile(lockfile, args.lockfile_out, cwd)
@@ -74,5 +74,5 @@ def run_test(conan_api, path, ref, profile_host, profile_build, remotes, lockfil
 
     conan_api.install.install_binaries(deps_graph=deps_graph, remotes=remotes)
     _check_tested_reference_matches(deps_graph, ref, out)
-    test_package(conan_api, deps_graph, path, tested_python_requires)
+    test_package(conan_api, deps_graph, path)
     return deps_graph

--- a/conan/cli/commands/test.py
+++ b/conan/cli/commands/test.py
@@ -55,6 +55,11 @@ def run_test(conan_api, path, ref, profile_host, profile_build, remotes, lockfil
                                                          update=update,
                                                          lockfile=lockfile,
                                                          tested_python_requires=tested_python_requires)
+    if isinstance(tested_python_requires, str):  # create python-require
+        conanfile = root_node.conanfile
+        if not getattr(conanfile, "python_requires", None) == "tested_reference_str":
+            ConanOutput().warning("test_package/conanfile.py should declare 'python_requires"
+                                  " = \"tested_reference_str\"'", warn_tag="deprecated")
 
     out = ConanOutput()
     out.title("Launching test_package")

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -40,8 +40,7 @@ class ConanFileLoader:
                                       update, check_update)[0]
 
     def load_basic_module(self, conanfile_path, graph_lock=None, display="", remotes=None,
-                          update=None, check_update=None, tested_python_requires=None,
-                          tested_python_require_ref=None):
+                          update=None, check_update=None, tested_python_requires=None):
         """ loads a conanfile basic object without evaluating anything, returns the module too
         """
         cached = self._cached_conanfile_classes.get(conanfile_path)
@@ -55,9 +54,9 @@ class ConanFileLoader:
 
         try:
             module, conanfile = _parse_conanfile(conanfile_path)
-            if getattr(conanfile, "python_requires", None) == "tested_reference_str":
-                assert tested_python_require_ref
-                conanfile.python_requires = [tested_python_require_ref]
+            if isinstance(tested_python_requires, RecipeReference):
+                if getattr(conanfile, "python_requires", None) == "tested_reference_str":
+                    conanfile.python_requires = tested_python_requires.repr_notime()
             elif tested_python_requires:
                 conanfile.python_requires = tested_python_requires
 
@@ -97,14 +96,12 @@ class ConanFileLoader:
         return data or {}
 
     def load_named(self, conanfile_path, name, version, user, channel, graph_lock=None,
-                   remotes=None, update=None, check_update=None, tested_python_requires=None,
-                   tested_python_require_ref=None):
+                   remotes=None, update=None, check_update=None, tested_python_requires=None):
         """ loads the basic conanfile object and evaluates its name and version
         """
         conanfile, _ = self.load_basic_module(conanfile_path, graph_lock, remotes=remotes,
                                               update=update, check_update=check_update,
-                                              tested_python_requires=tested_python_requires,
-                                              tested_python_require_ref=tested_python_require_ref)
+                                              tested_python_requires=tested_python_requires)
 
         # Export does a check on existing name & version
         if name:
@@ -157,13 +154,12 @@ class ConanFileLoader:
 
     def load_consumer(self, conanfile_path, name=None, version=None, user=None,
                       channel=None, graph_lock=None,  remotes=None, update=None, check_update=None,
-                      tested_python_requires=None, tested_python_require_ref=None):
+                      tested_python_requires=None):
         """ loads a conanfile.py in user space. Might have name/version or not
         """
         conanfile = self.load_named(conanfile_path, name, version, user, channel, graph_lock,
                                     remotes, update, check_update,
-                                    tested_python_requires=tested_python_requires,
-                                    tested_python_require_ref=tested_python_require_ref)
+                                    tested_python_requires=tested_python_requires)
 
         ref = RecipeReference(conanfile.name, conanfile.version, user, channel)
         if str(ref):

--- a/conans/test/integration/py_requires/python_requires_test.py
+++ b/conans/test/integration/py_requires/python_requires_test.py
@@ -1013,12 +1013,16 @@ class TestTestPackagePythonRequire:
             from conan import ConanFile
 
             class Tool(ConanFile):
+                python_requires = "tested_reference_str"
                 def test(self):
                     self.output.info("{}!!!".format(self.python_requires["common"].module.mycommon()))
             """)
         c.save({"conanfile.py": conanfile,
                 "test_package/conanfile.py": test})
         c.run("create .")
+        assert "common/0.1 (test package): 42!!!" in c.out
+
+        c.run("test test_package common/0.1")
         assert "common/0.1 (test package): 42!!!" in c.out
 
     def test_test_package_python_requires_configs(self):

--- a/conans/test/integration/py_requires/python_requires_test.py
+++ b/conans/test/integration/py_requires/python_requires_test.py
@@ -1052,6 +1052,7 @@ class TestTestPackagePythonRequire:
                 "test_package/conanfile.py": test})
         c.run("create . ")
         assert "common/0.1 (test package): RELEASEOK!!!" in c.out
+        assert "WARN: deprecated: test_package/conanfile.py should declare 'python_requires" in c.out
         c.run("create . -s build_type=Debug")
         assert "common/0.1 (test package): DEBUGOK!!!" in c.out
 


### PR DESCRIPTION
Changelog: Feature: Define ``python_requires = "tested_reference_str"`` for explicit ``test_package`` of ``python_requires``.
Changelog: Bugfix: Avoid ``conan test`` failing for ``python_requires`` test-package.
Docs: https://github.com/conan-io/docs/pull/3537

Close https://github.com/conan-io/conan/issues/15484
