### PR TITLE
[DRAFT] Add environment to presets inheriting from other presets

### DIFF
--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -206,10 +206,7 @@ class _CMakePresets:
 
     @staticmethod
     def environment_preset_name(conanfile, scope):
-        build_type = conanfile.settings.get_safe("build_type")
-        arch = conanfile.settings.get_safe("arch")
-        preset_name = "-".join(filter(None, ["conan", scope, "environment", build_type, arch])).lower()
-        return preset_name
+        return "environment-" + _CMakePresets._build_and_test_preset_name(conanfile) + "-" + scope
 
     @staticmethod
     def _build_and_test_preset_name(conanfile):

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -96,7 +96,7 @@ class _CMakePresets:
         build = _CMakePresets._build_preset_fields(conanfile, multiconfig, preset_prefix)
         test = _CMakePresets._test_preset_fields(conanfile, multiconfig, preset_prefix, add_env)
 
-        ret = {"version": 4,
+        ret = {"version": 4 if add_env else 3,
                "vendor": {"conan": {}},
                "cmakeMinimumRequired": {"major": 3, "minor": 15, "patch": 0},
                "configurePresets": [conf],

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -160,6 +160,8 @@ class CMakeToolchain(object):
         self.find_builddirs = True
         self.user_presets_path = "CMakeUserPresets.json"
         self.presets_prefix = "conan"
+        self.presets_build_environment = None
+        self.presets_run_environment = None
 
     def _context(self):
         """ Returns dict, the context for the template
@@ -220,11 +222,8 @@ class CMakeToolchain(object):
         if self._conanfile.conf.get("tools.cmake.cmaketoolchain:presets_environment", default="",
                                     check_type=str, choices=("disabled", "")) != "disabled":
 
-            benv = self._conanfile.buildenv
-            renv = self._conanfile.runenv
-
-            build_env = VirtualBuildEnv(self._conanfile, auto_generate=True).vars()
-            run_env = VirtualRunEnv(self._conanfile, auto_generate=True).vars()
+            build_env = self.presets_build_environment.vars() if self.presets_build_environment else VirtualBuildEnv(self._conanfile, auto_generate=True).vars()
+            run_env = self.presets_run_environment.vars() if self.presets_run_environment else VirtualRunEnv(self._conanfile, auto_generate=True).vars()
 
             buildenv = {name: value for name, value in
                         build_env.items(variable_reference="$penv{{{name}}}")}

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -160,8 +160,6 @@ class CMakeToolchain(object):
         self.find_builddirs = True
         self.user_presets_path = "CMakeUserPresets.json"
         self.presets_prefix = "conan"
-        self.presets_build_environment = None
-        self.presets_run_environment = None
 
     def _context(self):
         """ Returns dict, the context for the template
@@ -217,21 +215,8 @@ class CMakeToolchain(object):
             else:
                 cache_variables[name] = value
 
-        buildenv, runenv = None, None
-
-        if self._conanfile.conf.get("tools.cmake.cmaketoolchain:presets_environment", default="",
-                                    check_type=str, choices=("disabled", "")) != "disabled":
-
-            build_env = self.presets_build_environment.vars() if self.presets_build_environment else VirtualBuildEnv(self._conanfile, auto_generate=True).vars()
-            run_env = self.presets_run_environment.vars() if self.presets_run_environment else VirtualRunEnv(self._conanfile, auto_generate=True).vars()
-
-            buildenv = {name: value for name, value in
-                        build_env.items(variable_reference="$penv{{{name}}}")}
-            runenv = {name: value for name, value in
-                      run_env.items(variable_reference="$penv{{{name}}}")}
-
         write_cmake_presets(self._conanfile, toolchain, self.generator, cache_variables,
-                            self.user_presets_path, self.presets_prefix, buildenv, runenv)
+                            self.user_presets_path, self.presets_prefix)
 
     def _get_generator(self, recipe_generator):
         # Returns the name of the generator to be used by CMake

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -220,6 +220,9 @@ class CMakeToolchain(object):
         if self._conanfile.conf.get("tools.cmake.cmaketoolchain:presets_environment", default="",
                                     check_type=str, choices=("disabled", "")) != "disabled":
 
+            benv = self._conanfile.buildenv
+            renv = self._conanfile.runenv
+
             build_env = VirtualBuildEnv(self._conanfile, auto_generate=True).vars()
             run_env = VirtualRunEnv(self._conanfile, auto_generate=True).vars()
 

--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -1,3 +1,4 @@
+import json
 import os
 import textwrap
 from collections import OrderedDict
@@ -508,6 +509,12 @@ class EnvVars:
         content = f'script_folder="{os.path.abspath(filepath)}"\n' + content
         save(file_location, content)
 
+    def save_json(self, file_location):
+        env_vars = EnvVars(self._conanfile, self._values, self._scope)
+        env = {name: value for name, value in env_vars.items(variable_reference="$penv{{{name}}}")}
+        content = json.dumps(env, indent=1)
+        save(file_location, content)
+
     def save_script(self, filename):
         """
         Saves a script file (bat, sh, ps1) with a launcher to set the environment.
@@ -540,7 +547,10 @@ class EnvVars:
             self.save_sh(path)
 
         if self._scope:
+            json_path = os.path.splitext(path)[0] + ".json"
+            self.save_json(json_path)
             register_env_script(self._conanfile, path, self._scope)
+            register_env_script(self._conanfile, json_path, self._scope)
 
 
 class ProfileEnvironment:

--- a/conan/tools/env/virtualbuildenv.py
+++ b/conan/tools/env/virtualbuildenv.py
@@ -9,6 +9,7 @@ class VirtualBuildEnv:
     """
 
     def __init__(self, conanfile, auto_generate=False):
+        self._buildenv = None
         self._conanfile = conanfile
         if not auto_generate:
             self._conanfile.virtualbuildenv = False
@@ -42,33 +43,36 @@ class VirtualBuildEnv:
 
         :return: an ``Environment`` object instance containing the obtained variables.
         """
-        # FIXME: Cache value?
-        build_env = Environment()
+
+        if self._buildenv is None:
+            self._buildenv = Environment()
+        else:
+            return self._buildenv
 
         # Top priority: profile
         profile_env = self._conanfile.buildenv
-        build_env.compose_env(profile_env)
+        self._buildenv.compose_env(profile_env)
 
         build_requires = self._conanfile.dependencies.build.topological_sort
         for require, build_require in reversed(build_requires.items()):
             if require.direct:  # Only buildenv_info from direct deps is propagated
                 # higher priority, explicit buildenv_info
                 if build_require.buildenv_info:
-                    build_env.compose_env(build_require.buildenv_info)
+                    self._buildenv.compose_env(build_require.buildenv_info)
             # Lower priority, the runenv of all transitive "requires" of the build requires
             if build_require.runenv_info:
-                build_env.compose_env(build_require.runenv_info)
+                self._buildenv.compose_env(build_require.runenv_info)
             # Then the implicit
             os_name = self._conanfile.settings_build.get_safe("os")
-            build_env.compose_env(runenv_from_cpp_info(build_require, os_name))
+            self._buildenv.compose_env(runenv_from_cpp_info(build_require, os_name))
 
         # Requires in host context can also bring some direct buildenv_info
         host_requires = self._conanfile.dependencies.host.topological_sort
         for require in reversed(host_requires.values()):
             if require.buildenv_info:
-                build_env.compose_env(require.buildenv_info)
+                self._buildenv.compose_env(require.buildenv_info)
 
-        return build_env
+        return self._buildenv
 
     def vars(self, scope="build"):
         """

--- a/conan/tools/env/virtualrunenv.py
+++ b/conan/tools/env/virtualrunenv.py
@@ -34,6 +34,7 @@ class VirtualRunEnv:
 
         :param conanfile:  The current recipe object. Always use ``self``.
         """
+        self._runenv = None
         self._conanfile = conanfile
         if not auto_generate:
             self._conanfile.virtualrunenv = False
@@ -60,23 +61,27 @@ class VirtualRunEnv:
 
         :return: an ``Environment`` object instance containing the obtained variables.
         """
-        runenv = Environment()
+
+        if self._runenv is None:
+            self._runenv = Environment()
+        else:
+            return self._runenv
 
         # Top priority: profile
         profile_env = self._conanfile.runenv
-        runenv.compose_env(profile_env)
+        self._runenv.compose_env(profile_env)
         # FIXME: Cache value?
 
         host_req = self._conanfile.dependencies.host
         test_req = self._conanfile.dependencies.test
         for require, dep in list(host_req.items()) + list(test_req.items()):
             if dep.runenv_info:
-                runenv.compose_env(dep.runenv_info)
+                self._runenv.compose_env(dep.runenv_info)
             if require.run:  # Only if the require is run (shared or application to be run)
                 _os = self._conanfile.settings.get_safe("os")
-                runenv.compose_env(runenv_from_cpp_info(dep, _os))
+                self._runenv.compose_env(runenv_from_cpp_info(dep, _os))
 
-        return runenv
+        return self._runenv
 
     def vars(self, scope="run"):
         """

--- a/conan/tools/env/virtualrunenv.py
+++ b/conan/tools/env/virtualrunenv.py
@@ -70,7 +70,6 @@ class VirtualRunEnv:
         # Top priority: profile
         profile_env = self._conanfile.runenv
         self._runenv.compose_env(profile_env)
-        # FIXME: Cache value?
 
         host_req = self._conanfile.dependencies.host
         test_req = self._conanfile.dependencies.test

--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -142,6 +142,8 @@ def _receive_conf(conanfile):
 
 def _generate_aggregated_env(conanfile):
 
+    from conan.tools.cmake.presets import _CMakePresets
+
     def deactivates(filenames):
         # FIXME: Probably the order needs to be reversed
         result = []
@@ -188,8 +190,6 @@ def _generate_aggregated_env(conanfile):
                     file_json = json.loads(file_content)
                     combined_environment.update(file_json)
                 preset_type = "testPresets" if group == "run" else "configurePresets"
-
-                from conan.tools.cmake.presets import _CMakePresets
                 preset_name = _CMakePresets.environment_preset_name(conanfile, group)
 
                 preset = {

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1649,7 +1649,7 @@ def test_add_generate_env_to_presets():
                 #envvars = buildenv.environment()
                 #envvars.define("MY_BUILD_VAR", "MY_BUILDVAR_VALUE_OVERRIDEN")
                 #envvarsbuild = envvars.vars(self, scope="run")
-                #envvarsbuild.save_script("myproject-run-{}".format(str(self.settings.build_type).lower()))
+                #envvarsbuild.save_script("myproject-build-{}".format(str(self.settings.build_type).lower()))
 
 
                 deps = CMakeDeps(self)

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1609,7 +1609,7 @@ def test_add_env_to_presets():
     assert "tests passed" in c.out
 
 
-#@pytest.mark.tool("cmake", "3.23")
+@pytest.mark.tool("cmake", "3.23")
 def test_add_generate_env_to_presets():
     c = TestClient()
 

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1655,6 +1655,8 @@ def test_add_generate_env_to_presets():
                 deps = CMakeDeps(self)
                 deps.generate()
                 tc = CMakeToolchain(self)
+                tc.presets_build_environment = buildenv
+                tc.presets_run_environment = runenv
                 tc.generate()
     """)
 

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1607,3 +1607,79 @@ def test_add_env_to_presets():
 
     c.run_command("ctest --preset conan-debug")
     assert "tests passed" in c.out
+
+
+#@pytest.mark.tool("cmake", "3.23")
+def test_add_generate_env_to_presets():
+    c = TestClient()
+
+    tool = textwrap.dedent(r"""
+        import os
+        from conan import ConanFile
+        from conan.tools.files import chdir, save
+        class Tool(ConanFile):
+            version = "0.1"
+            name = "tool"
+            settings = "os", "compiler", "arch", "build_type"
+            def package_info(self):
+                self.buildenv_info.define("MY_BUILD_VAR", "MY_BUILDVAR_VALUE")
+        """)
+
+    consumer = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+        from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
+        from conan.tools.env import VirtualBuildEnv
+        class mypkgRecipe(ConanFile):
+            name = "mypkg"
+            version = "1.0"
+            settings = "os", "compiler", "build_type", "arch"
+            tool_requires = "tool/0.1"
+            #generators = "CMakeDeps", "CMakeToolchain"
+            def layout(self):
+                cmake_layout(self)
+
+            def generate(self):
+                buildenv = VirtualBuildEnv(self)
+                buildenv.environment().define("MY_BUILD_VAR", "MY_BUILDVAR_VALUE_OVERRIDEN")
+                buildenv.environment().define("MY_ADDED_BUILD_VAR", "MY_ADDED_BUILD_VAR_VALUE")
+                buildenv.generate()
+
+                #buildenv = VirtualBuildEnv(self)
+                #envvars = buildenv.environment()
+                #envvars.define("MY_BUILD_VAR", "MY_BUILDVAR_VALUE_OVERRIDEN")
+                #envvarsbuild = envvars.vars(self, scope="run")
+                #envvarsbuild.save_script("myproject-run-{}".format(str(self.settings.build_type).lower()))
+
+
+                deps = CMakeDeps(self)
+                deps.generate()
+                tc = CMakeToolchain(self)
+                tc.generate()
+    """)
+
+    cmakelists = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.15)
+        project(MyProject)
+        # build var should be available at configure
+        set(MY_BUILD_VAR $ENV{MY_BUILD_VAR})
+        set(MY_ADDED_BUILD_VAR $ENV{MY_BUILD_VAR})
+        if (MY_BUILD_VAR)
+            message("MY_BUILD_VAR:${MY_BUILD_VAR}")
+        else()
+            message("MY_BUILD_VAR NOT FOUND")
+        endif()
+    """)
+
+    c.save({"tool.py": tool,
+            "conanfile.py": consumer,
+            "CMakeLists.txt": cmakelists})
+
+    c.run("create tool.py")
+
+    c.run("install .")
+
+    preset = "conan-default" if platform.system() == "Windows" else "conan-release"
+
+    c.run_command(f"cmake --preset {preset}")
+    assert "MY_BUILD_VAR:MY_BUILDVAR_VALUE" in c.out

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1495,7 +1495,7 @@ def test_redirect_stdout():
     assert re.search("Install stderr: ''", client.out)
 
 
-@pytest.mark.tool("cmake", "3.23")
+#@pytest.mark.tool("cmake", "3.23")
 def test_add_env_to_presets():
     c = TestClient()
 
@@ -1578,7 +1578,9 @@ def test_add_env_to_presets():
         if platform.system() != "Windows" else os.path.join("build", "generators", "CMakePresets.json")
     presets = json.loads(c.load(presets_path))
 
-    assert presets["configurePresets"][0].get("env") is None
+    assert presets["configurePresets"][0].get("inherits") is None
+    assert presets["testPresets"][0].get("inherits") is None
+    assert presets.get("include") is None
 
     c.run("install . -g CMakeToolchain -g CMakeDeps")
     c.run("install . -g CMakeToolchain -g CMakeDeps -s:h build_type=Debug")
@@ -1607,85 +1609,3 @@ def test_add_env_to_presets():
 
     c.run_command("ctest --preset conan-debug")
     assert "tests passed" in c.out
-
-
-@pytest.mark.tool("cmake", "3.23")
-def test_add_generate_env_to_presets():
-    c = TestClient()
-
-    tool = textwrap.dedent(r"""
-        import os
-        from conan import ConanFile
-        from conan.tools.files import chdir, save
-        class Tool(ConanFile):
-            version = "0.1"
-            name = "tool"
-            settings = "os", "compiler", "arch", "build_type"
-            def package_info(self):
-                self.buildenv_info.define("MY_BUILD_VAR", "MY_BUILDVAR_VALUE")
-        """)
-
-    consumer = textwrap.dedent("""
-        import os
-        from conan import ConanFile
-        from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
-        from conan.tools.env import VirtualBuildEnv
-        class mypkgRecipe(ConanFile):
-            name = "mypkg"
-            version = "1.0"
-            settings = "os", "compiler", "build_type", "arch"
-            tool_requires = "tool/0.1"
-            #generators = "CMakeDeps", "CMakeToolchain"
-            def layout(self):
-                cmake_layout(self)
-
-            def generate(self):
-                buildenv = VirtualBuildEnv(self)
-                buildenv.environment().define("MY_BUILD_VAR", "MY_BUILDVAR_VALUE_OVERRIDEN")
-                buildenv.environment().define("MY_ADDED_BUILD_VAR", "MY_ADDED_BUILD_VAR_VALUE")
-                buildenv.generate()
-
-                #buildenv = VirtualBuildEnv(self)
-                #envvars = buildenv.environment()
-                #envvars.define("MY_BUILD_VAR", "MY_BUILDVAR_VALUE_OVERRIDEN")
-                #envvarsbuild = envvars.vars(self, scope="run")
-                #envvarsbuild.save_script("myproject-build-{}".format(str(self.settings.build_type).lower()))
-
-
-                deps = CMakeDeps(self)
-                deps.generate()
-                tc = CMakeToolchain(self)
-                tc.presets_build_environment = buildenv
-                tc.generate()
-    """)
-
-    cmakelists = textwrap.dedent("""
-        cmake_minimum_required(VERSION 3.15)
-        project(MyProject)
-
-        function(check_and_report_variable var_name)
-            set(var_value $ENV{${var_name}})
-            if (var_value)
-                message("${var_name}:${var_value}")
-            else()
-                message(FATAL_ERROR "${var_name} NOT FOUND")
-            endif()
-        endfunction()
-
-        check_and_report_variable("MY_BUILD_VAR")
-        check_and_report_variable("MY_ADDED_BUILD_VAR")
-    """)
-
-    c.save({"tool.py": tool,
-            "conanfile.py": consumer,
-            "CMakeLists.txt": cmakelists})
-
-    c.run("create tool.py")
-
-    c.run("install .")
-
-    preset = "conan-default" if platform.system() == "Windows" else "conan-release"
-
-    c.run_command(f"cmake --preset {preset}")
-    assert "MY_BUILD_VAR:MY_BUILDVAR_VALUE_OVERRIDEN" in c.out
-    assert "MY_ADDED_BUILD_VAR:MY_ADDED_BUILD_VAR_VALUE" in c.out

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1674,7 +1674,6 @@ def test_add_generate_env_to_presets():
 
         check_and_report_variable("MY_BUILD_VAR")
         check_and_report_variable("MY_ADDED_BUILD_VAR")
-        check_and_report_variable("PATH_VAR")
     """)
 
     c.save({"tool.py": tool,


### PR DESCRIPTION
Changelog: Feature: Add environment to presets inheriting from other presets.
Changelog: Feature: Ability to use modified environment in generate() method in CMakePresets.
Docs: https://github.com/conan-io/docs/pull/XXXX

It would also allow to do the same proposed here: https://github.com/conan-io/conan/pull/15470 
This would be an alternative to the other PR.
