### PR TITLE
remove --lockfile-packages

### DIFF
--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -31,7 +31,7 @@ def add_lockfile_args(parser):
     parser.add_argument("--lockfile-out", action=OnceArgument,
                         help="Filename of the updated lockfile")
     parser.add_argument("--lockfile-packages", action="store_true",
-                        help="Lock package-id and package-revision information")
+                        help=argparse.SUPPRESS)
     parser.add_argument("--lockfile-clean", action="store_true",
                         help="Remove unused entries from the lockfile")
     parser.add_argument("--lockfile-overrides",

--- a/conan/cli/command.py
+++ b/conan/cli/command.py
@@ -107,6 +107,8 @@ class ConanArgumentParser(argparse.ArgumentParser):
     def parse_args(self, args=None, namespace=None):
         args = super().parse_args(args)
         ConanOutput.define_log_level(os.getenv("CONAN_LOG_LEVEL", args.v))
+        if getattr(args, "lockfile_packages", None):
+            ConanOutput().error("The --lockfile-packages arg is private and shouldn't be used")
         if args.core_conf:
             from conans.model.conf import ConfDefinition
             confs = ConfDefinition()

--- a/conans/test/integration/lockfile/test_lock_packages.py
+++ b/conans/test/integration/lockfile/test_lock_packages.py
@@ -22,6 +22,7 @@ def test_lock_packages(requires):
     prev = client.created_package_revision("pkg/0.1")
 
     client.run("lock create consumer/conanfile.txt --lockfile-packages")
+    assert "ERROR: The --lockfile-packages arg is private and shouldn't be used" in client.out
     assert "pkg/0.1#" in client.out
     lock = client.load("consumer/conan.lock")
     assert NO_SETTINGS_PACKAGE_ID in lock


### PR DESCRIPTION
Changelog: Fix: Remove ``--lockfile-packages`` argument, it was not documented as it is was not intended for public usage.
Docs: https://github.com/conan-io/docs/pull/3536

Close https://github.com/conan-io/conan/issues/15496