### PR TITLE
Avoid missing file stacktrace when no metadata exists for a source backup

### DIFF
--- a/conan/api/subapi/upload.py
+++ b/conan/api/subapi/upload.py
@@ -99,7 +99,7 @@ class UploadAPI:
             thread_pool.close()
             thread_pool.join()
         elapsed = time.time() - t
-        ConanOutput().success(f"Upload complete in {int(elapsed)}s\n")
+        ConanOutput().success(f"Upload completed in {int(elapsed)}s\n")
 
     def get_backup_sources(self, package_list=None):
         """Get list of backup source files currently present in the cache,

--- a/conans/client/downloaders/download_cache.py
+++ b/conans/client/downloaders/download_cache.py
@@ -3,6 +3,7 @@ import os
 from contextlib import contextmanager
 from threading import Lock
 
+from conan.api.output import ConanOutput
 from conans.util.dates import timestamp_now
 from conans.util.files import load, save
 from conans.util.locks import SimpleLock
@@ -78,6 +79,9 @@ class DownloadCache:
             if not path.endswith(".json"):
                 blob_path = os.path.join(path_backups, path)
                 metadata_path = os.path.join(blob_path + ".json")
+                if not os.path.exists(metadata_path):
+                    ConanOutput().warning(f"Missing metadata file for backup source {blob_path}")
+                    continue
                 metadata = json.loads(load(metadata_path))
                 refs = metadata["references"]
                 # unknown entries are not uploaded at this moment unless no package_list is passed

--- a/conans/client/downloaders/download_cache.py
+++ b/conans/client/downloaders/download_cache.py
@@ -3,7 +3,7 @@ import os
 from contextlib import contextmanager
 from threading import Lock
 
-from conan.api.output import ConanOutput
+from conans.errors import ConanException
 from conans.util.dates import timestamp_now
 from conans.util.files import load, save
 from conans.util.locks import SimpleLock
@@ -80,8 +80,7 @@ class DownloadCache:
                 blob_path = os.path.join(path_backups, path)
                 metadata_path = os.path.join(blob_path + ".json")
                 if not os.path.exists(metadata_path):
-                    ConanOutput().warning(f"Missing metadata file for backup source {blob_path}")
-                    continue
+                    raise ConanException(f"Missing metadata file for backup source {blob_path}")
                 metadata = json.loads(load(metadata_path))
                 refs = metadata["references"]
                 # unknown entries are not uploaded at this moment unless no package_list is passed

--- a/conans/test/integration/cache/backup_sources_test.py
+++ b/conans/test/integration/cache/backup_sources_test.py
@@ -83,6 +83,8 @@ class TestDownloadCacheBackupSources:
         self.file_server = TestFileServer()
         self.client.servers["file_server"] = self.file_server
         self.download_cache_folder = temp_folder()
+        # To test #15501 that it works even with extra files in the local cache
+        save(os.path.join(self.download_cache_folder, "s", "extrafile"), "Hello, world!")
 
     def test_upload_sources_backup(self):
         http_server_base_folder_backups = os.path.join(self.file_server.store, "backups")
@@ -154,6 +156,7 @@ class TestDownloadCacheBackupSources:
             path=self.client.cache.cache_folder)
         self.client.run("create .")
         self.client.run("upload * -c -r=default")
+        assert "FileNotFoundError: [Errno 2] No such file or directory" not in self.client.out
 
         server_contents = os.listdir(http_server_base_folder_backups)
         assert hello_world_sha256 in server_contents


### PR DESCRIPTION
Changelog: Fix: Avoid missing file stacktrace when no metadata exists for a source backup.
Docs: Omit
