### PR TITLE
fix export-pkg json output

### DIFF
--- a/conan/api/subapi/export.py
+++ b/conan/api/subapi/export.py
@@ -2,7 +2,7 @@ from conan.api.output import ConanOutput
 from conan.internal.conan_app import ConanApp
 from conans.client.cmd.export import cmd_export
 from conans.client.conanfile.package import run_package_method
-from conans.client.graph.graph import BINARY_BUILD
+from conans.client.graph.graph import BINARY_BUILD, RECIPE_INCACHE
 from conans.model.package_ref import PkgReference
 from conans.util.files import mkdir
 
@@ -52,6 +52,7 @@ class ExportAPI:
         cache.assign_prev(pkg_layout)
         pkg_node.prev = prev
         pkg_node.pref_timestamp = pref.timestamp  # assigned by assign_prev
+        pkg_node.recipe = RECIPE_INCACHE
         pkg_node.binary = BINARY_BUILD
         # Make sure folder is updated
         final_folder = pkg_layout.package()

--- a/conan/cli/commands/export_pkg.py
+++ b/conan/cli/commands/export_pkg.py
@@ -93,9 +93,10 @@ def export_pkg(conan_api, parser, *args):
 
     if test_conanfile_path:
         from conan.cli.commands.test import run_test
-        deps_graph = run_test(conan_api, test_conanfile_path, ref, profile_host, profile_build,
-                              remotes=remotes, lockfile=lockfile, update=False, build_modes=None)
-        # TODO: Do something with lockfile, same as create()
+        # same as ``conan create`` the lockfile, and deps graph is the one of the exported-pkg
+        # not the one from test_package
+        run_test(conan_api, test_conanfile_path, ref, profile_host, profile_build,
+                 remotes=remotes, lockfile=lockfile, update=False, build_modes=None)
 
     conan_api.lockfile.save_lockfile(lockfile, args.lockfile_out, cwd)
     return {"graph": deps_graph,

--- a/conans/test/integration/command/export_pkg_test.py
+++ b/conans/test/integration/command/export_pkg_test.py
@@ -283,8 +283,8 @@ class TestConan(ConanFile):
         client.save({"conanfile.py": GenConanfile("pkg", "0.1")})
 
         # Wrong folders
-        client.run("export-pkg . --format=json")
-        graph = json.loads(client.stdout)
+        client.run("export-pkg . --format=json", redirect_stdout="exported.json")
+        graph = json.loads(client.load("exported.json"))
         node = graph["graph"]["nodes"]["0"]
         assert "pkg/0.1" in node["ref"]
         # https://github.com/conan-io/conan/issues/15041
@@ -294,6 +294,12 @@ class TestConan(ConanFile):
         assert "Build" == node["binary"]
         assert node["rrev_timestamp"] is not None
         assert node["prev_timestamp"] is not None
+
+        # Make sure the exported json file can be used for ``conan lsit --graph`` input to upload
+        client.run("list --graph=exported.json -gb=build --format=json")
+        pkglist = json.loads(client.stdout)
+        revs = pkglist["Local Cache"]["pkg/0.1"]["revisions"]["485dad6cb11e2fa99d9afbe44a57a164"]
+        assert "da39a3ee5e6b4b0d3255bfef95601890afd80709" in revs["packages"]
 
     def test_export_pkg_no_ref(self):
         client = TestClient()


### PR DESCRIPTION
Changelog: Bugfix: The ``conan export-pkg --format=json`` output now returns ``recipe = "cache"`` status, as the recipe is in the cache after the command.
Changelog: Bugfix: The ``conan export-pkg`` command stores the lockfile excluding the ``test_package``, following the same behavior as ``conan create``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/15502
