### PR TITLE
Allow offline usage for skipped binaries

### DIFF
--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -65,11 +65,9 @@ class GraphBinariesAnalyzer(object):
             except NotFoundException:
                 pass
             except ConanConnectionError:
-                # Not fail yet, the binary might be "Skip" and if we are offline we don't need a
-                # hard error
-                node.conanfile.output.warning(f"Failed checking binary in remote {r.name}, "
-                                              f"remote not available")
-
+                ConanOutput().error(f"Failed checking for binary '{pref}' in remote '{r.name}': "
+                                    "remote not available")
+                raise
         if not remotes and update:
             node.conanfile.output.warning("Can't update, there are no remotes defined")
 

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -65,6 +65,8 @@ class GraphBinariesAnalyzer(object):
             except NotFoundException:
                 pass
             except ConanConnectionError:
+                # Not fail yet, the binary might be "Skip" and if we are offline we don't need a
+                # hard error
                 node.conanfile.output.warning(f"Failed checking binary in remote {r.name}, "
                                               f"remote not available")
 

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -9,7 +9,7 @@ from conans.client.graph.graph import (BINARY_BUILD, BINARY_CACHE, BINARY_DOWNLO
                                        BINARY_INVALID, BINARY_EDITABLE_BUILD, RECIPE_PLATFORM,
                                        BINARY_PLATFORM)
 from conans.errors import NoRemoteAvailable, NotFoundException, \
-    PackageNotFoundException, conanfile_exception_formatter
+    PackageNotFoundException, conanfile_exception_formatter, ConanConnectionError
 
 
 class GraphBinariesAnalyzer(object):
@@ -64,6 +64,9 @@ class GraphBinariesAnalyzer(object):
                     break
             except NotFoundException:
                 pass
+            except ConanConnectionError:
+                node.conanfile.output.warning(f"Failed checking binary in remote {r.name}, "
+                                              f"remote not available")
 
         if not remotes and update:
             node.conanfile.output.warning("Can't update, there are no remotes defined")

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -237,9 +237,10 @@ class RemoteManager(object):
         try:
             return self._auth_manager.call_rest_api_method(remote, method, *args, **kwargs)
         except ConnectionError as exc:
-            raise ConanConnectionError(("%s\n\nUnable to connect to %s=%s\n" +
-                                        "1. Make sure the remote is reachable or,\n" +
-                                        "2. Disable it by using conan remote disable,\n" +
+            raise ConanConnectionError(("%s\n\nUnable to connect to remote %s=%s\n"
+                                        "1. Make sure the remote is reachable or,\n"
+                                        "2. Disable it with 'conan remote disable <remote>' or,\n"
+                                        "3. Use the '-nr/--no-remote' argument\n"
                                         "Then try again."
                                         ) % (str(exc), remote.name, remote.url))
         except ConanException as exc:

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -239,7 +239,7 @@ class RemoteManager(object):
         except ConnectionError as exc:
             raise ConanConnectionError(("%s\n\nUnable to connect to %s=%s\n" +
                                         "1. Make sure the remote is reachable or,\n" +
-                                        "2. Disable it by using conan remote disable,\n" +
+                                        "2. Disable it by using 'conan remote disable\n" +
                                         "Then try again."
                                         ) % (str(exc), remote.name, remote.url))
         except ConanException as exc:

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -239,7 +239,7 @@ class RemoteManager(object):
         except ConnectionError as exc:
             raise ConanConnectionError(("%s\n\nUnable to connect to %s=%s\n" +
                                         "1. Make sure the remote is reachable or,\n" +
-                                        "2. Disable it by using 'conan remote disable\n" +
+                                        "2. Disable it by using conan remote disable,\n" +
                                         "Then try again."
                                         ) % (str(exc), remote.name, remote.url))
         except ConanException as exc:

--- a/conans/errors.py
+++ b/conans/errors.py
@@ -224,18 +224,10 @@ class PackageNotFoundException(NotFoundException):
                                                          self.remote_message())
 
 
-class UserInterfaceErrorException(RequestErrorException):
-    """
-        420 error
-    """
-    pass
-
-
 EXCEPTION_CODE_MAPPING = {InternalErrorException: 500,
                           RequestErrorException: 400,
                           AuthenticationException: 401,
                           ForbiddenException: 403,
                           NotFoundException: 404,
                           RecipeNotFoundException: 404,
-                          PackageNotFoundException: 404,
-                          UserInterfaceErrorException: 420}
+                          PackageNotFoundException: 404}

--- a/conans/test/integration/remote/multi_remote_test.py
+++ b/conans/test/integration/remote/multi_remote_test.py
@@ -181,11 +181,11 @@ class MultiRemoteTest(unittest.TestCase):
 
         servers["s1"].fake_url = "http://asdlhaljksdhlajkshdljakhsd.com"  # Do not exist
         client2 = TestClient(servers=servers)
-        err = client2.run("install --requires=mylib/0.1@conan/testing --build=missing", assert_error=True)
-        self.assertTrue(err)
+        client2.run("install --requires=mylib/0.1@conan/testing --build=missing", assert_error=True)
         self.assertIn("mylib/0.1@conan/testing: Checking remote: s0", client2.out)
         self.assertIn("mylib/0.1@conan/testing: Checking remote: s1", client2.out)
-        self.assertIn("Unable to connect to s1=http://asdlhaljksdhlajkshdljakhsd.com", client2.out)
+        self.assertIn("Unable to connect to remote s1=http://asdlhaljksdhlajkshdljakhsd.com",
+                      client2.out)
         # s2 is not even tried
         self.assertNotIn("mylib/0.1@conan/testing: Trying with 's2'...", client2.out)
 

--- a/conans/test/integration/remote/test_offline.py
+++ b/conans/test/integration/remote/test_offline.py
@@ -1,3 +1,5 @@
+import re
+
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
 
@@ -29,6 +31,18 @@ def test_offline_uploaded():
 
 
 def test_offline_build_requires():
+    """
+    When there are tool-requires that are not installed locally, Conan will try to check
+    its existence in the remote, because that package might be needed later. Even if some
+    packages can be marked later as "skip" and not fail, that cannot be known a priori, so if the
+    package is not in the cache, it will be checked in servers
+    https://github.com/conan-io/conan/issues/15339
+
+    Approaches:
+    - conan remote disable <remotes>
+    - conan install ... -nr (--no-remotes)
+    - prepopulate the cache with all tool-requires with `-c:a tools.graph:skip_binaries=False`
+    """
     c = TestClient(default_server_user=True)
     c.save({"tool/conanfile.py": GenConanfile("tool", "0.1"),
             "lib/conanfile.py": GenConanfile("pkg", "0.1").with_tool_requires("tool/0.1")})
@@ -44,6 +58,14 @@ def test_offline_build_requires():
     # is not locally installed, and Conan will check for it. Later it might decide that it can
     # be skipped, but initially it will look for it, and as it is not in the cache, it will look
     # in the remotes.
+    assert "ERROR: 'NoneType' object has no attribute 'fake_url'. [Remote: default]" in c.out
     # Explicitly telling that no-remotes, works
     c.run("install --requires=pkg/0.1 -nr")
     assert "Install finished successfully" in c.out
+
+    # graph info also breaks
+    c.run("graph info --requires=pkg/0.1", assert_error=True)
+    assert "ERROR: 'NoneType' object has no attribute 'fake_url'. [Remote: default]" in c.out
+
+    c.run("graph info --requires=pkg/0.1 -nr")
+    assert re.search(r"Skipped binaries(\s*)tool/0.1", c.out)

--- a/conans/test/integration/remote/test_offline.py
+++ b/conans/test/integration/remote/test_offline.py
@@ -1,0 +1,49 @@
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.tools import TestClient
+
+
+def test_offline():
+    c = TestClient(servers={"default": None}, requester_class=None)
+    c.save({"conanfile.py": GenConanfile("pkg", "0.1")})
+    c.run("create .")
+    c.run("install --requires=pkg/0.1")
+    # doesn't fail, install without issues
+    assert "Install finished successfully" in c.out
+
+
+def test_offline_uploaded():
+    c = TestClient(default_server_user=True)
+    c.save({"conanfile.py": GenConanfile("pkg")})
+    c.run("create . --version=0.1")
+    c.run("create . --version=0.2")
+    c.run("upload * -r=default -c")
+    c.run("remove * -c")
+    c.run("install --requires=pkg/0.1")
+    assert "Install finished successfully" in c.out
+    c.servers = {"default": None}
+    c.run("install --requires=pkg/0.1")
+    assert "Install finished successfully" in c.out
+    # Lets make sure the server is broken
+    c.run("install --requires=pkg/0.2", assert_error=True)
+    assert "ERROR: Package 'pkg/0.2' not resolved" in c.out
+
+
+def test_offline_build_requires():
+    c = TestClient(default_server_user=True)
+    c.save({"tool/conanfile.py": GenConanfile("tool", "0.1"),
+            "lib/conanfile.py": GenConanfile("pkg", "0.1").with_tool_requires("tool/0.1")})
+    c.run("create tool")
+    c.run("create lib")
+    c.run("upload * -r=default -c")
+    c.run("remove * -c")
+    c.run("install --requires=pkg/0.1")
+    assert "Install finished successfully" in c.out
+    c.servers = {"default": None}
+    c.run("install --requires=pkg/0.1", assert_error=True)
+    # At the moment this fails, it doesn't work offline, because the package for the build-require
+    # is not locally installed, and Conan will check for it. Later it might decide that it can
+    # be skipped, but initially it will look for it, and as it is not in the cache, it will look
+    # in the remotes.
+    # Explicitly telling that no-remotes, works
+    c.run("install --requires=pkg/0.1 -nr")
+    assert "Install finished successfully" in c.out


### PR DESCRIPTION
Changelog: Fix: Raise a helpful error when the remote is not reachable in case the user wants to work in offline mode.
Docs: Omit

Close https://github.com/conan-io/conan/issues/15339
