### PR TITLE
fix: simplify the targets .cmake generation

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/targets.py
+++ b/conan/tools/cmake/cmakedeps/templates/targets.py
@@ -19,7 +19,7 @@ class TargetsTemplate(CMakeDepsFileTemplate):
 
     @property
     def context(self):
-        data_pattern = "${_DIR}/" if not self.generating_module else "${_DIR}/module-"
+        data_pattern = "${CMAKE_CURRENT_LIST_DIR}/" if not self.generating_module else "${CMAKE_CURRENT_LIST_DIR}/module-"
         data_pattern += "{}-*-data.cmake".format(self.file_name)
 
         target_pattern = "" if not self.generating_module else "module-"
@@ -55,7 +55,6 @@ class TargetsTemplate(CMakeDepsFileTemplate):
     def template(self):
         return textwrap.dedent("""\
         # Load the debug and release variables
-        get_filename_component(_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
         file(GLOB DATA_FILES "{{data_pattern}}")
 
         foreach(f ${DATA_FILES})
@@ -98,8 +97,7 @@ class TargetsTemplate(CMakeDepsFileTemplate):
         {%- endfor %}
 
         # Load the debug and release library finders
-        get_filename_component(_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-        file(GLOB CONFIG_FILES "${_DIR}/{{ target_pattern }}")
+        file(GLOB CONFIG_FILES "${CMAKE_CURRENT_LIST_DIR}/{{ target_pattern }}")
 
         foreach(f ${CONFIG_FILES})
             include(${f})


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

No need to pull the PATH component from CMAKE_CURRENT_LIST_FILE since CMake provides this directly via CMAKE_CURRENT_LIST_DIR.

* Replaced CMAKE_CURRENT_LIST_FILE with CMAKE_CURRENT_LIST_DIR and updated the usage of _DIR.

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
