### PR TITLE
Fix `graph build-order --order=configuration` text format output

### DIFF
--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -41,9 +41,13 @@ def cli_build_order(build_order):
     # TODO: Very simple cli output, probably needs to be improved
     for level in build_order:
         for item in level:
-            for package_level in item['packages']:
-                for package in package_level:
-                    cli_out_write(f"{item['ref']}:{package['package_id']} - {package['binary']}")
+            # If this is a configuration order, it has no packages entry, each item is a package
+            if 'packages' in item:
+                for package_level in item['packages']:
+                    for package in package_level:
+                        cli_out_write(f"{item['ref']}:{package['package_id']} - {package['binary']}")
+            else:
+                cli_out_write(f"{item['ref']}:{item['package_id']} - {item['binary']}")
 
 
 def json_build_order(build_order):

--- a/conans/test/integration/command_v2/test_info_build_order.py
+++ b/conans/test/integration/command_v2/test_info_build_order.py
@@ -111,6 +111,21 @@ def test_info_build_order_configuration():
     assert bo_json == result
 
 
+def test_info_build_order_configuration_text_formatter():
+    c = TestClient()
+    c.save({"dep/conanfile.py": GenConanfile(),
+            "pkg/conanfile.py": GenConanfile().with_requires("dep/0.1"),
+            "consumer/conanfile.txt": "[requires]\npkg/0.1"})
+    c.run("export dep --name=dep --version=0.1")
+    c.run("export pkg --name=pkg --version=0.1")
+    c.run("graph build-order consumer --build=missing --order=configuration --format=text")
+    assert textwrap.dedent("""\
+    ======== Computing the build order ========
+    dep/0.1#4d670581ccb765839f2239cc8dff8fbd:da39a3ee5e6b4b0d3255bfef95601890afd80709 - Build
+    pkg/0.1#1ac8dd17c0f9f420935abd3b6a8fa032:59205ba5b14b8f4ebc216a6c51a89553021e82c1 - Build
+    """) in c.out
+
+
 def test_info_build_order_build_require():
     c = TestClient()
     c.save({"dep/conanfile.py": GenConanfile(),


### PR DESCRIPTION
Changelog: Fix: Fix `graph build-order --order=configuration` text format output.
Docs: Omit

The text formatter was not aware of the new --order=configuration output 