### PR TITLE
fix compile_definitions with no value

### DIFF
--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -112,7 +112,11 @@ class CMakeToolchain(object):
 
         # Preprocessor definitions
         {% for it, value in preprocessor_definitions.items() %}
+        {% if value is none %}
+        add_compile_definitions("{{ it }}")
+        {% else %}
         add_compile_definitions("{{ it }}={{ value }}")
+        {% endif %}
         {% endfor %}
         # Preprocessor definitions per configuration
         {{ iterate_configs(preprocessor_definitions_config, action='add_compile_definitions') }}

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -338,6 +338,7 @@ def test_cmake_toolchain_definitions_complex_strings():
                 tc.preprocessor_definitions["spaces2"] = "me you"
                 tc.preprocessor_definitions["foobar2"] = "bazbuz"
                 tc.preprocessor_definitions["answer2"] = 42
+                tc.preprocessor_definitions["NOVALUE_DEF"] = None
                 tc.preprocessor_definitions.release["escape_release"] = "release partially \"escaped\""
                 tc.preprocessor_definitions.release["spaces_release"] = "release me you"
                 tc.preprocessor_definitions.release["foobar_release"] = "release bazbuz"
@@ -382,6 +383,9 @@ def test_cmake_toolchain_definitions_complex_strings():
             SHOW_DEFINE(foobar_debug);
             SHOW_DEFINE(answer_debug);
             #endif
+            #ifdef NOVALUE_DEF
+            printf("NO VALUE!!!!");
+            #endif
             return 0;
         }
         """)
@@ -411,6 +415,7 @@ def test_cmake_toolchain_definitions_complex_strings():
     assert 'spaces_release=release me you' in client.out
     assert 'foobar_release=release bazbuz' in client.out
     assert 'answer_release=42' in client.out
+    assert "NO VALUE!!!!" in client.out
 
     client.run("install . -pr=./profile -s build_type=Debug")
     client.run("build . -pr=./profile -s build_type=Debug")


### PR DESCRIPTION
Changelog: Fix: Allow ``None`` values for ``CMakeToolchain.preprocessor_definitions`` that will map to definitions without values.
Docs: https://github.com/conan-io/docs/pull/3551

Close https://github.com/conan-io/conan/issues/8284