### PR TITLE
adding self.info to json serialized output

### DIFF
--- a/conan/api/model.py
+++ b/conan/api/model.py
@@ -128,6 +128,7 @@ class MultiPackagesList:
             if any(b == "*" or b == binary for b in binaries):
                 cache_list.add_refs([ref])  # Binary listed forces recipe listed
                 cache_list.add_prefs(ref, [pref])
+                cache_list.add_configurations({pref: node["info"]})
         return pkglist
 
 

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -165,6 +165,8 @@ class ConanFile:
         result["cpp_info"] = self.cpp_info.serialize()
         result["conf_info"] = self.conf_info.serialize()
         result["label"] = self.display_name
+        if self.info is not None:
+            result["info"] = self.info.serialize()
         return result
 
     @property

--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -168,7 +168,7 @@ class RequirementsInfo(UserRequirementsDict):
         return RequirementsInfo(data)
 
     def serialize(self):
-        return [str(r) for r in sorted(self._data.values())]
+        return [r.dumps() for r in self._data.values()]
 
     def __bool__(self):
         return bool(self._data)
@@ -245,6 +245,9 @@ class PythonRequiresInfo:
         # For build_id() implementation
         refs = {r._ref: r.package_id_mode for r in self._refs} if self._refs else None
         return PythonRequiresInfo(refs, self._default_package_id_mode)
+
+    def serialize(self):
+        return [r.dumps() for r in self._refs or []]
 
     def __bool__(self):
         return bool(self._refs)
@@ -328,6 +331,32 @@ class ConanInfo:
         result.python_requires = self.python_requires.copy()
         result.conf = self.conf.copy()
         result.settings_target = self.settings_target.copy() if self.settings_target else None
+        return result
+
+    def serialize(self):
+        result = {}
+        settings_dumps = self.settings.serialize()
+        if settings_dumps:
+            result["settings"] = settings_dumps
+        if self.settings_target is not None:
+            settings_target_dumps = self.settings_target.serialize()
+            if settings_target_dumps:
+                result["settings_target"] = settings_target_dumps
+        options_dumps = self.options.serialize()
+        if options_dumps:
+            result["options"] = options_dumps
+        requires_dumps = self.requires.serialize()
+        if requires_dumps:
+            result["requires"] = requires_dumps
+        python_requires_dumps = self.python_requires.serialize()
+        if python_requires_dumps:
+            result["python_requires"] = python_requires_dumps
+        build_requires_dumps = self.build_requires.serialize()
+        if build_requires_dumps:
+            result["build_requires"] = build_requires_dumps
+        conf_dumps = self.conf.serialize()
+        if conf_dumps:
+            result["conf"] = conf_dumps
         return result
 
     def dumps(self):

--- a/conans/test/integration/command/info/info_test.py
+++ b/conans/test/integration/command/info/info_test.py
@@ -202,6 +202,8 @@ class TestAdvancedCliOutput:
         info = json.loads(client.stdout)
         pyrequires = info["graph"]["nodes"]["0"]["python_requires"]
         tool = pyrequires["tool/0.1#4d670581ccb765839f2239cc8dff8fbd"]
+        info = info["graph"]["nodes"]["0"]["info"]
+        assert info["python_requires"] == ["tool/0.1.Z"]
         # lets make sure the path exists
         assert tool["recipe"] == "Cache"
         assert tool["remote"] is None

--- a/conans/test/integration/command/upload/upload_test.py
+++ b/conans/test/integration/command/upload/upload_test.py
@@ -1,3 +1,4 @@
+import json
 import os
 import platform
 import stat
@@ -534,3 +535,15 @@ def test_upload_list_only_recipe():
     c.run("list --graph=graph.json --format=json", redirect_stdout="installed.json")
     c.run("upload --list=installed.json --only-recipe -r=default -c")
     assert "conan_package.tgz" not in c.out
+
+
+def test_upload_json_output():
+    c = TestClient(default_server_user=True)
+    c.save({"conanfile.py": GenConanfile("liba", "0.1").with_settings("os")
+                                                       .with_shared_option(False)})
+    c.run("create . -s os=Linux")
+    c.run("upload * -r=default -c --format=json")
+    list_pkgs = json.loads(c.stdout)
+    revs = list_pkgs["default"]["liba/0.1"]["revisions"]["a565bd5defd3a99e157698fcc6e23b25"]
+    pkg = revs["packages"]["9e0f8140f0fe6b967392f8d5da9881e232e05ff8"]
+    assert pkg["info"] == {"settings": {"os": "Linux"}, "options": {"shared": "False"}}

--- a/conans/test/integration/command_v2/test_combined_pkglist_flows.py
+++ b/conans/test/integration/command_v2/test_combined_pkglist_flows.py
@@ -79,14 +79,20 @@ class TestCreateGraphToPkgList:
     def test_graph_pkg_list_only_built(self):
         c = TestClient()
         c.save({"zlib/conanfile.py": GenConanfile("zlib", "1.0"),
-                "app/conanfile.py": GenConanfile("app", "1.0").with_requires("zlib/1.0")})
+                "app/conanfile.py": GenConanfile("app", "1.0").with_requires("zlib/1.0")
+                                                              .with_settings("os")
+                                                              .with_shared_option(False)})
         c.run("create zlib")
-        c.run("create app --format=json", redirect_stdout="graph.json")
+        c.run("create app --format=json -s os=Windows", redirect_stdout="graph.json")
         c.run("list --graph=graph.json --graph-binaries=build --format=json")
         pkglist = json.loads(c.stdout)["Local Cache"]
         assert len(pkglist) == 1
-        assert len(pkglist["app/1.0"]["revisions"]
-                   ["0fa1ff1b90576bb782600e56df642e19"]["packages"]) == 1
+        pkgs = pkglist["app/1.0"]["revisions"]["8263c3c32802e14a2f03a0b1fcce0d95"]["packages"]
+        assert len(pkgs) == 1
+        pkg_app = pkgs["e0bcc80c3f095670b71e535c193114d0155426cb"]
+        assert pkg_app["info"]["requires"] == ["zlib/1.0.Z"]
+        assert pkg_app["info"]["settings"] == {'os': 'Windows'}
+        assert pkg_app["info"]["options"] == {'shared': 'False'}
 
     def test_graph_pkg_list_all_recipes_only(self):
         """

--- a/conans/test/integration/configuration/conf/test_conf_package_id.py
+++ b/conans/test/integration/configuration/conf/test_conf_package_id.py
@@ -1,3 +1,4 @@
+import json
 import textwrap
 
 import pytest
@@ -32,3 +33,9 @@ def test_package_id(client):
     client.assert_listed_binary({"pkg/0.1": ("7501c16e6c5c93e534dd760829859340e2dc73bc", "Build")})
     client.run("create . --name=pkg --version=0.1 -pr=profile2")
     client.assert_listed_binary({"pkg/0.1": ("4eb2bd276f75d2df8fa0f4b58bd86014b7f51693", "Build")})
+
+
+def test_json_output(client):
+    client.run("create . --name=pkg --version=0.1 -c user.myconf:myitem=1 --format=json")
+    graph = json.loads(client.stdout)
+    assert graph["graph"]["nodes"]["1"]["info"]["conf"] == {'user.myconf:myitem': 1}

--- a/conans/test/integration/settings/per_package_settings_test.py
+++ b/conans/test/integration/settings/per_package_settings_test.py
@@ -1,3 +1,4 @@
+import json
 import textwrap
 import unittest
 
@@ -119,9 +120,13 @@ def test_per_package_settings_target():
     c.run("create . -s:b arch=x86_64 -s:h arch=armv7 --build-require")
     pkg_id = c.created_package_id("gcc/0.1")
 
-    c.run("install --tool-requires=gcc/0.1 -s:b arch=x86_64 -s arch=armv8 -s:h gcc*:arch=armv7")
+    c.run("install --tool-requires=gcc/0.1 -s:b arch=x86_64 -s arch=armv8 -s:h gcc*:arch=armv7"
+          " --format=json")
     # it will not fail due to armv8, but use the binary for armv7
     c.assert_listed_binary({"gcc/0.1": (pkg_id, "Cache")}, build=True)
+
+    graph = json.loads(c.stdout)
+    assert graph["graph"]["nodes"]["1"]["info"]["settings_target"] == {"arch": "armv7"}
 
 
 def test_per_package_settings_build():


### PR DESCRIPTION
Changelog: Feature: Add ``self.info`` information of ``package_id`` to serialized output in the graph, and forward it to package-lists.
Docs: https://github.com/conan-io/docs/pull/3553

Close https://github.com/conan-io/conan/issues/15551
