### PR TITLE
Add deactivate_conanvcvars file with message

### DIFF
--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -153,7 +153,7 @@ class VCVars:
         from conan.tools.env.environment import create_env_script
         conan_vcvars_bat = f"{CONAN_VCVARS}.bat"
         create_env_script(conanfile, content, conan_vcvars_bat, scope)
-        _create_deactivate_file(conanfile, conan_vcvars_bat)
+        _create_deactivate_vcvars_file(conanfile, conan_vcvars_bat)
 
         is_ps1 = conanfile.conf.get("tools.env.virtualenv:powershell", check_type=bool, default=False)
         if is_ps1:
@@ -171,11 +171,11 @@ class VCVars:
             """)
             conan_vcvars_ps1 = f"{CONAN_VCVARS}.ps1"
             create_env_script(conanfile, content_ps1, conan_vcvars_ps1, scope)
-            _create_deactivate_file(conanfile, conan_vcvars_ps1)
+            _create_deactivate_vcvars_file(conanfile, conan_vcvars_ps1)
 
 
 
-def _create_deactivate_file(conanfile, filename):
+def _create_deactivate_vcvars_file(conanfile, filename):
     deactivate_filename = f"deactivate_{filename}"
     message = f"[{deactivate_filename}]: vcvars env cannot be deactivated"
     is_ps1 = filename.endswith(".ps1")

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -153,7 +153,7 @@ class VCVars:
         from conan.tools.env.environment import create_env_script
         conan_vcvars_bat = f"{CONAN_VCVARS}.bat"
         create_env_script(conanfile, content, conan_vcvars_bat, scope)
-        create_deactivate_file(conanfile, conan_vcvars_bat)
+        _create_deactivate_file(conanfile, conan_vcvars_bat)
 
         is_ps1 = conanfile.conf.get("tools.env.virtualenv:powershell", check_type=bool, default=False)
         if is_ps1:
@@ -171,12 +171,11 @@ class VCVars:
             """)
             conan_vcvars_ps1 = f"{CONAN_VCVARS}.ps1"
             create_env_script(conanfile, content_ps1, conan_vcvars_ps1, scope)
-            create_deactivate_file(conanfile, conan_vcvars_ps1)
+            _create_deactivate_file(conanfile, conan_vcvars_ps1)
 
 
 
-
-def create_deactivate_file(conanfile, filename):
+def _create_deactivate_file(conanfile, filename):
     deactivate_filename = f"deactivate_{filename}"
     message = f"[{deactivate_filename}]: vcvars env cannot be deactivated"
     is_ps1 = conanfile.conf.get("tools.env.virtualenv:powershell", check_type=bool)

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -178,7 +178,7 @@ class VCVars:
 def _create_deactivate_file(conanfile, filename):
     deactivate_filename = f"deactivate_{filename}"
     message = f"[{deactivate_filename}]: vcvars env cannot be deactivated"
-    is_ps1 = conanfile.conf.get("tools.env.virtualenv:powershell", check_type=bool)
+    is_ps1 = filename.endswith(".ps1")
     if is_ps1:
         content = f"Write-Host {message}"
     else:

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -6,9 +6,9 @@ from conans.client.conf.detect_vs import vs_installation_path
 from conan.errors import ConanException, ConanInvalidConfiguration
 from conan.tools.scm import Version
 from conan.tools.intel.intel_cc import IntelCC
+from conans.util.files import save
 
-CONAN_VCVARS_BAT = "conanvcvars.bat"
-CONAN_VCVARS_PS1 = "conanvcvars.ps1"
+CONAN_VCVARS = "conanvcvars"
 
 
 def check_min_vs(conanfile, version, raise_invalid=True):
@@ -151,7 +151,9 @@ class VCVars:
             {vcvars}
             """)
         from conan.tools.env.environment import create_env_script
-        create_env_script(conanfile, content, CONAN_VCVARS_BAT, scope)
+        conan_vcvars_bat = f"{CONAN_VCVARS}.bat"
+        create_env_script(conanfile, content, conan_vcvars_bat, scope)
+        create_deactivate_file(conanfile, conan_vcvars_bat)
 
         is_ps1 = conanfile.conf.get("tools.env.virtualenv:powershell", check_type=bool, default=False)
         if is_ps1:
@@ -167,9 +169,23 @@ class VCVars:
                 Pop-Location
                 write-host conanvcvars.ps1: Activated environment}}
             """)
-            create_env_script(conanfile, content_ps1, CONAN_VCVARS_PS1, scope)
+            conan_vcvars_ps1 = f"{CONAN_VCVARS}.ps1"
+            create_env_script(conanfile, content_ps1, conan_vcvars_ps1, scope)
+            create_deactivate_file(conanfile, conan_vcvars_ps1)
 
 
+
+
+def create_deactivate_file(conanfile, filename):
+    deactivate_filename = f"deactivate_{filename}"
+    message = f"[{deactivate_filename}]: vcvars env cannot be deactivated"
+    is_ps1 = conanfile.conf.get("tools.env.virtualenv:powershell", check_type=bool)
+    if is_ps1:
+        content = f"Write-Host {message}"
+    else:
+        content = f"echo {message}"
+    path = os.path.join(conanfile.generators_folder, deactivate_filename)
+    save(path, content)
 
 def vs_ide_version(conanfile):
     """

--- a/conans/test/integration/toolchains/microsoft/vcvars_test.py
+++ b/conans/test/integration/toolchains/microsoft/vcvars_test.py
@@ -126,3 +126,19 @@ def test_vcvars_winsdk_version():
 
     vcvars = client.load("conanvcvars.bat")
     assert 'vcvarsall.bat"  amd64 8.1 -vcvars_ver=14.3' in vcvars
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows")
+def test_deactivate_vcvars_message():
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            class TestConan(ConanFile):
+                generators = "VCVars"
+                settings = "os", "compiler", "arch", "build_type"
+        """)
+    client.save({"conanfile.py": conanfile})
+    client.run('install .')
+    client.run_command(r'conanbuild.bat')
+    assert "[vcvarsall.bat] Environment initialized" in client.out
+    client.run_command(r'deactivate_conanvcvars.bat')
+    assert "vcvars env cannot be deactivated" in client.out

--- a/conans/test/integration/toolchains/microsoft/vcvars_test.py
+++ b/conans/test/integration/toolchains/microsoft/vcvars_test.py
@@ -137,8 +137,24 @@ def test_deactivate_vcvars_message():
                 settings = "os", "compiler", "arch", "build_type"
         """)
     client.save({"conanfile.py": conanfile})
-    client.run('install .')
+    client.run('install . -s compiler.version=193')
     client.run_command(r'conanbuild.bat')
     assert "[vcvarsall.bat] Environment initialized" in client.out
     client.run_command(r'deactivate_conanvcvars.bat')
+    assert "vcvars env cannot be deactivated" in client.out
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows Powershell")
+def test_deactivate_vcvars_with_powershell():
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+                from conan import ConanFile
+                class TestConan(ConanFile):
+                    generators = "VCVars"
+                    settings = "os", "compiler", "arch", "build_type"
+            """)
+    client.save({"conanfile.py": conanfile})
+    client.run('install . -c tools.env.virtualenv:powershell=True')
+    client.run_command(r'powershell.exe ".\conanbuild.ps1"')
+    assert "conanvcvars.ps1: Activated environment" in client.out
+    client.run_command(r'powershell.exe ".\deactivate_conanvcvars.ps1"')
     assert "vcvars env cannot be deactivated" in client.out


### PR DESCRIPTION
Changelog: Feature: Display message when calling `deactivate_conanvcvars`.
Docs: Omit

Issue: Running the deactivate_conanbuild script after activating a environment with vcvars gave an error because the deactivate_conanvcvars file didn't exist.
To fix this the file is now created and it displays a message saying `conanvcvars` env can't be deactivated when called.