### PR TITLE
Fix build scope OS detection in tools.microsoft.visual.VCVars

### DIFF
--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -3,7 +3,6 @@ import textwrap
 
 from conan.internal import check_duplicated_generator
 from conans.client.conf.detect_vs import vs_installation_path
-from conans.client.subsystems import deduce_subsystem, WINDOWS
 from conan.errors import ConanException, ConanInvalidConfiguration
 from conan.tools.scm import Version
 from conan.tools.intel.intel_cc import IntelCC
@@ -102,9 +101,10 @@ class VCVars:
         check_duplicated_generator(self, self._conanfile)
         conanfile = self._conanfile
 
-        # Derive subsystem name from the current scope.
-        subsystem = deduce_subsystem(conanfile, scope)
-        if subsystem != WINDOWS:
+        os_ = conanfile.settings.get_safe("os")
+        build_os_ = conanfile.settings_build.get_safe("os")
+
+        if os_ != "Windows" or build_os_ != "Windows":
             return
 
         compiler = conanfile.settings.get_safe("compiler")

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -3,6 +3,7 @@ import textwrap
 
 from conan.internal import check_duplicated_generator
 from conans.client.conf.detect_vs import vs_installation_path
+from conans.client.subsystems import deduce_subsystem, WINDOWS
 from conan.errors import ConanException, ConanInvalidConfiguration
 from conan.tools.scm import Version
 from conan.tools.intel.intel_cc import IntelCC
@@ -100,8 +101,10 @@ class VCVars:
         """
         check_duplicated_generator(self, self._conanfile)
         conanfile = self._conanfile
-        os_ = conanfile.settings.get_safe("os")
-        if os_ != "Windows":
+
+        # Derive subsystem name from the current scope.
+        subsystem = deduce_subsystem(conanfile, scope)
+        if subsystem != WINDOWS:
             return
 
         compiler = conanfile.settings.get_safe("compiler")

--- a/conans/test/integration/toolchains/microsoft/vcvars_test.py
+++ b/conans/test/integration/toolchains/microsoft/vcvars_test.py
@@ -51,6 +51,19 @@ def test_vcvars_generator_skip():
     client.run('install . -pr=profile')
     assert not os.path.exists(os.path.join(client.current_folder, "conanvcvars.bat"))
 
+@pytest.mark.skipif(platform.system() not in ["Linux"], reason="Requires Linux")
+def test_vcvars_generator_skip_on_linux():
+    """
+    Skip creation of conanvcvars.bat on Linux build systems
+    """
+    client = TestClient()
+    client.save({"conanfile.py": GenConanfile().with_generator("VCVars")
+                                               .with_settings("os", "compiler",
+                                                              "arch", "build_type")})
+
+    client.run('install . -s os=Windows -s compiler=msvc -s compiler.version=193 '
+               '-s compiler.runtime=dynamic')
+    assert not os.path.exists(os.path.join(client.current_folder, "conanvcvars.bat"))
 
 @pytest.mark.skipif(platform.system() not in ["Windows"], reason="Requires Windows")
 def test_vcvars_generator_string():


### PR DESCRIPTION
Get the build scope OS type using the common subsystems API. Do not assume that the host profile OS is the same as the build profile OS and do not generate "conanvcvars.bat" on Unix build systems.

The same method of build OS detection is already used in tools.env.EnvVars to generate the appropriate virtual environment script type and in tools.cmake.toolchain to write correct file paths.

This change makes cross-compilation from Linux to Windows work when using MSVC compilers running natively on Linux.

The original cross-compilation failure looks like:

    ConanException: Cannot wrap command with different envs,['/build/Debug/generators/conanbuild.bat'] - ['/build/Debug/generators/conanbuild.sh']

and is caused by conanvcvars.bat script being generated unconditionally and included into conanbuild.bat even when running on Linux.

Changelog: Bugfix: Fix build scope OS detection in `tools.microsoft.visual.VCVars`.
Docs: Omit