### PR TITLE
Add toolset_cuda conf for cmaketoolchain

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -711,6 +711,10 @@ class GenericSystemBlock(Block):
         if toolset_arch is not None:
             toolset_arch = "host={}".format(toolset_arch)
             toolset = toolset_arch if toolset is None else "{},{}".format(toolset, toolset_arch)
+        toolset_cuda = conanfile.conf.get("tools.cmake.cmaketoolchain:toolset_cuda")
+        if toolset_cuda is not None:
+            toolset_cuda = f"cuda={toolset_cuda}"
+            toolset = toolset_cuda if toolset is None else f"{toolset},{toolset_cuda}"
         return toolset
 
     @staticmethod

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -69,6 +69,7 @@ BUILT_IN_CONFS = {
     "tools.cmake.cmaketoolchain:system_version": "Define CMAKE_SYSTEM_VERSION in CMakeToolchain",
     "tools.cmake.cmaketoolchain:system_processor": "Define CMAKE_SYSTEM_PROCESSOR in CMakeToolchain",
     "tools.cmake.cmaketoolchain:toolset_arch": "Toolset architecture to be used as part of CMAKE_GENERATOR_TOOLSET in CMakeToolchain",
+    "tools.cmake.cmaketoolchain:toolset_cuda": "Path to a CUDA toolset to use, or version if installed at the system level",
     "tools.cmake.cmaketoolchain:presets_environment": "String to define wether to add or not the environment section to the CMake presets. Empty by default, will generate the environment section in CMakePresets. Can take values: 'disabled'.",
     "tools.cmake.cmake_layout:build_folder_vars": "Settings and Options that will produce a different build folder and different CMake presets names",
     "tools.cmake:cmake_program": "Path to CMake executable",

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -69,7 +69,7 @@ BUILT_IN_CONFS = {
     "tools.cmake.cmaketoolchain:system_version": "Define CMAKE_SYSTEM_VERSION in CMakeToolchain",
     "tools.cmake.cmaketoolchain:system_processor": "Define CMAKE_SYSTEM_PROCESSOR in CMakeToolchain",
     "tools.cmake.cmaketoolchain:toolset_arch": "Toolset architecture to be used as part of CMAKE_GENERATOR_TOOLSET in CMakeToolchain",
-    "tools.cmake.cmaketoolchain:toolset_cuda": "Path to a CUDA toolset to use, or version if installed at the system level",
+    "tools.cmake.cmaketoolchain:toolset_cuda": "(Experimental) Path to a CUDA toolset to use, or version if installed at the system level",
     "tools.cmake.cmaketoolchain:presets_environment": "String to define wether to add or not the environment section to the CMake presets. Empty by default, will generate the environment section in CMakePresets. Can take values: 'disabled'.",
     "tools.cmake.cmake_layout:build_folder_vars": "Settings and Options that will produce a different build folder and different CMake presets names",
     "tools.cmake:cmake_program": "Path to CMake executable",

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -232,6 +232,12 @@ def test_toolset_x64(conanfile_msvc):
     assert 'CMAKE_CXX_STANDARD 20' in toolchain.content
 
 
+def test_toolset_cuda(conanfile_msvc):
+    conanfile_msvc.conf.define("tools.cmake.cmaketoolchain:toolset_cuda", "C:/Path/To/CUDA")
+    toolchain = CMakeToolchain(conanfile_msvc)
+    assert 'set(CMAKE_GENERATOR_TOOLSET "v143,cuda=C:/Path/To/CUDA" CACHE STRING "" FORCE)' in toolchain.content
+
+
 def test_older_msvc_toolset():
     c = ConanFile(None)
     c.settings = Settings({"os": ["Windows"],


### PR DESCRIPTION
Changelog: Feature: Add configuration to specify desired CUDA Toolkit in CMakeToolchain for Visual Studio CMake generators.
Docs: https://github.com/conan-io/docs/pull/3568


This allows to append the `cuda=xxx` key to `CMAKE_GENERATOR_TOOLSET` ([docs](https://cmake.org/cmake/help/latest/variable/CMAKE_GENERATOR_TOOLSET.html)) This is useful for a couple of cases:
- CUDA Toolkit is installed on a system location ("Program Files") and the user wants to select a specific version
- CUDA Toolkit is in a Conan recipe, and we want to define this in the `package_info` such that CMake will correctly use that toolkit for a CMake project on Windows with MSVC


Tests incoming!