### PR TITLE
InstallGraph.reduce

### DIFF
--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -63,7 +63,8 @@ def graph_build_order(conan_api, parser, subparser, *args):
     subparser.add_argument("--order", choices=['recipe', 'configuration'], default="recipe",
                            help='Select how to order the output, "recipe" by default if not set.')
     subparser.add_argument("--reduce", action='store_true', default=False,
-                           help='Reduce the build order, output only those to build')
+                           help='Reduce the build order, output only those to build. Use this '
+                                'only if the result will not be merged later with other build-order')
     args = parser.parse_args(*args)
 
     # parameter validation
@@ -119,6 +120,9 @@ def graph_build_order_merge(conan_api, parser, subparser, *args):
     Merge more than 1 build-order file.
     """
     subparser.add_argument("--file", nargs="?", action="append", help="Files to be merged")
+    subparser.add_argument("--reduce", action='store_true', default=False,
+                           help='Reduce the build order, output only those to build. Use this '
+                                'only if the result will not be merged later with other build-order')
     args = parser.parse_args(*args)
     if not args.file or len(args.file) < 2:
         raise ConanException("At least 2 files are needed to be merged")
@@ -128,6 +132,8 @@ def graph_build_order_merge(conan_api, parser, subparser, *args):
         install_graph = InstallGraph.load(make_abs_path(f))
         result.merge(install_graph)
 
+    if args.reduce:
+        result.reduce()
     install_order_serialized = result.install_build_order()
     return install_order_serialized
 

--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -62,6 +62,8 @@ def graph_build_order(conan_api, parser, subparser, *args):
     common_graph_args(subparser)
     subparser.add_argument("--order", choices=['recipe', 'configuration'], default="recipe",
                            help='Select how to order the output, "recipe" by default if not set.')
+    subparser.add_argument("--reduce", action='store_true', default=False,
+                           help='Reduce the build order, output only those to build')
     args = parser.parse_args(*args)
 
     # parameter validation
@@ -100,6 +102,8 @@ def graph_build_order(conan_api, parser, subparser, *args):
     out = ConanOutput()
     out.title("Computing the build order")
     install_graph = InstallGraph(deps_graph, order=args.order)
+    if args.reduce:
+        install_graph.reduce()
     install_order_serialized = install_graph.install_build_order()
 
     lockfile = conan_api.lockfile.update_lockfile(lockfile, deps_graph, args.lockfile_packages,

--- a/conans/client/graph/install_graph.py
+++ b/conans/client/graph/install_graph.py
@@ -384,7 +384,9 @@ class InstallGraph:
                 # Find all consumers
                 for n in self._nodes.values():
                     if k in n.depends:
-                        n.depends = [d for d in n.depends if d != k] + dependencies
+                        n.depends = [d for d in n.depends if d != k]  # Discard the removed node
+                        # Add new edges, without repetition
+                        n.depends.extend(d for d in dependencies if d not in n.depends)
         self._nodes = result
 
     def install_order(self, flat=False):

--- a/conans/client/graph/install_graph.py
+++ b/conans/client/graph/install_graph.py
@@ -303,6 +303,8 @@ class _InstallConfiguration:
         return result
 
     def merge(self, other):
+        assert self.binary == other.binary, f"Binary for {self.ref}: {self.binary}!={other.binary}"
+
         assert self.ref == other.ref
         for d in other.depends:
             if d not in self.depends:


### PR DESCRIPTION
Changelog: Feature: Provide a new ``graph build-order --reduce`` argument to reduce the order exclusively to packages that need to be built from source.
Docs: https://github.com/conan-io/docs/pull/3584

Close https://github.com/conan-io/conan/issues/15566
