### PR TITLE
Check sha256 of local back source cache files and improve `.dirty` handling on backup upload 

### DIFF
--- a/conans/client/downloaders/caching_file_downloader.py
+++ b/conans/client/downloaders/caching_file_downloader.py
@@ -61,6 +61,7 @@ class SourcesCachingDownloader:
             remove_if_dirty(cached_path)
 
             if os.path.exists(cached_path):
+                self._file_downloader.check_checksum(cached_path, md5, sha1, sha256)
                 self._output.info(f"Source {urls} retrieved from local download cache")
             else:
                 with set_dirty_context_manager(cached_path):

--- a/conans/client/downloaders/caching_file_downloader.py
+++ b/conans/client/downloaders/caching_file_downloader.py
@@ -61,7 +61,6 @@ class SourcesCachingDownloader:
             remove_if_dirty(cached_path)
 
             if os.path.exists(cached_path):
-                self._file_downloader.check_checksum(cached_path, md5, sha1, sha256)
                 self._output.info(f"Source {urls} retrieved from local download cache")
             else:
                 with set_dirty_context_manager(cached_path):

--- a/conans/client/downloaders/download_cache.py
+++ b/conans/client/downloaders/download_cache.py
@@ -5,7 +5,7 @@ from threading import Lock
 
 from conans.errors import ConanException
 from conans.util.dates import timestamp_now
-from conans.util.files import load, save
+from conans.util.files import load, save, remove_if_dirty
 from conans.util.locks import SimpleLock
 from conans.util.sha import sha256 as compute_sha256
 
@@ -73,25 +73,33 @@ class DownloadCache:
                 if ref.get("upload") or any(should_upload_sources(p) for p in packages):
                     all_refs.add(str(k))
 
-        files_to_upload = []
+        path_backups_contents = []
 
+        dirty_ext = ".dirty"
         for path in os.listdir(path_backups):
-            if path.endswith(".dirty"):
-                # There can be dirty downloads, just ignore them
+            if remove_if_dirty(os.path.join(path_backups, path)):
+                continue
+            if path.endswith(dirty_ext):
+                # TODO: Clear the dirty file marker if it does not have a matching downloaded file
                 continue
             if not path.endswith(".json"):
-                blob_path = os.path.join(path_backups, path)
-                metadata_path = os.path.join(blob_path + ".json")
-                if not os.path.exists(metadata_path):
-                    raise ConanException(f"Missing metadata file for backup source {blob_path}")
-                metadata = json.loads(load(metadata_path))
-                refs = metadata["references"]
-                # unknown entries are not uploaded at this moment unless no package_list is passed
-                for ref, urls in refs.items():
-                    if not has_excluded_urls(urls) and (package_list is None or ref in all_refs):
-                        files_to_upload.append(metadata_path)
-                        files_to_upload.append(blob_path)
-                        break
+                path_backups_contents.append(path)
+
+        files_to_upload = []
+
+        for path in path_backups_contents:
+            blob_path = os.path.join(path_backups, path)
+            metadata_path = os.path.join(blob_path + ".json")
+            if not os.path.exists(metadata_path):
+                raise ConanException(f"Missing metadata file for backup source {blob_path}")
+            metadata = json.loads(load(metadata_path))
+            refs = metadata["references"]
+            # unknown entries are not uploaded at this moment unless no package_list is passed
+            for ref, urls in refs.items():
+                if not has_excluded_urls(urls) and (package_list is None or ref in all_refs):
+                    files_to_upload.append(metadata_path)
+                    files_to_upload.append(blob_path)
+                    break
         return files_to_upload
 
     @staticmethod

--- a/conans/client/downloaders/download_cache.py
+++ b/conans/client/downloaders/download_cache.py
@@ -76,6 +76,9 @@ class DownloadCache:
         files_to_upload = []
 
         for path in os.listdir(path_backups):
+            if path.endswith(".dirty"):
+                # There can be dirty downloads, just ignore them
+                continue
             if not path.endswith(".json"):
                 blob_path = os.path.join(path_backups, path)
                 metadata_path = os.path.join(blob_path + ".json")

--- a/conans/test/integration/cache/backup_sources_test.py
+++ b/conans/test/integration/cache/backup_sources_test.py
@@ -737,6 +737,9 @@ class TestDownloadCacheBackupSources:
             self.client.run("source .", assert_error=True)
             # The mock does not actually download a file, let's add it for the test
             save(os.path.join(self.download_cache_folder, "s", sha256), "__corrupted download__")
+            # Check that the dirty file was not removed.
+            # This check should go away once we refactor dirty handling
+            assert os.path.exists(os.path.join(self.download_cache_folder, "s", f"{sha256}.dirty"))
 
         # A .dirty file was created, now try to source again, it should detect the dirty download and re-download it
         self.client.run("source .")

--- a/conans/test/integration/cache/backup_sources_test.py
+++ b/conans/test/integration/cache/backup_sources_test.py
@@ -704,9 +704,8 @@ class TestDownloadCacheBackupSources:
         # Now simulate a dirty download, the file is there but the sha256 is wrong
         save(os.path.join(self.download_cache_folder, "s", sha256), "Bye bye, world!")
 
-        # Now try to source again, it should detect the dirty download and re-download it
-        self.client.run("source .", assert_error=True)
-        assert f"ConanException: sha256 signature failed for '{sha256}' file." in self.client.out
+        # Now try to source again, it should eat it up
+        self.client.run("source .")
 
     def test_backup_source_dirty_download_handle(self):
         def custom_download(this, *args, **kwargs):

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -44,6 +44,8 @@ def remove_if_dirty(item):
             else:
                 rmdir(item)
         clean_dirty(item)
+        return True
+    return False
 
 
 @contextmanager


### PR DESCRIPTION
Changelog: Fix: Improve handling of `.dirty` download files when uploading backup sources.
Docs: Omit

