### PR TITLE
Add format json option to conan cache path

### DIFF
--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -1,3 +1,5 @@
+import json
+
 from conan.api.conan_api import ConanAPI
 from conan.api.model import ListPattern, MultiPackagesList
 from conan.api.output import cli_out_write, ConanOutput
@@ -9,6 +11,10 @@ from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
 
 
+def json_export(data):
+    cli_out_write(json.dumps({"cache_path": data}))
+
+
 @conan_command(group="Consumer")
 def cache(conan_api: ConanAPI, parser, *args):
     """
@@ -17,7 +23,7 @@ def cache(conan_api: ConanAPI, parser, *args):
     pass
 
 
-@conan_subcommand(formatters={"text": cli_out_write})
+@conan_subcommand(formatters={"text": cli_out_write, "json": json_export})
 def cache_path(conan_api: ConanAPI, parser, subparser, *args):
     """
     Show the path to the Conan cache for a given reference.

--- a/conans/test/integration/command_v2/test_cache_path.py
+++ b/conans/test/integration/command_v2/test_cache_path.py
@@ -1,3 +1,6 @@
+import json
+import os
+
 import pytest
 
 from conans.test.assets.genconanfile import GenConanfile
@@ -111,3 +114,14 @@ def test_cache_path_does_not_exist_folder():
     client.run(f"install --requires mypkg/0.1")
     client.run(f"cache path {pref} --folder build", assert_error=True)
     assert f"ERROR: 'build' folder does not exist for the reference {pref}" in client.out
+
+def test_cache_path_output_json():
+    client = TestClient()
+    conanfile = GenConanfile("mypkg", "0.1")
+    client.save({"conanfile.py": conanfile})
+    client.run("export .")
+    layout = client.exported_layout()
+    client.run("cache path mypkg/0.1 --format=json", redirect_stdout="out.json")
+    output = json.loads(client.load("out.json"))
+    cache_path = os.path.join(layout.base_folder, "e")
+    assert output == {"cache_path": f"{cache_path}"}

--- a/conans/test/integration/command_v2/test_cache_path.py
+++ b/conans/test/integration/command_v2/test_cache_path.py
@@ -123,5 +123,4 @@ def test_cache_path_output_json():
     layout = client.exported_layout()
     client.run("cache path mypkg/0.1 --format=json", redirect_stdout="out.json")
     output = json.loads(client.load("out.json"))
-    cache_path = os.path.join(layout.base_folder, "e")
-    assert output == {"cache_path": f"{cache_path}"}
+    assert output == {"cache_path": os.path.join(layout.base_folder, "e")}

--- a/conans/test/integration/command_v2/test_cache_path.py
+++ b/conans/test/integration/command_v2/test_cache_path.py
@@ -121,6 +121,6 @@ def test_cache_path_output_json():
     client.save({"conanfile.py": conanfile})
     client.run("export .")
     layout = client.exported_layout()
-    client.run("cache path mypkg/0.1 --format=json", redirect_stdout="out.json")
-    output = json.loads(client.load("out.json"))
+    client.run("cache path mypkg/0.1 --format=json")
+    output = json.loads(client.stdout)
     assert output == {"cache_path": os.path.join(layout.base_folder, "e")}


### PR DESCRIPTION
Changelog: Feature: Add `--format=json` option to `conan cache path`.
Docs: Omit

Added `--format=json` option to the `conan cache path` command that returns a json as: 
`{"cache_path": "C:\\Users\\user\\.conan2\\p\\zlib2cad50ee1214e\\e"}`

Closes: https://github.com/conan-io/conan/issues/15599