### PR TITLE
[feature] Added cross-building conf variable

### DIFF
--- a/conan/tools/build/cross_building.py
+++ b/conan/tools/build/cross_building.py
@@ -9,6 +9,9 @@ def cross_building(conanfile=None, skip_x64_x86=False):
            x86_64 to x86, sparcv9 to sparc or ppc64 to ppc32
     :return: ``True`` if we are cross building, ``False`` otherwise.
     """
+    force = conanfile.conf.get("tools.build.cross_building:force", check_type=bool)
+    if force is not None:
+        return force
 
     build_os = conanfile.settings_build.get_safe('os')
     build_arch = conanfile.settings_build.get_safe('arch')

--- a/conan/tools/build/cross_building.py
+++ b/conan/tools/build/cross_building.py
@@ -9,9 +9,9 @@ def cross_building(conanfile=None, skip_x64_x86=False):
            x86_64 to x86, sparcv9 to sparc or ppc64 to ppc32
     :return: ``True`` if we are cross building, ``False`` otherwise.
     """
-    force = conanfile.conf.get("tools.build.cross_building:force", check_type=bool)
-    if force is not None:
-        return force
+    cross_build = conanfile.conf.get("tools.build.cross_building:cross_build", check_type=bool)
+    if cross_build is not None:
+        return cross_build
 
     build_os = conanfile.settings_build.get_safe('os')
     build_arch = conanfile.settings_build.get_safe('arch')
@@ -35,7 +35,7 @@ def cross_building(conanfile=None, skip_x64_x86=False):
 def can_run(conanfile):
     """
     Validates whether is possible to run a non-native app on the same architecture.
-    It’s an useful feature for the case your architecture can run more than one target.
+    It’s a useful feature for the case your architecture can run more than one target.
     For instance, Mac M1 machines can run both `armv8` and `x86_64`.
 
     :param conanfile: The current recipe object. Always use ``self``.

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -108,6 +108,7 @@ BUILT_IN_CONFS = {
     "tools.apple:enable_visibility": "(boolean) Enable/Disable Visibility Apple Clang flags",
     "tools.env.virtualenv:powershell": "If it is set to True it will generate powershell launchers if os=Windows",
     # Compilers/Flags configurations
+    "tools.build.cross_building:force": "Force cross-building regardless of arch/OS settings.",
     "tools.build:compiler_executables": "Defines a Python dict-like with the compilers path to be used. Allowed keys {'c', 'cpp', 'cuda', 'objc', 'objcxx', 'rc', 'fortran', 'asm', 'hip', 'ispc'}",
     "tools.build:cxxflags": "List of extra CXX flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:cflags": "List of extra C flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -108,7 +108,7 @@ BUILT_IN_CONFS = {
     "tools.apple:enable_visibility": "(boolean) Enable/Disable Visibility Apple Clang flags",
     "tools.env.virtualenv:powershell": "If it is set to True it will generate powershell launchers if os=Windows",
     # Compilers/Flags configurations
-    "tools.build.cross_building:force": "Force cross-building regardless of arch/OS settings.",
+    "tools.build.cross_building:cross_build": "Decides whether cross-building or not regardless of arch/OS settings. Used by 'conan.tools.build.cross_building' function.",
     "tools.build:compiler_executables": "Defines a Python dict-like with the compilers path to be used. Allowed keys {'c', 'cpp', 'cuda', 'objc', 'objcxx', 'rc', 'fortran', 'asm', 'hip', 'ispc'}",
     "tools.build:cxxflags": "List of extra CXX flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:cflags": "List of extra C flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",

--- a/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -298,7 +298,7 @@ def test_apple_arch_flag():
 
     # Only set when crossbuilding
     conanfile = ConanFileMock()
-    conanfile.conf = {"tools.apple:sdk_path": "/path/to/sdk"}
+    conanfile.conf.define("tools.apple:sdk_path", "/path/to/sdk")
     conanfile.settings = MockSettings(
         {"build_type": "Debug",
          "os": "Macos",
@@ -365,7 +365,7 @@ def test_apple_isysrootflag():
 
     # Only set when crossbuilding
     conanfile = ConanFileMock()
-    conanfile.conf = {"tools.apple:sdk_path": "/path/to/sdk"}
+    conanfile.conf.define("tools.apple:sdk_path", "/path/to/sdk")
     conanfile.settings = MockSettings(
         {"build_type": "Debug",
          "os": "Macos",

--- a/conans/test/unittests/tools/build/test_cross_building.py
+++ b/conans/test/unittests/tools/build/test_cross_building.py
@@ -1,0 +1,16 @@
+import pytest
+
+from conan.tools.build import cross_building
+from conans.test.utils.mocks import ConanFileMock
+
+
+@pytest.mark.parametrize("force", (True, False))
+def test_using_force_conf(force):
+    """
+    Tests cross_building function is using the conf variable to force or not.
+
+    Issue related: https://github.com/conan-io/conan/issues/15392
+    """
+    conanfile = ConanFileMock()
+    conanfile.conf.define("tools.build.cross_building:force", force)
+    assert cross_building(conanfile) == force

--- a/conans/test/unittests/tools/build/test_cross_building.py
+++ b/conans/test/unittests/tools/build/test_cross_building.py
@@ -4,13 +4,13 @@ from conan.tools.build import cross_building
 from conans.test.utils.mocks import ConanFileMock
 
 
-@pytest.mark.parametrize("force", (True, False))
-def test_using_force_conf(force):
+@pytest.mark.parametrize("cross_build", (True, False))
+def test_using_cross_build_conf(cross_build):
     """
     Tests cross_building function is using the conf variable to force or not.
 
     Issue related: https://github.com/conan-io/conan/issues/15392
     """
     conanfile = ConanFileMock()
-    conanfile.conf.define("tools.build.cross_building:force", force)
-    assert cross_building(conanfile) == force
+    conanfile.conf.define("tools.build.cross_building:cross_build", cross_build)
+    assert cross_building(conanfile) == cross_build


### PR DESCRIPTION
Changelog: Feature: Added `tools.build.cross_building:cross_build` to decide whether cross-building or not regardless of the internal Conan mechanism.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/15392
