### PR TITLE
fix MSBuildDeps with components and skipped deps

### DIFF
--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -315,6 +315,7 @@ class MSBuildDeps(object):
         condition = self._condition()
         dep_name = self._dep_name(dep, build)
         result = {}
+        pkg_deps = get_transitive_requires(self._conanfile, dep)  # only non-skipped dependencies
         if dep.cpp_info.has_components:
             pkg_aggregated_content = None
             for comp_name, comp_info in dep.cpp_info.components.items():
@@ -327,8 +328,9 @@ class MSBuildDeps(object):
                 public_deps = []  # To store the xml dependencies/file names
                 for required_pkg, required_comp in comp_info.parsed_requires():
                     if required_pkg is not None:  # Points to a component of a different package
-                        public_deps.append(required_pkg if required_pkg == required_comp
-                                           else "{}_{}".format(required_pkg, required_comp))
+                        if required_pkg in pkg_deps:  # The transitive dep might have been skipped
+                            public_deps.append(required_pkg if required_pkg == required_comp
+                                               else "{}_{}".format(required_pkg, required_comp))
                     else:  # Points to a component of same package
                         public_deps.append("{}_{}".format(dep_name, required_comp))
                 public_deps = [self._get_valid_xml_format(d) for d in public_deps]
@@ -348,7 +350,6 @@ class MSBuildDeps(object):
             vars_filename = "conan_%s_vars%s.props" % (dep_name, conf_name)
             activate_filename = "conan_%s%s.props" % (dep_name, conf_name)
             pkg_filename = "conan_%s.props" % dep_name
-            pkg_deps = get_transitive_requires(self._conanfile, dep)
             public_deps = [self._dep_name(d, build) for d in pkg_deps.values()]
 
             result[vars_filename] = self._vars_props_file(require, dep, dep_name, cpp_info,


### PR DESCRIPTION
Changelog: Bugfix: Fix ``MSBuildDeps`` with components and skipped dependencies.
Docs: Omit

Close https://github.com/conan-io/conan/issues/15624
Close https://github.com/conan-io/conan/issues/15334


