### PR TITLE
Added macOS workaround to avoid tqdm failing

### DIFF
--- a/conans/conan.py
+++ b/conans/conan.py
@@ -1,5 +1,11 @@
 import sys
 import os
+import platform
+
+# https://github.com/icloud-photos-downloader/icloud_photos_downloader/commit/5450392a6d7c28c6926207b03e063f1ec049da2f#
+if platform.system() == "Darwin":
+    from multiprocessing import freeze_support
+    freeze_support() # fixing tqdm on macos
 
 if os.getenv("CONAN_V2_CLI"):
     from conans.cli.cli import main


### PR DESCRIPTION
Changelog: Fix: Adding a workaround to avoid `tqdm` failing on macOS.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/15609
