### PR TITLE
fix crash in copy() with relative paths

### DIFF
--- a/conan/tools/files/copy_pattern.py
+++ b/conan/tools/files/copy_pattern.py
@@ -112,7 +112,10 @@ def _copy_files(files, src, dst, keep_path):
         abs_src_name = os.path.join(src, filename)
         filename = filename if keep_path else os.path.basename(filename)
         abs_dst_name = os.path.normpath(os.path.join(dst, filename))
-        os.makedirs(os.path.dirname(abs_dst_name), exist_ok=True)
+        parent_folder = os.path.dirname(abs_dst_name)
+        if parent_folder:  # There are cases where this folder will be empty for relative paths
+            os.makedirs(parent_folder, exist_ok=True)
+
         if os.path.islink(abs_src_name):
             linkto = os.readlink(abs_src_name)  # @UndefinedVariable
             try:

--- a/conans/test/unittests/tools/files/test_tool_copy.py
+++ b/conans/test/unittests/tools/files/test_tool_copy.py
@@ -7,7 +7,7 @@ import pytest
 
 from conan.tools.files import copy
 from conans.test.utils.test_files import temp_folder
-from conans.util.files import load, save, mkdir, save_files
+from conans.util.files import load, save, mkdir, save_files, chdir
 
 
 class ToolCopyTest(unittest.TestCase):
@@ -275,3 +275,12 @@ class ToolCopyTest(unittest.TestCase):
                          sorted(os.listdir(os.path.join(dst_folder, "include"))))
         self.assertEqual(sorted(["AttributeStorage.h", "file.h"]),
                          sorted(os.listdir(os.path.join(dst_folder, "include", "sub"))))
+
+    def test_empty_parent_folder_makedirs(self):
+        src_folder = temp_folder()
+        save(os.path.join(src_folder, "file.h"), "")
+        sources = os.path.join(src_folder, "src")
+        os.makedirs(sources)
+        with chdir(sources):
+            copy(None, "*", "..", dst=".")  # This used to crash
+            assert "file.h" in os.listdir(sources)


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

To fix https://github.com/conan-io/conan/pull/15513#issuecomment-1938502862
(merged in 2.1, not released yet)