### PR TITLE
Switched to cc pattern in compiler detection

### DIFF
--- a/conan/internal/api/detect_api.py
+++ b/conan/internal/api/detect_api.py
@@ -276,7 +276,7 @@ def detect_default_compiler():
         command = cc or cxx
         if "clang" in command.lower():
             return _clang_compiler(command)
-        if "gcc" in command or "g++" in command or "c++" in command:
+        if "cc" in command or "g++" in command or "c++" in command:
             gcc, gcc_version, compiler_exe = _gcc_compiler(command)
             if platform.system() == "Darwin" and gcc is None:
                 output.error("%s detected as a frontend using apple-clang. "

--- a/conan/internal/api/detect_api.py
+++ b/conan/internal/api/detect_api.py
@@ -276,7 +276,7 @@ def detect_default_compiler():
         command = cc or cxx
         if "clang" in command.lower():
             return _clang_compiler(command)
-        if "cc" in command or "g++" in command or "c++" in command:
+        if "gnu-cc" in command or "gcc" in command or "g++" in command or "c++" in command:
             gcc, gcc_version, compiler_exe = _gcc_compiler(command)
             if platform.system() == "Darwin" and gcc is None:
                 output.error("%s detected as a frontend using apple-clang. "


### PR DESCRIPTION
Changelog: Fix: Fix gcc detection in conda environments.
Docs: Omit

In a conda environment, the `CC` and `CXX` variables point to /opt/conda/envs/<env name>/bin/x86_64-conda-linux-gnu-cc and /opt/conda/envs/<env name>/bin/x86_64-conda-linux-gnu-c++ and the `command` searched for pattern ends up being /opt/conda/envs/<env name>/bin/x86_64-conda-linux-gnu-cc and thus `_gcc_compiler(command)` is never called.

Fixes #14575 

- [x] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
