### PR TITLE
Guarantee order of `generators` execution

### DIFF
--- a/conan/api/subapi/install.py
+++ b/conan/api/subapi/install.py
@@ -72,6 +72,11 @@ class InstallAPI:
             base_folder = deploy_folder or conanfile.folders.base_build
             do_deploys(self.conan_api, deps_graph, deploy, deploy_package, base_folder)
 
-        conanfile.generators = list(set(conanfile.generators).union(generators or []))
+        final_generators = []
+        # Don't use set for uniqueness because order matters
+        for gen in conanfile.generators + list(generators or []):
+            if gen not in final_generators:
+                final_generators.append(gen)
+        conanfile.generators = final_generators
         app = ConanApp(self.conan_api)
         write_generators(conanfile, app)

--- a/conan/api/subapi/install.py
+++ b/conan/api/subapi/install.py
@@ -74,7 +74,10 @@ class InstallAPI:
 
         final_generators = []
         # Don't use set for uniqueness because order matters
-        for gen in conanfile.generators + list(generators or []):
+        for gen in conanfile.generators:
+            if gen not in final_generators:
+                final_generators.append(gen)
+        for gen in (generators or []):
             if gen not in final_generators:
                 final_generators.append(gen)
         conanfile.generators = final_generators

--- a/conans/client/generators/__init__.py
+++ b/conans/client/generators/__init__.py
@@ -79,7 +79,10 @@ def write_generators(conanfile, app):
     # generators check that they are not present in the generators field,
     # to avoid duplicates between the generators attribute and the generate() method
     # They would raise an exception here if we don't invalidate the field while we call them
-    old_generators = set(conanfile.generators)
+    old_generators = []
+    for gen in conanfile.generators:
+        if gen not in old_generators:
+            old_generators.append(gen)
     conanfile.generators = []
     try:
         for generator_name in old_generators:


### PR DESCRIPTION
Changelog: Fix: Guarantee order of `generators` attribute execution.
Docs: Omit

For #15677
