### PR TITLE
Add detect_gnu_libc() and detect_musl_libc() functions

### DIFF
--- a/conan/internal/api/detect_api.py
+++ b/conan/internal/api/detect_api.py
@@ -196,7 +196,7 @@ def detect_libc(ldd="/usr/bin/ldd"):
         ConanOutput(scope="detect_api").warning(
             f"detect_libc() is only supported on Linux currently"
         )
-        return None
+        return None, None
     version = _detect_gnu_libc(ldd)
     if version is not None:
         return "gnu", version
@@ -206,7 +206,7 @@ def detect_libc(ldd="/usr/bin/ldd"):
     ConanOutput(scope="detect_api").warning(
         f"Couldn't detect the libc provider and version"
     )
-    return None
+    return None, None
 
 
 def detect_libcxx(compiler, version, compiler_exe=None):

--- a/conan/internal/api/detect_api.py
+++ b/conan/internal/api/detect_api.py
@@ -129,7 +129,7 @@ def _parse_gnu_libc(ldd_output):
     return None
 
 
-def detect_gnu_libc(ldd="/usr/bin/ldd"):
+def _detect_gnu_libc(ldd="/usr/bin/ldd"):
     if platform.system() != "Linux":
         ConanOutput(scope="detect_api").warning("detect_gnu_libc() only works on Linux")
         return None
@@ -157,7 +157,7 @@ def _parse_musl_libc(ldd_output):
     return lines[1].split()[-1].strip()
 
 
-def detect_musl_libc(ldd="/usr/bin/ldd"):
+def _detect_musl_libc(ldd="/usr/bin/ldd"):
     if platform.system() != "Linux":
         ConanOutput(scope="detect_api").warning(
             "detect_musl_libc() only works on Linux"
@@ -197,10 +197,10 @@ def detect_libc(ldd="/usr/bin/ldd"):
             f"detect_libc() is only supported on Linux currently"
         )
         return None
-    version = detect_gnu_libc(ldd)
+    version = _detect_gnu_libc(ldd)
     if version is not None:
         return "gnu", version
-    version = detect_musl_libc(ldd)
+    version = _detect_musl_libc(ldd)
     if version is not None:
         return "musl", version
     ConanOutput(scope="detect_api").warning(

--- a/conans/test/functional/test_profile_detect_api.py
+++ b/conans/test/functional/test_profile_detect_api.py
@@ -1,3 +1,4 @@
+import platform
 import textwrap
 
 import pytest
@@ -39,5 +40,32 @@ class TestProfileDetectAPI:
             compiler.version=193
             [conf]
             tools.microsoft.msbuild:vs_version=17
+            """)
+        assert expected in client.out
+
+    @pytest.mark.skipif(platform.system() != "Linux", reason="Only linux")
+    def test_profile_detect_libc(self):
+
+        client = TestClient()
+        tpl1 = textwrap.dedent("""
+            {% set libc, libc_version = detect_api.detect_libc() %}
+            [settings]
+            os=Linux
+            [conf]
+            user.confvar:libc={{libc}}
+            user.confvar:libc_version={{libc_version}}
+            """)
+
+        client.save({"profile1": tpl1})
+        client.run("profile show -pr=profile1")
+        libc_version = detect_api.detect_gnu_libc()
+        assert libc_version is not None
+        expected = textwrap.dedent(f"""\
+            Host profile:
+            [settings]
+            os=Linux
+            [conf]
+            user.confvar:libc=gnu
+            user.confvar:libc_version={libc_version}
             """)
         assert expected in client.out

--- a/conans/test/functional/test_profile_detect_api.py
+++ b/conans/test/functional/test_profile_detect_api.py
@@ -44,6 +44,36 @@ class TestProfileDetectAPI:
         assert expected in client.out
 
     @pytest.mark.skipif(platform.system() != "Linux", reason="Only linux")
+    def test_profile_detect_gnu_libc(self):
+
+        client = TestClient()
+        tpl1 = textwrap.dedent("""
+            {% set libc_version = detect_api.detect_gnu_libc() %}
+            [settings]
+            os=Linux
+            [conf]
+            user.confvar:libc_version={{libc_version}}
+            """)
+
+        client.save({"profile1": tpl1})
+        client.run("profile show -pr=profile1")
+
+    @pytest.mark.skipif(platform.system() != "Linux", reason="Only linux")
+    def test_profile_detect_musl_libc(self):
+
+        client = TestClient()
+        tpl1 = textwrap.dedent("""
+            {% set libc_version = detect_api.detect_musl_libc() %}
+            [settings]
+            os=Linux
+            [conf]
+            user.confvar:libc_version={{libc_version}}
+            """)
+
+        client.save({"profile1": tpl1})
+        client.run("profile show -pr=profile1")
+
+    @pytest.mark.skipif(platform.system() != "Linux", reason="Only linux")
     def test_profile_detect_libc(self):
 
         client = TestClient()
@@ -58,14 +88,15 @@ class TestProfileDetectAPI:
 
         client.save({"profile1": tpl1})
         client.run("profile show -pr=profile1")
-        libc_version = detect_api.detect_gnu_libc()
+        libc_name, libc_version = detect_api.detect_libc()
+        assert libc_name is not None
         assert libc_version is not None
         expected = textwrap.dedent(f"""\
             Host profile:
             [settings]
             os=Linux
             [conf]
-            user.confvar:libc=gnu
+            user.confvar:libc={libc_name}
             user.confvar:libc_version={libc_version}
             """)
         assert expected in client.out

--- a/conans/test/functional/test_profile_detect_api.py
+++ b/conans/test/functional/test_profile_detect_api.py
@@ -44,36 +44,6 @@ class TestProfileDetectAPI:
         assert expected in client.out
 
     @pytest.mark.skipif(platform.system() != "Linux", reason="Only linux")
-    def test_profile_detect_gnu_libc(self):
-
-        client = TestClient()
-        tpl1 = textwrap.dedent("""
-            {% set libc_version = detect_api.detect_gnu_libc() %}
-            [settings]
-            os=Linux
-            [conf]
-            user.confvar:libc_version={{libc_version}}
-            """)
-
-        client.save({"profile1": tpl1})
-        client.run("profile show -pr=profile1")
-
-    @pytest.mark.skipif(platform.system() != "Linux", reason="Only linux")
-    def test_profile_detect_musl_libc(self):
-
-        client = TestClient()
-        tpl1 = textwrap.dedent("""
-            {% set libc_version = detect_api.detect_musl_libc() %}
-            [settings]
-            os=Linux
-            [conf]
-            user.confvar:libc_version={{libc_version}}
-            """)
-
-        client.save({"profile1": tpl1})
-        client.run("profile show -pr=profile1")
-
-    @pytest.mark.skipif(platform.system() != "Linux", reason="Only linux")
     def test_profile_detect_libc(self):
 
         client = TestClient()

--- a/conans/test/unittests/util/detect_libc_test.py
+++ b/conans/test/unittests/util/detect_libc_test.py
@@ -1,0 +1,84 @@
+import unittest
+
+from parameterized import parameterized
+
+from conan.internal.api.detect_api import _parse_gnu_libc, _parse_musl_libc
+
+
+class DetectedLibcTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            [
+                """ldd (Debian GLIBC 2.36-9+rpt2+deb12u4) 2.36
+Copyright (C) 2022 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+Written by Roland McGrath and Ulrich Drepper.""",
+                "2.36",
+            ],
+            [
+                """ldd (Ubuntu GLIBC 2.35-0ubuntu3.6) 2.35
+Copyright (C) 2022 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+Written by Roland McGrath and Ulrich Drepper.""",
+                "2.35",
+            ],
+            [
+                """ldd (GNU libc) 2.38
+Copyright (C) 2023 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+Written by Roland McGrath and Ulrich Drepper.""",
+                "2.38",
+            ],
+            [
+                """musl libc (x86_64)
+Version 1.2.4_git20230717
+Dynamic Program Loader
+Usage: /lib/ld-musl-x86_64.so.1 [options] [--] pathname""",
+                None,
+            ],
+        ]
+    )
+    def test_parse_gnu_libc(self, ldd_output, expected_glibc_version):
+        parsed_glibc_version = _parse_gnu_libc(ldd_output)
+        self.assertEqual(expected_glibc_version, parsed_glibc_version, f"given '{parsed_glibc_version}' expected '{expected_glibc_version}'")
+
+    @parameterized.expand(
+        [
+            [
+                """musl libc (x86_64)
+Version 1.2.4
+Dynamic Program Loader
+Usage: /lib/ld-musl-x86_64.so.1 [options] [--] pathname""",
+                "1.2.4",
+            ],
+            [
+                """musl libc (x86_64)
+Version 1.2.4_git20230717
+Dynamic Program Loader
+Usage: /lib/ld-musl-x86_64.so.1 [options] [--] pathname""",
+                "1.2.4_git20230717",
+            ],
+            [
+                """ldd (Debian GLIBC 2.36-9+rpt2+deb12u4) 2.36
+Copyright (C) 2022 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+Written by Roland McGrath and Ulrich Drepper.""",
+                None,
+            ],
+            [
+                """ldd (GNU libc) 2.38
+Copyright (C) 2023 Free Software Foundation, Inc.
+This is free software; see the source for copying conditions.  There is NO
+warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+Written by Roland McGrath and Ulrich Drepper.""",
+                None,
+            ],
+        ]
+    )
+    def test_parse_musl_libc(self, ldd_output, expected_musl_libc_version):
+        parsed_musl_libc_version = _parse_musl_libc(ldd_output)
+        self.assertEqual(expected_musl_libc_version, parsed_musl_libc_version, f"given '{parsed_musl_libc_version}' expected '{expected_musl_libc_version}'")

--- a/conans/test/unittests/util/detect_libc_test.py
+++ b/conans/test/unittests/util/detect_libc_test.py
@@ -1,11 +1,9 @@
-import unittest
-
 from parameterized import parameterized
 
 from conan.internal.api.detect_api import _parse_gnu_libc, _parse_musl_libc
 
 
-class DetectedLibcTest(unittest.TestCase):
+class TestDetectLibc:
     @parameterized.expand(
         [
             [
@@ -43,7 +41,7 @@ Usage: /lib/ld-musl-x86_64.so.1 [options] [--] pathname""",
     )
     def test_parse_gnu_libc(self, ldd_output, expected_glibc_version):
         parsed_glibc_version = _parse_gnu_libc(ldd_output)
-        self.assertEqual(expected_glibc_version, parsed_glibc_version, f"given '{parsed_glibc_version}' expected '{expected_glibc_version}'")
+        assert expected_glibc_version == parsed_glibc_version
 
     @parameterized.expand(
         [
@@ -81,4 +79,4 @@ Written by Roland McGrath and Ulrich Drepper.""",
     )
     def test_parse_musl_libc(self, ldd_output, expected_musl_libc_version):
         parsed_musl_libc_version = _parse_musl_libc(ldd_output)
-        self.assertEqual(expected_musl_libc_version, parsed_musl_libc_version, f"given '{parsed_musl_libc_version}' expected '{expected_musl_libc_version}'")
+        assert expected_musl_libc_version == parsed_musl_libc_version

--- a/conans/util/runners.py
+++ b/conans/util/runners.py
@@ -79,7 +79,7 @@ def detect_runner(command):
     return proc.returncode, "".join(output_buffer)
 
 
-def check_output_runner(cmd, stderr=None):
+def check_output_runner(cmd, stderr=None, ignore_error=False):
     # Used to run several utilities, like Pacman detect, AIX version, uname, SCM
     assert isinstance(cmd, str)
     d = tempfile.mkdtemp()
@@ -91,7 +91,7 @@ def check_output_runner(cmd, stderr=None):
         process = subprocess.Popen(command, shell=True, stderr=stderr)
         stdout, stderr = process.communicate()
 
-        if process.returncode:
+        if process.returncode and not ignore_error:
             # Only in case of error, we print also the stderr to know what happened
             msg = f"Command '{cmd}' failed with errorcode '{process.returncode}'\n{stderr}"
             raise ConanException(msg)


### PR DESCRIPTION
Changelog: Feature: Add `detect_libc` to the `detect_api` to get the name and version of the C library.
Docs: https://github.com/conan-io/docs/pull/3590

This PR adds a simple function to detect the version of glibc to the detect_api. This functionality is only intended for Linux systems using glibc. The function is detect_gnu_libc().
It simply runs ldd --version to detect the version of glibc. It is also possible to detect the version of the libc library by running the libc.so file. The location of this library varies much more than the path to ldd, so ldd --version is used instead. The path to ldd is passed as an argument, /usr/bin/ldd by default. This can modified to suite alternate sysroots.
It can even be used in cross-compilation scenarios where emulation is available to execute ldd.

The detect_gnu_libc function does a simple sanity check to verify that glibc is indeed being used. This avoids confusion on systems using an alternative libc implementation, i.e. musl.

I also added a function to detect the version of the musl libc library as well. This function is detect_musl_libc() and works the same way.

Addresses conan-io/docs#3960, at least in part.



- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
