### PR TITLE
fix: gnu triplet for linux x86

### DIFF
--- a/conan/tools/gnu/get_gnu_triplet.py
+++ b/conan/tools/gnu/get_gnu_triplet.py
@@ -15,7 +15,7 @@ def _get_gnu_triplet(os_, arch, compiler=None):
                              "needed for os=Windows")
 
     # Calculate the arch
-    machine = {"x86": "i686" if os_ != "Linux" else "x86",
+    machine = {"x86": "i686",
                "x86_64": "x86_64",
                "armv8": "aarch64",
                "armv8_32": "aarch64",  # https://wiki.linaro.org/Platform/arm64-ilp32

--- a/conans/test/unittests/tools/gnu/test_triplets.py
+++ b/conans/test/unittests/tools/gnu/test_triplets.py
@@ -5,7 +5,7 @@ from conans.errors import ConanException
 
 
 @pytest.mark.parametrize("os_, arch, compiler, expected_triplet", [
-    ["Linux", "x86", None, "x86-linux-gnu"],
+    ["Linux", "x86", None, "i686-linux-gnu"],
     ["Linux", "x86_64", None, "x86_64-linux-gnu"],
     ["Linux", "armv6", None, "arm-linux-gnueabi"],
     ["Linux", "sparc", None, "sparc-linux-gnu"],


### PR DESCRIPTION
Changelog: Fix: Fix getting the gnu triplet for Linux x86.
Docs: Omit

Close #10211

Changed the gnu triplet for linux x86 systems from "x86-linux-gnu" to "i686-linux-gnu".