### PR TITLE
[POC][Meson] Using `DESTDIR` variable

### DIFF
--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -40,8 +40,7 @@ class Meson(object):
         cmd += "".join([f'{cmd_param} "{meson_option}"' for meson_option in meson_filenames])
         cmd += ' "{}" "{}"'.format(build_folder, source_folder)
         # Issue related: https://github.com/mesonbuild/meson/issues/12880
-        if platform.system() != "Windows":
-            cmd += ' --prefix=/'  # this must be an absolute path, otherwise, meson complains
+        cmd += ' --prefix=/'  # this must be an absolute path, otherwise, meson complains
         self._conanfile.output.info("Meson configure cmd: {}".format(cmd))
         self._conanfile.run(cmd)
 

--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -57,7 +57,7 @@ class Meson(object):
         self._conanfile.run(cmd)
 
     def install(self):
-        meson_build_folder = self._conanfile.build_folder
+        meson_build_folder = self._conanfile.build_folder.replace("\\", "/")
         meson_package_folder = self._conanfile.package_folder.replace("\\", "/")
         # TODO: Use --destdir [package_folder] param when requiring meson >= 0.57.
         if platform.system() == "Windows":


### PR DESCRIPTION
Changelog: Fix: Avoiding reconfigure process. Using `DESTDIR` instead. Deprecated `reconfigure` param in `Meson.configure() function`.
Docs: https://github.com/conan-io/docs/pull/XXXX
Closes: https://github.com/conan-io/conan/issues/11910
