### PR TITLE
print to stderr

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -205,7 +205,8 @@ class ConanFileLoader:
         conanfile._conan_is_consumer = True
         return conanfile
 
-    def _parse_conan_txt(self, contents, path, display_name):
+    @staticmethod
+    def _parse_conan_txt(contents, path, display_name):
         conanfile = ConanFile(display_name)
 
         try:
@@ -320,6 +321,9 @@ def _load_python_file(conan_file_path):
     if not os.path.exists(conan_file_path):
         raise NotFoundException("%s not found!" % conan_file_path)
 
+    def new_print(*args, **kwargs):  # Make sure that all user python files print() goes to stderr
+        print(*args, **kwargs, file=sys.stderr)
+
     module_id = str(uuid.uuid1())
     current_dir = os.path.dirname(conan_file_path)
     sys.path.insert(0, current_dir)
@@ -362,6 +366,7 @@ def _load_python_file(conan_file_path):
                 else:
                     if folder.startswith(current_dir):
                         module = sys.modules.pop(added)
+                        module.print = new_print
                         sys.modules["%s.%s" % (module_id, added)] = module
     except ConanException:
         raise
@@ -373,6 +378,7 @@ def _load_python_file(conan_file_path):
     finally:
         sys.path.pop(0)
 
+    loaded.print = new_print
     return loaded, module_id
 
 

--- a/conans/test/integration/conanfile/test_print_in_conanfile.py
+++ b/conans/test/integration/conanfile/test_print_in_conanfile.py
@@ -1,0 +1,35 @@
+import json
+import textwrap
+
+from conans.test.utils.tools import TestClient
+
+
+def test_print_in_conanfile():
+    """
+    Tests that prints in conanfiles will not ruin json stdout outputs
+    """
+    c = TestClient(light=True)
+    other = textwrap.dedent("""
+        def myprint(text):
+            print(text)
+        """)
+    conanfile = textwrap.dedent("""
+        import other
+        from conan import ConanFile
+
+        class MyTest(ConanFile):
+            name = "pkg"
+            version = "0.1"
+
+            def generate(self):
+                print("Hello world!!")
+                other.myprint("Bye world!!")
+        """)
+    c.save({"other.py": other,
+            "conanfile.py": conanfile})
+    c.run("install . --format=json")
+    assert "Hello world!!" in c.stderr
+    assert "Bye world!!" in c.stderr
+    info = json.loads(c.stdout)
+    # the json is correctly loaded
+    assert "graph" in info


### PR DESCRIPTION
Changelog: Fix: Make all recipe and plugins python file ``print()`` to ``stderr``, so json outputs to ``stdout`` are not broken.
Docs: omit

Close https://github.com/conan-io/conan/issues/15671
