### PR TITLE
allow self.name/self.version for build_folder_vars

### DIFF
--- a/conan/tools/cmake/layout.py
+++ b/conan/tools/cmake/layout.py
@@ -80,6 +80,8 @@ def get_build_folder_custom_vars(conanfile):
                     tmp = "shared" if value else "static"
                 else:
                     tmp = "{}_{}".format(var, value)
+        elif group == "self":
+            tmp = getattr(conanfile, var, None)
         else:
             raise ConanException("Invalid 'tools.cmake.cmake_layout:build_folder_vars' value, it has"
                                  " to start with 'settings.' or 'options.': {}".format(s))


### PR DESCRIPTION
Changelog: Feature: Allow ``self.name`` and ``self.version`` in ``build_folder_vars`` attribute and conf.
Docs: https://github.com/conan-io/docs/pull/3636

Close https://github.com/conan-io/conan/issues/12326