### PR TITLE
[Meson] Using `--destdir` variable 

### DIFF
--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -40,8 +40,7 @@ class Meson(object):
         cmd += "".join([f'{cmd_param} "{meson_option}"' for meson_option in meson_filenames])
         cmd += ' "{}" "{}"'.format(build_folder, source_folder)
         # Issue related: https://github.com/mesonbuild/meson/issues/12880
-        if platform.system() != "Windows":
-            cmd += ' --prefix=/'  # this must be an absolute path, otherwise, meson complains
+        cmd += ' --prefix=/'  # this must be an absolute path, otherwise, meson complains
         self._conanfile.output.info("Meson configure cmd: {}".format(cmd))
         self._conanfile.run(cmd)
 

--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -57,7 +57,7 @@ class Meson(object):
         self._conanfile.run(cmd)
 
     def install(self):
-        meson_build_folder = self._conanfile.build_folder
+        meson_build_folder = self._conanfile.build_folder.replace("\\", "/")
         meson_package_folder = self._conanfile.package_folder.replace("\\", "/")
         # TODO: Use --destdir [package_folder] param when requiring meson >= 0.57.
         if platform.system() == "Windows":

--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -1,9 +1,8 @@
 import os
-import platform
 
 from conan.tools.build import build_jobs
-from conan.tools.meson.toolchain import MesonToolchain
 from conan.tools.meson.mesondeps import MesonDeps
+from conan.tools.meson.toolchain import MesonToolchain
 
 
 class Meson(object):
@@ -58,11 +57,8 @@ class Meson(object):
     def install(self):
         meson_build_folder = self._conanfile.build_folder.replace("\\", "/")
         meson_package_folder = self._conanfile.package_folder.replace("\\", "/")
-        # TODO: Use --destdir [package_folder] param when requiring meson >= 0.57.
-        if platform.system() == "Windows":
-            cmd = f'set "DESTDIR={meson_package_folder}" && meson install -C "{meson_build_folder}"'
-        else:
-            cmd = f'DESTDIR="{meson_package_folder}" meson install -C "{meson_build_folder}"'
+        # Assuming meson >= 0.57.0
+        cmd = f'meson install -C "{meson_build_folder}" --destdir "{meson_package_folder}"'
         self._conanfile.run(cmd)
 
     def test(self):


### PR DESCRIPTION
Changelog: Fix: Avoiding reconfigure process. Using `--destdir` param instead. Deprecated `reconfigure` param in `Meson.configure() function`.
Changelog: Feature: `conan.tools.meson` helper requires meson >= 0.57.0.
Docs: https://github.com/conan-io/docs/pull/3663
Closes: https://github.com/conan-io/conan/issues/11910
