### PR TITLE
Fix traces showing on some wrong options syntax

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -235,11 +235,7 @@ class ConanFileLoader:
             conanfile.layout = types.MethodType(layout, conanfile)
 
         conanfile.generators = parser.generators
-        try:
-            conanfile.options = Options.loads(parser.options)
-        except Exception:
-            raise ConanException("Error while parsing [options] in conanfile.txt\n"
-                                 "Options should be specified as 'pkg/*:option=value'")
+        conanfile.options = Options.loads(parser.options)
 
         return conanfile
 

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -235,8 +235,11 @@ class ConanFileLoader:
             conanfile.layout = types.MethodType(layout, conanfile)
 
         conanfile.generators = parser.generators
-        conanfile.options = Options.loads(parser.options)
-
+        try:
+            conanfile.options = Options.loads(parser.options)
+        except Exception:
+            raise ConanException("Error while parsing [options] in conanfile.txt\n"
+                                 "Options should be specified as 'pkg/*:option=value'")
         return conanfile
 
     def load_virtual(self, requires=None, tool_requires=None, python_requires=None, graph_lock=None,

--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -234,7 +234,11 @@ class _ProfileValueParser(object):
 
         # Parse doc sections into Conan model, Settings, Options, etc
         settings, package_settings = _ProfileValueParser._parse_settings(doc)
-        options = Options.loads(doc.options) if doc.options else None
+        try:
+            options = Options.loads(doc.options) if doc.options else None
+        except Exception:
+            raise ConanException("Error while parsing options. "
+                                 "Options should be specified as 'pkg/*:option=value'")
         tool_requires = _ProfileValueParser._parse_tool_requires(doc)
 
         doc_platform_requires = doc.platform_requires or ""
@@ -383,7 +387,11 @@ def _profile_parse_args(settings, options, conf):
     settings, package_settings = _get_simple_and_package_tuples(settings)
 
     result = Profile()
-    result.options = Options.loads("\n".join(options or []))
+    try:
+        result.options = Options.loads("\n".join(options or []))
+    except Exception:
+        raise ConanException("Error while parsing options. "
+                             "Options should be specified as 'pkg/*:option=value'")
     result.settings = OrderedDict(settings)
     if conf:
         result.conf = ConfDefinition()

--- a/conans/client/profile_loader.py
+++ b/conans/client/profile_loader.py
@@ -234,11 +234,7 @@ class _ProfileValueParser(object):
 
         # Parse doc sections into Conan model, Settings, Options, etc
         settings, package_settings = _ProfileValueParser._parse_settings(doc)
-        try:
-            options = Options.loads(doc.options) if doc.options else None
-        except Exception:
-            raise ConanException("Error while parsing options. "
-                                 "Options should be specified as 'pkg/*:option=value'")
+        options = Options.loads(doc.options) if doc.options else None
         tool_requires = _ProfileValueParser._parse_tool_requires(doc)
 
         doc_platform_requires = doc.platform_requires or ""
@@ -387,11 +383,7 @@ def _profile_parse_args(settings, options, conf):
     settings, package_settings = _get_simple_and_package_tuples(settings)
 
     result = Profile()
-    try:
-        result.options = Options.loads("\n".join(options or []))
-    except Exception:
-        raise ConanException("Error while parsing options. "
-                             "Options should be specified as 'pkg/*:option=value'")
+    result.options = Options.loads("\n".join(options or []))
     result.settings = OrderedDict(settings)
     if conf:
         result.conf = ConfDefinition()

--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -278,8 +278,12 @@ class Options:
             line = line.strip()
             if not line or line.startswith("#"):
                 continue
-            name, value = line.split("=", 1)
-            values[name] = value
+            try:
+                name, value = line.split("=", 1)
+                values[name] = value
+            except ValueError:
+                raise ConanException(f"Error while parsing option '{line}'. "
+                                     f"Options should be specified as 'pkg/*:option=value'")
         return Options(options_values=values)
 
     def serialize(self):

--- a/conans/test/integration/options/options_test.py
+++ b/conans/test/integration/options/options_test.py
@@ -738,4 +738,4 @@ class TestImportantOptions:
         tc.save({"conanfile.py": GenConanfile().with_option("myoption", [1, 2, 3])})
         tc.run('create . -o="&:myoption"', assert_error=True)
         assert "ValueError" not in tc.out
-        assert "Error while parsing options" in tc.out
+        assert "Error while parsing option" in tc.out

--- a/conans/test/integration/options/options_test.py
+++ b/conans/test/integration/options/options_test.py
@@ -732,3 +732,10 @@ class TestImportantOptions:
 
         c.run("graph info app -o *:myoption!=4")
         assert "liba/0.1: MYOPTION: 4" in c.out
+
+    def test_wrong_option_syntax_no_trace(self):
+        tc = TestClient(light=True)
+        tc.save({"conanfile.py": GenConanfile().with_option("myoption", [1, 2, 3])})
+        tc.run('create . -o="&:myoption"', assert_error=True)
+        assert "ValueError" not in tc.out
+        assert "Error while parsing options" in tc.out

--- a/conans/test/unittests/client/conanfile_loader_test.py
+++ b/conans/test/unittests/client/conanfile_loader_test.py
@@ -117,7 +117,8 @@ OpenCV2/*:other_option=Cosa
         save(file_path, conanfile_txt)
         loader = ConanFileLoader(None, None)
         with self.assertRaisesRegex(ConanException,
-                                   r"Error while parsing"):
+                                    r"Error while parsing \[options\] in conanfile.txt\n"
+                                    r"Options should be specified as 'pkg/\*:option=value'"):
             loader.load_conanfile_txt(file_path)
 
     def test_layout_not_predefined(self):

--- a/conans/test/unittests/client/conanfile_loader_test.py
+++ b/conans/test/unittests/client/conanfile_loader_test.py
@@ -117,8 +117,7 @@ OpenCV2/*:other_option=Cosa
         save(file_path, conanfile_txt)
         loader = ConanFileLoader(None, None)
         with self.assertRaisesRegex(ConanException,
-                                   r"Error while parsing \[options\] in conanfile.txt\n"
-                                   "Options should be specified as 'pkg/\*:option=value'"):
+                                   r"Error while parsing"):
             loader.load_conanfile_txt(file_path)
 
     def test_layout_not_predefined(self):


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Did it outside of the `load` method because it has a comment specifying that no validation is to be done there, and thought this as some kind of validation, soo. - happy to move the try:catch inside though
