### PR TITLE
fix conan_server timestamp truncation

### DIFF
--- a/conans/test/integration/command/install/install_update_test.py
+++ b/conans/test/integration/command/install/install_update_test.py
@@ -1,6 +1,5 @@
 import os
 import textwrap
-import time
 from time import sleep
 
 from conans.model.recipe_ref import RecipeReference
@@ -36,7 +35,6 @@ def test_update_binaries():
 
     value = get_value_from_output(client2.out)
 
-    time.sleep(1)  # Make sure the new timestamp is later
     client.run("create . --name=pkg --version=0.1 --user=lasote --channel=testing")  # Because of random, this should be NEW prev
     client.run("upload pkg/0.1@lasote/testing -r default")
 
@@ -50,7 +48,6 @@ def test_update_binaries():
     assert value != new_value
 
     # Now check newer local modifications are not overwritten
-    time.sleep(1)  # Make sure the new timestamp is later
     client.run("create . --name=pkg --version=0.1 --user=lasote --channel=testing")
     client.run("upload pkg/0.1@lasote/testing -r default")
 
@@ -81,8 +78,6 @@ def test_update_not_date():
 
     initial_recipe_timestamp = client.cache.get_latest_recipe_reference(ref).timestamp
     initial_package_timestamp = prev.timestamp
-
-    time.sleep(1)
 
     # Change and rebuild package
     client.save({"conanfile.py": GenConanfile("hello0", "1.0").with_class_attribute("author = 'O'")},

--- a/conans/test/unittests/client/util/time_test.py
+++ b/conans/test/unittests/client/util/time_test.py
@@ -9,7 +9,7 @@ from conans.util.dates import from_timestamp_to_iso8601, _from_iso8601_to_dateti
 class TimeTest(unittest.TestCase):
 
     def test_time_conversions(self):
-        timestamp = "1547138099"
+        timestamp = 1547138099
         iso = from_timestamp_to_iso8601(timestamp)
         self.assertEqual(iso, "2019-01-10T16:34:59Z")
 

--- a/conans/util/dates.py
+++ b/conans/util/dates.py
@@ -9,7 +9,7 @@ from conans.errors import ConanException
 
 def from_timestamp_to_iso8601(timestamp):
     # Used exclusively by conan_server to return the date in iso format (same as artifactory)
-    return "%sZ" % datetime.datetime.utcfromtimestamp(int(timestamp)).isoformat()
+    return "%sZ" % datetime.datetime.utcfromtimestamp(timestamp).isoformat()
 
 
 def _from_iso8601_to_datetime(iso_str):


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Minor fix in ``conan_server`` that was truncating the timestamp, so 2 different revisions resulting in the same timestamp and order was not respected, specially in some tests.
