### PR TITLE
Fix/profile conf jinja win backslash

### DIFF
--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -656,10 +656,10 @@ class ConfDefinition:
         """
         try:
             # Isolated eval
-            parsed_value = eval(__v)
+            parsed_value = eval(__v)  # This destroys Windows path strings with backslash
             if isinstance(parsed_value, str):  # xxx:xxx = "my string"
-                # Let's respect the quotes introduced by any user
-                parsed_value = '"{}"'.format(parsed_value)
+                # If it is quoted string we respect it as-is
+                parsed_value = __v.strip()
         except:
             # It means eval() failed because of a string without quotes
             parsed_value = __v.strip()

--- a/conans/test/integration/configuration/test_profile_jinja.py
+++ b/conans/test/integration/configuration/test_profile_jinja.py
@@ -93,6 +93,22 @@ def test_profile_template_profile_dir():
     assert "conanfile.py: CONTENT: MyToolchainCMake!!!" in client.out
 
 
+def test_profile_dir_subdir():
+    c = TestClient()
+    myprofile = textwrap.dedent("""
+        include(fragment/os/windows)
+        """)
+    profilewin = textwrap.dedent("""
+        [conf]
+        user.team:myconf = "{{profile_dir}}"
+        """)
+    c.save({"profiles/myprofile": myprofile,
+            "profiles/fragment/os/windows": profilewin})
+    c.run("profile show -pr=profiles/myprofile")
+    print(c.out)
+    assert r"\profiles\fragment\os" in c.out
+
+
 def test_profile_version():
     client = TestClient()
     tpl1 = textwrap.dedent("""

--- a/conans/test/integration/configuration/test_profile_jinja.py
+++ b/conans/test/integration/configuration/test_profile_jinja.py
@@ -93,20 +93,16 @@ def test_profile_template_profile_dir():
     assert "conanfile.py: CONTENT: MyToolchainCMake!!!" in client.out
 
 
-def test_profile_dir_subdir():
+def test_profile_conf_backslash():
+    # https://github.com/conan-io/conan/issues/15726
     c = TestClient()
-    myprofile = textwrap.dedent("""
-        include(fragment/os/windows)
-        """)
-    profilewin = textwrap.dedent("""
+    profile = textwrap.dedent(r"""
         [conf]
-        user.team:myconf = "{{profile_dir}}"
+        user.team:myconf = "hello\test"
         """)
-    c.save({"profiles/myprofile": myprofile,
-            "profiles/fragment/os/windows": profilewin})
-    c.run("profile show -pr=profiles/myprofile")
-    print(c.out)
-    assert r"\profiles\fragment\os" in c.out
+    c.save({"profile": profile})
+    c.run("profile show -pr=profile")
+    assert r"hello\test" in c.out
 
 
 def test_profile_version():

--- a/conans/test/unittests/model/test_conf.py
+++ b/conans/test/unittests/model/test_conf.py
@@ -108,7 +108,7 @@ def test_parse_spaces():
     ("user.company.cpu:jobs=10", 10),
     ("user.company.build:ccflags=--m superflag", "--m superflag"),
     ("zlib:user.company.check:shared=True", True),
-    ("zlib:user.company.check:shared_str='True'", '"True"'),
+    ("zlib:user.company.check:shared_str='True'", "'True'"),
     ("user.company.list:objs=[1, 2, 3, 4, 'mystr', {'a': 1}]", [1, 2, 3, 4, 'mystr', {'a': 1}]),
     ("user.company.network:proxies={'url': 'http://api.site.com/api', 'dataType': 'json', 'method': 'GET'}",
      {'url': 'http://api.site.com/api', 'dataType': 'json', 'method': 'GET'})


### PR DESCRIPTION
Changelog: Bugfix: Solve broken profile ``[conf]`` when strings contains Windows backslash.
Docs: Omit

Close https://github.com/conan-io/conan/issues/15726