### PR TITLE
fixed --deployer-package for local

### DIFF
--- a/conan/internal/deploy.py
+++ b/conan/internal/deploy.py
@@ -4,8 +4,7 @@ import shutil
 from conan.internal.cache.home_paths import HomePaths
 from conan.api.output import ConanOutput
 from conans.client.loader import load_python_file
-from conans.errors import ConanException
-from conans.model.recipe_ref import ref_matches
+from conans.errors import ConanException, conanfile_exception_formatter
 from conans.util.files import rmdir, mkdir
 
 
@@ -42,15 +41,23 @@ def do_deploys(conan_api, graph, deploy, deploy_package, deploy_folder):
     mkdir(deploy_folder)
     # handle the recipe deploy()
     if deploy_package:
+        # Similar processing as BuildMode class
+        excluded = [p[1:] for p in deploy_package if p[0] in ["!", "~"]]
+        included = [p for p in deploy_package if p[0] not in ["!", "~"]]
         for node in graph.ordered_iterate():
             conanfile = node.conanfile
-            if not conanfile.ref or not any(ref_matches(conanfile.ref, p, None)
-                                            for p in deploy_package):
+            if not conanfile.ref:  # virtual or conanfile.txt, can't have deployer
+                continue
+            consumer = conanfile._conan_is_consumer
+            if any(conanfile.ref.matches(p, consumer) for p in excluded):
+                continue
+            if not any(conanfile.ref.matches(p, consumer) for p in included):
                 continue
             if hasattr(conanfile, "deploy"):
                 conanfile.output.info("Executing deploy()")
                 conanfile.deploy_folder = deploy_folder
-                conanfile.deploy()
+                with conanfile_exception_formatter(conanfile, "deploy"):
+                    conanfile.deploy()
     # Handle the deploys
     cache = HomePaths(conan_api.cache_folder)
     for d in deploy or []:

--- a/conan/tools/files/copy_pattern.py
+++ b/conan/tools/files/copy_pattern.py
@@ -2,6 +2,7 @@ import fnmatch
 import os
 import shutil
 
+from conans.errors import ConanException
 from conans.util.files import mkdir
 
 
@@ -26,8 +27,12 @@ def copy(conanfile, pattern, src, dst, keep_path=True, excludes=None,
            ``True``
     :return: list of copied files
     """
-    assert src != dst
-    assert not pattern.startswith("..")
+    if src == dst:
+        raise ConanException("copy() 'src' and 'dst' arguments must have different values")
+    if pattern.startswith(".."):
+        raise ConanException("copy() it is not possible to use relative patterns starting with '..'")
+    if src is None:
+        raise ConanException("copy() received 'src=None' argument")
 
     # This is necessary to add the trailing / so it is not reported as symlink
     src = os.path.join(src, "")

--- a/conans/test/integration/conanfile/test_deploy_method.py
+++ b/conans/test/integration/conanfile/test_deploy_method.py
@@ -44,3 +44,35 @@ def test_deploy_method():
     c.run("install --requires=pkg/0.1 --deployer-package=pkg/* --deployer-folder=mydeploy")
     assert "dep/0.1: Executing deploy()" not in c.out
     assert "pkg/0.1: Executing deploy()" in c.out
+
+
+def test_deploy_local():
+    c = TestClient()
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.files import copy
+        class Pkg(ConanFile):
+            name = "pkg"
+            version = "0.1"
+            def deploy(self):
+                copy(self, "*", src=self.package_folder, dst=self.deploy_folder)
+        """)
+    c.save({"conanfile.py": conanfile})
+    c.run("install . --deployer-package=*", assert_error=True)
+    assert "ERROR: conanfile.py (pkg/0.1): Error in deploy() method, line 8" in c.out
+    assert "copy() received 'src=None' argument" in c.out
+
+    # Without name/version same error
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        class Pkg(ConanFile):
+            def deploy(self):
+                assert self.package_folder  # will fail if None
+        """)
+    c.save({"conanfile.py": conanfile})
+    c.run("install . --deployer-package=*", assert_error=True)
+    assert "ERROR: conanfile.py: Error in deploy() method, line 5" in c.out
+
+    # I can exclude the current consumer, it won't fail
+    c.run("install . --deployer-package=!& --deployer-package=*")
+    assert "Install finished successfully" in c.out

--- a/conans/test/unittests/source/merge_directories_test.py
+++ b/conans/test/unittests/source/merge_directories_test.py
@@ -5,6 +5,7 @@ from os.path import join
 
 import pytest
 
+from conans.errors import ConanException
 from conans.test.utils.test_files import temp_folder
 from conans.util.files import mkdir, save, merge_directories, load
 
@@ -73,7 +74,7 @@ class MergeDirectoriesTest(unittest.TestCase):
 
     def test_same_directory(self):
         # Same directory cannot be merged, this should never happen
-        with pytest.raises(AssertionError):
+        with pytest.raises(ConanException):
             merge_directories(self.source, self.source)
 
     def test_parent_directory(self):


### PR DESCRIPTION
Changelog: Fix: Improved ``conan install <path> --deployer-package=*`` case that was crashing when using ``self.package_folder``. 
Docs: Omit

Close https://github.com/conan-io/conan/issues/15729
