### PR TITLE
add --output-folder to export-pkg

### DIFF
--- a/conans/client/cmd/export_pkg.py
+++ b/conans/client/cmd/export_pkg.py
@@ -10,7 +10,7 @@ from conans.model.ref import PackageReference
 
 
 def export_pkg(app, recorder, full_ref, source_folder, build_folder, package_folder, install_folder,
-               graph_info, force, remotes, source_conanfile_path):
+               graph_info, force, remotes, source_conanfile_path, output_folder):
     ref = full_ref.copy_clear_rev()
     cache, output, hook_manager = app.cache, app.out, app.hook_manager
     graph_manager = app.graph_manager
@@ -59,7 +59,7 @@ def export_pkg(app, recorder, full_ref, source_folder, build_folder, package_fol
     conanfile.develop = True
     if hasattr(conanfile, "layout"):
         conanfile_folder = os.path.dirname(source_conanfile_path)
-        conanfile.folders.set_base_folders(conanfile_folder, output_folder=None)
+        conanfile.folders.set_base_folders(conanfile_folder, output_folder=output_folder)
         conanfile.folders.set_base_package(dest_package_folder)
     else:
         conanfile.folders.set_base_build(build_folder)

--- a/conans/client/command.py
+++ b/conans/client/command.py
@@ -1021,6 +1021,8 @@ class Command(object):
                             help="folder containing a locally created package. If a value is given,"
                                  " it won't call the recipe 'package()' method, and will run a copy"
                                  " of the provided folder.")
+        parser.add_argument("-of", "--output-folder", action=OnceArgument,
+                            help="To be used with 'layout()' recipes, useless otherwise")
         parser.add_argument("-sf", "--source-folder", action=OnceArgument, help=_SOURCE_FOLDER_HELP)
         parser.add_argument("-j", "--json", default=None, action=OnceArgument,
                             help='Path to a json file where the install information will be '
@@ -1057,6 +1059,7 @@ class Command(object):
                                           build_folder=args.build_folder,
                                           package_folder=args.package_folder,
                                           install_folder=args.install_folder,
+                                          output_folder=args.output_folder,
                                           profile_names=args.profile_host,
                                           env=args.env_host,
                                           settings=args.settings_host,

--- a/conans/client/conan_api.py
+++ b/conans/client/conan_api.py
@@ -407,7 +407,7 @@ class ConanAPIV1(object):
                    package_folder=None, install_folder=None, profile_names=None, settings=None,
                    options=None, env=None, force=False, user=None, version=None, cwd=None,
                    lockfile=None, lockfile_out=None, ignore_dirty=False, profile_build=None,
-                   conf=None):
+                   conf=None, output_folder=None):
         profile_host = ProfileData(profiles=profile_names, settings=settings, options=options,
                                    env=env, conf=conf)
         remotes = self.app.load_remotes()
@@ -423,6 +423,7 @@ class ConanAPIV1(object):
                                          "and source folders")
                 package_folder = _make_abs_path(package_folder, cwd)
 
+            output_folder = _make_abs_path(output_folder, cwd) if output_folder else None
             build_folder = _make_abs_path(build_folder, cwd)
             if install_folder:
                 install_folder = _make_abs_path(install_folder, cwd)
@@ -453,7 +454,8 @@ class ConanAPIV1(object):
             export_pkg(self.app, recorder, new_ref, source_folder=source_folder,
                        build_folder=build_folder, package_folder=package_folder,
                        install_folder=install_folder, graph_info=graph_info, force=force,
-                       remotes=remotes, source_conanfile_path=conanfile_path)
+                       remotes=remotes, source_conanfile_path=conanfile_path,
+                       output_folder=output_folder)
             if lockfile_out:
                 lockfile_out = _make_abs_path(lockfile_out, cwd)
                 graph_lock_file = GraphLockFile(graph_info.profile_host, graph_info.profile_build,

--- a/conans/test/functional/layout/test_local_commands.py
+++ b/conans/test/functional/layout/test_local_commands.py
@@ -454,9 +454,14 @@ def test_local_folders_without_layout():
 
 
 class TestLocalFlowExportPkg:
-    def test_local_flow_layout(self):
+    @pytest.mark.parametrize("with_layout", [True, False])
+    def test_local_flow_layout(self, with_layout):
         c = TestClient()
         c.run("new hello/0.1 -m=cmake_lib")
+        if not with_layout:
+            conanfile = c.load("conanfile.py")
+            conanfile = conanfile.replace("def layout(", "def layout2(")
+            c.save({"conanfile.py": conanfile})
 
         c.run("install . -of=build -if=build")
         c.run("build . -bf=build -if=build")
@@ -466,55 +471,5 @@ class TestLocalFlowExportPkg:
         pref = PackageReference(ref, package_id)
         pf = c.cache.package_layout(ref).package(pref)
         assert os.path.exists(os.path.join(pf, "include", "hello.h"))
-        ext = ".lib" if platform.system() == "Windows" else ".a"
-        assert os.path.exists(os.path.join(pf, "lib", f"hello{ext}"))
-
-    def test_local_flow_nolayout(self):
-        c = TestClient()
-        c.run("new hello/0.1 -m=cmake_lib")
-        conanfile = textwrap.dedent("""
-            from conan import ConanFile
-            from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
-
-            class HelloConan(ConanFile):
-                name = "hello"
-                version = "0.1"
-
-                settings = "os", "compiler", "build_type", "arch"
-                options = {"shared": [True, False], "fPIC": [True, False]}
-                default_options = {"shared": False, "fPIC": True}
-
-                # Sources are located in the same place as this recipe, copy them to the recipe
-                exports_sources = "CMakeLists.txt", "src/*", "include/*"
-
-                def config_options(self):
-                    if self.settings.os == "Windows":
-                        del self.options.fPIC
-
-                def generate(self):
-                    tc = CMakeToolchain(self)
-                    tc.generate()
-
-                def build(self):
-                    cmake = CMake(self)
-                    cmake.configure()
-                    cmake.build()
-
-                def package(self):
-                    cmake = CMake(self)
-                    cmake.install()
-
-                def package_info(self):
-                    self.cpp_info.libs = ["hello"]
-            """)
-        c.save({"conanfile.py": conanfile})
-        c.run("install . -of=build -if=build")
-        c.run("build . -bf=build -if=build")
-        c.run("export-pkg . -bf=build -of=build")
-        package_id = re.search(r"hello/0.1: Package '(\S+)' created", str(c.out)).group(1)
-        ref = ConanFileReference.loads("hello/0.1@")
-        pref = PackageReference(ref, package_id)
-        pf = c.cache.package_layout(ref).package(pref)
-        assert os.path.exists(os.path.join(pf, "include", "hello.h"))
-        ext = ".lib" if platform.system() == "Windows" else ".a"
-        assert os.path.exists(os.path.join(pf, "lib", f"hello{ext}"))
+        libname = "hello.lib" if platform.system() == "Windows" else "libhello.a"
+        assert os.path.exists(os.path.join(pf, "lib", libname))

--- a/conans/test/functional/layout/test_local_commands.py
+++ b/conans/test/functional/layout/test_local_commands.py
@@ -451,3 +451,18 @@ def test_local_folders_without_layout():
     client.run("install .")
     assert "conanfile.py (test/1.2.3): generate sf: {}".format(client.current_folder) in client.out
     assert "conanfile.py (test/1.2.3): generate bf: {}".format(client.current_folder) in client.out
+
+
+def test_local_flow_layout():
+    c = TestClient()
+    c.run("new hello/0.1 -m=cmake_lib")
+    c.run("install . -of=build -if=build")
+    c.run("build . -bf=build -if=build")
+    c.run("export-pkg . -bf=build -of=build")
+    package_id = re.search(r"hello/0.1: Package '(\S+)' created", str(c.out)).group(1)
+    ref = ConanFileReference.loads("hello/0.1@")
+    pref = PackageReference(ref, package_id)
+    pf = c.cache.package_layout(ref).package(pref)
+    assert os.path.exists(os.path.join(pf, "include", "hello.h"))
+    ext = ".lib" if platform.system() == "Windows" else ".a"
+    assert os.path.exists(os.path.join(pf, "lib", f"hello{ext}"))


### PR DESCRIPTION
Changelog: Feature: Add ``--output-folder`` to ``export-pkg`` command to be used when ``layout()`` is declared.
Docs: https://github.com/conan-io/docs/pull/3661

Close https://github.com/conan-io/conan/issues/15732
