### PR TITLE
Fix legacy usage of update arg in conan api

### DIFF
--- a/conans/client/graph/proxy.py
+++ b/conans/client/graph/proxy.py
@@ -147,5 +147,8 @@ class ConanProxy:
 def should_update_reference(reference, update):
     if update is None:
         return False
+    # Old API usages only ever passed a bool
+    if isinstance(update, bool):
+        return update
     # Legacy syntax had --update without pattern, it manifests as a "*" pattern
     return any(name == "*" or reference.name == name for name in update)


### PR DESCRIPTION
Changelog: Bugfix: Fix legacy usage of `update` argument in Conan API.
Docs: Omit

In https://github.com/conan-io/conan/pull/15652 we moved from passing a boolean to the `update` argument for graph loading to a list of references - While we tested that no Conan code was using the old syntax, I forgot to take into account that this would be used by other people directly from the API, which even if not properly documented yet, has valid usages outside our control

This PR ensures that old behaviour for the API is respected - to be released as 2.1.1 probably

Closes #15742
