### PR TITLE
Fix `conan profile show --format=json` for profiles with scoped confs

### DIFF
--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -645,7 +645,7 @@ class ConfDefinition:
             if pattern is None:
                 result.update(conf.serialize())
             else:
-                for k, v in conf.serialize():
+                for k, v in conf.serialize().items():
                     result[f"{pattern}:{k}"] = v
         return result
 

--- a/conans/test/integration/command/test_profile.py
+++ b/conans/test/integration/command/test_profile.py
@@ -133,9 +133,13 @@ def test_shorthand_syntax():
 
 def test_profile_show_json():
     c = TestClient()
-    c.save({"myprofilewin": "[settings]\nos=Windows\n[tool_requires]\nmytool/*:mytool/1.0",
+    c.save({"myprofilewin": "[settings]\nos=Windows\n"
+                            "[tool_requires]\nmytool/*:mytool/1.0\n"
+                            "[conf]\nuser.conf:value=42\nlibiconv/*:tools.env.virtualenv:powershell=False\n"
+                            "[options]\n*:myoption=True",
             "myprofilelinux": "[settings]\nos=Linux"})
     c.run("profile show -pr:b=myprofilewin -pr:h=myprofilelinux --format=json")
+
     profile = json.loads(c.stdout)
     assert profile["host"]["settings"] == {"os": "Linux"}
 


### PR DESCRIPTION
Changelog: Bugfix: Fix `conan profile show --format=json` for profiles with scoped confs.
Docs: Omit

Weird that we didn't get it reported sooner, but this seems to have been here for some months now

Closes https://github.com/conan-io/conan/issues/15746