### PR TITLE
Fix compiler path with meson on Windows when using Android NDK

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -329,8 +329,10 @@ class MesonToolchain(object):
                           'armv8': 'aarch64-linux-android',
                           'x86': 'i686-linux-android',
                           'x86_64': 'x86_64-linux-android'}.get(arch)
-        self.c = os.path.join(ndk_bin, "{}{}-clang".format(android_target, android_api_level))
-        self.cpp = os.path.join(ndk_bin, "{}{}-clang++".format(android_target, android_api_level))
+        os_build = self._conanfile.settings_build.get_safe('os')
+        compiler_extension = ".cmd" if os_build == "Windows" else ""
+        self.c = os.path.join(ndk_bin, "{}{}-clang{}".format(android_target, android_api_level, compiler_extension))
+        self.cpp = os.path.join(ndk_bin, "{}{}-clang++{}".format(android_target, android_api_level, compiler_extension))
         self.ar = os.path.join(ndk_bin, "llvm-ar")
 
     def _get_extra_flags(self):

--- a/conans/test/functional/toolchains/meson/test_cross_compilation.py
+++ b/conans/test/functional/toolchains/meson/test_cross_compilation.py
@@ -204,3 +204,76 @@ def test_android_meson_toolchain_cross_compiling(arch, expected_arch):
     if platform.system() == "Darwin":
         client.run_command('objdump -f "%s"' % libhello)
         assert "architecture: %s" % expected_arch in client.out
+
+
+@pytest.mark.parametrize("arch, expected_arch", [('armv8', 'aarch64'),
+                                                 ('armv7', 'arm'),
+                                                 ('x86', 'i386'),
+                                                 ('x86_64', 'x86_64')])
+@pytest.mark.tool("meson")
+@pytest.mark.tool("android_ndk")
+@pytest.mark.skipif(platform.system() == "Darwin", reason="MacOS tests are covered above")
+def test_android_meson_toolchain_cross_compiling_on_win_linux(arch, expected_arch):
+    api_level = 21
+    ndk_path = os.getenv("TEST_CONAN_ANDROID_NDK")
+    profile_host = textwrap.dedent("""
+    include(default)
+
+    [settings]
+    os = Android
+    os.api_level = {api_level}
+    arch = {arch}
+
+    [conf]
+    tools.android:ndk_path={ndk_path}
+    """)
+    hello_h = gen_function_h(name="hello")
+    hello_cpp = gen_function_cpp(name="hello", preprocessor=["STRING_DEFINITION"])
+    app = gen_function_cpp(name="main", includes=["hello"], calls=["hello"])
+    profile_host = profile_host.format(
+        api_level=api_level,
+        arch=arch,
+        ndk_path=ndk_path
+    )
+
+    client = TestClient()
+    client.save({"conanfile.py": _conanfile_py,
+                 "meson.build": _meson_build,
+                 "meson_options.txt": _meson_options_txt,
+                 "hello.h": hello_h,
+                 "hello.cpp": hello_cpp,
+                 "main.cpp": app,
+                 "profile_host": profile_host})
+
+    client.run("build . --profile:build=default --profile:host=profile_host")
+    content = client.load(os.path.join("conan_meson_cross.ini"))
+    clang_path="{ndk_path}/toolchains/llvm/prebuilt/{platform}-x86_64/bin/{arch}-linux-android{api_level}-{compiler}{extension}"
+    c_clang_path = clang_path.format(
+        platform=platform.system().lower(),
+        arch=arch,
+        api_level=api_level,
+        compiler="clang",
+        extension=".cmd" if platform.system() == "Windows" else ""
+    )
+    cpp_clang_path = clang_path.format(
+        platform=platform.system().lower(),
+        arch=arch,
+        api_level=api_level,
+        compiler="clang++",
+        extension=".cmd" if platform.system() == "Windows" else ""
+    )
+    assert "needs_exe_wrapper = true" in content
+    assert "c = {}".format(c_clang_path) in content
+    assert "cpp = {}".format(cpp_clang_path) in content
+    assert "Target machine cpu family: {}".format(expected_arch if expected_arch != "i386" else "x86") in client.out
+    assert "Target machine cpu: {}".format(arch) in client.out
+    libhello_name = "libhello.a" if platform.system() != "Windows" else "libhello.lib"
+    libhello = os.path.join(client.current_folder, "build", libhello_name)
+    demo = os.path.join(client.current_folder, "build", "demo")
+    assert os.path.isfile(libhello)
+    assert os.path.isfile(demo)
+
+    # Check binaries architecture
+    if platform.system() == "Darwin" or platform.system() == "Linux":
+        client.run_command('objdump -f "%s"' % libhello)
+        assert "architecture: %s" % expected_arch in client.out


### PR DESCRIPTION
Changelog: Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.

# Description 

Trying to build `lcms/2.14` on Windows using Android NDK results in a build error.

```
..\src\meson.build:1:0: ERROR: Failed running 'C:\\Users\\edukaj\\.conan2\\p\\b\\andro0a7659df7e598\\p\\bin\\toolchains\\llvm\\prebuilt\\windows-x86_64\\bin\\aarch64-linux-android29-clang', binary or interpreter not executable.
Possibly wrong architecture or the executable bit is not set.
```

The issue is that on Windows the right path for the toolchain should end with `.cmd`. 

I opened an issue on [conan-center-index](https://github.com/conan-io/conan-center-index/issues/22909), and I am proposing a fix here: