### PR TITLE
fix PkgConfigDeps in build context

### DIFF
--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -43,22 +43,22 @@ def _get_component_aliases(dep, comp_name):
     return comp_aliases or []
 
 
-def _get_package_name(dep, build_context_suffix=None):
+def _get_package_name(req, dep, build_context_suffix=None):
     pkg_name = dep.cpp_info.get_property("pkg_config_name") or _get_package_reference_name(dep)
-    suffix = _get_suffix(dep, build_context_suffix)
+    suffix = _get_suffix(req, build_context_suffix)
     return f"{pkg_name}{suffix}"
 
 
-def _get_component_name(dep, comp_name, build_context_suffix=None):
+def _get_component_name(req, dep, comp_name, build_context_suffix=None):
     if comp_name not in dep.cpp_info.components:
         # foo::foo might be referencing the root cppinfo
         if _get_package_reference_name(dep) == comp_name:
-            return _get_package_name(dep, build_context_suffix)
+            return _get_package_name(req, dep, build_context_suffix)
         raise ConanException("Component '{name}::{cname}' not found in '{name}' "
                              "package requirement".format(name=_get_package_reference_name(dep),
                                                           cname=comp_name))
     comp_name = dep.cpp_info.components[comp_name].get_property("pkg_config_name")
-    suffix = _get_suffix(dep, build_context_suffix)
+    suffix = _get_suffix(req, build_context_suffix)
     return f"{comp_name}{suffix}" if comp_name else None
 
 
@@ -67,11 +67,11 @@ def _get_suffix(req, build_context_suffix=None):
     Get the package name suffix coming from PkgConfigDeps.build_context_suffix attribute, but only
     for requirements declared as build requirement.
 
-    :param req: requirement ConanFile instance
+    :param req: requirement
     :param build_context_suffix: `dict` with all the suffixes
     :return: `str` with the suffix
     """
-    if not build_context_suffix or not req.is_build_context:
+    if not build_context_suffix or not req.build:
         return ""
     return build_context_suffix.get(req.ref.name, "")
 
@@ -201,8 +201,9 @@ class _PCContentGenerator:
 
 class _PCGenerator:
 
-    def __init__(self, conanfile, dep, build_context_suffix=None):
+    def __init__(self, conanfile, require, dep, build_context_suffix=None):
         self._conanfile = conanfile
+        self._require = require
         self._build_context_suffix = build_context_suffix or {}
         self._dep = dep
         self._content_generator = _PCContentGenerator(self._conanfile, self._dep)
@@ -240,9 +241,9 @@ class _PCGenerator:
                     continue  # If the dependency is not in the transitive, might be skipped
             else:  # For instance, dep == "hello/1.0" and req == "hello::cmp1" -> hello == hello
                 req_conanfile = self._dep
-            comp_name = _get_component_name(req_conanfile, comp_ref_name, self._build_context_suffix)
+            comp_name = _get_component_name(self._require, req_conanfile, comp_ref_name, self._build_context_suffix)
             if not comp_name:
-                pkg_name = _get_package_name(req_conanfile, self._build_context_suffix)
+                pkg_name = _get_package_name(self._require, req_conanfile, self._build_context_suffix)
                 # Creating a component name with namespace, e.g., dep-comp1
                 comp_name = _get_name_with_namespace(pkg_name, comp_ref_name)
             ret.append(comp_name)
@@ -256,13 +257,14 @@ class _PCGenerator:
 
         :return: `list` of `_PCInfo` objects with all the components information
         """
-        pkg_name = _get_package_name(self._dep, self._build_context_suffix)
+        pkg_name = _get_package_name(self._require, self._dep, self._build_context_suffix)
         components_info = []
         # Loop through all the package's components
         for comp_ref_name, cpp_info in self._dep.cpp_info.get_sorted_components().items():
             # At first, let's check if we have defined some components requires, e.g., "dep::cmp1"
             comp_requires_names = self._get_cpp_info_requires_names(cpp_info)
-            comp_name = _get_component_name(self._dep, comp_ref_name, self._build_context_suffix)
+            comp_name = _get_component_name(self._require, self._dep, comp_ref_name,
+                                            self._build_context_suffix)
             if not comp_name:
                 comp_name = _get_name_with_namespace(pkg_name, comp_ref_name)
                 comp_description = f"Conan component: {comp_name}"
@@ -281,14 +283,14 @@ class _PCGenerator:
 
         :return: `_PCInfo` object with the package information
         """
-        pkg_name = _get_package_name(self._dep, self._build_context_suffix)
+        pkg_name = _get_package_name(self._require, self._dep, self._build_context_suffix)
         # At first, let's check if we have defined some global requires, e.g., "other::cmp1"
         requires = self._get_cpp_info_requires_names(self._dep.cpp_info)
         # If we have found some component requires it would be enough
         if not requires:
             # If no requires were found, let's try to get all the direct visible dependencies,
             # e.g., requires = "other_pkg/1.0"
-            requires = [_get_package_name(req, self._build_context_suffix)
+            requires = [_get_package_name(self._require, req, self._build_context_suffix)
                         for req in self._transitive_reqs.values()]
         description = "Conan package: %s" % pkg_name
         aliases = _get_package_aliases(self._dep)
@@ -337,7 +339,7 @@ class _PCGenerator:
         # Second, let's load the root package's PC file ONLY
         # if it does not already exist in components one
         # Issue related: https://github.com/conan-io/conan/issues/10341
-        pkg_name = _get_package_name(self._dep, self._build_context_suffix)
+        pkg_name = _get_package_name(self._require, self._dep, self._build_context_suffix)
         if f"{pkg_name}.pc" not in pc_files:
             package_info = _PCInfo(pkg_name, pkg_requires, f"Conan package: {pkg_name}",
                                    self._dep.cpp_info, _get_package_aliases(self._dep))
@@ -400,7 +402,8 @@ class PkgConfigDeps:
             if require.build and dep.ref.name not in self.build_context_activated:
                 continue
 
-            pc_generator = _PCGenerator(self._conanfile, dep, build_context_suffix=self.build_context_suffix)
+            pc_generator = _PCGenerator(self._conanfile, require, dep,
+                                        build_context_suffix=self.build_context_suffix)
             pc_files.update(pc_generator.pc_files)
         return pc_files
 


### PR DESCRIPTION
Changelog: Bugfix: Fix ``PkgConfigDeps`` generating .pc files for its ``tool_requires`` when it is in the build context already.
Docs: Omit

Close https://github.com/conan-io/conan/issues/14920

I have already tried to backport this to Conan 1.X, but it seems it is not possible, because the graph model there does not support the correct processing of ``tool_requires`` when already in the build context.

