### PR TITLE
fix conf evaluation types

### DIFF
--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -1,4 +1,3 @@
-import collections
 import copy
 import numbers
 import re
@@ -652,20 +651,20 @@ class ConfDefinition:
         return result
 
     @staticmethod
-    def _get_evaluated_value(__v):
+    def _get_evaluated_value(_v):
         """
         Function to avoid eval() catching local variables
         """
         try:
-            # Isolated eval
-            parsed_value = eval(__v)  # This destroys Windows path strings with backslash
-            if not isinstance(numbers.Number, collections.Collection):
+            value = eval(_v)  # This destroys Windows path strings with backslash
+        except:  # It means eval() failed because of a string without quotes
+            value = _v.strip()
+        else:
+            if not isinstance(value, (numbers.Number, bool, dict, list, set, tuple)) \
+                    and value is not None:
                 # If it is quoted string we respect it as-is
-                parsed_value = __v.strip()
-        except:
-            # It means eval() failed because of a string without quotes
-            parsed_value = __v.strip()
-        return parsed_value
+                value = _v.strip()
+        return value
 
     def loads(self, text, profile=False):
         self._pattern_confs = {}

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -1,4 +1,6 @@
+import collections
 import copy
+import numbers
 import re
 import os
 import fnmatch
@@ -657,7 +659,7 @@ class ConfDefinition:
         try:
             # Isolated eval
             parsed_value = eval(__v)  # This destroys Windows path strings with backslash
-            if isinstance(parsed_value, str):  # xxx:xxx = "my string"
+            if not isinstance(numbers.Number, collections.Collection):
                 # If it is quoted string we respect it as-is
                 parsed_value = __v.strip()
         except:

--- a/conans/test/integration/configuration/conf/test_conf.py
+++ b/conans/test/integration/configuration/conf/test_conf.py
@@ -396,3 +396,21 @@ def test_conf_should_be_immutable():
     assert "dep/0.1: user.myteam:myconf: ['root_value', 'value1']" in c.out
     # The pkg/0.1 output should be non-modified
     assert "pkg/0.1: user.myteam:myconf: ['root_value']" in c.out
+
+
+def test_especial_strings_fail():
+    # https://github.com/conan-io/conan/issues/15777
+    c = TestClient()
+    global_conf = textwrap.dedent("""
+        user.mycompany:myfile = re
+        user.mycompany:myother = fnmatch
+        user.mycompany:myfunct = re.search
+        user.mycompany:mydict = {1: 're', 2: 'fnmatch'}
+        """)
+    save(c.cache.new_config_path, global_conf)
+    c.run("config show *")
+    print(c.out)
+    assert "user.mycompany:myfile: re" in c.out
+    assert "user.mycompany:myother: fnmatch" in c.out
+    assert "user.mycompany:myfunct: re.search" in c.out
+    assert "user.mycompany:mydict: {1: 're', 2: 'fnmatch'}" in c.out

--- a/conans/test/integration/configuration/conf/test_conf.py
+++ b/conans/test/integration/configuration/conf/test_conf.py
@@ -409,7 +409,6 @@ def test_especial_strings_fail():
         """)
     save(c.cache.new_config_path, global_conf)
     c.run("config show *")
-    print(c.out)
     assert "user.mycompany:myfile: re" in c.out
     assert "user.mycompany:myother: fnmatch" in c.out
     assert "user.mycompany:myfunct: re.search" in c.out


### PR DESCRIPTION
Changelog: Bugfix: Solved evaluation of ``conf`` items when they matched a Python module
Docs: Omit

Close https://github.com/conan-io/conan/issues/15777
