### PR TITLE
Fix CMake toolchain template env corruption and abseil build regression

### DIFF
--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -157,7 +157,7 @@ class CMakeToolchain(object):
         self.extra_sharedlinkflags = []
         self.extra_exelinkflags = []
 
-        self._template_env = Environment(trim_blocks=True, lstrip_blocks=True)
+        self._template_env = Environment(trim_blocks=True, lstrip_blocks=True, keep_trailing_newline=True)
         self._template_env.filters["cmake_value"] = _cmake_value
 
         self.blocks = ToolchainBlocks(self._conanfile, self._template_env, self,

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -162,6 +162,12 @@ def test_user_toolchain(conanfile):
     assert 'include("myowntoolchain.cmake")' in content
 
 
+def test_final_newline(conanfile):
+    toolchain = CMakeToolchain(conanfile)
+    content = toolchain.content
+    assert content[-1] == '\n'
+
+
 @pytest.fixture
 def conanfile_apple():
     c = ConanFile(None)


### PR DESCRIPTION
This pull request changes Conan 2's `CMakeToolchain` to end in a new line by setting Jinja's `keep_final_newline` flag.  This resolves #15785, where invalid CMake code was emitted.

Setting the flag as-is in the original code would however entirely break the CMake toolchain generation due to a silent corruption of Jinja environments caused by a usage error. The original code would make `cmake_value` available from blocks.py to toolchain.py by corrupting Jinja shared environments. The whole thing worked incidentally! Any Jinja improvement to make Jinja more robust against this usage error would have broken Conan. This refactors the code to fix the silent corruption and properly inherit `cmake_value` from toolchain.py into blocks.py.

It also adds a test to ensure that this does not regress again in future versions.

Changelog:
* Bugfix: A build error when cross-compiling Abseil was resolved (#15785). 
* Bugfix: Jinja2 shared template environment is no longer corrupted silently by `CMakeToolchain`.

Docs: https://github.com/conan-io/docs/pull/XXXX

- [x] Refer to the issue that supports this Pull Request.
- [x] ~If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.~
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
