### PR TITLE
fix CMakeToolchain newline

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -41,14 +41,7 @@ class Block(object):
         if context is None:
             return
 
-        def cmake_value(value):
-            if isinstance(value, bool):
-                return "ON" if value else "OFF"
-            else:
-                return '"{}"'.format(value)
-
         template = Template(self.template, trim_blocks=True, lstrip_blocks=True)
-        template.environment.filters["cmake_value"] = cmake_value
         return template.render(**context)
 
     def context(self):

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -100,9 +100,9 @@ class CMakeToolchain(object):
         # Variables
         {% for it, value in variables.items() %}
         {% if value is boolean %}
-        set({{ it }} {{ value|cmake_value }} CACHE BOOL "Variable {{ it }} conan-toolchain defined")
+        set({{ it }} {{ "ON" if value else "OFF"}} CACHE BOOL "Variable {{ it }} conan-toolchain defined")
         {% else %}
-        set({{ it }} {{ value|cmake_value }} CACHE STRING "Variable {{ it }} conan-toolchain defined")
+        set({{ it }} "{{ value }}" CACHE STRING "Variable {{ it }} conan-toolchain defined")
         {% endif %}
         {% endfor %}
         # Variables  per configuration
@@ -130,7 +130,6 @@ class CMakeToolchain(object):
         $<$<CONFIG:{{conf}}>:${CONAN_DEF_{{conf}}_{{name}}}>
         {%- endfor -%})
         {% endfor %}
-
 
 
         if(CMAKE_POLICY_DEFAULT_CMP0091)  # Avoid unused and not-initialized warnings
@@ -198,7 +197,8 @@ class CMakeToolchain(object):
     @property
     def content(self):
         context = self._context()
-        content = Template(self._template, trim_blocks=True, lstrip_blocks=True).render(**context)
+        content = Template(self._template, trim_blocks=True, lstrip_blocks=True,
+                           keep_trailing_newline=True).render(**context)
         content = relativize_generated_file(content, self._conanfile, "${CMAKE_CURRENT_LIST_DIR}")
         return content
 

--- a/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/conans/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -1325,3 +1325,12 @@ def test_add_cmakeexe_to_presets():
 
     presets = json.loads(c.load(presets_path))
     assert presets["configurePresets"][0].get("cmakeExecutable") is None
+
+
+def test_toolchain_ends_newline():
+    # https://github.com/conan-io/conan/issues/15785
+    client = TestClient()
+    client.save({"conanfile.py": GenConanfile()})
+    client.run("install . -g CMakeToolchain")
+    toolchain = client.load("conan_toolchain.cmake")
+    assert toolchain[-1] == "\n"


### PR DESCRIPTION
Changelog: Fix: Make ``CMakeToolchain`` end with newline.
Docs: Omit

Close https://github.com/conan-io/conan/issues/15785
