### PR TITLE
Fix/platform requires with options

### DIFF
--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -353,7 +353,8 @@ class DepsGraphBuilder(object):
             else:
                 down_options = Options(options_values=node.conanfile.default_build_options)
 
-        self._prepare_node(new_node, profile_host, profile_build, down_options)
+        if recipe_status != RECIPE_PLATFORM:
+            self._prepare_node(new_node, profile_host, profile_build, down_options)
         require.process_package_type(node, new_node)
         graph.add_node(new_node)
         graph.add_edge(node, new_node, require)

--- a/conans/test/integration/graph/test_platform_requires.py
+++ b/conans/test/integration/graph/test_platform_requires.py
@@ -161,7 +161,7 @@ class TestPlatformRequires:
                                                                 options={"dep/1.0:myoption": True})
         client.save({"conanfile.py": conanfile,
                      "profile": "[platform_requires]\ndep/1.0"})
-        client.run("create . -pr=profile")
+        client.run("create . -pr=profile")  # This crashed before for non-existing options
         assert "dep/1.0 - Platform" in client.out
 
 

--- a/conans/test/integration/graph/test_platform_requires.py
+++ b/conans/test/integration/graph/test_platform_requires.py
@@ -148,6 +148,22 @@ class TestPlatformRequires:
         client.run("install . -pr=profile", assert_error=True)
         assert "ERROR: Package 'dep/1.1' not resolved" in client.out
 
+    def test_platform_requires_with_options(self):
+        """ https://github.com/conan-io/conan/issues/15685
+        """
+        client = TestClient()
+        client.save({"conanfile.py": GenConanfile("pkg", "1.0").with_requires("dep/1.0"),
+                     "profile": "[platform_requires]\ndep/1.0"})
+        client.run("create . -pr=profile -o *:myoption=True")
+        assert "dep/1.0 - Platform" in client.out
+
+        conanfile = GenConanfile("pkg", "1.0").with_requirement("dep/1.0",
+                                                                options={"dep/1.0:myoption": True})
+        client.save({"conanfile.py": conanfile,
+                     "profile": "[platform_requires]\ndep/1.0"})
+        client.run("create . -pr=profile")
+        assert "dep/1.0 - Platform" in client.out
+
 
 class TestPlatformTestRequires:
     def test_platform_requires(self):
@@ -209,7 +225,7 @@ class TestPackageID:
         or package_id
         """
         client = TestClient()
-        save(client.cache.new_config_path, f"core.package_id:default_build_mode={package_id_mode}")
+        save(client.cache.new_config_path, f"core.package_id:default_unknown_mode={package_id_mode}")
         client.save({"conanfile.py": GenConanfile("pkg", "1.0").with_requires("dep/1.0"),
                      "profile": "[platform_requires]\ndep/1.0"})
         client.run("create . -pr=profile")
@@ -220,17 +236,36 @@ class TestPackageID:
         Changing the platform_requires revision affects consumers if package_revision_mode=recipe_revision
         """
         client = TestClient()
-        save(client.cache.new_config_path, "core.package_id:default_build_mode=recipe_revision_mode")
+        save(client.cache.new_config_path, "core.package_id:default_unknown_mode=recipe_revision_mode")
         client.save({"conanfile.py": GenConanfile("pkg", "1.0").with_requires("dep/1.0"),
                      "profile": "[platform_requires]\ndep/1.0#r1",
                      "profile2": "[platform_requires]\ndep/1.0#r2"})
         client.run("create . -pr=profile")
         assert "dep/1.0#r1 - Platform" in client.out
         assert "pkg/1.0#7ed9bbd2a7c3c4381438c163c93a9f21:" \
-               "abfcc78fa8242cabcd1e3d92896aa24808c789a3 - Build" in client.out
+               "d9d32dd13cfc9734becc01287570721cd048ba19 - Build" in client.out
 
         client.run("create . -pr=profile2")
         # pkg gets a new package_id because it is a different revision
         assert "dep/1.0#r2 - Platform" in client.out
         assert "pkg/1.0#7ed9bbd2a7c3c4381438c163c93a9f21:" \
-               "abfcc78fa8242cabcd1e3d92896aa24808c789a3 - Build" in client.out
+               "2f6bc9cf5015a7210181592d454f36687791a941 - Build" in client.out
+
+    def test_package_id_full_mode(self):
+        """
+        platform_requires do not have settings or package_id, so it is ignored
+        """
+        client = TestClient()
+        save(client.cache.new_config_path, "core.package_id:default_unknown_mode=full_package_mode")
+        client.save({"conanfile.py": GenConanfile("pkg", "1.0").with_requires("dep/1.0"),
+                     "profile": "[platform_requires]\ndep/1.0"})
+        client.run("create . -pr=profile -s os=Linux")
+        assert "dep/1.0 - Platform" in client.out
+        assert "pkg/1.0#7ed9bbd2a7c3c4381438c163c93a9f21:" \
+               "f2cfe57716d0a3320019f058edcd728d3379ab32 - Build" in client.out
+
+        client.run("create . -pr=profile -s os=Windows")
+        # pkg gets exactly same package_id, changing the settings, do not affect plaform package-id
+        assert "dep/1.0 - Platform" in client.out
+        assert "pkg/1.0#7ed9bbd2a7c3c4381438c163c93a9f21:" \
+               "f2cfe57716d0a3320019f058edcd728d3379ab32 - Build" in client.out


### PR DESCRIPTION
Changelog: Fix: Avoid ``platform_requires`` to fail when explicit options are being passed via ``requires(.., options={})``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/15685
