### PR TITLE
Added clang-18 to default settings.yml

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -109,7 +109,7 @@ compiler:
     clang:
         version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
                   "5.0", "6.0", "7.0", "7.1",
-                  "8", "9", "10", "11", "12", "13", "14", "15", "16", "17"]
+                  "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18"]
         libcxx: [null, libstdc++, libstdc++11, libc++, c++_shared, c++_static]
         cppstd: [null, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
         runtime: [null, static, dynamic]


### PR DESCRIPTION
Changelog: Feature: Added support for Clang 18.
Docs: https://github.com/conan-io/docs/pull/3637

Clang-18 is being downloaded by default from apt.llvm.org, and it gets stable tomorrow. I think it's time to add it to the default `settings.yml` :)

- [ ] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
