### PR TITLE
fix msbuild_lib template with static-library

### DIFF
--- a/conan/internal/api/new/msbuild_lib.py
+++ b/conan/internal/api/new/msbuild_lib.py
@@ -216,6 +216,7 @@ class {{package_name}}Conan(ConanFile):
     version = "{{version}}"
 
     # Binary configuration
+    package_type = "static-library" # hardcoded in .vcxproj
     settings = "os", "compiler", "build_type", "arch"
 
     # Sources are located in the same place as this recipe, copy them to the recipe

--- a/conans/test/functional/toolchains/microsoft/test_v2_msbuild_template.py
+++ b/conans/test/functional/toolchains/microsoft/test_v2_msbuild_template.py
@@ -45,14 +45,14 @@ def test_msbuild_lib_2022():
     client.run("create . -s compiler.version=191 -c tools.microsoft.msbuild:vs_version=17")
     assert "hello/0.1: Hello World Release!" in client.out
     # This is the default compiler.version=191 in conftest
-    assert "Visual Studio 2022" in client.out
+    assert "Activating environment Visual Studio 17" in client.out
     assert "hello/0.1: _MSC_VER191" in client.out
 
     # Create works
     client.run("create . -s compiler.version=193")
     assert "hello/0.1: Hello World Release!" in client.out
     # This is the default compiler.version=191 in conftest
-    assert "Visual Studio 2022" in client.out
+    assert "Activating environment Visual Studio 17" in client.out
     assert "hello/0.1: _MSC_VER193" in client.out
 
 


### PR DESCRIPTION
Changelog: Fix: Add ``package_type="static-library"`` to the ``conan new msbuild_lib`` template.
Docs: Omit
