### PR TITLE
Update _meson_cpu_family_map to support arm64ec

### DIFF
--- a/conan/tools/meson/helpers.py
+++ b/conan/tools/meson/helpers.py
@@ -35,6 +35,7 @@ _meson_cpu_family_map = {
     'armv8': ('aarch64', 'armv8', 'little'),
     'armv8_32': ('aarch64', 'armv8_32', 'little'),
     'armv8.3': ('aarch64', 'armv8.3', 'little'),
+    'arm64ec': ('aarch64', 'arm64ec', 'little'),
     'avr': ('avr', 'avr', 'little'),
     'mips': ('mips', 'mips', 'big'),
     'mips64': ('mips64', 'mips64', 'big'),

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -297,7 +297,8 @@ def _vcvars_arch(conanfile):
         arch = {'x86': "amd64_x86",
                 'x86_64': 'amd64',
                 'armv7': 'amd64_arm',
-                'armv8': 'amd64_arm64'}.get(arch_host)
+                'armv8': 'amd64_arm64',
+                'arm64ec':'amd64_arm64'}.get(arch_host)
     elif arch_build == 'x86':
         arch = {'x86': 'x86',
                 'x86_64': 'x86_amd64',


### PR DESCRIPTION
Changelog: Feature: Update `_meson_cpu_family_map` to support `arm64ec`.
Docs: Omit

Close https://github.com/conan-io/conan/issues/15809

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.


building lcms/2.16 with below command:
```bash
conan create all --version=2.16 -pr:b windows-build-x86_64 -pr windows-msvc17.6.0-arm64ec -s build_type=Debug --build=missing
```
It always get below error:
```
fatal error LNK1392: Incompatible object type found. Did you mean /machine:arm64x or /machine:arm64ec?
```