### PR TITLE
[PkgConfigDeps][MesonToolchain] Added `build` context folder mechanism

### DIFF
--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -381,9 +381,11 @@ class PkgConfigDeps:
         test_req = self._conanfile.dependencies.test
         # If self.build_context_suffix is not defined, the build requires will be saved
         # in the self.build_context_folder
-        if self.build_context_suffix:
-            self._conanfile.output.warning("build_context_suffix attribute has been deprecated. Use the"
-                                           " build_context_folder one instead.")
+        if self.build_context_folder is None:
+            if self.build_context_suffix:
+                # deprecation warning
+                self._conanfile.output.warning("build_context_suffix attribute has been deprecated. Use the"
+                                               " build_context_folder one instead.")
             # Check if it exists both as require and as build require without a suffix
             self._validate_build_requires(host_req, build_req)
 

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -348,7 +348,8 @@ class PkgConfigDeps:
         # will have no effect.
         # Issue: https://github.com/conan-io/conan/issues/12342
         # Issue: https://github.com/conan-io/conan/issues/14935
-        self.build_context_folder = "build"
+        # FIXME: Conan 3.x: build_context_folder = "build" by default
+        self.build_context_folder = None  # Keeping backward-compatibility
 
     def _validate_build_requires(self, host_req, build_req):
         """

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -179,8 +179,6 @@ class MesonToolchain(object):
             elif compiler == "gcc":
                 default_comp = "gcc"
                 default_comp_cpp = "g++"
-            # If not cross-building, setting build_pkg_config_path to "build" by default
-            self.build_pkg_config_path = os.path.join(self._conanfile.generators_folder, "build")
 
         if "Visual" in compiler or compiler == "msvc":
             default_comp = "cl"

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -173,7 +173,6 @@ class MesonToolchain(object):
             if is_apple_os(self._conanfile):  # default cross-compiler in Apple is common
                 default_comp = "clang"
                 default_comp_cpp = "clang++"
-
         else:
             if "clang" in compiler:
                 default_comp = "clang"

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -65,6 +65,7 @@ class MesonToolchain(object):
     {% if cpp_std %}cpp_std = '{{cpp_std}}' {% endif %}
     {% if backend %}backend = '{{backend}}' {% endif %}
     {% if pkg_config_path %}pkg_config_path = '{{pkg_config_path}}'{% endif %}
+    {% if build_pkg_config_path %}build.pkg_config_path = '{{build_pkg_config_path}}'{% endif %}
     # C/C++ arguments
     c_args = {{c_args}} + preprocessor_definitions
     c_link_args = {{c_link_args}}
@@ -145,6 +146,10 @@ class MesonToolchain(object):
 
         #: Defines the Meson ``pkg_config_path`` variable
         self.pkg_config_path = self._conanfile.generators_folder
+        #: Defines the Meson ``build.pkg_config_path`` variable (build context)
+        # Issue: https://github.com/conan-io/conan/issues/12342
+        # Issue: https://github.com/conan-io/conan/issues/14935
+        self.build_pkg_config_path = os.path.join(self._conanfile.generators_folder, "build")
 
         self.libcxx, self.gcc_cxx11_abi = libcxx_flags(self._conanfile)
 
@@ -168,6 +173,7 @@ class MesonToolchain(object):
             if is_apple_os(self._conanfile):  # default cross-compiler in Apple is common
                 default_comp = "clang"
                 default_comp_cpp = "clang++"
+
         else:
             if "clang" in compiler:
                 default_comp = "clang"
@@ -422,6 +428,7 @@ class MesonToolchain(object):
             "objcpp_args": to_meson_value(self._filter_list_empty_fields(self.objcpp_args)),
             "objcpp_link_args": to_meson_value(self._filter_list_empty_fields(self.objcpp_link_args)),
             "pkg_config_path": self.pkg_config_path,
+            "build_pkg_config_path": self.build_pkg_config_path,
             "preprocessor_definitions": self.preprocessor_definitions,
             "cross_build": self.cross_build,
             "is_apple_system": self._is_apple_system

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -149,8 +149,7 @@ class MesonToolchain(object):
         #: Defines the Meson ``build.pkg_config_path`` variable (build context)
         # Issue: https://github.com/conan-io/conan/issues/12342
         # Issue: https://github.com/conan-io/conan/issues/14935
-        self.build_pkg_config_path = os.path.join(self._conanfile.generators_folder, "build")
-
+        self.build_pkg_config_path = None
         self.libcxx, self.gcc_cxx11_abi = libcxx_flags(self._conanfile)
 
         #: Dict-like object with the build, host, and target as the Meson machine context
@@ -180,6 +179,9 @@ class MesonToolchain(object):
             elif compiler == "gcc":
                 default_comp = "gcc"
                 default_comp_cpp = "g++"
+            # If not cross-building, setting build_pkg_config_path to "build" by default
+            self.build_pkg_config_path = os.path.join(self._conanfile.generators_folder, "build")
+
         if "Visual" in compiler or compiler == "msvc":
             default_comp = "cl"
             default_comp_cpp = "cl"

--- a/conans/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -758,7 +758,6 @@ def test_tool_requires_raise_exception_if_exist_both_require_and_build_one():
             def generate(self):
                 tc = PkgConfigDeps(self)
                 tc.build_context_activated = ["tool"]
-                tc.build_context_suffix = {"tool": ""}  # No suffix defined
                 tc.generate()
         """)
     client.save({"conanfile.py": conanfile}, clean_first=True)

--- a/conans/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/conans/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -914,7 +914,7 @@ class TestPCGenerationBuildContext:
         c.run("install app -s:h build_type=Debug --build=missing")
         assert "Install finished successfully" in c.out  # the asserts in build() didn't fail
 
-    @pytest.mark.parametrize("build_folder_name", ["DEFAULT", "my_build", ""])
+    @pytest.mark.parametrize("build_folder_name", ["build", ""])
     def test_pc_generate_components_in_build_context_folder(self, build_folder_name):
         c = TestClient()
         tool = textwrap.dedent("""
@@ -931,9 +931,7 @@ class TestPCGenerationBuildContext:
                 def generate(self):
                     deps = PkgConfigDeps(self)
                     deps.build_context_activated = ["wayland", "dep"]
-                    # if "DEFAULT" using the default deps.build_context_folder == "build"
-                    if "{build_folder_name}" != "DEFAULT":
-                        deps.build_context_folder = "{build_folder_name}"
+                    deps.build_context_folder = "{build_folder_name}"
                     deps.generate()
 
                 def build(self):
@@ -944,12 +942,11 @@ class TestPCGenerationBuildContext:
 
                     # Issue: https://github.com/conan-io/conan/issues/12342
                     # Issue: https://github.com/conan-io/conan/issues/14935
-                    folder = "build" if "{build_folder_name}" == "DEFAULT" else "{build_folder_name}"
-                    if folder:
-                        assert os.path.exists(folder + "/wayland.pc")
-                        assert os.path.exists(folder + "/wayland-client.pc")
-                        assert os.path.exists(folder + "/wayland-server.pc")
-                        assert os.path.exists(folder + "/dep.pc")
+                    if "{build_folder_name}":
+                        assert os.path.exists("{build_folder_name}/wayland.pc")
+                        assert os.path.exists("{build_folder_name}/wayland-client.pc")
+                        assert os.path.exists("{build_folder_name}/wayland-server.pc")
+                        assert os.path.exists("{build_folder_name}/dep.pc")
                 """.format(build_folder_name=build_folder_name))
         wayland = textwrap.dedent("""
             from conan import ConanFile

--- a/conans/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/conans/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -286,19 +286,9 @@ def test_check_c_cpp_ld_list_formats():
 def test_check_pkg_config_paths():
     # Issue: https://github.com/conan-io/conan/issues/12342
     # Issue: https://github.com/conan-io/conan/issues/14935
-    default = textwrap.dedent("""
-    [settings]
-    os=Macos
-    arch=x86_64
-    compiler=apple-clang
-    compiler.version=12.0
-    compiler.libcxx=libc++
-    build_type=Release
-    """)
     t = TestClient()
-    t.save({"conanfile.txt": "[generators]\nMesonToolchain",
-            "profile": default})
-    t.run("install . -pr:h=profile -pr:b=profile")
+    t.save({"conanfile.txt": "[generators]\nMesonToolchain"})
+    t.run("install .")
     content = t.load(MesonToolchain.native_filename)
     base_folder = t.current_folder
     assert f"pkg_config_path = '{base_folder}'" in content

--- a/conans/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/conans/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import textwrap
 
@@ -280,3 +281,25 @@ def test_check_c_cpp_ld_list_formats():
     assert "c = ['aarch64-poky-linux-gcc', '-mcpu=cortex-a53', '-march=armv8-a+crc+crypto']" in content
     assert "cpp = ['aarch64-poky-linux-g++', '-mcpu=cortex-a53', '-march=armv8-a+crc+crypto']" in content
     assert "ld = ['aarch64-poky-linux-ld', '--sysroot=/opt/sysroots/cortexa53-crypto-poky-linux']" in content
+
+
+def test_check_pkg_config_paths():
+    # Issue: https://github.com/conan-io/conan/issues/12342
+    # Issue: https://github.com/conan-io/conan/issues/14935
+    default = textwrap.dedent("""
+    [settings]
+    os=Macos
+    arch=x86_64
+    compiler=apple-clang
+    compiler.version=12.0
+    compiler.libcxx=libc++
+    build_type=Release
+    """)
+    t = TestClient()
+    t.save({"conanfile.txt": "[generators]\nMesonToolchain",
+            "profile": default})
+    t.run("install . -pr:h=profile -pr:b=profile")
+    content = t.load(MesonToolchain.native_filename)
+    base_folder = t.current_folder
+    assert f"pkg_config_path = '{base_folder}'" in content
+    assert f"build.pkg_config_path = '{os.path.join(base_folder, 'build')}'" in content

--- a/conans/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/conans/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -290,6 +290,22 @@ def test_check_pkg_config_paths():
     t.save({"conanfile.txt": "[generators]\nMesonToolchain"})
     t.run("install .")
     content = t.load(MesonToolchain.native_filename)
+    assert f"pkg_config_path = '{t.current_folder}'" in content
+    assert f"build.pkg_config_path = " not in content
+    conanfile = textwrap.dedent("""
+    import os
+    from conan import ConanFile
+    from conan.tools.meson import MesonToolchain
+    class Pkg(ConanFile):
+        settings = "os", "compiler", "arch", "build_type"
+        def generate(self):
+            tc = MesonToolchain(self)
+            tc.build_pkg_config_path = os.path.join(self.generators_folder, "build")
+            tc.generate()
+    """)
+    t.save({"conanfile.py": conanfile}, clean_first=True)
+    t.run("install .")
+    content = t.load(MesonToolchain.native_filename)
     base_folder = t.current_folder
     assert f"pkg_config_path = '{base_folder}'" in content
     assert f"build.pkg_config_path = '{os.path.join(base_folder, 'build')}'" in content


### PR DESCRIPTION
Changelog: Feature: Added `build_context_folder ` to PkgConfigDeps.
Changelog: Feature: Included `build.pkg_config_path ` in the built-in options section in the MesonToolchain template.
Docs: https://github.com/conan-io/docs/pull/3640
Closes: https://github.com/conan-io/conan/issues/12342
Closes: https://github.com/conan-io/conan/issues/14935
