### PR TITLE
fix graph explain with no binaries

### DIFF
--- a/conan/api/subapi/list.py
+++ b/conan/api/subapi/list.py
@@ -223,7 +223,6 @@ class ListAPI:
                 ConanOutput().info(f"Finding binaries in remote {remote.name}")
                 pkg_configurations = self.packages_configurations(ref, remote=remote)
             except Exception as e:
-                pass
                 ConanOutput(f"ERROR IN REMOTE {remote.name}: {e}")
             else:
                 candidates.extend(_BinaryDistance(pref, data, conaninfo, remote)
@@ -232,8 +231,7 @@ class ListAPI:
         candidates.sort()
         pkglist = PackagesList()
         pkglist.add_refs([ref])
-        # If there are exact matches, only return the matches
-        # else, limit to the number specified
+        # Return the closest matches, stop adding when distance is increased
         candidate_distance = None
         for candidate in candidates:
             if candidate_distance and candidate.distance != candidate_distance:

--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -22,6 +22,11 @@ def explain_formatter_text(data):
         # we need to wrap this in a MultiPackagesList
         pkglist = data["closest_binaries"]
         prepare_pkglist_compact(pkglist)
+        # Now we make sure that if there are no binaries we will print something that makes sense
+        for ref, ref_info in pkglist.items():
+            for rrev, rrev_info in ref_info.items():
+                if not rrev_info:
+                    rrev_info["ERROR"] = "No package binaries exist"
         print_serial(pkglist)
 
 

--- a/conans/test/integration/command_v2/test_graph_find_binaries.py
+++ b/conans/test/integration/command_v2/test_graph_find_binaries.py
@@ -454,3 +454,13 @@ class TestDistance:
         assert "a657a8fc96dd855e2a1c90a9fe80125f0c4635a0" not in tc.out
         # We expect the closer binary to show
         assert "a6923b987deb1469815dda84aab36ac34f370c48" in tc.out
+
+
+def test_no_binaries():
+    # https://github.com/conan-io/conan/issues/15819
+    c = TestClient()
+    c.save({"conanfile.py": GenConanfile("pkg", "0.1")})
+    c.run("export .")
+    c.run("graph explain --requires=pkg/0.1")
+    assert "ERROR: No package binaries exist" in c.out
+    # The json is not an issue, it won't have anything as contents


### PR DESCRIPTION
Changelog: Fix: Print a clear message for ``conan graph explain`` when no binaries exist for one revision.
Docs: Omit

Close https://github.com/conan-io/conan/issues/15819