### PR TITLE
Add: parameter on `trim_conandata` to block the raise an exception when conandata.yml file doesn't exist

### DIFF
--- a/conan/tools/files/conandata.py
+++ b/conan/tools/files/conandata.py
@@ -41,7 +41,7 @@ def update_conandata(conanfile, data):
     save(path, new_content)
 
 
-def trim_conandata(conanfile):
+def trim_conandata(conanfile, raise_if_missing=True):
     """
     Tool to modify the ``conandata.yml`` once it is exported, to limit it to the current version
     only
@@ -50,7 +50,10 @@ def trim_conandata(conanfile):
         raise ConanException("The 'trim_conandata()' can only be used in the 'export()' method")
     path = os.path.join(conanfile.export_folder, "conandata.yml")
     if not os.path.exists(path):
-        raise ConanException("conandata.yml file doesn't exist")
+        if raise_if_missing:
+            raise ConanException("conandata.yml file doesn't exist")
+        else:
+            return None
 
     conandata = load(path)
     conandata = yaml.safe_load(conandata)

--- a/conan/tools/files/conandata.py
+++ b/conan/tools/files/conandata.py
@@ -53,7 +53,8 @@ def trim_conandata(conanfile, raise_if_missing=True):
         if raise_if_missing:
             raise ConanException("conandata.yml file doesn't exist")
         else:
-            return None
+            conanfile.output.warning("conandata.yml file doesn't exist")
+            return
 
     conandata = load(path)
     conandata = yaml.safe_load(conandata)

--- a/conans/test/integration/conanfile/conan_data_test.py
+++ b/conans/test/integration/conanfile/conan_data_test.py
@@ -375,3 +375,17 @@ def test_trim_conandata_as_hook():
     assert "1.1" not in data2
     assert data1 == data2
     assert "pkg/1.0: Exported: pkg/1.0#03af39add1c7c9d68dcdb10b6968a14d" in c.out
+
+
+def test_trim_conandata_as_hook_without_conandata():
+    c = TestClient()
+    c.save_home({"extensions/hooks/hook_trim.py": textwrap.dedent("""
+    from conan.tools.files import trim_conandata
+
+    def post_export(conanfile):
+        trim_conandata(conanfile, raise_if_missing=False)
+    """)})
+
+    c.save({"conanfile.py": GenConanfile("pkg")})
+    c.run("export . --version=1.0")
+    assert c.exported_recipe_revision() == "a9ec2e5fbb166568d4670a9cd1ef4b26"


### PR DESCRIPTION
Changelog: Feature: Add a parameter to `trim_conandata` to avoid raising an exception when conandata.yml file doesn't exist.
Docs: https://github.com/conan-io/docs/pull/3624

Close: #15672

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
