### PR TITLE
CMakeToolchain: implement vs debugger path

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -114,14 +114,9 @@ class VSRuntimeBlock(Block):
 
 class VSDebuggerEnvironment(Block):
     template = textwrap.dedent("""
-        # Definition of CMAKE_VS_DEBUGGER_ENVIRONMENT
         {% if vs_debugger_path %}
-        {% set genexpr = namespace(str='') %}
-        {% for config, value in vs_debugger_path.items() %}
-        {% set genexpr.str = genexpr.str +
-                                '$<$<CONFIG:' + config + '>:' + value|string + '>' %}
-        {% endfor %}
-        set(CMAKE_VS_DEBUGGER_ENVIRONMENT "PATH={{ genexpr.str }};%PATH%")                      
+        # Definition of CMAKE_VS_DEBUGGER_ENVIRONMENT
+        set(CMAKE_VS_DEBUGGER_ENVIRONMENT "{{ vs_debugger_path }}")                      
         {% endif %}
         """)
     
@@ -132,18 +127,17 @@ class VSDebuggerEnvironment(Block):
         if (os_ and not "Windows" in os_) or not build_type:
             return None
         
-        generator = self._conanfile.conf.get("tools.cmake.cmaketoolchain:generator", default="Visual Studio")
-        if not "Visual Studio" in generator:
+        if "Visual" not in self._toolchain.generator:
             return None
         
         config_dict = {}
         if os.path.exists(CONAN_TOOLCHAIN_FILENAME):
             existing_include = load(CONAN_TOOLCHAIN_FILENAME)
-            vs_debugger_environment = re.search(r"set\(CMAKE_VS_DEBUGGER_ENVIRONMENT \"PATH=([^)]*)>;%PATH%\"\)",
+            vs_debugger_environment = re.search(r"set\(CMAKE_VS_DEBUGGER_ENVIRONMENT \"PATH=([^)]*);%PATH%\"\)",
                                            existing_include)
             if vs_debugger_environment:
                 capture = vs_debugger_environment.group(1)
-                matches = re.findall(r"\$<\$<CONFIG:([A-Za-z]*)>:(.*)", capture)
+                matches = re.findall(r"\$<\$<CONFIG:([A-Za-z]*)>:([^>]*)>", capture)
                 config_dict = dict(matches)
         
         host_deps = self._conanfile.dependencies.host.values()
@@ -157,7 +151,12 @@ class VSDebuggerEnvironment(Block):
         if all(value is '' for value in config_dict.values()):
             return None
         
-        return {"vs_debugger_path": config_dict}
+        vs_debugger_path = ""
+        for config, value in config_dict.items():
+            vs_debugger_path += f"$<$<CONFIG:{config}>:{value}>"
+        vs_debugger_path = f"PATH={vs_debugger_path};%PATH%"
+        
+        return {"vs_debugger_path": vs_debugger_path}
     
 
 class FPicBlock(Block):

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -148,16 +148,17 @@ class VSDebuggerEnvironment(Block):
         bin_dirs.extend(test_bindirs)
         bin_dirs = [p.replace("\\", "/") for p in bin_dirs]
 
-        bin_dirs = ";".join(bin_dirs)
-        config_dict[build_type] = bin_dirs
-        if all(value is '' for value in config_dict.values()):
-            return None
+        bin_dirs = ";".join(bin_dirs) if bin_dirs else None
+        if bin_dirs:
+            config_dict[build_type] = bin_dirs
 
+        if not config_dict:
+            return None
+        
         vs_debugger_path = ""
         for config, value in config_dict.items():
             vs_debugger_path += f"$<$<CONFIG:{config}>:{value}>"
         vs_debugger_path = f"PATH={vs_debugger_path};%PATH%"
-
         return {"vs_debugger_path": vs_debugger_path}
 
 

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -112,52 +112,54 @@ class VSRuntimeBlock(Block):
 
         return {"vs_runtimes": config_dict}
 
+
 class VSDebuggerEnvironment(Block):
     template = textwrap.dedent("""
         {% if vs_debugger_path %}
         # Definition of CMAKE_VS_DEBUGGER_ENVIRONMENT
-        set(CMAKE_VS_DEBUGGER_ENVIRONMENT "{{ vs_debugger_path }}")                      
+        set(CMAKE_VS_DEBUGGER_ENVIRONMENT "{{ vs_debugger_path }}")
         {% endif %}
         """)
-    
+
     def context(self):
         os_ = self._conanfile.settings.get_safe("os")
         build_type = self._conanfile.settings.get_safe("build_type")
 
-        if (os_ and not "Windows" in os_) or not build_type:
+        if (os_ and "Windows" not in os_) or not build_type:
             return None
-        
+
         if "Visual" not in self._toolchain.generator:
             return None
-        
+
         config_dict = {}
         if os.path.exists(CONAN_TOOLCHAIN_FILENAME):
             existing_include = load(CONAN_TOOLCHAIN_FILENAME)
-            vs_debugger_environment = re.search(r"set\(CMAKE_VS_DEBUGGER_ENVIRONMENT \"PATH=([^)]*);%PATH%\"\)",
-                                           existing_include)
+            pattern = r"set\(CMAKE_VS_DEBUGGER_ENVIRONMENT \"PATH=([^)]*);%PATH%\"\)"
+            vs_debugger_environment = re.search(pattern, existing_include)
             if vs_debugger_environment:
                 capture = vs_debugger_environment.group(1)
                 matches = re.findall(r"\$<\$<CONFIG:([A-Za-z]*)>:([^>]*)>", capture)
                 config_dict = dict(matches)
-        
+
         host_deps = self._conanfile.dependencies.host.values()
         test_deps = self._conanfile.dependencies.test.values()
-        bin_dirs = [p.replace('\\','/') for dep in host_deps for p in dep.cpp_info.aggregated_components().bindirs]
-        test_bin_dirs = [p.replace('\\','/') for dep in test_deps for p in dep.cpp_info.aggregated_components().bindirs]
-        bin_dirs.extend(test_bin_dirs)
+        bin_dirs = [p for dep in host_deps for p in dep.cpp_info.aggregated_components().bindirs]
+        test_bindirs = [p for dep in test_deps for p in dep.cpp_info.aggregated_components().bindirs]
+        bin_dirs.extend(test_bindirs)
+        bin_dirs = [p.replace("\\", "/") for p in bin_dirs]
 
         bin_dirs = ";".join(bin_dirs)
         config_dict[build_type] = bin_dirs
         if all(value is '' for value in config_dict.values()):
             return None
-        
+
         vs_debugger_path = ""
         for config, value in config_dict.items():
             vs_debugger_path += f"$<$<CONFIG:{config}>:{value}>"
         vs_debugger_path = f"PATH={vs_debugger_path};%PATH%"
-        
+
         return {"vs_debugger_path": vs_debugger_path}
-    
+
 
 class FPicBlock(Block):
     template = textwrap.dedent("""

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -12,7 +12,8 @@ from conan.tools.cmake.toolchain import CONAN_TOOLCHAIN_FILENAME
 from conan.tools.cmake.toolchain.blocks import ToolchainBlocks, UserToolchain, GenericSystemBlock, \
     AndroidSystemBlock, AppleSystemBlock, FPicBlock, ArchitectureBlock, GLibCXXBlock, VSRuntimeBlock, \
     CppStdBlock, ParallelBlock, CMakeFlagsInitBlock, TryCompileBlock, FindFiles, PkgConfigBlock, \
-    SkipRPath, SharedLibBock, OutputDirsBlock, ExtraFlagsBlock, CompilersBlock, LinkerScriptsBlock
+    SkipRPath, SharedLibBock, OutputDirsBlock, ExtraFlagsBlock, CompilersBlock, LinkerScriptsBlock, \
+    VSDebuggerEnvironment
 from conan.tools.cmake.utils import is_multi_configuration
 from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
 from conan.tools.intel import IntelCC
@@ -160,6 +161,7 @@ class CMakeToolchain(object):
                                        ("linker_scripts", LinkerScriptsBlock),
                                        ("libcxx", GLibCXXBlock),
                                        ("vs_runtime", VSRuntimeBlock),
+                                       ("vs_debugger_environment", VSDebuggerEnvironment),
                                        ("cppstd", CppStdBlock),
                                        ("parallel", ParallelBlock),
                                        ("extra_flags", ExtraFlagsBlock),

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -189,6 +189,31 @@ def test_cmake_toolchain_without_build_type():
     assert "CMAKE_BUILD_TYPE" not in toolchain
 
 
+@pytest.mark.skipif(platform.system() != "Windows",
+                    reason="Only on Windows with msvc")
+@pytest.mark.tool("cmake")
+def test_cmake_toolchain_cmake_vs_debugger_environment():
+    client = TestClient()
+    client.run("new -d name=mylib -d version=1.0 -f cmake_lib")
+    client.run("create . -s:h build_type=Release -o:h  mylib/*:shared=True -tf=''")
+    client.run("create . -s:h build_type=Debug -o:h mylib/*:shared=True -tf=''")
+    
+    client.run("install --require=mylib/1.0 -o:h  mylib/*:shared=True -s:h build_type=Debug -g CMakeToolchain" \
+               " --format=json", redirect_stdout="debug.json")
+    client.run("install --require=mylib/1.0 -o:h  mylib/*:shared=True -s:h build_type=Release -g CMakeToolchain" \
+               " --format=json", redirect_stdout="release.json")
+
+    debug_graph = json.loads(client.load('debug.json'))
+    debug_bindir = debug_graph['graph']['nodes']['1']['cpp_info']['root']['bindirs'][0].replace('\\', '/')
+    release_graph = json.loads(client.load('release.json'))
+    release_bindir = release_graph['graph']['nodes']['1']['cpp_info']['root']['bindirs'][0].replace('\\', '/')
+
+    debugger_environment = f"PATH=$<$<CONFIG:Debug>:{debug_bindir}>$<$<CONFIG:Release>:{release_bindir}>;%PATH%"
+
+    toolchain = client.load("conan_toolchain.cmake")
+    assert f'set(CMAKE_VS_DEBUGGER_ENVIRONMENT "{debugger_environment}")' in toolchain
+
+
 @pytest.mark.tool("cmake")
 def test_cmake_toolchain_multiple_user_toolchain():
     """ A consumer consuming two packages that declare:

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -228,6 +228,18 @@ def test_cmake_toolchain_cmake_vs_debugger_environment():
                            f"$<$<CONFIG:Release>:{release_bindir}>" \
                            f"$<$<CONFIG:MinSizeRel>:{minsizerel_bindir}>;%PATH%"
     assert debugger_environment in toolchain
+@pytest.mark.tool("cmake")
+def test_cmake_toolchain_cmake_vs_debugger_environment_not_needed():
+    client = TestClient()
+    client.save({"conanfile.py": GenConanfile("pkg", "1.0").with_package_type("shared-library")
+                                                           .with_settings("build_type")})
+    client.run("create . -s build_type=Release")
+
+    cmake_generator = "" if platform.system() != "Windows" else "-c tools.cmake.cmaketoolchain:generator=Ninja"
+    client.run(f"install --require=pkg/1.0 -s build_type=Release -g CMakeToolchain {cmake_generator}")
+    toolchain = client.load("conan_toolchain.cmake")
+    assert "CMAKE_VS_DEBUGGER_ENVIRONMENT" not in toolchain
+
 
 
 @pytest.mark.tool("cmake")


### PR DESCRIPTION
Changelog: Feature: Set `CMAKE_VS_DEBUGGER_ENVIRONMENT` from CMakeToolchain to point to all binary directories when using Visual Studio. This negates the need to copy DLLs to launch executables from the Visual Studio IDE (requires CMake 3.27 or newer).

Docs: https://github.com/conan-io/docs/pull/3639
