### PR TITLE
fix: need return 3 None on detect_default_compiler() to avoid errors

### DIFF
--- a/conan/internal/api/detect_api.py
+++ b/conan/internal/api/detect_api.py
@@ -397,6 +397,7 @@ def detect_default_compiler():
         clang, clang_version, compiler_exe = _clang_compiler()  # prioritize clang
         if clang:
             return clang, clang_version, compiler_exe
+        return None, None, None
     else:
         gcc, gcc_version, compiler_exe = _gcc_compiler()
         if gcc:

--- a/conan/internal/api/detect_api.py
+++ b/conan/internal/api/detect_api.py
@@ -397,12 +397,12 @@ def detect_default_compiler():
         clang, clang_version, compiler_exe = _clang_compiler()  # prioritize clang
         if clang:
             return clang, clang_version, compiler_exe
-        return
     else:
         gcc, gcc_version, compiler_exe = _gcc_compiler()
         if gcc:
             return gcc, gcc_version, compiler_exe
         return _clang_compiler()
+    return None, None, None
 
 
 def default_msvc_ide_version(version):


### PR DESCRIPTION
Changelog: Fix: Make sure `detect_default_compiler()` always returns a 3-tuple.
Docs: Omit

Close: #15712

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
