### PR TITLE
fix graph infinite loop while computing install order

### DIFF
--- a/conans/client/graph/install_graph.py
+++ b/conans/client/graph/install_graph.py
@@ -436,7 +436,7 @@ class InstallGraph:
         msg = "\n".join(msg)
         instructions = "This graph is ill-formed, and cannot be installed\n" \
                        "Most common cause is having dependencies both in build and host contexts\n"\
-                       "forming a cycle, because tool_requires having transitive requires.\n"\
+                       "forming a cycle, due to tool_requires having transitive requires.\n"\
                        "Check your profile [tool_requires] and recipe tool and regular requires\n"\
                        "You might inspect the dependency graph with:\n"\
                        "  $ conan graph info . --format=html > graph.html"

--- a/conans/client/graph/install_graph.py
+++ b/conans/client/graph/install_graph.py
@@ -111,6 +111,9 @@ class _InstallRecipeReference:
         self.packages = {}  # {package_id: _InstallPackageReference}
         self.depends = []  # Other REFs, defines the graph topology and operation ordering
 
+    def __str__(self):
+        return f"{self.ref} ({self._node.binary}) -> {[str(d) for d in self.depends]}"
+
     @property
     def need_build(self):
         for package in self.packages.values():
@@ -218,6 +221,9 @@ class _InstallConfiguration:
         self.filenames = []  # The build_order.json filenames e.g. "windows_build_order"
         self.depends = []  # List of full prefs
         self.overrides = Overrides()
+
+    def __str__(self):
+        return f"{self.ref}:{self.package_id} ({self.binary}) -> {[str(d) for d in self.depends]}"
 
     @property
     def need_build(self):
@@ -412,11 +418,30 @@ class InstallGraph:
 
             if current_level:
                 levels.append(current_level)
+            else:
+                self._raise_loop_detected(opened)
+
             # now initialize new level
             opened = {k: v for k, v in opened.items() if v not in closed}
         if flat:
             return [r for level in levels for r in level]
         return levels
+
+    @staticmethod
+    def _raise_loop_detected(nodes):
+        """
+        We can exclude the nodes that have already been processed they do not content loops
+        """
+        msg = [f"{n}" for n in nodes.values()]
+        msg = "\n".join(msg)
+        instructions = "This graph is ill-formed, and cannot be installed\n" \
+                       "Most common cause is having dependencies both in build and host contexts\n"\
+                       "forming a cycle, because tool_requires having transitive requires.\n"\
+                       "Check your profile [tool_requires] and recipe tool and regular requires\n"\
+                       "You might inspect the dependency graph with:\n"\
+                       "  $ conan graph info . --format=html > graph.html"
+        raise ConanException("There is a loop in the graph (some packages already ommitted):\n"
+                             f"{msg}\n\n{instructions}")
 
     def install_build_order(self):
         # TODO: Rename to serialize()?

--- a/conans/test/integration/graph/ux/loop_detection_test.py
+++ b/conans/test/integration/graph/ux/loop_detection_test.py
@@ -41,7 +41,7 @@ def test_install_order_infinite_loop():
     assert "fmt/1.0 (Build) -> ['tool/1.0']" in c.out
     assert "tool/1.0 (Build) -> ['fmt/1.0']" in c.out
 
-    # Graph build-order faisl in teh same way
+    # Graph build-order fails in the same way
     c.run("graph build-order tool -pr:h=tool_profile -b=missing",
           assert_error=True)
     assert "ERROR: There is a loop in the graph" in c.out

--- a/conans/test/integration/graph/ux/loop_detection_test.py
+++ b/conans/test/integration/graph/ux/loop_detection_test.py
@@ -26,3 +26,32 @@ class LoopDetectionTest(unittest.TestCase):
         client.run('export pkg1.py --name=pkg1 --version=0.1 --user=lasote --channel=stable')
         client.run("install --requires=pkg1/0.1@lasote/stable --build='*'", assert_error=True)
         self.assertIn("ERROR: There is a cycle/loop in the graph", client.out)
+
+
+def test_install_order_infinite_loop():
+    c = TestClient()
+    c.save({"fmt/conanfile.py": GenConanfile("fmt", "1.0"),
+            "tool/conanfile.py": GenConanfile("tool", "1.0").with_requires("fmt/1.0"),
+            "tool_profile": "[tool_requires]\n!tool/*: tool/1.0"})
+    c.run("export fmt")
+    c.run("export tool")
+    c.run("install tool -pr:h=tool_profile -b=missing",
+          assert_error=True)
+    assert "ERROR: There is a loop in the graph" in c.out
+    assert "fmt/1.0 (Build) -> ['tool/1.0']" in c.out
+    assert "tool/1.0 (Build) -> ['fmt/1.0']" in c.out
+
+    # Graph build-order faisl in teh same way
+    c.run("graph build-order tool -pr:h=tool_profile -b=missing",
+          assert_error=True)
+    assert "ERROR: There is a loop in the graph" in c.out
+    assert "fmt/1.0 (Build) -> ['tool/1.0']" in c.out
+    assert "tool/1.0 (Build) -> ['fmt/1.0']" in c.out
+
+    c.run("graph build-order tool -pr:h=tool_profile --order-by=configuration -b=missing",
+          assert_error=True)
+    assert "ERROR: There is a loop in the graph" in c.out
+    assert "fmt/1.0:da39a3ee5e6b4b0d3255bfef95601890afd80709 (Build) -> " \
+           "['tool/1.0:044d18636d2b7da86d3aa46a2aabf1400db525b1']" in c.out
+    assert "tool/1.0:044d18636d2b7da86d3aa46a2aabf1400db525b1 (Build) -> " \
+           "['fmt/1.0:da39a3ee5e6b4b0d3255bfef95601890afd80709']" in c.out


### PR DESCRIPTION
Changelog: Fix: Raising an error when an infinite loop is found in the install graph (ill-formed dependency graph with loops).
Docs: Omit

