### PR TITLE
Add conan graph outdated command

### DIFF
--- a/conan/api/model.py
+++ b/conan/api/model.py
@@ -3,7 +3,7 @@ import json
 
 from conans.client.graph.graph import RECIPE_EDITABLE, RECIPE_CONSUMER, RECIPE_PLATFORM, \
     RECIPE_VIRTUAL, BINARY_SKIP, BINARY_MISSING, BINARY_INVALID
-from conans.errors import ConanException
+from conans.errors import ConanException, NotFoundException
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
 from conans.util.files import load
@@ -278,7 +278,7 @@ class ListPattern:
 
     def check_refs(self, refs):
         if not refs and self.ref and "*" not in self.ref:
-            raise ConanException(f"Recipe '{self.ref}' not found")
+            raise NotFoundException(f"Recipe '{self.ref}' not found")
 
     def filter_rrevs(self, rrevs):
         if self._only_latest(self.rrev):

--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -14,7 +14,7 @@ from conan.errors import ConanException
 from conan.internal.deploy import do_deploys
 from conans.client.graph.graph import BINARY_MISSING
 from conans.client.graph.install_graph import InstallGraph
-from conans.errors import ConanConnectionError
+from conans.errors import ConanConnectionError, NotFoundException
 from conans.model.recipe_ref import ref_matches, RecipeReference
 from conans.model.version_range import VersionRange
 
@@ -398,10 +398,10 @@ def _find_in_remotes(conan_api, dict_nodes, remotes):
             try:
                 remote_ref_list = conan_api.list.select(ref_pattern, package_query=None,
                                                         remote=remote)
-            except ConanConnectionError as error:
-                raise error
-            except ConanException:
+            except NotFoundException:
                 continue
+            except ConanException as error:
+                raise error
             if not remote_ref_list.recipes:
                 continue
             str_latest_ref = list(remote_ref_list.recipes.keys())[-1]

--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -410,8 +410,6 @@ def _find_in_remotes(conan_api, dict_nodes, remotes):
                                                         remote=remote)
             except NotFoundException:
                 continue
-            except ConanException as error:
-                raise error
             if not remote_ref_list.recipes:
                 continue
             str_latest_ref = list(remote_ref_list.recipes.keys())[-1]

--- a/conans/test/integration/command_v2/test_outdated.py
+++ b/conans/test/integration/command_v2/test_outdated.py
@@ -116,12 +116,12 @@ def test_recipe_with_no_remote_ref():
 
     tc.save({"conanfile.py": GenConanfile("app", "1.0").with_requires("zlib/1.0",
                                                                       "libcurl/[>=1.0]")})
-    tc.run("graph outdated . --format=json")
-    output = json.loads(tc.stdout)
+    tc.run("graph outdated .")
     # Check that libcurl doesn't appear as there is no version in the remotes
-    assert "zlib" in output
-    assert "foo" in output
-    assert "libcurl" not in output
+    assert "Recipe 'libcurl' not found in remote default" in tc.stderr
+    assert "zlib" in tc.stdout
+    assert "foo" in tc.stdout
+    assert "libcurl" not in tc.stdout
 
 
 def test_cache_ref_newer_than_latest_in_remote():

--- a/conans/test/integration/command_v2/test_outdated.py
+++ b/conans/test/integration/command_v2/test_outdated.py
@@ -1,0 +1,75 @@
+import textwrap
+
+from assets.genconanfile import GenConanfile
+from utils.tools import TestClient
+
+
+def test_invalid_output_level():
+    tc = TestClient(default_server_user=True)
+    #Create libraries needed to generate the dependency graph
+    tc.save({"conanfile.py": GenConanfile()})
+    tc.run("create . --name=zlib --version=1.0")
+
+    tc.run("create . --name=foo --version=1.0")
+    tc.save({"conanfile.py": GenConanfile().with_requires("foo/[>=1.0]")})
+    tc.run("create . --name=libcurl --version=1.0")
+
+    #Upload the created libraries to remote
+    tc.run("upload * -c -r=default")
+
+    #Create new version of libraries in remote and remove them from cache
+    tc.save({"conanfile.py": GenConanfile()})
+    tc.run("create . --name=foo --version=2.0")
+    tc.run("create . --name=zlib --version=2.0")
+    tc.run("upload * -c -r=default")
+    tc.run("remove foo/2.0 -c")
+    tc.run("remove zlib/2.0 -c")
+
+    tc.save({"conanfile.py": GenConanfile("app", "1.0").with_requires("zlib/1.0", "libcurl/[>=1.0]")})
+    # tc.run("graph info . --update")
+    tc.run("graph outdated .")
+
+    print()
+
+def test_invalid_output_level_with_lockfile():
+    tc = TestClient(default_server_user=True)
+    # Create libraries needed to generate the dependency graph
+    tc.save({"conanfile.py": GenConanfile()})
+    tc.run("create . --name=zlib --version=1.0")
+
+    tc.run("create . --name=foo --version=1.0")
+    tc.save({"conanfile.py": GenConanfile().with_requires("foo/[>=1.0]")})
+    tc.run("create . --name=libcurl --version=1.0")
+
+    # Upload the created libraries to remote
+    tc.run("upload * -c -r=default")
+
+    # Create new version of libraries in remote and remove them from cache
+    tc.save({"conanfile.py": GenConanfile()})
+    tc.run("create . --name=foo --version=2.0")
+    tc.run("create . --name=zlib --version=2.0")
+    tc.run("upload * -c -r=default")
+    tc.run("remove foo/2.0 -c")
+    tc.run("remove zlib/2.0 -c")
+
+    tc.save({"conanfile.py": GenConanfile("app", "1.0").with_requires("zlib/1.0",
+                                                                      "libcurl/[>=1.0]")})
+    conan_lock = textwrap.dedent("""
+    {
+        "version": "0.5",
+        "requires": [
+            "zlib/2.0",
+            "zlib/1.0#4d670581ccb765839f2239cc8dff8fbd%1709873018.9729314",
+            "libcurl/1.0#05ea7551a2e08adf4f01d0061b458db5%1709873019.221777",
+            "foo/1.0#4d670581ccb765839f2239cc8dff8fbd%1709873019.09337"
+        ],
+        "build_requires": [],
+        "python_requires": []
+    }
+    """)
+    tc.save({"conan.lock": conan_lock})
+    # tc.run("lock create .")
+    # tc.run("graph info . --update")
+    tc.run("graph outdated .")
+
+    print()

--- a/conans/test/integration/command_v2/test_outdated.py
+++ b/conans/test/integration/command_v2/test_outdated.py
@@ -173,3 +173,15 @@ def test_duplicated_tool_requires():
     assert sorted(output["cmake"]["current_versions"]) == ["cmake/1.0", "cmake/2.0", "cmake/3.0"]
     assert sorted(output["cmake"]["version_ranges"]) == ["cmake/[<=2.0]", "cmake/[>=1.0]"]
     assert output["cmake"]["latest_remote"]["ref"] == "cmake/3.0"
+
+
+def test_no_outdated_dependencies():
+    tc = TestClient(default_server_user=True)
+
+    tc.save({"conanfile.py": GenConanfile()})
+    tc.run("create . --name=foo --version=1.0")
+    tc.run("upload * -c -r=default")
+
+    tc.run("graph outdated .")
+
+    assert "No outdated dependencies in graph" in tc.stdout

--- a/conans/test/integration/command_v2/test_outdated.py
+++ b/conans/test/integration/command_v2/test_outdated.py
@@ -33,12 +33,14 @@ def test_outdated_command():
     assert "zlib" in output
     assert "foo" in output
     assert "libcurl" not in output
-    assert output["zlib"]["current"] == "zlib/1.0"
-    assert output["zlib"]["latest_range"] == "zlib/1.0"
-    assert output["zlib"]["latest_remote"] == {"ref": "zlib/2.0","remote": "default"}
-    assert output["foo"]["current"] == "foo/1.0"
-    assert output["foo"]["latest_range"] == "foo/2.0"
-    assert output["foo"]["latest_remote"] == {"ref": "foo/2.0","remote": "default"}
+    assert output["zlib"]["current"].startswith("zlib/1.0")
+    assert output["zlib"]["latest_range"].startswith("zlib/1.0")
+    assert output["zlib"]["latest_remote"]["ref"].startswith("zlib/2.0")
+    assert output["zlib"]["latest_remote"]["remote"].startswith("default")
+    assert output["foo"]["current"].startswith("foo/1.0")
+    assert output["foo"]["latest_range"].startswith("foo/2.0")
+    assert output["foo"]["latest_remote"]["ref"].startswith("foo/2.0")
+    assert output["foo"]["latest_remote"]["remote"].startswith("default")
 
 
 def test_recipe_with_lockfile():
@@ -70,13 +72,13 @@ def test_recipe_with_lockfile():
     assert "zlib" in output
     assert "foo" in output
     assert "libcurl" not in output
-    assert output["foo"]["latest_range"] == "foo/2.0"
+    assert output["foo"]["latest_range"].startswith("foo/2.0")
 
     # Creating the lockfile sets foo/1.0 as only valid version for the recipe
     tc.run("lock create .")
     tc.run("graph outdated . --format=json")
     output = json.loads(tc.stdout)
-    assert output["foo"]["latest_range"] == "foo/1.0"
+    assert output["foo"]["latest_range"].startswith("foo/1.0")
 
     # Adding foo/2.0 to the lockfile forces the download so foo is no longer outdated
     tc.run("lock add --requires=foo/2.0")
@@ -188,7 +190,8 @@ def test_two_remotes():
     assert "zlib" in output
     assert "libcurl" in output
     assert "foo" not in output
-    assert output["zlib"]["latest_remote"] == {"ref": "zlib/2.0", "remote": "remote2"}
-    assert output["libcurl"]["latest_remote"] == {"ref": "libcurl/2.0", "remote": "remote1"}
-
+    assert output["libcurl"]["latest_remote"]["ref"].startswith("libcurl/2.0")
+    assert output["libcurl"]["latest_remote"]["remote"].startswith("remote1")
+    assert output["zlib"]["latest_remote"]["ref"].startswith("zlib/2.0")
+    assert output["zlib"]["latest_remote"]["remote"].startswith("remote2")
     #test donde version del remoto esta por encima de un rango

--- a/conans/test/integration/command_v2/test_outdated.py
+++ b/conans/test/integration/command_v2/test_outdated.py
@@ -1,7 +1,8 @@
-import textwrap
+import json
+from collections import OrderedDict
 
-from assets.genconanfile import GenConanfile
-from utils.tools import TestClient
+from conans.test.assets.genconanfile import GenConanfile
+from conans.test.utils.tools import TestClient, TestServer
 
 
 def test_outdated_command():
@@ -27,9 +28,18 @@ def test_outdated_command():
 
     tc.save({"conanfile.py": GenConanfile("app", "1.0").with_requires("zlib/1.0", "libcurl/[>=1.0]")})
     # tc.run("graph info . --update")
-    tc.run("graph outdated .")
+    tc.run("graph outdated . --format=json")
+    output = json.loads(tc.stdout)
+    assert "zlib" in output
+    assert "foo" in output
+    assert "libcurl" not in output
+    assert output["zlib"]["current"] == "zlib/1.0"
+    assert output["zlib"]["latest_range"] == "zlib/1.0"
+    assert output["zlib"]["latest_remote"] == {"ref": "zlib/2.0","remote": "default"}
+    assert output["foo"]["current"] == "foo/1.0"
+    assert output["foo"]["latest_range"] == "foo/2.0"
+    assert output["foo"]["latest_remote"] == {"ref": "foo/2.0","remote": "default"}
 
-    print()
 
 def test_recipe_with_lockfile():
     tc = TestClient(default_server_user=True)
@@ -55,30 +65,33 @@ def test_recipe_with_lockfile():
     tc.save({"conanfile.py": GenConanfile("app", "1.0").with_requires("zlib/1.0",
                                                                       "libcurl/[>=1.0]")})
 
-    tc.run("graph outdated .")
-    # assert que el wanted de foo es 2.0
+    tc.run("graph outdated . --format=json")
+    output = json.loads(tc.stdout)
+    assert "zlib" in output
+    assert "foo" in output
+    assert "libcurl" not in output
+    assert output["foo"]["latest_range"] == "foo/2.0"
 
+    # Creating the lockfile sets foo/1.0 as only valid version for the recipe
     tc.run("lock create .")
-    tc.run("graph outdated .")
-    # assert que el wanted de foo es 1.0
+    tc.run("graph outdated . --format=json")
+    output = json.loads(tc.stdout)
+    assert output["foo"]["latest_range"] == "foo/1.0"
 
+    # Adding foo/2.0 to the lockfile forces the download so foo is no longer outdated
     tc.run("lock add --requires=foo/2.0")
-    tc.run("graph outdated .")
-    # assert que el wanted de foo es 2.0
+    tc.run("graph outdated . --format=json")
+    output = json.loads(tc.stdout)
+    assert "foo" not in output
 
-
-    # tc.run("graph info . --update")
-    tc.run("graph outdated .")
-
-    print()
 
 def test_recipe_with_no_remote_ref():
     tc = TestClient(default_server_user=True)
     # Create libraries needed to generate the dependency graph
     tc.save({"conanfile.py": GenConanfile()})
     tc.run("create . --name=zlib --version=1.0")
-
     tc.run("create . --name=foo --version=1.0")
+
     tc.save({"conanfile.py": GenConanfile().with_requires("foo/[>=1.0]")})
     tc.run("upload * -c -r=default")
 
@@ -97,9 +110,12 @@ def test_recipe_with_no_remote_ref():
     tc.save({"conanfile.py": GenConanfile("app", "1.0").with_requires("zlib/1.0",
                                                                       "libcurl/[>=1.0]")})
     # tc.run("graph info . --update")
-    tc.run("graph outdated .")
+    tc.run("graph outdated . --format=json")
+    output = json.loads(tc.stdout)
+    assert "zlib" in output
+    assert "foo" in output
+    assert "libcurl" not in output
 
-    print()
 
 def test_cache_ref_newer_than_latest_in_remote():
     tc = TestClient(default_server_user=True)
@@ -125,7 +141,54 @@ def test_cache_ref_newer_than_latest_in_remote():
 
     tc.run("list foo")
     tc.run("list foo -r default")
-    # tc.run("graph info . --update")
-    tc.run("graph outdated .")
 
-    print()
+    tc.run("graph outdated . --format=json")
+    output = json.loads(tc.stdout)
+    assert "zlib" in output
+    assert "libcurl" not in output
+    assert "foo" not in output
+
+
+
+def test_two_remotes():
+    servers = OrderedDict()
+    for i in [1, 2]:
+        test_server = TestServer()
+        servers["remote%d" % i] = test_server
+
+    tc = TestClient(servers=servers, inputs=2 * ["admin", "password"], light=True)
+
+    tc.save({"conanfile.py": GenConanfile()})
+    tc.run("create . --name=zlib --version=1.0")
+    tc.run("create . --name=foo --version=1.0")
+    tc.run("create . --name=zlib --version=2.0")
+
+    tc.save({"conanfile.py": GenConanfile().with_requires("foo/[>=1.0]")})
+    tc.run("create . --name=libcurl --version=1.0")
+    tc.run("create . --name=libcurl --version=2.0")
+
+    # Upload the created libraries  1.0 to remotes
+    tc.run("upload zlib/1.0 -c -r=remote1")
+    tc.run("upload libcurl/2.0 -c -r=remote1")
+    tc.run("upload foo/1.0 -c -r=remote1")
+
+    tc.run("upload zlib/* -c -r=remote2")
+    tc.run("upload libcurl/1.0 -c -r=remote2")
+    tc.run("upload foo/1.0 -c -r=remote2")
+
+    # Remove from cache the 2.0 libraries
+    tc.run("remove libcurl/2.0 -c")
+    tc.run("remove zlib/2.0 -c")
+
+    tc.save({"conanfile.py": GenConanfile("app", "1.0").with_requires("zlib/1.0",
+                                                                      "libcurl/[>=1.0]")})
+
+    tc.run("graph outdated . --format=json")
+    output = json.loads(tc.stdout)
+    assert "zlib" in output
+    assert "libcurl" in output
+    assert "foo" not in output
+    assert output["zlib"]["latest_remote"] == {"ref": "zlib/2.0", "remote": "remote2"}
+    assert output["libcurl"]["latest_remote"] == {"ref": "libcurl/2.0", "remote": "remote1"}
+
+    #test donde version del remoto esta por encima de un rango

--- a/conans/test/integration/command_v2/test_outdated.py
+++ b/conans/test/integration/command_v2/test_outdated.py
@@ -4,7 +4,7 @@ from assets.genconanfile import GenConanfile
 from utils.tools import TestClient
 
 
-def test_invalid_output_level():
+def test_outdated_command():
     tc = TestClient(default_server_user=True)
     #Create libraries needed to generate the dependency graph
     tc.save({"conanfile.py": GenConanfile()})
@@ -31,13 +31,13 @@ def test_invalid_output_level():
 
     print()
 
-def test_invalid_output_level_with_lockfile():
+def test_recipe_with_lockfile():
     tc = TestClient(default_server_user=True)
     # Create libraries needed to generate the dependency graph
     tc.save({"conanfile.py": GenConanfile()})
     tc.run("create . --name=zlib --version=1.0")
-
     tc.run("create . --name=foo --version=1.0")
+
     tc.save({"conanfile.py": GenConanfile().with_requires("foo/[>=1.0]")})
     tc.run("create . --name=libcurl --version=1.0")
 
@@ -54,21 +54,77 @@ def test_invalid_output_level_with_lockfile():
 
     tc.save({"conanfile.py": GenConanfile("app", "1.0").with_requires("zlib/1.0",
                                                                       "libcurl/[>=1.0]")})
-    conan_lock = textwrap.dedent("""
-    {
-        "version": "0.5",
-        "requires": [
-            "zlib/2.0",
-            "zlib/1.0#4d670581ccb765839f2239cc8dff8fbd%1709873018.9729314",
-            "libcurl/1.0#05ea7551a2e08adf4f01d0061b458db5%1709873019.221777",
-            "foo/1.0#4d670581ccb765839f2239cc8dff8fbd%1709873019.09337"
-        ],
-        "build_requires": [],
-        "python_requires": []
-    }
-    """)
-    tc.save({"conan.lock": conan_lock})
-    # tc.run("lock create .")
+
+    tc.run("graph outdated .")
+    # assert que el wanted de foo es 2.0
+
+    tc.run("lock create .")
+    tc.run("graph outdated .")
+    # assert que el wanted de foo es 1.0
+
+    tc.run("lock add --requires=foo/2.0")
+    tc.run("graph outdated .")
+    # assert que el wanted de foo es 2.0
+
+
+    # tc.run("graph info . --update")
+    tc.run("graph outdated .")
+
+    print()
+
+def test_recipe_with_no_remote_ref():
+    tc = TestClient(default_server_user=True)
+    # Create libraries needed to generate the dependency graph
+    tc.save({"conanfile.py": GenConanfile()})
+    tc.run("create . --name=zlib --version=1.0")
+
+    tc.run("create . --name=foo --version=1.0")
+    tc.save({"conanfile.py": GenConanfile().with_requires("foo/[>=1.0]")})
+    tc.run("upload * -c -r=default")
+
+    #libcurl recipe only exists in local
+    tc.run("create . --name=libcurl --version=1.0")
+
+    # Create new version of libraries in remote and remove them from cache
+    tc.save({"conanfile.py": GenConanfile()})
+    tc.run("create . --name=foo --version=2.0")
+    tc.run("create . --name=zlib --version=2.0")
+    tc.run("upload foo/* -c -r=default")
+    tc.run("upload zlib/* -c -r=default")
+    tc.run("remove foo/2.0 -c")
+    tc.run("remove zlib/2.0 -c")
+
+    tc.save({"conanfile.py": GenConanfile("app", "1.0").with_requires("zlib/1.0",
+                                                                      "libcurl/[>=1.0]")})
+    # tc.run("graph info . --update")
+    tc.run("graph outdated .")
+
+    print()
+
+def test_cache_ref_newer_than_latest_in_remote():
+    tc = TestClient(default_server_user=True)
+    # Create libraries needed to generate the dependency graph
+    tc.save({"conanfile.py": GenConanfile()})
+    tc.run("create . --name=zlib --version=1.0")
+    tc.run("create . --name=foo --version=1.0")
+
+    tc.save({"conanfile.py": GenConanfile().with_requires("foo/[>=1.0]")})
+    tc.run("create . --name=libcurl --version=1.0")
+
+    # Upload the created libraries to remote
+    tc.run("upload * -c -r=default")
+
+    # Create new version of libraries in remote and remove them from cache
+    tc.save({"conanfile.py": GenConanfile()})
+    tc.run("create . --name=zlib --version=2.0")
+    tc.run("upload * -c -r=default")
+    tc.run("create . --name=foo --version=2.0")
+
+    tc.save({"conanfile.py": GenConanfile("app", "1.0").with_requires("zlib/1.0",
+                                                                      "libcurl/[>=1.0]")})
+
+    tc.run("list foo")
+    tc.run("list foo -r default")
     # tc.run("graph info . --update")
     tc.run("graph outdated .")
 

--- a/conans/test/integration/command_v2/test_outdated.py
+++ b/conans/test/integration/command_v2/test_outdated.py
@@ -116,12 +116,12 @@ def test_recipe_with_no_remote_ref():
 
     tc.save({"conanfile.py": GenConanfile("app", "1.0").with_requires("zlib/1.0",
                                                                       "libcurl/[>=1.0]")})
-    tc.run("graph outdated .")
+    tc.run("graph outdated . --format=json")
+    output = json.loads(tc.stdout)
     # Check that libcurl doesn't appear as there is no version in the remotes
-    assert "Recipe 'libcurl' not found in remote default" in tc.stderr
-    assert "zlib" in tc.stdout
-    assert "foo" in tc.stdout
-    assert "libcurl" not in tc.stdout
+    assert "zlib" in output
+    assert "foo" in output
+    assert "libcurl" not in output
 
 
 def test_cache_ref_newer_than_latest_in_remote():


### PR DESCRIPTION
Changelog: Feature: Add `conan graph outdated` command that lists the dependencies that have newer versions in remotes
Docs: https://github.com/conan-io/docs/pull/3641

The command looks for newer versions of a recipe and its dependencies in the remotes, and displays the available versions. It also shows the version ranges for each library.
It requires the path to a conanfile or an specific library with `--requires`.
The remotes which should be looked at can be defined with `--remote`.

Possible updates: 
- Add revisions to check if there are newer revisions.
- Solve version ranges to specify the possible update for each range.

Closes https://github.com/conan-io/conan/issues/9823
https://github.com/conan-io/conan/issues/7778

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
