### PR TITLE
Don't break on empty patch list for version in conandata.yml (#15841)

### DIFF
--- a/conan/tools/files/patches.py
+++ b/conan/tools/files/patches.py
@@ -88,6 +88,9 @@ def apply_conandata_patches(conanfile):
     if isinstance(patches, dict):
         assert conanfile.version, "Can only be applied if conanfile.version is already defined"
         entries = patches.get(str(conanfile.version), [])
+        if entries is None:
+            conanfile.output.info("apply_conandata_patches(): No patches defined for version in conandata")
+            return
     elif isinstance(patches, list):
         entries = patches
     else:
@@ -127,6 +130,9 @@ def export_conandata_patches(conanfile):
     if isinstance(patches, dict):
         assert conanfile.version, "Can only be exported if conanfile.version is already defined"
         entries = patches.get(conanfile.version, [])
+        if entries is None:
+            conanfile.output.info("export_conandata_patches(): No patches defined for version in conandata")
+            return
     elif isinstance(patches, list):
         entries = patches
     else:

--- a/conan/tools/files/patches.py
+++ b/conan/tools/files/patches.py
@@ -131,7 +131,7 @@ def export_conandata_patches(conanfile):
         assert conanfile.version, "Can only be exported if conanfile.version is already defined"
         entries = patches.get(conanfile.version, [])
         if entries is None:
-            conanfile.output.info("export_conandata_patches(): No patches defined for version in conandata")
+            conanfile.output.warning(f"export_conandata_patches(): No patches defined for version {conanfile.version} in conandata.yml")
             return
     elif isinstance(patches, list):
         entries = patches

--- a/conan/tools/files/patches.py
+++ b/conan/tools/files/patches.py
@@ -89,7 +89,7 @@ def apply_conandata_patches(conanfile):
         assert conanfile.version, "Can only be applied if conanfile.version is already defined"
         entries = patches.get(str(conanfile.version), [])
         if entries is None:
-            conanfile.output.info("apply_conandata_patches(): No patches defined for version in conandata")
+            conanfile.output.warning(f"apply_conandata_patches(): No patches defined for version {conanfile.version} in conandata.yml")
             return
     elif isinstance(patches, list):
         entries = patches


### PR DESCRIPTION
Changelog: Bugfix: Avoid TypeError when a version in conandata.yml lists no patches.
Docs: Omit

 (#15841)

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
