### PR TITLE
Add backup source removal from `conan cache clean` - defaults of OFF

### DIFF
--- a/conan/api/subapi/upload.py
+++ b/conan/api/subapi/upload.py
@@ -3,11 +3,9 @@ import time
 from multiprocessing.pool import ThreadPool
 
 from conan.api.output import ConanOutput
-from conan.internal.cache.home_paths import HomePaths
 from conan.internal.conan_app import ConanApp
 from conan.internal.upload_metadata import gather_metadata
 from conans.client.cmd.uploader import PackagePreparator, UploadExecutor, UploadUpstreamChecker
-from conans.client.downloaders.download_cache import DownloadCache
 from conans.client.pkg_sign import PkgSignaturesPlugin
 from conans.client.rest.file_uploader import FileUploader
 from conans.errors import ConanException, AuthenticationException, ForbiddenException
@@ -83,7 +81,7 @@ class UploadAPI:
             if not dry_run:
                 subtitle("Uploading artifacts")
                 self.upload(pkglist, remote)
-                backup_files = self.get_backup_sources(pkglist)
+                backup_files = self.conan_api.cache.get_backup_sources(pkglist)
                 self.upload_backup_sources(backup_files)
 
         t = time.time()
@@ -100,17 +98,6 @@ class UploadAPI:
             thread_pool.join()
         elapsed = time.time() - t
         ConanOutput().success(f"Upload completed in {int(elapsed)}s\n")
-
-    def get_backup_sources(self, package_list=None, exclude=True, only_upload=True):
-        """Get list of backup source files currently present in the cache,
-        either all of them if no argument, else filter by those belonging to the references in the package_list"""
-        config = self.conan_api.config.global_conf
-        download_cache_path = config.get("core.sources:download_cache")
-        download_cache_path = download_cache_path or HomePaths(
-            self.conan_api.cache_folder).default_sources_backup_folder
-        excluded_urls = config.get("core.sources:exclude_urls", check_type=list, default=[]) if exclude else []
-        download_cache = DownloadCache(download_cache_path)
-        return download_cache.get_backup_sources_files(excluded_urls, package_list, only_upload)
 
     def upload_backup_sources(self, files):
         config = self.conan_api.config.global_conf

--- a/conan/api/subapi/upload.py
+++ b/conan/api/subapi/upload.py
@@ -101,16 +101,16 @@ class UploadAPI:
         elapsed = time.time() - t
         ConanOutput().success(f"Upload completed in {int(elapsed)}s\n")
 
-    def get_backup_sources(self, package_list=None):
+    def get_backup_sources(self, package_list=None, exclude=True, only_upload=True):
         """Get list of backup source files currently present in the cache,
         either all of them if no argument, else filter by those belonging to the references in the package_list"""
         config = self.conan_api.config.global_conf
         download_cache_path = config.get("core.sources:download_cache")
         download_cache_path = download_cache_path or HomePaths(
             self.conan_api.cache_folder).default_sources_backup_folder
-        excluded_urls = config.get("core.sources:exclude_urls", check_type=list, default=[])
+        excluded_urls = config.get("core.sources:exclude_urls", check_type=list, default=[]) if exclude else []
         download_cache = DownloadCache(download_cache_path)
-        return download_cache.get_backup_sources_files_to_upload(excluded_urls, package_list)
+        return download_cache.get_backup_sources_files(excluded_urls, package_list, only_upload)
 
     def upload_backup_sources(self, files):
         config = self.conan_api.config.global_conf

--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -162,5 +162,5 @@ def cache_backup_upload(conan_api: ConanAPI, parser, subparser, *args):
     """
     Upload all the source backups present in the cache
     """
-    files = conan_api.upload.get_backup_sources()
+    files = conan_api.cache.get_backup_sources()
     conan_api.upload.upload_backup_sources(files)

--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -79,6 +79,8 @@ def cache_clean(conan_api: ConanAPI, parser, subparser, *args):
                            help="Clean download and metadata folders")
     subparser.add_argument("-t", "--temp", action='store_true', default=False,
                            help="Clean temporary folders")
+    subparser.add_argument("-bs", "--backup-sources", action='store_true', default=False,
+                           help="Clean backup sources")
     subparser.add_argument('-p', '--package-query', action=OnceArgument,
                            help="Remove only the packages matching a specific query, e.g., "
                                 "os=Windows AND (arch=x86 OR compiler=gcc)")
@@ -86,9 +88,10 @@ def cache_clean(conan_api: ConanAPI, parser, subparser, *args):
 
     ref_pattern = ListPattern(args.pattern or "*", rrev="*", package_id="*", prev="*")
     package_list = conan_api.list.select(ref_pattern, package_query=args.package_query)
-    if args.build or args.source or args.download or args.temp:
+    if args.build or args.source or args.download or args.temp or args.backup_sources:
         conan_api.cache.clean(package_list, source=args.source, build=args.build,
-                              download=args.download, temp=args.temp)
+                              download=args.download, temp=args.temp,
+                              backup_sources=args.backup_sources)
     else:
         conan_api.cache.clean(package_list)
 

--- a/conans/client/downloaders/download_cache.py
+++ b/conans/client/downloaders/download_cache.py
@@ -45,7 +45,7 @@ class DownloadCache:
             finally:
                 thread_lock.release()
 
-    def get_backup_sources_files_to_upload(self, excluded_urls, package_list=None):
+    def get_backup_sources_files(self, excluded_urls, package_list=None, only_upload=True):
         """ from a package_list of packages to upload, collect from the backup-sources cache
         the matching references to upload those backups too.
         If no package_list is passed, it gets all
@@ -64,13 +64,13 @@ class DownloadCache:
                        for url in backup_urls)
 
         def should_upload_sources(package):
-            return any(prev["upload"] for prev in package["revisions"].values())
+            return any(prev.get("upload") for prev in package["revisions"].values())
 
         all_refs = set()
         if package_list is not None:
             for k, ref in package_list.refs().items():
                 packages = ref.get("packages", {}).values()
-                if ref.get("upload") or any(should_upload_sources(p) for p in packages):
+                if not only_upload or ref.get("upload") or any(should_upload_sources(p) for p in packages):
                     all_refs.add(str(k))
 
         path_backups_contents = []

--- a/conans/client/downloaders/download_cache.py
+++ b/conans/client/downloaders/download_cache.py
@@ -46,10 +46,14 @@ class DownloadCache:
                 thread_lock.release()
 
     def get_backup_sources_files(self, excluded_urls, package_list=None, only_upload=True):
-        """ from a package_list of packages to upload, collect from the backup-sources cache
-        the matching references to upload those backups too.
-        If no package_list is passed, it gets all
-        """
+        """Get list of backup source files currently present in the cache,
+        either all of them if no package_list is give, or filtered by those belonging to the references in the package_list
+
+        Will exclude the sources that come from URLs present in excluded_urls
+
+        @param excluded_urls: a list of URLs to exclude backup sources files if they come from any of these URLs
+        @param package_list: a PackagesList object to filter backup files from (The files should have been downloaded form any of the references in the package_list)
+        @param only_upload: if True, only return the files for packages that are set to be uploaded"""
         path_backups = os.path.join(self._path, self._SOURCE_BACKUP)
 
         if not os.path.exists(path_backups):

--- a/conans/test/integration/cache/backup_sources_test.py
+++ b/conans/test/integration/cache/backup_sources_test.py
@@ -615,6 +615,9 @@ class TestDownloadCacheBackupSources:
         self.client.run("create .")
         self.client.run("upload * -c -r=default")
         assert sha256 in os.listdir(http_server_base_folder_backup)
+        self.client.run("cache clean * -bs")
+        backups = os.listdir(os.path.join(self.download_cache_folder, "s"))
+        assert len(backups) == 0
 
     def test_export_then_upload_recipe_only_workflow(self):
         http_server_base_folder_internet = os.path.join(self.file_server.store, "internet")


### PR DESCRIPTION
Changelog: Feature: Add `--backup-sources` flag to `conan cache clean`.
Changelog: Bugfix: Move `get_backup_sources()` method to expected `CacheAPI` from `UploadAPI`.
Docs: Omit

The flag is not on by default, meaning that simply running `conan cache clean` won't clear the backups, you need to explicitly enable it

Closes https://github.com/conan-io/conan/issues/14707 