### PR TITLE
fix conan_home_folder windows backslash

### DIFF
--- a/conan/api/subapi/config.py
+++ b/conan/api/subapi/config.py
@@ -128,6 +128,7 @@ class ConfigAPI:
             if platform.system() in ["Linux", "FreeBSD"]:
                 import distro
             template = Environment(loader=FileSystemLoader(home_folder)).from_string(text)
+            home_folder = home_folder.replace("\\", "/")
             content = template.render({"platform": platform, "os": os, "distro": distro,
                                        "conan_version": conan_version,
                                        "conan_home_folder": home_folder,

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1476,7 +1476,7 @@ def test_cmaketoolchain_conf_from_tool_require():
     assert "set(CMAKE_SYSTEM_PROCESSOR ARM-POTATO)" in toolchain
 
 
-def test_inject_user_toolchain_profile():
+def test_inject_user_toolchain():
     client = TestClient()
 
     conanfile = textwrap.dedent("""
@@ -1509,8 +1509,17 @@ def test_inject_user_toolchain_profile():
     save(os.path.join(client.cache.profiles_path, "myvars.cmake"), 'set(MY_USER_VAR1 "MYVALUE1")')
     client.save({"conanfile.py": conanfile,
                  "CMakeLists.txt": cmake})
-    client.run("create . -pr=myprofile")
+    client.run("build . -pr=myprofile")
     assert "-- MYVAR1 MYVALUE1!!" in client.out
+
+    # Now test with the global.conf
+    global_conf = 'tools.cmake.cmaketoolchain:user_toolchain=' \
+                  '["{{conan_home_folder}}/my.cmake"]'
+    save(client.cache.new_config_path, global_conf)
+    save(os.path.join(client.cache_folder, "my.cmake"), 'message(STATUS "IT WORKS!!!!")')
+    client.run("build .")
+    # The toolchain is found and can be used
+    assert "IT WORKS!!!!" in client.out
 
 
 def test_no_build_type():

--- a/conans/test/integration/configuration/conf/test_conf.py
+++ b/conans/test/integration/configuration/conf/test_conf.py
@@ -223,7 +223,8 @@ def test_jinja_global_conf_paths():
     global_conf = 'user.mycompany:myfile = {{os.path.join(conan_home_folder, "myfile")}}'
     save(c.cache.new_config_path, global_conf)
     c.run("config show *")
-    assert f"user.mycompany:myfile: {os.path.join(c.cache_folder, 'myfile')}" in c.out
+    cache_folder = c.cache_folder.replace("\\", "/")
+    assert f"user.mycompany:myfile: {os.path.join(cache_folder, 'myfile')}" in c.out
 
 
 def test_profile_detect_os_arch():


### PR DESCRIPTION
Changelog: Bugfix: Solve backslash issues with ``conan_home_folder`` in ``global.conf`` when used in strings inside lists.
Docs: Omit

Close https://github.com/conan-io/conan/issues/15868
