### PR TITLE
fix --build=missing for repeated tool-requires

### DIFF
--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -104,6 +104,8 @@ class GraphBinariesAnalyzer(object):
             node.binary_remote = previous_node.binary_remote
             node.prev = previous_node.prev
             node.pref_timestamp = previous_node.pref_timestamp
+            node.should_build = previous_node.should_build
+            node.build_allowed = previous_node.build_allowed
 
             # this line fixed the compatible_packages with private case.
             # https://github.com/conan-io/conan/issues/9880


### PR DESCRIPTION
Changelog: Fix: Avoid unnecessary build of ``tool_requires`` when ``--build=missing`` and repeated ``tool_requires``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/15657
