### PR TITLE
Warn on misplaced requirement function calls

### DIFF
--- a/conans/client/conanfile/configure.py
+++ b/conans/client/conanfile/configure.py
@@ -7,6 +7,8 @@ from conans.client.conanfile.implementations import auto_shared_fpic_config_opti
 def run_configure_method(conanfile, down_options, profile_options, ref):
     """ Run all the config-related functions for the given conanfile object """
 
+    initial_requires_count = len(conanfile.requires)
+
     if hasattr(conanfile, "config_options"):
         with conanfile_exception_formatter(conanfile, "config_options"):
             conanfile.config_options()
@@ -22,6 +24,9 @@ def run_configure_method(conanfile, down_options, profile_options, ref):
             conanfile.configure()
     elif "auto_shared_fpic" in conanfile.implements:
         auto_shared_fpic_configure(conanfile)
+
+    if initial_requires_count != len(conanfile.requires):
+        conanfile.output.warning("Requirements should only be added in the requirements()/build_requirements() methods, not configure()/config_options(), which might raise errors in the future.", warn_tag="deprecated")
 
     result = conanfile.options.get_upstream_options(down_options, ref, is_consumer)
     self_options, up_options, private_up_options = result

--- a/conans/client/conanfile/configure.py
+++ b/conans/client/conanfile/configure.py
@@ -33,9 +33,11 @@ def run_configure_method(conanfile, down_options, profile_options, ref):
 
     PackageType.compute_package_type(conanfile)
 
-    conanfile.build_requires = BuildRequirements(conanfile.requires)
-    conanfile.test_requires = TestRequirements(conanfile.requires)
-    conanfile.tool_requires = ToolRequirements(conanfile.requires)
+    conanfile._conan_add_requirement_allowed = True
+
+    conanfile.build_requires = BuildRequirements(conanfile)
+    conanfile.test_requires = TestRequirements(conanfile)
+    conanfile.tool_requires = ToolRequirements(conanfile)
 
     if hasattr(conanfile, "requirements"):
         with conanfile_exception_formatter(conanfile, "requirements"):
@@ -44,3 +46,5 @@ def run_configure_method(conanfile, down_options, profile_options, ref):
     if hasattr(conanfile, "build_requirements"):
         with conanfile_exception_formatter(conanfile, "build_requirements"):
             conanfile.build_requirements()
+
+    delattr(conanfile, "_conan_add_requirement_allowed")

--- a/conans/client/conanfile/configure.py
+++ b/conans/client/conanfile/configure.py
@@ -33,11 +33,9 @@ def run_configure_method(conanfile, down_options, profile_options, ref):
 
     PackageType.compute_package_type(conanfile)
 
-    conanfile._conan_add_requirement_allowed = True
-
-    conanfile.build_requires = BuildRequirements(conanfile)
-    conanfile.test_requires = TestRequirements(conanfile)
-    conanfile.tool_requires = ToolRequirements(conanfile)
+    conanfile.build_requires = BuildRequirements(conanfile.requires)
+    conanfile.test_requires = TestRequirements(conanfile.requires)
+    conanfile.tool_requires = ToolRequirements(conanfile.requires)
 
     if hasattr(conanfile, "requirements"):
         with conanfile_exception_formatter(conanfile, "requirements"):
@@ -46,5 +44,3 @@ def run_configure_method(conanfile, down_options, profile_options, ref):
     if hasattr(conanfile, "build_requirements"):
         with conanfile_exception_formatter(conanfile, "build_requirements"):
             conanfile.build_requirements()
-
-    delattr(conanfile, "_conan_add_requirement_allowed")

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -94,7 +94,7 @@ class ConanFile:
             self.generators = [self.generators]
         if isinstance(self.settings, str):
             self.settings = [self.settings]
-        self.requires = Requirements(self, self.requires, self.build_requires, self.test_requires,
+        self.requires = Requirements(self.requires, self.build_requires, self.test_requires,
                                      self.tool_requires)
 
         self.options = Options(self.options or {}, self.default_options)

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -94,7 +94,7 @@ class ConanFile:
             self.generators = [self.generators]
         if isinstance(self.settings, str):
             self.settings = [self.settings]
-        self.requires = Requirements(self.requires, self.build_requires, self.test_requires,
+        self.requires = Requirements(self, self.requires, self.build_requires, self.test_requires,
                                      self.tool_requires)
 
         self.options = Options(self.options or {}, self.default_options)

--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -574,3 +574,6 @@ class Requirements:
 
     def serialize(self):
         return [v.serialize() for v in self._requires.values()]
+
+    def __len__(self):
+        return len(self._requires)

--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -387,42 +387,52 @@ class Requirement:
 
 class BuildRequirements:
     # Just a wrapper around requires for backwards compatibility with self.build_requires() syntax
-    def __init__(self, requires):
-        self._requires = requires
+    def __init__(self, conanfile):
+        self._conanfile = conanfile
+        self._requires = conanfile.requires
 
     def __call__(self, ref, package_id_mode=None, visible=False, run=None, options=None,
                  override=None):
         # TODO: Check which arguments could be user-defined
+        if not getattr(self._conanfile, "_conan_add_requirement_allowed", False):
+            self._conanfile.output.warning("build_requires() should only be declared in requirements()/build_requirements()", warn_tag="misplaced_requirement")
         self._requires.build_require(ref, package_id_mode=package_id_mode, visible=visible, run=run,
                                      options=options, override=override)
 
 
 class ToolRequirements:
     # Just a wrapper around requires for backwards compatibility with self.build_requires() syntax
-    def __init__(self, requires):
-        self._requires = requires
+    def __init__(self, conanfile):
+        self._conanfile = conanfile
+        self._requires = conanfile.requires
 
     def __call__(self, ref, package_id_mode=None, visible=False, run=True, options=None,
                  override=None):
         # TODO: Check which arguments could be user-defined
+        if not getattr(self._conanfile, "_conan_add_requirement_allowed", False):
+            self._conanfile.output.warning("tool_requires() should only be declared in requirements()/build_requirements()", warn_tag="misplaced_requirement")
         self._requires.tool_require(ref, package_id_mode=package_id_mode, visible=visible, run=run,
                                     options=options, override=override)
 
 
 class TestRequirements:
     # Just a wrapper around requires for backwards compatibility with self.build_requires() syntax
-    def __init__(self, requires):
-        self._requires = requires
+    def __init__(self, conanfile):
+        self._conanfile = conanfile
+        self._requires = conanfile.requires
 
     def __call__(self, ref, run=None, options=None, force=None):
+        if not getattr(self._conanfile, "_conan_add_requirement_allowed", False):
+            self._conanfile.output.warning("test_requires() should only be declared in requirements()/build_requirements()", warn_tag="misplaced_requirement")
         self._requires.test_require(ref, run=run, options=options, force=force)
 
 
 class Requirements:
     """ User definitions of all requires in a conanfile
     """
-    def __init__(self, declared=None, declared_build=None, declared_test=None,
+    def __init__(self, conanfile, declared=None, declared_build=None, declared_test=None,
                  declared_build_tool=None):
+        self._conanfile = conanfile
         self._requires = OrderedDict()
         # Construct from the class definitions
         if declared is not None:
@@ -486,6 +496,8 @@ class Requirements:
 
     # TODO: Plan the interface for smooth transition from 1.X
     def __call__(self, str_ref, **kwargs):
+        if not getattr(self._conanfile, "_conan_add_requirement_allowed", False):
+            self._conanfile.output.warning("requires() should only be declared in requirements()/build_requirements()", warn_tag="misplaced_requirement")
         if str_ref is None:
             return
         assert isinstance(str_ref, str)

--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -387,52 +387,42 @@ class Requirement:
 
 class BuildRequirements:
     # Just a wrapper around requires for backwards compatibility with self.build_requires() syntax
-    def __init__(self, conanfile):
-        self._conanfile = conanfile
-        self._requires = conanfile.requires
+    def __init__(self, requires):
+        self._requires = requires
 
     def __call__(self, ref, package_id_mode=None, visible=False, run=None, options=None,
                  override=None):
         # TODO: Check which arguments could be user-defined
-        if not getattr(self._conanfile, "_conan_add_requirement_allowed", False):
-            self._conanfile.output.warning("build_requires() should only be declared in requirements()/build_requirements()", warn_tag="misplaced_requirement")
         self._requires.build_require(ref, package_id_mode=package_id_mode, visible=visible, run=run,
                                      options=options, override=override)
 
 
 class ToolRequirements:
     # Just a wrapper around requires for backwards compatibility with self.build_requires() syntax
-    def __init__(self, conanfile):
-        self._conanfile = conanfile
-        self._requires = conanfile.requires
+    def __init__(self, requires):
+        self._requires = requires
 
     def __call__(self, ref, package_id_mode=None, visible=False, run=True, options=None,
                  override=None):
         # TODO: Check which arguments could be user-defined
-        if not getattr(self._conanfile, "_conan_add_requirement_allowed", False):
-            self._conanfile.output.warning("tool_requires() should only be declared in requirements()/build_requirements()", warn_tag="misplaced_requirement")
         self._requires.tool_require(ref, package_id_mode=package_id_mode, visible=visible, run=run,
                                     options=options, override=override)
 
 
 class TestRequirements:
     # Just a wrapper around requires for backwards compatibility with self.build_requires() syntax
-    def __init__(self, conanfile):
-        self._conanfile = conanfile
-        self._requires = conanfile.requires
+    def __init__(self, requires):
+        self._requires = requires
 
     def __call__(self, ref, run=None, options=None, force=None):
-        if not getattr(self._conanfile, "_conan_add_requirement_allowed", False):
-            self._conanfile.output.warning("test_requires() should only be declared in requirements()/build_requirements()", warn_tag="misplaced_requirement")
         self._requires.test_require(ref, run=run, options=options, force=force)
 
 
 class Requirements:
     """ User definitions of all requires in a conanfile
     """
-    def __init__(self, conanfile, declared=None, declared_build=None, declared_test=None,
+    def __init__(self, declared=None, declared_build=None, declared_test=None,
                  declared_build_tool=None):
-        self._conanfile = conanfile
         self._requires = OrderedDict()
         # Construct from the class definitions
         if declared is not None:
@@ -496,8 +486,6 @@ class Requirements:
 
     # TODO: Plan the interface for smooth transition from 1.X
     def __call__(self, str_ref, **kwargs):
-        if not getattr(self._conanfile, "_conan_add_requirement_allowed", False):
-            self._conanfile.output.warning("requires() should only be declared in requirements()/build_requirements()", warn_tag="misplaced_requirement")
         if str_ref is None:
             return
         assert isinstance(str_ref, str)

--- a/conans/test/integration/build_requires/build_requires_test.py
+++ b/conans/test/integration/build_requires/build_requires_test.py
@@ -581,18 +581,3 @@ def test_build_missing_build_requires():
     c.run("install app --build=missing")
     assert "- Build" not in c.out
     assert re.search(r"Skipped binaries(\s*)tool/0.1, tooldep/0.1", c.out)
-
-
-def test_requirement_in_wrong_method():
-    tc = TestClient()
-    tc.save({"conanfile.py": textwrap.dedent("""
-        from conan import ConanFile
-        class Pkg(ConanFile):
-            name = "pkg"
-            version = "0.1"
-            def configure(self):
-                self.requires("foo/1.0")
-        """)})
-    tc.run('create . -cc="core:warnings_as_errors=[\'*\']"', assert_error=True)
-    assert "ERROR: misplaced_requirement: requires() should only be declared in requirements()/build_requirements()" in tc.out
-

--- a/conans/test/integration/build_requires/build_requires_test.py
+++ b/conans/test/integration/build_requires/build_requires_test.py
@@ -581,3 +581,18 @@ def test_build_missing_build_requires():
     c.run("install app --build=missing")
     assert "- Build" not in c.out
     assert re.search(r"Skipped binaries(\s*)tool/0.1, tooldep/0.1", c.out)
+
+
+def test_requirement_in_wrong_method():
+    tc = TestClient()
+    tc.save({"conanfile.py": textwrap.dedent("""
+        from conan import ConanFile
+        class Pkg(ConanFile):
+            name = "pkg"
+            version = "0.1"
+            def configure(self):
+                self.requires("foo/1.0")
+        """)})
+    tc.run('create . -cc="core:warnings_as_errors=[\'*\']"', assert_error=True)
+    assert "ERROR: misplaced_requirement: requires() should only be declared in requirements()/build_requirements()" in tc.out
+

--- a/conans/test/integration/build_requires/build_requires_test.py
+++ b/conans/test/integration/build_requires/build_requires_test.py
@@ -581,3 +581,17 @@ def test_build_missing_build_requires():
     c.run("install app --build=missing")
     assert "- Build" not in c.out
     assert re.search(r"Skipped binaries(\s*)tool/0.1, tooldep/0.1", c.out)
+
+
+def test_requirement_in_wrong_method():
+    tc = TestClient(light=True)
+    tc.save({"conanfile.py": textwrap.dedent("""
+        from conan import ConanFile
+        class Pkg(ConanFile):
+            name = "pkg"
+            version = "0.1"
+            def configure(self):
+                self.requires("foo/1.0")
+        """)})
+    tc.run('create . -cc="core:warnings_as_errors=[\'*\']"', assert_error=True)
+    assert "ERROR: deprecated: Requirements should only be added in the requirements()/build_requirements() methods, not configure()/config_options(), which might raise errors in the future." in tc.out


### PR DESCRIPTION
Changelog: Feature: Warn on misplaced requirement function calls
Docs: Omit

Only open question is the warn_tag. Is deprecated appropiate?