### PR TITLE
Fixed conan1 not able to find prerelease Visual Studio instances.

### DIFF
--- a/conans/client/tools/win.py
+++ b/conans/client/tools/win.py
@@ -260,7 +260,7 @@ def vs_installation_path(version, preference=None):
     return result_vs_installation_path
 
 
-def vswhere(all_=False, prerelease=False, products=None, requires=None, version="", latest=False,
+def vswhere(all_=False, prerelease=True, products=None, requires=None, version="", latest=False,
             legacy=False, property_="", nologo=True):
 
     # 'version' option only works if Visual Studio 2017 is installed:


### PR DESCRIPTION
Changelog: (Bugfix): Conan 1 is unable to find Visual Studio experimental versions. This is fixed in Conan 2 by simply changing the `vswhere` function to always allow prerelease products. See https://github.com/conan-io/conan/blob/caad83b34bd19fe53a60918b0265a0f7a59f0957/conans/client/conf/detect_vs.py#L58  This backports this change to Conan 1.
Docs: https://github.com/conan-io/docs/pull/XXXX

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
