### PR TITLE
Fix: remove existing 'file' arg when overwriting print

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -323,7 +323,8 @@ def _load_python_file(conan_file_path):
         raise NotFoundException("%s not found!" % conan_file_path)
 
     def new_print(*args, **kwargs):  # Make sure that all user python files print() goes to stderr
-        print(*args, **kwargs, file=sys.stderr)
+        kwargs['file'] = sys.stderr
+        print(*args, **kwargs)
 
     module_id = str(uuid.uuid1())
     current_dir = os.path.dirname(conan_file_path)

--- a/conans/test/unittests/model/conanfile_test.py
+++ b/conans/test/unittests/model/conanfile_test.py
@@ -37,3 +37,15 @@ class Pkg(ConanFile):
         client.save({"conanfile.py": conanfile.replace("pass",
                                                        "requires = 'pkgb/0.1@user/testing'")})
         client.run("create . --name=pkgc --version=0.1 --user=user --channel=testing")
+
+    def test_conanfile_new_print(self):
+        client = TestClient()
+        conanfile = """from conan import ConanFile
+import sys
+class Pkg(ConanFile):
+    def source(self):
+        print("Test", file=sys.stderr)
+        print("Test")
+"""
+        client.save({"conanfile.py": conanfile})
+        client.run("source .")


### PR DESCRIPTION
Changelog: Fix: Fix broken calls to `print(x, file=y)` with duplicate keyword arguments.
Docs:  Omit

To prevent this, when overwriting the print() function overwrite the existing 'file' argument



- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
