### PR TITLE
Fix/graph templates

### DIFF
--- a/conan/cli/formatters/graph/info_graph_dot.py
+++ b/conan/cli/formatters/graph/info_graph_dot.py
@@ -1,8 +1,12 @@
 
 graph_info_dot = """\
 digraph {
-    {%- for src, dst in graph.edges %}
-        "{{ src.label }}" -> "{{ dst.label }}"
+    {%- for node_id, node in deps_graph["nodes"].items() %}
+        {%- for dep_id, dep in node["dependencies"].items() %}
+        {%- if dep["direct"] %}
+        "{{ node["label"] }}" -> "{{ deps_graph["nodes"][dep_id]["label"] }}"
+        {%- endif %}
+        {%- endfor %}
     {%- endfor %}
 }
 

--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -57,7 +57,7 @@ graph_info_html = r"""
         </div>
 
         <script type="text/javascript">
-            const graph_data = {{ deps_graph }};
+            const graph_data = {{ json.dumps(deps_graph) }};
             let hide_build = false;
             let hide_test = false;
             let search_pkg = null;

--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -57,7 +57,7 @@ graph_info_html = r"""
         </div>
 
         <script type="text/javascript">
-            const graph_data = {{ json.dumps(deps_graph) }};
+            const graph_data = {{ deps_graph | tojson }};
             let hide_build = false;
             let hide_test = false;
             let search_pkg = null;
@@ -261,13 +261,13 @@ graph_info_html = r"""
                     control.removeChild(control.firstChild);
                 }
                 if(ids[0] || ids_edges[0]) {
-                    console.log("Selected ", ids_edges[0], global_edges.length);
-                    console.log("   selected", global_edges[ids_edges[0]]);
                     selected = graph_data["nodes"][ids[0]] || global_edges[ids_edges[0]];
                     let div = document.createElement('div');
                     let f = Object.fromEntries(Object.entries(selected).filter(([_, v]) => v != null));
-                    div.innerHTML = "<pre>" + JSON.stringify(f, undefined, 2) + "</pre>";
-                    control.appendChild(div);
+                    div.innerText = JSON.stringify(f, undefined, 2);
+                    let div2 = document.createElement('div');
+                    div2.innerHTML = "<pre>" + div.innerHTML + "</pre>";
+                    control.appendChild(div2);
                 }
                 else {
                     control.innerHTML = "<b>Info</b>: Click on a package or edge for more info";


### PR DESCRIPTION
Changelog: Fix: Fix html escaping of new ``--format=html`` graph output, and pass the graph serialized object instead of the string.
Docs: Omit

Also refactor ``--format=dot`` formatter to receive the full serialized graph. 

Close https://github.com/conan-io/conan/pull/15907
