### PR TITLE
do not warn on - in refs

### DIFF
--- a/conans/model/recipe_ref.py
+++ b/conans/model/recipe_ref.py
@@ -149,7 +149,7 @@ class RecipeReference:
         if self.channel and validation_pattern.match(self.channel) is None:
             raise ConanException(f"Invalid package channel '{self.channel}'")
 
-        # Warn if they use .+- in the name/user/channel, as it can be problematic for generators
+         # Warn if they use .+ in the name/user/channel, as it can be problematic for generators
         pattern = re.compile(r'[.+]')
         if pattern.search(self.name):
             ConanOutput().warning(f"Name containing special chars is discouraged '{self.name}'")

--- a/conans/model/recipe_ref.py
+++ b/conans/model/recipe_ref.py
@@ -150,7 +150,7 @@ class RecipeReference:
             raise ConanException(f"Invalid package channel '{self.channel}'")
 
         # Warn if they use .+- in the name/user/channel, as it can be problematic for generators
-        pattern = re.compile(r'[.+-]')
+        pattern = re.compile(r'[.+]')
         if pattern.search(self.name):
             ConanOutput().warning(f"Name containing special chars is discouraged '{self.name}'")
         if self.user and pattern.search(self.user):

--- a/conans/test/integration/command/export/export_test.py
+++ b/conans/test/integration/command/export/export_test.py
@@ -434,8 +434,8 @@ def test_warn_special_chars_refs():
     assert "WARN: Name containing special chars is discouraged 'pkg.name'" in c.out
     c.run("export . --name=name --version=0.1 --user=user+some")
     assert "WARN: User containing special chars is discouraged 'user+some'" in c.out
-    c.run("export . --name=pkg.name --version=0.1 --user=user --channel=channel-some")
-    assert "WARN: Channel containing special chars is discouraged 'channel-some'" in c.out
+    c.run("export . --name=pkg.name --version=0.1 --user=user --channel=channel+some")
+    assert "WARN: Channel containing special chars is discouraged 'channel+some'" in c.out
 
 
 def test_export_json():


### PR DESCRIPTION
Changelog: Fix: Do not warn with package names containing the `-` character.
Docs: Omit

Close: https://github.com/conan-io/docs/issues/3086
Close: https://github.com/conan-io/docs/issues/3329


Keep the warning for + and .