### PR TITLE
Fix handling of `tools.build:defines` for multiconfig CMake (#15921)

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -613,10 +613,9 @@ class ExtraFlagsBlock(Block):
         {% endif %}
         {% if defines %}
         {% if config %}
-        add_compile_definitions(
-        {%- for define in defines %}
-        "$<$<CONFIG:{{config}}>:{{define}}>"
-        {%- endfor -%})
+        {% for define in defines %}
+        add_compile_definitions($<$<CONFIG:{{config}}>:{{ define }}>)
+        {% endfor %}
         {% else %}
         add_compile_definitions({% for define in defines %} "{{ define }}"{% endfor %})
         {% endif %}

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -614,7 +614,7 @@ class ExtraFlagsBlock(Block):
         {% if defines %}
         {% if config %}
         {% for define in defines %}
-        add_compile_definitions($<$<CONFIG:{{config}}>:{{ define }}>)
+        add_compile_definitions($<$<CONFIG:{{config}}>:"{{ define }}">)
         {% endfor %}
         {% else %}
         add_compile_definitions({% for define in defines %} "{{ define }}"{% endfor %})

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -154,7 +154,7 @@ class VSDebuggerEnvironment(Block):
 
         if not config_dict:
             return None
-        
+
         vs_debugger_path = ""
         for config, value in config_dict.items():
             vs_debugger_path += f"$<$<CONFIG:{config}>:{value}>"
@@ -613,7 +613,10 @@ class ExtraFlagsBlock(Block):
         {% endif %}
         {% if defines %}
         {% if config %}
-        add_compile_definitions($<$<CONFIG:{{config}}>:{% for define in defines %}" {{ define }}"{% endfor %}>)
+        add_compile_definitions(
+        {%- for define in defines %}
+        "$<$<CONFIG:{{config}}>:{{define}}>"
+        {%- endfor -%})
         {% else %}
         add_compile_definitions({% for define in defines %} "{{ define }}"{% endfor %})
         {% endif %}

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1833,7 +1833,7 @@ def test_cmake_toolchain_cxxflags_multi_config():
     profile_release = textwrap.dedent(r"""
         include(default)
         [conf]
-        tools.build:defines=["answer=42"]
+        tools.build:defines=["answer=42", "other=24"]
         tools.build:cxxflags=["/Zc:__cplusplus"]
         """)
     profile_debug = textwrap.dedent(r"""
@@ -1872,6 +1872,9 @@ def test_cmake_toolchain_cxxflags_multi_config():
 
         int main() {
             SHOW_DEFINE(answer);
+            # ifdef other
+            SHOW_DEFINE(other);
+            # endif
             char a = 123L;  // to trigger warnings
 
             #if __cplusplus
@@ -1903,8 +1906,10 @@ def test_cmake_toolchain_cxxflags_multi_config():
 
     c.run_command(r"build\Release\example.exe")
     assert 'answer=42' in c.out
+    assert 'other=24' in c.out
     assert "CPLUSPLUS: __cplusplus20" in c.out
 
     c.run_command(r"build\Debug\example.exe")
     assert 'answer=123' in c.out
+    assert 'other=' not in c.out
     assert "CPLUSPLUS: __cplusplus19" in c.out

--- a/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/conans/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1833,7 +1833,7 @@ def test_cmake_toolchain_cxxflags_multi_config():
     profile_release = textwrap.dedent(r"""
         include(default)
         [conf]
-        tools.build:defines=["answer=42", "other=24"]
+        tools.build:defines=["conan_test_answer=42", "conan_test_other=24"]
         tools.build:cxxflags=["/Zc:__cplusplus"]
         """)
     profile_debug = textwrap.dedent(r"""
@@ -1841,7 +1841,7 @@ def test_cmake_toolchain_cxxflags_multi_config():
         [settings]
         build_type=Debug
         [conf]
-        tools.build:defines=["answer=123"]
+        tools.build:defines=["conan_test_answer=123"]
         tools.build:cxxflags=["/W4"]
         """)
 
@@ -1868,13 +1868,13 @@ def test_cmake_toolchain_cxxflags_multi_config():
         #include <stdio.h>
 
         #define STR(x)   #x
-        #define SHOW_DEFINE(x) printf("%s=%s\n", #x, STR(x))
+        #define SHOW_DEFINE(x) printf("DEFINE %s=%s!\n", #x, STR(x))
 
         int main() {
-            SHOW_DEFINE(answer);
-            # ifdef other
-            SHOW_DEFINE(other);
-            # endif
+            SHOW_DEFINE(conan_test_answer);
+            #ifdef conan_test_other
+            SHOW_DEFINE(conan_test_other);
+            #endif
             char a = 123L;  // to trigger warnings
 
             #if __cplusplus
@@ -1905,11 +1905,11 @@ def test_cmake_toolchain_cxxflags_multi_config():
         assert "warning C4189" in c.out
 
     c.run_command(r"build\Release\example.exe")
-    assert 'answer=42' in c.out
-    assert 'other=24' in c.out
+    assert 'DEFINE conan_test_answer=42!' in c.out
+    assert 'DEFINE conan_test_other=24!' in c.out
     assert "CPLUSPLUS: __cplusplus20" in c.out
 
     c.run_command(r"build\Debug\example.exe")
-    assert 'answer=123' in c.out
+    assert 'DEFINE conan_test_answer=123' in c.out
     assert 'other=' not in c.out
     assert "CPLUSPLUS: __cplusplus19" in c.out


### PR DESCRIPTION
Changelog: Bugfix: Fix handling of `tools.build:defines` for multiconfig CMake.
Docs: Omit

Closes #15921

The fix is not as simple as fixing the quote spacing. The problem is CMake [generator expressions](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html), which are a pain to work with. We can't just pass multiple strings to one generator expression, since the expression needs to be in one string argument to `add_compile_definitions`.
This PR fixes it similarly to how it is done in:
https://github.com/conan-io/conan/blob/19b7cf6b398b36213758c56f60292c6ad14af32c/conan/tools/cmake/toolchain/toolchain.py#L122-L132
But it uses quoted strings instead of variables.

Note that this still is not perfect, since we should really escape characters in the generator expression, such as `>` as [`$<ANGLE-R>`](https://cmake.org/cmake/help/latest/manual/cmake-generator-expressions.7.html#escaped-characters), which would otherwise close the generator expression, and `$` as `$<1:$>`, but also `;` as `\;` to prevent variables containing it to be split as a list. But this issue is also present with the variable-based approach in `toolchain.py`. ~~I'll create a separate issue for this~~ See #15926.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
