### PR TITLE
Add support for Pop!_OS in package_manager

### DIFF
--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -39,7 +39,7 @@ class _SystemPackageManagerTool(object):
             os_name = distro.id() or os_name
         elif os_name == "Windows" and self._conanfile.conf.get("tools.microsoft.bash:subsystem") == "msys2":
             os_name = "msys2"
-        manager_mapping = {"apt-get": ["Linux", "ubuntu", "debian", "raspbian", "linuxmint", 'astra', 'elbrus', 'altlinux'],
+        manager_mapping = {"apt-get": ["Linux", "ubuntu", "debian", "raspbian", "linuxmint", 'astra', 'elbrus', 'altlinux', 'pop'],
                            "apk": ["alpine"],
                            "yum": ["pidora", "scientific", "xenserver", "amazon", "oracle", "amzn",
                                    "almalinux", "rocky"],
@@ -61,7 +61,7 @@ class _SystemPackageManagerTool(object):
             for d in distros:
                 if d in os_name:
                     return tool
-                
+
         # No default package manager was found for the system,
         # so notify the user
         self._conanfile.output.info("A default system package manager couldn't be found for {}, "

--- a/conans/test/integration/tools/system/package_manager_test.py
+++ b/conans/test/integration/tools/system/package_manager_test.py
@@ -62,6 +62,7 @@ def test_msys2():
     ('altlinux', "apt-get"),
     ("astra", 'apt-get'),
     ('elbrus', 'apt-get'),
+    ('pop', "apt-get"),
 ])
 @pytest.mark.skipif(platform.system() != "Linux", reason="Only linux")
 def test_package_manager_distro(distro, tool):


### PR DESCRIPTION
Fixes #15930.

Changelog: Fix: Add ``Pop!_OS`` to the distros using ``apt-get`` as system package manager.
Docs: Omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
