### PR TITLE
conan profile detect --nonexistent

### DIFF
--- a/conan/cli/commands/profile.py
+++ b/conan/cli/commands/profile.py
@@ -58,12 +58,18 @@ def profile_detect(conan_api, parser, subparser, *args):
     """
     subparser.add_argument("--name", help="Profile name, 'default' if not specified")
     subparser.add_argument("-f", "--force", action='store_true', help="Overwrite if exists")
+    subparser.add_argument("-n", "--nonexistent", action='store_true',
+                           help="Only detect if it doesn't exist already")
     args = parser.parse_args(*args)
 
     profile_name = args.name or "default"
     profile_pathname = conan_api.profiles.get_path(profile_name, os.getcwd(), exists=False)
-    if not args.force and os.path.exists(profile_pathname):
-        raise ConanException(f"Profile '{profile_pathname}' already exists")
+    if os.path.exists(profile_pathname):
+        if args.nonexistent:
+            ConanOutput().info(f"Profile '{profile_name}' already exists, skipping detection")
+            return
+        if not args.force:
+            raise ConanException(f"Profile '{profile_pathname}' already exists")
 
     detected_profile = conan_api.profiles.detect()
     ConanOutput().success("\nDetected profile:")

--- a/conan/cli/commands/profile.py
+++ b/conan/cli/commands/profile.py
@@ -58,14 +58,14 @@ def profile_detect(conan_api, parser, subparser, *args):
     """
     subparser.add_argument("--name", help="Profile name, 'default' if not specified")
     subparser.add_argument("-f", "--force", action='store_true', help="Overwrite if exists")
-    subparser.add_argument("-n", "--nonexistent", action='store_true',
-                           help="Only detect if it doesn't exist already")
+    subparser.add_argument("-e", "--exist-ok", action='store_true',
+                           help="If the profile already exist, do not detect a new one")
     args = parser.parse_args(*args)
 
     profile_name = args.name or "default"
     profile_pathname = conan_api.profiles.get_path(profile_name, os.getcwd(), exists=False)
     if os.path.exists(profile_pathname):
-        if args.nonexistent:
+        if args.exist_ok:
             ConanOutput().info(f"Profile '{profile_name}' already exists, skipping detection")
             return
         if not args.force:

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -128,7 +128,12 @@ class DetectCompilersTest(unittest.TestCase):
         assert "MyProfile2' already exists" in c.out
 
         c.run("profile detect --name=./MyProfile2 --force")  # will not raise error
-    
+        assert "build_type=Release" in c.load("MyProfile2")
+        c.save({"MyProfile2": "potato"})
+        c.run("profile detect --name=./MyProfile2 --nonexistent")  # wont raise, won't overwrite
+        assert "Profile './MyProfile2' already exists, skipping detection" in c.out
+        assert c.load("MyProfile2") == "potato"
+
     @pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows and msvc")
     def test_profile_new_msvc_vcvars(self):
         c = TestClient()
@@ -140,8 +145,8 @@ class DetectCompilersTest(unittest.TestCase):
         cl_executable = c.out.splitlines()[-1]
         assert os.path.isfile(cl_executable)
         cl_location = os.path.dirname(cl_executable)
-        
-        # Try different variations, including full path and full path with quotes 
+
+        # Try different variations, including full path and full path with quotes
         for var in ["cl", "cl.exe", cl_executable, f'"{cl_executable}"']:
             output = RedirectedTestOutput()
             with redirect_output(output):

--- a/conans/test/functional/command/profile_test.py
+++ b/conans/test/functional/command/profile_test.py
@@ -130,7 +130,7 @@ class DetectCompilersTest(unittest.TestCase):
         c.run("profile detect --name=./MyProfile2 --force")  # will not raise error
         assert "build_type=Release" in c.load("MyProfile2")
         c.save({"MyProfile2": "potato"})
-        c.run("profile detect --name=./MyProfile2 --nonexistent")  # wont raise, won't overwrite
+        c.run("profile detect --name=./MyProfile2 --exist-ok")  # wont raise, won't overwrite
         assert "Profile './MyProfile2' already exists, skipping detection" in c.out
         assert c.load("MyProfile2") == "potato"
 


### PR DESCRIPTION
Changelog: Feature: Add ``--exist-ok`` argument to ``conan profile detect`` to not fail if the profile already exists, without overwriting it.
Docs: Omit

Close https://github.com/conan-io/conan/issues/15902