### PR TITLE
fix print - stderr

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -323,7 +323,7 @@ def _load_python_file(conan_file_path):
         raise NotFoundException("%s not found!" % conan_file_path)
 
     def new_print(*args, **kwargs):  # Make sure that all user python files print() goes to stderr
-        kwargs['file'] = sys.stderr
+        kwargs.setdefault("file", sys.stderr)
         print(*args, **kwargs)
 
     module_id = str(uuid.uuid1())

--- a/conans/test/unittests/model/conanfile_test.py
+++ b/conans/test/unittests/model/conanfile_test.py
@@ -1,3 +1,4 @@
+import textwrap
 import unittest
 
 from conans.model.conan_file import ConanFile
@@ -40,12 +41,30 @@ class Pkg(ConanFile):
 
     def test_conanfile_new_print(self):
         client = TestClient()
-        conanfile = """from conan import ConanFile
-import sys
-class Pkg(ConanFile):
-    def source(self):
-        print("Test", file=sys.stderr)
-        print("Test")
-"""
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            import sys
+            class Pkg(ConanFile):
+                def source(self):
+                    print("Test1", file=sys.stderr)
+                    print("Test2")
+            """)
         client.save({"conanfile.py": conanfile})
         client.run("source .")
+        assert "Test1" in client.stderr
+        assert "Test2" in client.stderr
+        assert "" == client.stdout
+
+    def test_conanfile_new_print_save(self):
+        client = TestClient()
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            import sys
+            class Pkg(ConanFile):
+                def source(self):
+                    with open("myfile.txt", "w") as f:
+                        print("Test1", file=f)
+            """)
+        client.save({"conanfile.py": conanfile})
+        client.run("source .")
+        assert "Test1" in client.load("myfile.txt")


### PR DESCRIPTION
Changelog: Fix: Avoid issues with recipe ``print(..., file=fileobj)``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/15932
