### PR TITLE
Fix: remove existing 'file' arg when overwriting print (#15912)

### DIFF
--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -323,7 +323,8 @@ def _load_python_file(conan_file_path):
         raise NotFoundException("%s not found!" % conan_file_path)
 
     def new_print(*args, **kwargs):  # Make sure that all user python files print() goes to stderr
-        print(*args, **kwargs, file=sys.stderr)
+        kwargs['file'] = sys.stderr
+        print(*args, **kwargs)
 
     module_id = str(uuid.uuid1())
     current_dir = os.path.dirname(conan_file_path)

--- a/conans/test/unittests/model/conanfile_test.py
+++ b/conans/test/unittests/model/conanfile_test.py
@@ -37,3 +37,15 @@ class Pkg(ConanFile):
         client.save({"conanfile.py": conanfile.replace("pass",
                                                        "requires = 'pkgb/0.1@user/testing'")})
         client.run("create . --name=pkgc --version=0.1 --user=user --channel=testing")
+
+    def test_conanfile_new_print(self):
+        client = TestClient()
+        conanfile = """from conan import ConanFile
+import sys
+class Pkg(ConanFile):
+    def source(self):
+        print("Test", file=sys.stderr)
+        print("Test")
+"""
+        client.save({"conanfile.py": conanfile})
+        client.run("source .")


### PR DESCRIPTION
Changelog: Fix: Existing calls to print(xxxx, file=yyyyy) are broken with duplicate keyword arguments in conan 2.2.
Docs: Omit

Taking this PR: https://github.com/conan-io/conan/pull/15912 to release/2.2

