### PR TITLE
Fix autootoolstoolchain "rc" compiler

### DIFF
--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -166,7 +166,7 @@ class AutotoolsToolchain:
         compilers_by_conf = self._conanfile.conf.get("tools.build:compiler_executables", default={},
                                                      check_type=dict)
         if compilers_by_conf:
-            compilers_mapping = {"c": "CC", "cpp": "CXX", "cuda": "NVCC", "fortran": "FC"}
+            compilers_mapping = {"c": "CC", "cpp": "CXX", "cuda": "NVCC", "fortran": "FC", "rc": "RC"}
             for comp, env_var in compilers_mapping.items():
                 if comp in compilers_by_conf:
                     compiler = compilers_by_conf[comp]

--- a/conans/test/integration/toolchains/gnu/test_autotoolstoolchain.py
+++ b/conans/test/integration/toolchains/gnu/test_autotoolstoolchain.py
@@ -215,7 +215,7 @@ def test_toolchain_and_compilers_build_context():
     os=Linux
 
     [conf]
-    tools.build:compiler_executables={"c": "gcc", "cpp": "g++"}
+    tools.build:compiler_executables={"c": "gcc", "cpp": "g++", "rc": "windres"}
     """)
     build = textwrap.dedent("""
     [settings]
@@ -265,6 +265,7 @@ def test_toolchain_and_compilers_build_context():
             content = load(self, toolchain)
             assert 'export CC="gcc"' in content
             assert 'export CXX="g++"' in content
+            assert 'export RC="windres"' in content
     """)
     client = TestClient()
     client.save({


### PR DESCRIPTION
Changelog: Fix: Add ``rc`` to ``AutotoolsToolchain`` mapping of ``compiler_executables`` for cross-build Linux->Windows.
Docs: Omit

Close https://github.com/conan-io/conan/issues/15945
Coming from https://github.com/conan-io/cmake-conan/issues/631

cc @f-scholer
