### PR TITLE
VCVars uses compiler.update

### DIFF
--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -133,7 +133,13 @@ class VCVars:
                           "v143": "14.3"}.get(toolset_version)
         else:
             vs_version = vs_ide_version(conanfile)
-            vcvars_ver = _vcvars_vers(conanfile, compiler, vs_version)
+            if int(vs_version) <= 14:
+                vcvars_ver = None
+            else:
+                compiler_version = str(conanfile.settings.compiler.version)
+                compiler_update = conanfile.settings.get_safe("compiler.update", "")
+                # The equivalent of compiler 19.26 is toolset 14.26
+                vcvars_ver = "14.{}{}".format(compiler_version[-1], compiler_update)
         vcvarsarch = _vcvars_arch(conanfile)
 
         winsdk_version = conanfile.conf.get("tools.microsoft:winsdk_version", check_type=str)
@@ -177,7 +183,6 @@ class VCVars:
             _create_deactivate_vcvars_file(conanfile, conan_vcvars_ps1)
 
 
-
 def _create_deactivate_vcvars_file(conanfile, filename):
     deactivate_filename = f"deactivate_{filename}"
     message = f"[{deactivate_filename}]: vcvars env cannot be deactivated"
@@ -188,6 +193,7 @@ def _create_deactivate_vcvars_file(conanfile, filename):
         content = f"echo {message}"
     path = os.path.join(conanfile.generators_folder, deactivate_filename)
     save(path, content)
+
 
 def vs_ide_version(conanfile):
     """
@@ -298,7 +304,7 @@ def _vcvars_arch(conanfile):
                 'x86_64': 'amd64',
                 'armv7': 'amd64_arm',
                 'armv8': 'amd64_arm64',
-                'arm64ec':'amd64_arm64'}.get(arch_host)
+                'arm64ec': 'amd64_arm64'}.get(arch_host)
     elif arch_build == 'x86':
         arch = {'x86': 'x86',
                 'x86_64': 'x86_amd64',
@@ -314,18 +320,6 @@ def _vcvars_arch(conanfile):
         raise ConanException('vcvars unsupported architectures %s-%s' % (arch_build, arch_host))
 
     return arch
-
-
-def _vcvars_vers(conanfile, compiler, vs_version):
-    if int(vs_version) <= 14:
-        return None
-
-    assert compiler == "msvc"
-    # Code similar to CMakeToolchain toolset one
-    compiler_version = str(conanfile.settings.compiler.version)
-    # The equivalent of compiler 192 is toolset 14.2
-    vcvars_ver = "14.{}".format(compiler_version[-1])
-    return vcvars_ver
 
 
 def is_msvc(conanfile, build_context=False):

--- a/conans/test/integration/toolchains/microsoft/vcvars_test.py
+++ b/conans/test/integration/toolchains/microsoft/vcvars_test.py
@@ -51,6 +51,7 @@ def test_vcvars_generator_skip():
     client.run('install . -pr=profile')
     assert not os.path.exists(os.path.join(client.current_folder, "conanvcvars.bat"))
 
+
 @pytest.mark.skipif(platform.system() not in ["Linux"], reason="Requires Linux")
 def test_vcvars_generator_skip_on_linux():
     """
@@ -64,6 +65,7 @@ def test_vcvars_generator_skip_on_linux():
     client.run('install . -s os=Windows -s compiler=msvc -s compiler.version=193 '
                '-s compiler.runtime=dynamic')
     assert not os.path.exists(os.path.join(client.current_folder, "conanvcvars.bat"))
+
 
 @pytest.mark.skipif(platform.system() not in ["Windows"], reason="Requires Windows")
 def test_vcvars_generator_string():
@@ -140,6 +142,26 @@ def test_vcvars_winsdk_version():
     vcvars = client.load("conanvcvars.bat")
     assert 'vcvarsall.bat"  amd64 8.1 -vcvars_ver=14.3' in vcvars
 
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows")
+def test_vcvars_compiler_update():
+    client = TestClient(path_with_spaces=False)
+
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        class TestConan(ConanFile):
+            generators = "VCVars"
+            settings = "os", "compiler", "arch", "build_type"
+    """)
+    client.save({"conanfile.py": conanfile})
+    client.run('install . -s os=Windows -s compiler=msvc -s compiler.version=193 '
+               '-s compiler.cppstd=14 -s compiler.runtime=static '
+               '-s compiler.update=3')
+
+    vcvars = client.load("conanvcvars.bat")
+    assert 'vcvarsall.bat"  amd64 -vcvars_ver=14.33' in vcvars
+
+
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows")
 def test_deactivate_vcvars_message():
     client = TestClient()
@@ -155,6 +177,7 @@ def test_deactivate_vcvars_message():
     assert "[vcvarsall.bat] Environment initialized" in client.out
     client.run_command(r'deactivate_conanvcvars.bat')
     assert "vcvars env cannot be deactivated" in client.out
+
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows Powershell")
 def test_deactivate_vcvars_with_powershell():

--- a/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/conans/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -195,7 +195,7 @@ def conanfile_msvc():
     c = ConanFile(None)
     c.settings = Settings({"os": ["Windows"],
                            "compiler": {"msvc": {"version": ["193"], "cppstd": ["20"],
-                                                 "update": [None]}},
+                                                 "update": [None, 8, 9]}},
                            "build_type": ["Release"],
                            "arch": ["x86"]})
     c.settings.build_type = "Release"
@@ -218,6 +218,12 @@ def test_toolset(conanfile_msvc):
     assert 'set(CMAKE_GENERATOR_TOOLSET "v143" CACHE STRING "" FORCE)' in toolchain.content
     assert 'Visual Studio 17 2022' in toolchain.generator
     assert 'CMAKE_CXX_STANDARD 20' in toolchain.content
+
+
+def test_toolset_update_version(conanfile_msvc):
+    conanfile_msvc.settings.compiler.update = "8"
+    toolchain = CMakeToolchain(conanfile_msvc)
+    assert 'set(CMAKE_GENERATOR_TOOLSET "v143,version=14.38" CACHE STRING "" FORCE)' in toolchain.content
 
 
 def test_toolset_x64(conanfile_msvc):


### PR DESCRIPTION
Changelog: Fix: Make ``VCVars`` use the ``compiler.update`` to specify the toolset.
Docs: Omit

Close https://github.com/conan-io/conan/issues/15522

Note that the equivalent doesn't work easily with CMake Visual Studio generators