### PR TITLE
[AutotoolsToolchain] Backported bugfix from #13230

### DIFF
--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -1,6 +1,7 @@
 from conan.tools._check_build_profile import check_using_build_profile
 from conan.tools._compilers import architecture_flag, build_type_flags, cppstd_flag, \
     build_type_link_flags, libcxx_flags
+from conan.tools.apple import is_apple_os
 from conan.tools.apple.apple import apple_min_version_flag, to_apple_arch, \
     apple_sdk_path
 from conan.tools.build.cross_building import cross_building, get_cross_building_settings
@@ -59,7 +60,7 @@ class AutotoolsToolchain:
             # Build triplet
             self._build = _get_gnu_triplet(os_build, arch_build, compiler=compiler)
             # Apple Stuff
-            if os_build == "Macos":
+            if os_build == "Macos" and is_apple_os(self._conanfile):
                 sdk_path = apple_sdk_path(conanfile)
                 apple_arch = to_apple_arch(self._conanfile)
                 # https://man.archlinux.org/man/clang.1.en#Target_Selection_Options

--- a/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/conans/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -315,6 +315,19 @@ def test_apple_min_os_flag():
     assert expected in env["LDFLAGS"]
 
 
+def test_crossbuild_from_macos_to_non_apple_os():
+    """Check we are not adding Apple-specific flags
+        when the os_build is Macos, but we are targetting
+        a non-Apple OS (e.g. Linux, Android, QNX)"""
+    conanfile = ConanFileMock()
+    conanfile.settings = MockSettings({"os": "Android", "arch": "armv8"})
+    conanfile.settings_build = MockSettings({"os": "Macos", "arch": "armv8"})
+    be = AutotoolsToolchain(conanfile)
+    assert be.apple_min_version_flag == ''
+    assert be.apple_arch_flag is None
+    assert be.apple_isysroot_flag is None
+
+
 def test_apple_isysrootflag():
     """Even when no cross building it is adjusted because it could target a Mac version"""
     conanfile = ConanFileMock()


### PR DESCRIPTION
Changelog: Fix: Fix flags passed by AutotoolsToolchain when cross compiling from macOS to a non-Apple OS. Backported from Conan 2.
Docs: omit

Backported from #13230.
Closes: https://github.com/conan-io/conan/issues/15429
