### PR TITLE
Allow custom separators for append and prepend from profile

### DIFF
--- a/conans/test/unittests/tools/env/test_env.py
+++ b/conans/test/unittests/tools/env/test_env.py
@@ -155,6 +155,11 @@ def test_profile():
         # unset
         MyPath4=!
 
+        # Custom append/prepend
+        MyCustomList=is;+something
+        MyCustomList=+(sep=;+)this
+        MyCustomList+=(sep=;+)weird
+
         # PER-PACKAGE
         mypkg*:MyVar2=MyValue2
         """)
@@ -171,6 +176,7 @@ def test_profile():
         assert env.get("MyVar3", "$MyVar3") == 'MyValue3 $MyVar3'
         assert env.get("MyVar4") == ""
         assert env.get("MyVar5") == ''
+        assert env.get("MyCustomList") == 'this;+is;+something;+weird'
 
         env = profile_env.get_profile_env(RecipeReference.loads("mypkg1/1.0"))
         env = env.vars(ConanFileMock())
@@ -356,29 +362,46 @@ class TestProfileEnvRoundTrip:
     def test_append(self):
         myprofile = textwrap.dedent("""
             # define
-            MyVar1+=MyValue1
-            MyPath1 +=(path)/my/path1
+            MyVar+=MyValue1
+            MyVar+=MyValue2
+            MyPath+=(path)/my/path1
+            MyPath += (path)/my/path2
+            MyList+=(sep=;)item1
+            MyList += (sep=;)item2
             """)
 
         env = ProfileEnvironment.loads(myprofile)
         text = env.dumps()
         assert text == textwrap.dedent("""\
-            MyVar1+=MyValue1
-            MyPath1+=(path)/my/path1
+            MyVar+=MyValue1
+            MyVar+=MyValue2
+            MyPath+=(path)/my/path1
+            MyPath+=(path)/my/path2
+            MyList+=(sep=;)item1
+            MyList+=(sep=;)item2
             """)
 
     def test_prepend(self):
         myprofile = textwrap.dedent("""
             # define
-            MyVar1=+MyValue1
-            MyPath1=+(path)/my/path1
+            MyVar=+MyValue1
+            MyVar=+MyValue2
+            MyPath =+ (path)/my/path1
+            MyPath=+(path)/my/path2
+            MyList =+ (sep=++)item1
+            MyList=+(sep=++)item2
             """)
 
         env = ProfileEnvironment.loads(myprofile)
         text = env.dumps()
+        # XXX: This seems wrong?
         assert text == textwrap.dedent("""\
-            MyVar1=+MyValue1
-            MyPath1=+(path)/my/path1
+            MyVar=+MyValue2
+            MyVar=+MyValue1
+            MyPath=+(path)/my/path2
+            MyPath=+(path)/my/path1
+            MyList=+(sep=++)item2
+            MyList=+(sep=++)item1
             """)
 
     def test_combined(self):
@@ -387,6 +410,8 @@ class TestProfileEnvRoundTrip:
             MyVar1+=MyValue12
             MyPath1=+(path)/my/path11
             MyPath1+=(path)/my/path12
+            MyList1=+(sep=;)item11
+            MyList1+=(sep=;)item12
             """)
 
         env = ProfileEnvironment.loads(myprofile)
@@ -396,6 +421,8 @@ class TestProfileEnvRoundTrip:
             MyVar1+=MyValue12
             MyPath1=+(path)/my/path11
             MyPath1+=(path)/my/path12
+            MyList1=+(sep=;)item11
+            MyList1+=(sep=;)item12
             """)
 
     def test_combined2(self):
@@ -404,6 +431,8 @@ class TestProfileEnvRoundTrip:
             MyVar1=+MyValue12
             MyPath1+=(path)/my/path11
             MyPath1=+(path)/my/path12
+            MyList1+=(sep=;)item11
+            MyList1=+(sep=;)item12
             """)
 
         env = ProfileEnvironment.loads(myprofile)
@@ -414,6 +443,8 @@ class TestProfileEnvRoundTrip:
             MyVar1+=MyValue11
             MyPath1=+(path)/my/path12
             MyPath1+=(path)/my/path11
+            MyList1=+(sep=;)item12
+            MyList1+=(sep=;)item11
             """)
 
 


### PR DESCRIPTION
fixes #15908

This is pertains to the [question] issue #15908 about mixed Windows and Unix paths in Msys2 when appending to INCLUDE or similar variables in the profile.
This proposed solution introduces the a notation like "+=(sep=;)" to gain fine grained control over the separator used for appending or prepending, and is intended to serve as a more concrete basis for discussion.

While adding the tests for this, I noticed that there might be an issue with TestProfileEnvRoundTrip::test_prepend. It reverses the order of definitions. Maybe someone can comment on this. It seems wrong, and was previously untested.

As this is for discussion, no documentation was added.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
