### PR TITLE
add response error message to 401 error in file downloader

### DIFF
--- a/conans/client/downloaders/file_downloader.py
+++ b/conans/client/downloaders/file_downloader.py
@@ -86,7 +86,7 @@ class FileDownloader:
                     raise AuthenticationException(response_to_str(response))
                 raise ForbiddenException(response_to_str(response))
             elif response.status_code == 401:
-                raise AuthenticationException()
+                raise AuthenticationException(response_to_str(response))
             raise ConanException("Error %d downloading file %s" % (response.status_code, url))
 
         def get_total_length():


### PR DESCRIPTION
The source download step attempts to load source_credentials.json when it is present. When following the recommended steps of passing credentials to the source_credentials.json via os.getenv('BACKUP_USER') etc., this can result in the json string "None" when no authentication is provided.
This effectively gets translated to the curl call when being read:

    curl -i -u None:None https://artifactory.example.org/artifactory/source-backup/

This causes an error with status code 401, which currently does not propagate the error message and is slightly misleading, as a source_credentials.json is provided but the content is wrong:

    ERROR: conanfile.py (example/1.0): Error in source() method, line 17
            get(self, self.url, sha256=sha256, strip_root=True)
            ConanException: The source backup server 'https://artifactory.example.org/artifactory/source-backup/' needs authentication: . Please provide 'source_credentials.json'

With this fix, the error message is propagated in the same way others in the same block, resulting in a more useful message, although the "please provide" is still misleading.

    ERROR: conanfile.py (example/1.0): Error in source() method, line 17
            get(self, self.url, sha256=sha256, strip_root=True)
            ConanException: The source backup server 'https://artifactory.example.org/artifactory/source-backup/' needs authentication: {
      "errors" : [ {
        "status" : 401,
        "message" : "Bad credentials"
      } ]
    }. Please provide 'source_credentials.json'

Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
