### PR TITLE
Add response error message output to HTTP Status 401 Errors in FileDownloader

### DIFF
--- a/conans/client/downloaders/file_downloader.py
+++ b/conans/client/downloaders/file_downloader.py
@@ -86,7 +86,7 @@ class FileDownloader:
                     raise AuthenticationException(response_to_str(response))
                 raise ForbiddenException(response_to_str(response))
             elif response.status_code == 401:
-                raise AuthenticationException()
+                raise AuthenticationException(response_to_str(response))
             raise ConanException("Error %d downloading file %s" % (response.status_code, url))
 
         def get_total_length():

--- a/conans/requirements_dev.txt
+++ b/conans/requirements_dev.txt
@@ -4,3 +4,5 @@ parameterized>=0.6.3
 mock>=1.3.0, <1.4.0
 WebTest>=2.0.18, <2.1.0
 bottle
+PyJWT
+pluginbase

--- a/conans/test/unittests/tools/files/test_downloads.py
+++ b/conans/test/unittests/tools/files/test_downloads.py
@@ -77,6 +77,27 @@ class TestDownload:
             download(conanfile, file_server.fake_url + "/forbidden", dest)
         assert "403 Forbidden" in str(exc.value)
 
+    def test_download_unauthorized_no_credentials(self, _manual):
+        conanfile, file_server = _manual
+        dest = os.path.join(temp_folder(), "manual.html")
+        # Not authorized without credentials
+        with pytest.raises(AuthenticationException) as exc:
+            download(conanfile, file_server.fake_url + "/basic-auth/manual.html", dest)
+        assert "401 Unauthorized" in str(exc.value)
+        assert "Not authorized" in str(exc.value)
+
+    def test_download_unauthorized_literal_none_credentials(self, _manual):
+        conanfile, file_server = _manual
+        dest = os.path.join(temp_folder(), "manual.html")
+        # os.getenv('SOME_UNSET_VARIABLE') causes source_credentials.json to contain
+        # "None" as a string literal, causing auth to be ("None", "None") or with
+        # a "None" token.
+        auth = ("None", "None")
+        with pytest.raises(AuthenticationException) as exc:
+            download(conanfile, file_server.fake_url + "/basic-auth/manual.html", dest, auth=auth)
+        assert "401 Unauthorized" in str(exc.value)
+        assert "Bad credentials" in str(exc.value)
+
     def test_download_authorized(self, _manual):
         conanfile, file_server = _manual
         dest = os.path.join(temp_folder(), "manual.html")

--- a/conans/test/utils/file_server.py
+++ b/conans/test/utils/file_server.py
@@ -50,7 +50,7 @@ class TestFileServer:
             auth = bottle.request.auth
             if auth is not None:
                 if auth != ("user", "password"):
-                    return bottle.HTTPError(401, "Not authorized")
+                    return bottle.HTTPError(401, "Bad credentials")
                 return bottle.static_file(file, store)
 
             auth = bottle.request.headers.get("Authorization")


### PR DESCRIPTION
Changelog: Fix: Add response error message output to HTTP Status 401 Errors in FileDownloader.
Docs: Omit


(was #15981, but I committed with the wrong mail address so the GPG signatures were broken)

The source download step attempts to load source_credentials.json when it is present. When following the recommended steps of passing credentials to the source_credentials.json via os.getenv('BACKUP_USER') etc., this can result in the json string "None" when no authentication is provided.
This effectively gets translated to the curl call when being read:

    curl -i -u None:None https://artifactory.example.org/artifactory/source-backup/

This causes an error with status code 401, which currently does not propagate the error message and is slightly misleading, as a source_credentials.json is provided but the content is wrong:

    ERROR: conanfile.py (example/1.0): Error in source() method, line 17
            get(self, self.url, sha256=sha256, strip_root=True)
            ConanException: The source backup server 'https://artifactory.example.org/artifactory/source-backup/' needs authentication: . Please provide 'source_credentials.json'

With this fix, the error message is propagated in the same way others in the same block, resulting in a more useful message, although the "please provide" is still misleading.

    ERROR: conanfile.py (example/1.0): Error in source() method, line 17
            get(self, self.url, sha256=sha256, strip_root=True)
            ConanException: The source backup server 'https://artifactory.example.org/artifactory/source-backup/' needs authentication: {
      "errors" : [ {
        "status" : 401,
        "message" : "Bad credentials"
      } ]
    }. Please provide 'source_credentials.json'


- [x] Refer to the issue that supports this Pull Request: Closes: #15982
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).

(after creating the PR... sorry for not following the exact procedure of waiting for feedback etc.)

- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
