### PR TITLE
remove duplicated cmd print

### DIFF
--- a/conan/tools/gnu/autotools.py
+++ b/conan/tools/gnu/autotools.py
@@ -55,7 +55,6 @@ class Autotools(object):
         subsystem = deduce_subsystem(self._conanfile, scope="build")
         configure_cmd = subsystem_path(subsystem, configure_cmd)
         cmd = '"{}" {}'.format(configure_cmd, self._configure_args)
-        self._conanfile.output.info("Calling:\n > %s" % cmd)
         self._conanfile.run(cmd)
 
     def make(self, target=None, args=None):


### PR DESCRIPTION
Changelog: Fix: Remove duplicated printing of command line in ``Autotools`` helper.
Docs: Omit

Close https://github.com/conan-io/conan/issues/15970
