### PR TITLE
test_package only if build missing

### DIFF
--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -93,10 +93,10 @@ def create(conan_api, parser, *args):
 
     test_folder = args.test_folder
     if test_folder and test_folder.startswith("missing"):
-        test_folder = ""  # disable it
         if deps_graph.root.dependencies[0].dst.binary == BINARY_BUILD:
             test_folder = test_folder.split(":", 1)[1] if ":" in test_folder else "test_package"
-
+        else:
+            test_folder = ""  # disable it
     test_conanfile_path = _get_test_conanfile_path(test_folder, path)
     if test_conanfile_path:
         # TODO: We need arguments for:

--- a/conans/test/integration/command/create_test.py
+++ b/conans/test/integration/command/create_test.py
@@ -819,18 +819,45 @@ def test_create_test_package_only_build():
             "test_package/conanfile.py": GenConanfile().with_test("self.output.info('TEST1!!!')"),
             "test_package2/conanfile.py": GenConanfile().with_test("self.output.info('TEST2!!!')")})
     # As it doesn't exist, it builds and test it
-    c.run("create . -tf=missing")
+    c.run("create . -tm")
     assert "Testing the package" in c.out
     assert "TEST1!!!" in c.out
     # this will not create the binary, so it won't test it
-    c.run("create . --build=missing -tf=missing")
+    c.run("create . --build=missing --test-missing")
     assert "Testing the package" not in c.out
     assert "TEST" not in c.out
-    c.run("create . -tf=missing:test_package2")
+    c.run("create . -tf=test_package2 -tm")
     assert "Testing the package" in c.out
     assert "TEST2!!!" in c.out
     assert "TEST1!!!" not in c.out
-    c.run("create . -tf=missing:test_package2 --build=missing")
+    c.run("create . -tf=test_package2 --build=missing --test-missing")
     assert "Testing the package" not in c.out
     assert "TEST2!!!" not in c.out
     assert "TEST1!!!" not in c.out
+
+    # error
+    c.run("create . -tm -tf=", assert_error=True)
+    assert '--test-folder="" is incompatible with --test-missing' in c.out
+
+
+def test_create_test_package_only_build_python_require():
+    c = TestClient()
+    test = textwrap.dedent("""
+        from conan import ConanFile
+
+        class Tool(ConanFile):
+            python_requires = "tested_reference_str"
+            def test(self):
+                self.output.info("TEST!!!!")
+        """)
+    c.save({"conanfile.py": GenConanfile("pkg", "0.1").with_package_type("python-require"),
+            "test_package/conanfile.py": test})
+    c.run("create .")
+    assert "Testing the package" in c.out
+    assert "pkg/0.1 (test package): TEST!!!" in c.out
+    c.run("create . -tm")
+    assert "Testing the package" in c.out
+    assert "pkg/0.1 (test package): TEST!!!" in c.out
+    c.run("create . -tm --build=missing")
+    assert "Testing the package" in c.out
+    assert "pkg/0.1 (test package): TEST!!!" in c.out


### PR DESCRIPTION
Changelog: Feature: New ``conan create --test-missing`` syntax to optionally run the ``test_package`` only when the package is actually created (useful with ``--build=missing``).
Docs: https://github.com/conan-io/docs/pull/3705

Close https://github.com/conan-io/conan/issues/15967
Close https://github.com/conan-io/conan/issues/14999