### PR TITLE
new test_package_folder attribute

### DIFF
--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -97,8 +97,9 @@ def create(conan_api, parser, *args):
         lockfile = conan_api.lockfile.update_lockfile(lockfile, deps_graph, args.lockfile_packages,
                                                       clean=args.lockfile_clean)
 
-    test_package_folder = getattr(conanfile, "test_package_folder", None)
-    test_conanfile_path = _get_test_conanfile_path(args.test_folder or test_package_folder, path)
+    test_package_folder = getattr(conanfile, "test_package_folder", None) \
+        if args.test_folder is None else args.test_folder
+    test_conanfile_path = _get_test_conanfile_path(test_package_folder, path)
     # If the user provide --test-missing and the binary was not built from source, skip test_package
     if args.test_missing and deps_graph.root.dependencies\
             and deps_graph.root.dependencies[0].dst.binary != BINARY_BUILD:

--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -40,7 +40,6 @@ def create(conan_api, parser, *args):
 
     cwd = os.getcwd()
     path = conan_api.local.get_conanfile_path(args.path, cwd, py=True)
-    test_conanfile_path = _get_test_conanfile_path(args.test_folder, path)
     overrides = eval(args.lockfile_overrides) if args.lockfile_overrides else None
     lockfile = conan_api.lockfile.get_lockfile(lockfile=args.lockfile,
                                                conanfile_path=path,
@@ -98,6 +97,8 @@ def create(conan_api, parser, *args):
         lockfile = conan_api.lockfile.update_lockfile(lockfile, deps_graph, args.lockfile_packages,
                                                       clean=args.lockfile_clean)
 
+    test_package_folder = getattr(conanfile, "test_package_folder", None)
+    test_conanfile_path = _get_test_conanfile_path(args.test_folder or test_package_folder, path)
     # If the user provide --test-missing and the binary was not built from source, skip test_package
     if args.test_missing and deps_graph.root.dependencies\
             and deps_graph.root.dependencies[0].dst.binary != BINARY_BUILD:


### PR DESCRIPTION
Changelog: Feature: Add new ``test_package_folder`` attribute to ``conanfile.py`` to define a different custom location and name rather than ``test_package`` default.
Docs: https://github.com/conan-io/docs/pull/3705

Close https://github.com/conan-io/conan/issues/16008