### PR TITLE
autotools: PKG_CONFIG_PATH is now set correctly if it wasn't declared…

### DIFF
--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -178,7 +178,11 @@ class AutotoolsToolchain:
         env.append("CXXFLAGS", self.cxxflags)
         env.append("CFLAGS", self.cflags)
         env.append("LDFLAGS", self.ldflags)
-        env.prepend_path("PKG_CONFIG_PATH", self._conanfile.generators_folder)
+        pkg_config_path = env.vars(self._conanfile).get("PKG_CONFIG_PATH")
+        if pkg_config_path:
+            env.prepend_path("PKG_CONFIG_PATH", self._conanfile.generators_folder)
+        else:
+            env.define_path("PKG_CONFIG_PATH", self._conanfile.generators_folder)
         return env
 
     def vars(self):

--- a/conans/test/unittests/tools/gnu/autotoolschain_test.py
+++ b/conans/test/unittests/tools/gnu/autotoolschain_test.py
@@ -1,3 +1,4 @@
+import pathlib
 from unittest.mock import patch
 
 import pytest
@@ -211,3 +212,18 @@ def test_update_or_prune_any_args(cross_building_conanfile):
     at.update_make_args({"--new-complex-flag": "new-value"})
     new_make_args = cmd_args_to_string(at.make_args)
     assert "--new-complex-flag=new-value" in new_make_args
+
+
+def test_pkg_config_path():
+    conanfile = ConanFileMock()
+    conanfile.conf = Conf()
+    settings = MockSettings({"build_type": "Release",
+                             "os": "Windows",
+                             "arch": "x86_64",
+                             "compiler": "msvc"})
+    conanfile.settings = settings
+    autotoolschain = AutotoolsToolchain(conanfile)
+    env = autotoolschain.environment().vars(conanfile)
+    pkg_config_path = str(env["PKG_CONFIG_PATH"])
+    assert not pkg_config_path.endswith((':', ';'))
+


### PR DESCRIPTION
Changelog: Bugfix: some packages are failing because the environment variable `PKG_CONFIG_PATH` is wrongly set on Windows with msys2.

I found the initial issue trying to build `ffmpeg` on Windows with msvc and I hit build error. More information can be find in the following issues on conan center index. I think all of them are related:

- https://github.com/conan-io/conan-center-index/issues/23309
- https://github.com/conan-io/conan-center-index/issues/21591
- https://github.com/conan-io/conan-center-index/issues/21694

After a bit of investigation, I found out that on MSYS2 the `PKG_CONFIG_PATH` is wrongly set because an extra ':' was added after the path. Please refer to [this issue](https://github.com/conan-io/conan-center-index/issues/21694) for further detail.

The fix consists just in checking if the variable is already existing, in this case the path is pre-appended otherwise the variable is defined as new.

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
