### PR TITLE
allow conf in exports-sources and export

### DIFF
--- a/conans/client/cmd/export.py
+++ b/conans/client/cmd/export.py
@@ -25,6 +25,7 @@ def cmd_export(app, global_conf, conanfile_path, name, version, user, channel, g
     ref.validate_ref(allow_uppercase=global_conf.get("core:allow_uppercase_pkg_names",
                                                      check_type=bool))
 
+    conanfile.conf = global_conf.get_conanfile_conf(ref, is_consumer=True)
     conanfile.display_name = str(ref)
     conanfile.output.scope = conanfile.display_name
     scoped_output = conanfile.output


### PR DESCRIPTION
Changelog: Feature: Allow ``.conf`` access (exclusively to ``global.conf`` information, not to profile information) in the ``export()`` and ``export_sources()`` methods.
Docs: https://github.com/conan-io/docs/pull/3703

Close https://github.com/conan-io/conan/issues/16032