### PR TITLE
Allow to unhide git url

### DIFF
--- a/conans/test/functional/tools/scm/test_git.py
+++ b/conans/test/functional/tools/scm/test_git.py
@@ -310,7 +310,7 @@ class TestGitBasicClone:
         folder = os.path.join(temp_folder(), "myrepo")
         url, _ = create_local_git_repo(files={"CMakeLists.txt": "mycmake"}, folder=folder)
 
-        c = TestClient()
+        c = TestClient(light=True)
         c.save({"conanfile.py": conanfile.format(url=url)})
         c.run("create . -v")
         # Clone URL is explicitly printed

--- a/conans/test/functional/tools/scm/test_git.py
+++ b/conans/test/functional/tools/scm/test_git.py
@@ -289,6 +289,37 @@ class TestGitBasicClone:
         assert c.load("source/src/myfile.h") == "myheader!"
         assert c.load("source/CMakeLists.txt") == "mycmake"
 
+    def test_clone_url_not_hidden(self):
+        conanfile = textwrap.dedent("""
+            import os
+            from conan import ConanFile
+            from conan.tools.scm import Git
+            from conan.tools.files import load
+
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "0.1"
+
+                def layout(self):
+                    self.folders.source = "source"
+
+                def source(self):
+                    git = Git(self)
+                    git.clone(url="{url}", target=".", hide_url=False)
+            """)
+        folder = os.path.join(temp_folder(), "myrepo")
+        url, _ = create_local_git_repo(files={"CMakeLists.txt": "mycmake"}, folder=folder)
+
+        c = TestClient()
+        c.save({"conanfile.py": conanfile.format(url=url)})
+        c.run("create . -v")
+        # Clone URL is explicitly printed
+        assert f'pkg/0.1: RUN: git clone "{url}"  "."' in c.out
+
+        # It also works in local flow
+        c.run("source .")
+        assert f'conanfile.py (pkg/0.1): RUN: git clone "{url}"  "."' in c.out
+
     def test_clone_target(self):
         # Clone to a different target folder
         # https://github.com/conan-io/conan/issues/14058
@@ -421,6 +452,37 @@ class TestGitShallowClone:
         assert "conanfile.py (pkg/0.1): MYFILE: myheader!" in c.out
         assert c.load("source/src/myfile.h") == "myheader!"
         assert c.load("source/CMakeLists.txt") == "mycmake"
+
+    def test_clone_url_not_hidden(self):
+        conanfile = textwrap.dedent("""
+            import os
+            from conan import ConanFile
+            from conan.tools.scm import Git
+            from conan.tools.files import load
+
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "0.1"
+
+                def layout(self):
+                    self.folders.source = "source"
+
+                def source(self):
+                    git = Git(self)
+                    git.fetch_commit(url="{url}", commit="{commit}", hide_url=False)
+            """)
+        folder = os.path.join(temp_folder(), "myrepo")
+        url, commit = create_local_git_repo(files={"CMakeLists.txt": "mycmake"}, folder=folder)
+
+        c = TestClient()
+        c.save({"conanfile.py": conanfile.format(url=url, commit=commit)})
+        c.run("create . -v")
+        # Clone URL is explicitly printed
+        assert f'pkg/0.1: RUN: git remote add origin "{url}"' in c.out
+
+        # It also works in local flow
+        c.run("source .")
+        assert f'conanfile.py (pkg/0.1): RUN: git remote add origin "{url}"' in c.out
 
 
 class TestGitCloneWithArgs:

--- a/conans/test/functional/tools/scm/test_git.py
+++ b/conans/test/functional/tools/scm/test_git.py
@@ -474,7 +474,7 @@ class TestGitShallowClone:
         folder = os.path.join(temp_folder(), "myrepo")
         url, commit = create_local_git_repo(files={"CMakeLists.txt": "mycmake"}, folder=folder)
 
-        c = TestClient()
+        c = TestClient(light=True)
         c.save({"conanfile.py": conanfile.format(url=url, commit=commit)})
         c.run("create . -v")
         # Clone URL is explicitly printed


### PR DESCRIPTION
Changelog: Feature: Add an argument `hide_url` to Git operations to allow logging of the repository URL. By default, URLs will stay `<hidden>`, but users may opt-out of this.
Docs: Omit

Close #15684

- [x] Refer to the issue that supports this Pull Request: #15684
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
