### PR TITLE
Improve error messages for invalid version ranges operators

### DIFF
--- a/conans/model/version_range.py
+++ b/conans/model/version_range.py
@@ -88,8 +88,8 @@ class _ConditionSet:
             if expression[1] == "=":
                 operator += "="
                 index = 2
-        elif operator == "=" and expression[1] == "=":
-            raise ConanException(f"Invalid version range operator '==' in {expression}")
+        elif expression[1] == "=":
+            raise ConanException(f"Invalid version range operator '{operator}=' in {expression}")
         version = expression[index:]
         if version == "":
             raise ConanException(f'Error parsing version range "{expression}"')
@@ -113,7 +113,7 @@ class _ConditionSet:
         else:
             return [_Condition(operator, Version(version))]
 
-    def _valid(self, version, conf_resolve_prepreleases):
+    def valid(self, version, conf_resolve_prepreleases):
         if version.pre:
             # Follow the expression desires only if core.version_ranges:resolve_prereleases is None,
             # else force to the conf's value
@@ -182,7 +182,7 @@ class VersionRange:
         """
         assert isinstance(version, Version), type(version)
         for condition_set in self.condition_sets:
-            if condition_set._valid(version, resolve_prerelease):
+            if condition_set.valid(version, resolve_prerelease):
                 return True
         return False
 

--- a/conans/model/version_range.py
+++ b/conans/model/version_range.py
@@ -88,6 +88,8 @@ class _ConditionSet:
             if expression[1] == "=":
                 operator += "="
                 index = 2
+        elif operator == "=" and expression[1] == "=":
+            raise ConanException(f"Invalid version range operator '==' in {expression}")
         version = expression[index:]
         if version == "":
             raise ConanException(f'Error parsing version range "{expression}"')

--- a/conans/model/version_range.py
+++ b/conans/model/version_range.py
@@ -89,7 +89,7 @@ class _ConditionSet:
                 operator += "="
                 index = 2
         elif expression[1] == "=":
-            raise ConanException(f"Invalid version range operator '{operator}=' in {expression}")
+            raise ConanException(f"Invalid version range operator '{operator}=' in {expression}, you should probably use {operator} instead.")
         version = expression[index:]
         if version == "":
             raise ConanException(f'Error parsing version range "{expression}"')

--- a/conans/test/unittests/model/version/test_version_range.py
+++ b/conans/test/unittests/model/version/test_version_range.py
@@ -116,7 +116,6 @@ def test_range_prereleases_conf(version_range, resolve_prereleases, versions_in,
 def test_wrong_range_syntax(version_range):
     with pytest.raises(ConanException) as e:
         VersionRange(version_range)
-    print(e)
 
 
 @pytest.mark.parametrize("version_range", [

--- a/conans/test/unittests/model/version/test_version_range.py
+++ b/conans/test/unittests/model/version/test_version_range.py
@@ -5,6 +5,7 @@ from conans.model.version import Version
 from conans.model.version_range import VersionRange
 
 values = [
+    ['=1.0.0',  [[['=', '1.0.0']]],                   ["1.0.0"],          ["0.1"]],
     ['>1.0.0',  [[['>', '1.0.0']]],                   ["1.0.1"],          ["0.1"]],
     ['<2.0',    [[['<', '2.0-']]],                     ["1.0.1"],          ["2.1"]],
     ['>1 <2.0', [[['>', '1'], ['<', '2.0-']]],         ["1.5.1"],          ["0.1", "2.1"]],
@@ -109,7 +110,8 @@ def test_range_prereleases_conf(version_range, resolve_prereleases, versions_in,
 
 @pytest.mark.parametrize("version_range", [
     ">= 1.0",  # https://github.com/conan-io/conan/issues/12692
-    ">=0.0.1 < 1.0"  # https://github.com/conan-io/conan/issues/14612
+    ">=0.0.1 < 1.0",  # https://github.com/conan-io/conan/issues/14612
+    "==1.0"  # https://github.com/conan-io/conan/issues/16066
 ])
 def test_wrong_range_syntax(version_range):
     with pytest.raises(ConanException):

--- a/conans/test/unittests/model/version/test_version_range.py
+++ b/conans/test/unittests/model/version/test_version_range.py
@@ -114,7 +114,7 @@ def test_range_prereleases_conf(version_range, resolve_prereleases, versions_in,
     "==1.0",  "~=1.0",  "^=1.0", "v=1.0"  # https://github.com/conan-io/conan/issues/16066
 ])
 def test_wrong_range_syntax(version_range):
-    with pytest.raises(ConanException) as e:
+    with pytest.raises(ConanException):
         VersionRange(version_range)
 
 

--- a/conans/test/unittests/model/version/test_version_range.py
+++ b/conans/test/unittests/model/version/test_version_range.py
@@ -111,10 +111,10 @@ def test_range_prereleases_conf(version_range, resolve_prereleases, versions_in,
 @pytest.mark.parametrize("version_range", [
     ">= 1.0",  # https://github.com/conan-io/conan/issues/12692
     ">=0.0.1 < 1.0",  # https://github.com/conan-io/conan/issues/14612
-    "==1.0"  # https://github.com/conan-io/conan/issues/16066
+    "==1.0",  "~=1.0",  "^=1.0"  # https://github.com/conan-io/conan/issues/16066
 ])
 def test_wrong_range_syntax(version_range):
-    with pytest.raises(ConanException):
+    with pytest.raises(ConanException) as e:
         VersionRange(version_range)
 
 

--- a/conans/test/unittests/model/version/test_version_range.py
+++ b/conans/test/unittests/model/version/test_version_range.py
@@ -111,11 +111,12 @@ def test_range_prereleases_conf(version_range, resolve_prereleases, versions_in,
 @pytest.mark.parametrize("version_range", [
     ">= 1.0",  # https://github.com/conan-io/conan/issues/12692
     ">=0.0.1 < 1.0",  # https://github.com/conan-io/conan/issues/14612
-    "==1.0",  "~=1.0",  "^=1.0"  # https://github.com/conan-io/conan/issues/16066
+    "==1.0",  "~=1.0",  "^=1.0", "v=1.0"  # https://github.com/conan-io/conan/issues/16066
 ])
 def test_wrong_range_syntax(version_range):
     with pytest.raises(ConanException) as e:
         VersionRange(version_range)
+    print(e)
 
 
 @pytest.mark.parametrize("version_range", [


### PR DESCRIPTION
Changelog: Fix: Improve the definition of version ranges UX with better error message for invalid ``==, ~=, ^=`` operators.
Docs: Omit

Close https://github.com/conan-io/conan/issues/16066