### PR TITLE
using cc executable to detect default compiler in Linux

### DIFF
--- a/conan/internal/api/detect_api.py
+++ b/conan/internal/api/detect_api.py
@@ -167,7 +167,6 @@ def _detect_musl_libc(ldd="/usr/bin/ldd"):
     d = tempfile.mkdtemp()
     tmp_file = os.path.join(d, "err")
     try:
-        ldd_output = None
         with open(tmp_file, 'w') as stderr:
             check_output_runner(f"{ldd}", stderr=stderr, ignore_error=True)
         ldd_output = load(tmp_file)
@@ -375,7 +374,7 @@ def detect_default_compiler():
         if platform.system() == "SunOS" and command.lower() == "cc":
             return _sun_cc_compiler(command)
         if (platform.system() == "Windows" and command.rstrip('"').endswith(("cl", "cl.exe"))
-            and "clang" not in command):
+                and "clang" not in command):
             return _msvc_cl_compiler(command)
 
         # I am not able to find its version
@@ -398,12 +397,14 @@ def detect_default_compiler():
         if clang:
             return clang, clang_version, compiler_exe
         return None, None, None
-    else:
+    else:  # linux like system
+        compiler, compiler_version, compiler_exe = _cc_compiler()
+        if compiler:
+            return compiler, compiler_version, compiler_exe
         gcc, gcc_version, compiler_exe = _gcc_compiler()
         if gcc:
             return gcc, gcc_version, compiler_exe
         return _clang_compiler()
-    return None, None, None
 
 
 def default_msvc_ide_version(version):
@@ -422,6 +423,22 @@ def _detect_vs_ide_version():
             ConanOutput(scope="detect_api").info("Found msvc %s" % version)
             return Version(version)
     return None
+
+
+def _cc_compiler():
+    # Try to detect the "cc" linux system "alternative". It could point to gcc or clang
+    try:
+        compiler_exe = "cc"
+        ret, out = detect_runner('%s --version' % compiler_exe)
+        if ret != 0:
+            return None, None, None
+        compiler = "clang" if "clang" in out else "gcc"
+        installed_version = re.search(r"([0-9]+(\.[0-9])?)", out).group()
+        if installed_version:
+            ConanOutput(scope="detect_api").info("Found cc=%s-%s" % (compiler, installed_version))
+            return compiler, Version(installed_version), compiler_exe
+    except (Exception,):  # to disable broad-except
+        return None, None, None
 
 
 def _gcc_compiler(compiler_exe="gcc"):
@@ -453,6 +470,7 @@ def detect_compiler():
     compiler, version, _ = detect_default_compiler()
     return compiler, version
 
+
 def _intel_compiler(compiler_exe="icx"):
     try:
         ret, out = detect_runner("%s --version" % compiler_exe)
@@ -465,6 +483,7 @@ def _intel_compiler(compiler_exe="icx"):
             return compiler, Version(installed_version), compiler_exe
     except (Exception,):  # to disable broad-except
         return None, None, None
+
 
 def _sun_cc_compiler(compiler_exe="cc"):
     try:


### PR DESCRIPTION
Changelog: Fix: Use ``cc`` executable in Linux systems for autodetect compiler (``conan profile detect`` and ``detect_api``).
Docs: Omit

Close https://github.com/conan-io/conan/issues/8866

Note that this has some risk of breaking autodetection for users that define a weird, unrelated ``cc`` executable in their system