### PR TITLE
Fix/cmakedeps transitive tool visible

### DIFF
--- a/conans/model/dependencies.py
+++ b/conans/model/dependencies.py
@@ -165,7 +165,9 @@ def get_transitive_requires(consumer, dependency):
     """ the transitive requires that we need are the consumer ones, not the current dependencey
     ones, so we get the current ones, then look for them in the consumer, and return those
     """
-    pkg_deps = dependency.dependencies.filter({"direct": True})
+    # The build dependencies cannot be transitive in generators like CMakeDeps,
+    # even if users make them visible
+    pkg_deps = dependency.dependencies.filter({"direct": True, "build": False})
     result = consumer.dependencies.transitive_requires(pkg_deps)
     result = result.filter({"skip": False})
     return result

--- a/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_transitive_build.py
+++ b/conans/test/functional/toolchains/cmake/cmakedeps/test_build_context_transitive_build.py
@@ -135,3 +135,21 @@ def test_error_cmakedeps_transitive_build_requires():
     c.run("export tool")
     c.run("install consumer --build=missing -s:b build_type=Release -s:h build_type=Debug")
     assert "tool/0.1: Created package" in c.out
+
+
+def test():
+    c = TestClient()
+    c.save({"tool/conanfile.py": GenConanfile("tool", "0.1").with_package_type("application"),
+            "pkgb/conanfile.py": GenConanfile("pkgb", "0.1").with_tool_requirement("tool/0.1", visible=True),
+            "app/conanfile.py": GenConanfile("app", "0.1").with_requires("pkgb/0.1")
+                                                          .with_settings("build_type")
+                                                          .with_tool_requirement("tool/0.1", visible=True)
+                                                          .with_generator("CMakeDeps")})
+
+    c.run("create tool")
+    c.run("create pkgb")
+    c.run("install app")
+    print(c.current_folder)
+    cmake = c.load("app/pkgb-release-data.cmake")
+    assert "list(APPEND pkgb_FIND_DEPENDENCY_NAMES )" in cmake
+


### PR DESCRIPTION
Changelog: Bugfix: Avoid the propagation of transitive dependencies of ``tool_requires`` to generators information even if they are marked as ``visible=True``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/16058
