### PR TITLE
Fix #16078 - add type to CMakePresets cacheVariables

### DIFF
--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 import textwrap
 from collections import OrderedDict
 
@@ -240,14 +241,21 @@ class CMakeToolchain(object):
         cache_variables = {}
         for name, value in self.cache_variables.items():
             if isinstance(value, bool):
-                cache_variables[name] = "ON" if value else "OFF"
+                cache_variables[name] = {"value": "ON" if value else "OFF", "type": "BOOL"}
+            elif isinstance(value, Path):
+                cache_variables[name] = {
+                    "value": str(value),
+                    "type": "FILEPATH" if value.is_file() else 'PATH'
+                }
+            elif isinstance(value, str):
+                cache_variables[name] = {"value": value, "type": "STRING"}
             elif isinstance(value, _PackageOption):
                 if str(value).lower() in ["true", "false", "none"]:
-                    cache_variables[name] = "ON" if bool(value) else "OFF"
+                    cache_variables[name] = {"value": "ON" if bool(value) else "OFF", "type": "BOOL"}
                 elif str(value).isdigit():
                     cache_variables[name] = int(value)
                 else:
-                    cache_variables[name] = str(value)
+                    cache_variables[name] = {"value": str(value), "type": "STRING"}
             else:
                 cache_variables[name] = value
 

--- a/conans/test/integration/configuration/profile_test.py
+++ b/conans/test/integration/configuration/profile_test.py
@@ -524,7 +524,8 @@ def test_consumer_specific_settings():
         # Verify the cmake toolchain takes Debug
         assert "I'm dep and my shared is False" in client.out
         presets = json.loads(client.load("CMakePresets.json"))
-        assert presets["configurePresets"][0]["cacheVariables"]['CMAKE_BUILD_TYPE'] == "Debug"
+        expected = {"value": "Debug", "type": "STRING"}
+        assert presets["configurePresets"][0]["cacheVariables"]['CMAKE_BUILD_TYPE'] == expected
 
 
 def test_create_and_priority_of_consumer_specific_setting():


### PR DESCRIPTION
Changelog: Feature: add type to CMakePresets cacheVariables

Close #16078

* Fix #16078 
* I am assuming I'm missing tests and co, but this is more a proof of concept than anything else, to show that it wouldn't be too much effort to implement
* Add types for BOOL, STRING, FILEPATH/PATH (based on assigning a `pathlib.Path` to the `tc.cache_variables`)

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
