### PR TITLE
Feature/exclude some deps from conan dependency graph

### DIFF
--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -44,7 +44,10 @@ graph_info_html = r"""
                     <label for="show_package_type">Show package type</label>
                 </div>
                  <div>
-                    <input type="search" placeholder="Search package..." oninput="searchPackage(this)">
+                    <input type="search" placeholder="Search packages..." oninput="searchPackages(this)">
+                </div>
+                 <div>
+                    <input type="search" placeholder="Filter packages..." oninput="filterPackages(this)">
                 </div>
                 <div>
                     <input type="checkbox" onchange="showhideclass('controls')" id="show_controls"/>
@@ -60,7 +63,8 @@ graph_info_html = r"""
             const graph_data = {{ deps_graph | tojson }};
             let hide_build = false;
             let hide_test = false;
-            let search_pkg = null;
+            let search_pkgs = null;
+            let filter_pkgs = null;
             let collapse_packages = false;
             let show_package_type = false;
             let color_map = {Cache: "SkyBlue",
@@ -101,6 +105,14 @@ graph_info_html = r"""
                         if (existing) continue;
                         collapsed_packages[label] = node_id;
                     }
+                    if (filter_pkgs) {
+                        let patterns = filter_pkgs.split(',')
+                            .map(pattern => pattern.trim())
+                            .filter(pattern => pattern.length > 0);
+                        if (patterns.some(pattern => label.match(pattern))) {
+                            continue;
+                        }
+                    }
                     if (show_package_type) {
                          label = "<b>" + label + "\n" + "<i>" + node.package_type + "</i>";
                     }
@@ -114,9 +126,14 @@ graph_info_html = r"""
                         color = "Black";
                         shape = "circle";
                     }
-                    if (search_pkg && label.match(search_pkg)) {
-                        borderWidth = 3;
-                        borderColor = "Magenta";
+                    if (search_pkgs) {
+                        let patterns = search_pkgs.split(',')
+                            .map(pattern => pattern.trim())
+                            .filter(pattern => pattern.length > 0);
+                        if (patterns.some(pattern => label.match(pattern))) {
+                            borderWidth = 3;
+                            borderColor = "Magenta";
+                        }
                     }
                     if (node.test) {
                         font.background = "lightgrey";
@@ -293,8 +310,12 @@ graph_info_html = r"""
                 collapse_packages = !collapse_packages;
                 draw();
             }
-            function searchPackage(e) {
-                search_pkg = e.value;
+            function searchPackages(e) {
+                search_pkgs = e.value;
+                draw();
+            }
+            function filterPackages(e) {
+                filter_pkgs = e.value;
                 draw();
             }
             function showPackageType(e) {

--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -47,7 +47,7 @@ graph_info_html = r"""
                     <input type="search" placeholder="Search packages..." oninput="searchPackages(this)">
                 </div>
                  <div>
-                    <input type="search" placeholder="Filter packages..." title="Add a comma to filter an additional package" oninput="filterPackages(this)">
+                    <input type="search" placeholder="Exclude packages..." title="Add a comma to exclude an additional package" oninput="excludePackages(this)">
                 </div>
                 <div>
                     <input type="checkbox" onchange="showhideclass('controls')" id="show_controls"/>
@@ -64,7 +64,7 @@ graph_info_html = r"""
             let hide_build = false;
             let hide_test = false;
             let search_pkgs = null;
-            let filter_pkgs = null;
+            let excluded_pkgs = null;
             let collapse_packages = false;
             let show_package_type = false;
             let color_map = {Cache: "SkyBlue",
@@ -105,8 +105,8 @@ graph_info_html = r"""
                         if (existing) continue;
                         collapsed_packages[label] = node_id;
                     }
-                    if (filter_pkgs) {
-                        let patterns = filter_pkgs.split(',')
+                    if (excluded_pkgs) {
+                        let patterns = excluded_pkgs.split(',')
                             .map(pattern => pattern.trim())
                             .filter(pattern => pattern.length > 0)
                             .map(pattern => pattern.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'));
@@ -316,8 +316,8 @@ graph_info_html = r"""
                 search_pkgs = e.value;
                 draw();
             }
-            function filterPackages(e) {
-                filter_pkgs = e.value;
+            function excludePackages(e) {
+                excluded_pkgs = e.value;
                 draw();
             }
             function showPackageType(e) {

--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -47,7 +47,7 @@ graph_info_html = r"""
                     <input type="search" placeholder="Search packages..." oninput="searchPackages(this)">
                 </div>
                  <div>
-                    <input type="search" placeholder="Filter packages..." oninput="filterPackages(this)">
+                    <input type="search" placeholder="Filter packages..." title="Add a comma to filter an additional package" oninput="filterPackages(this)">
                 </div>
                 <div>
                     <input type="checkbox" onchange="showhideclass('controls')" id="show_controls"/>

--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -108,7 +108,8 @@ graph_info_html = r"""
                     if (filter_pkgs) {
                         let patterns = filter_pkgs.split(',')
                             .map(pattern => pattern.trim())
-                            .filter(pattern => pattern.length > 0);
+                            .filter(pattern => pattern.length > 0)
+                            .map(pattern => pattern.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'));
                         if (patterns.some(pattern => label.match(pattern))) {
                             continue;
                         }
@@ -129,7 +130,8 @@ graph_info_html = r"""
                     if (search_pkgs) {
                         let patterns = search_pkgs.split(',')
                             .map(pattern => pattern.trim())
-                            .filter(pattern => pattern.length > 0);
+                            .filter(pattern => pattern.length > 0)
+                            .map(pattern => pattern.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&'));
                         if (patterns.some(pattern => label.match(pattern))) {
                             borderWidth = 3;
                             borderColor = "Magenta";


### PR DESCRIPTION
Changelog: Feature: In graph `html` search bar now takes in multiple search patterns separated by commas. 
Changelog: Feature: In graph `html` added 'filter packages' bar that takes in multiple search patterns separated by comma and hides filters them from graph.
Docs: Omit



Fixes #9303

**Demonstration of modified search bar functionality:**
![chrome_uOWBBaqrOK](https://github.com/conan-io/conan/assets/97642146/bb55866d-4c9a-46dd-944c-62dceec3c472)

**Demonstration of filter bar functionality:**
![chrome_ORugRtGWm6](https://github.com/conan-io/conan/assets/97642146/75b24aa0-6259-40aa-8fa7-d758b2a03781)

Footnote:
Our group wanted to suggest a design change for the filter packages search bar. Our design would modify the filter bar to only begin filtering upon pressing the enter key (or perhaps a button) instead of doing it for every state change of the filter bar.  

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
