### PR TITLE
Fix to_apple_archs method when using architectures from settings_user

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -398,13 +398,13 @@ class AppleSystemBlock(Block):
         if not is_apple_os(self._conanfile):
             return None
 
-        def to_apple_archs(conanfile, default=None):
+        def to_apple_archs(conanfile):
             f"""converts conan-style architectures into Apple-style archs
             to be used by CMake also supports multiple architectures
             separated by '{universal_arch_separator}'"""
             arch_ = conanfile.settings.get_safe("arch") if conanfile else None
             if arch_ is not None:
-                return ";".join([_to_apple_arch(arch, default) for arch in
+                return ";".join([_to_apple_arch(arch, default=arch) for arch in
                                  arch_.split(universal_arch_separator)])
 
         # check valid combinations of architecture - os ?

--- a/conans/test/integration/settings/test_settings_user.py
+++ b/conans/test/integration/settings/test_settings_user.py
@@ -1,5 +1,8 @@
 import os
+import platform
 import textwrap
+
+import pytest
 
 from conans.test.assets.genconanfile import GenConanfile
 from conans.test.utils.tools import TestClient
@@ -93,3 +96,17 @@ def test_settings_user_error():
     save(os.path.join(c.cache_folder, "settings_user.yml"), settings_user)
     c.run("profile show", assert_error=True)
     assert "ERROR: Definition of settings.yml 'settings.os.libc' cannot be null" in c.out
+
+
+def test_settings_user_breaking_universal_binaries():
+    # If you had a settings_user.yml with a custom architecture wit will error
+    # in the Apple block of CMakeToolchain
+    # https://github.com/conan-io/conan/issues/16086#issuecomment-2059118224
+    c = TestClient()
+    settings_user = textwrap.dedent("""\
+        arch: [universal]
+        """)
+    save(os.path.join(c.cache_folder, "settings_user.yml"), settings_user)
+    c.save({"conanfile.py": GenConanfile().with_settings("os").with_settings("arch").with_generator("CMakeToolchain")})
+    c.run('install . -s="arch=universal"')
+    assert "CMakeToolchain generated: conan_toolchain.cmake" in c.out


### PR DESCRIPTION
Changelog: Fix: Fix to_apple_archs method when using architectures from settings_user.
Docs: Omit

Closes: https://github.com/conan-io/conan/issues/16086