### PR TITLE
Fix to_apple_archs method when using architectures from settings_user

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -398,13 +398,13 @@ class AppleSystemBlock(Block):
         if not is_apple_os(self._conanfile):
             return None
 
-        def to_apple_archs(conanfile, default=None):
+        def to_apple_archs(conanfile):
             f"""converts conan-style architectures into Apple-style archs
             to be used by CMake also supports multiple architectures
             separated by '{universal_arch_separator}'"""
             arch_ = conanfile.settings.get_safe("arch") if conanfile else None
             if arch_ is not None:
-                return ";".join([_to_apple_arch(arch, default) for arch in
+                return ";".join([_to_apple_arch(arch, default=arch) for arch in
                                  arch_.split(universal_arch_separator)])
 
         # check valid combinations of architecture - os ?

--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -2,4 +2,4 @@ CHECKSUM_DEPLOY = "checksum_deploy"  # Only when v2
 REVISIONS = "revisions"  # Only when enabled in config, not by default look at server_launcher.py
 OAUTH_TOKEN = "oauth_token"
 
-__version__ = '2.2.2'
+__version__ = '2.2.3'

--- a/conans/test/integration/settings/test_settings_user.py
+++ b/conans/test/integration/settings/test_settings_user.py
@@ -81,3 +81,17 @@ def test_settings_user_convert_list_dict():
     c.run("install . -s arch=x86_64 -s arch.subarch=2 ")
     assert "arch=x86_64" in c.out
     assert "arch.subarch=2" in c.out
+
+
+def test_settings_user_breaking_universal_binaries():
+    # If you had a settings_user.yml with a custom architecture wit will error
+    # in the Apple block of CMakeToolchain
+    # https://github.com/conan-io/conan/issues/16086#issuecomment-2059118224
+    c = TestClient()
+    settings_user = textwrap.dedent("""\
+        arch: [universal]
+        """)
+    save(os.path.join(c.cache_folder, "settings_user.yml"), settings_user)
+    c.save({"conanfile.py": GenConanfile().with_settings("os").with_settings("arch").with_generator("CMakeToolchain")})
+    c.run('install . -s="arch=universal"')
+    assert "CMakeToolchain generated: conan_toolchain.cmake" in c.out


### PR DESCRIPTION
Changelog: Fix: Fix `to_apple_archs` method when using architectures from settings_user.
Docs: Omit

Closes: https://github.com/conan-io/conan/issues/16086