### PR TITLE
improve UX of error messages when wrong files

### DIFF
--- a/conan/api/subapi/remotes.py
+++ b/conan/api/subapi/remotes.py
@@ -257,7 +257,10 @@ def _load(remotes_file):
         _save(remotes_file, [remote])
         return [remote]
 
-    data = json.loads(load(remotes_file))
+    try:
+        data = json.loads(load(remotes_file))
+    except Exception as e:
+        raise ConanException(f"Error loading JSON remotes file '{remotes_file}': {e}")
     result = []
     for r in data.get("remotes", []):
         remote = Remote(r["name"], r["url"], r["verify_ssl"], r.get("disabled", False),

--- a/conans/client/rest/conan_requester.py
+++ b/conans/client/rest/conan_requester.py
@@ -32,9 +32,6 @@ class URLCredentials:
         creds_path = os.path.join(cache_folder, "source_credentials.json")
         if not os.path.exists(creds_path):
             return
-        template = Template(load(creds_path))
-        content = template.render({"platform": platform, "os": os})
-        content = json.loads(content)
 
         def _get_auth(credentials):
             result = {}
@@ -52,10 +49,13 @@ class URLCredentials:
                 raise ConanException(f"Unknown credentials method for '{credentials['url']}'")
 
         try:
+            template = Template(load(creds_path))
+            content = template.render({"platform": platform, "os": os})
+            content = json.loads(content)
             self._urls = {credentials["url"]: _get_auth(credentials)
                           for credentials in content["credentials"]}
-        except KeyError as e:
-            raise ConanException(f"Authentication error, wrong source_credentials.json layout: {e}")
+        except Exception as e:
+            raise ConanException(f"Error loading 'source_credentials.json' {creds_path}: {repr(e)}")
 
     def add_auth(self, url, kwargs):
         for u, creds in self._urls.items():

--- a/conans/client/rest/remote_credentials.py
+++ b/conans/client/rest/remote_credentials.py
@@ -17,13 +17,16 @@ class RemoteCredentials:
         creds_path = os.path.join(cache_folder, "credentials.json")
         if not os.path.exists(creds_path):
             return
-        template = Template(load(creds_path))
-        content = template.render({"platform": platform, "os": os})
-        content = json.loads(content)
+        try:
+            template = Template(load(creds_path))
+            content = template.render({"platform": platform, "os": os})
+            content = json.loads(content)
 
-        self._urls = {credentials["remote"]: {"user": credentials["user"],
-                                              "password": credentials["password"]}
-                      for credentials in content["credentials"]}
+            self._urls = {credentials["remote"]: {"user": credentials["user"],
+                                                  "password": credentials["password"]}
+                          for credentials in content["credentials"]}
+        except Exception as e:
+            raise ConanException(f"Error loading 'credentials.json' {creds_path}: {repr(e)}")
 
     def auth(self, remote, user=None, password=None):
         if user is not None and password is not None:

--- a/conans/test/integration/command/remote_test.py
+++ b/conans/test/integration/command/remote_test.py
@@ -344,6 +344,13 @@ def test_add_wrong_conancenter():
     assert "the correct remote API is https://center.conan.io" in c.out
 
 
+def test_wrong_remotes_json_file():
+    c = TestClient(light=True)
+    c.save_home({"remotes.json": ""})
+    c.run("remote list", assert_error=True)
+    assert "ERROR: Error loading JSON remotes file" in c.out
+
+
 def test_allowed_packages_remotes():
     tc = TestClient(light=True, default_server_user=True)
     tc.save({"conanfile.py": GenConanfile(),

--- a/conans/test/integration/remote/test_remote_file_credentials.py
+++ b/conans/test/integration/remote/test_remote_file_credentials.py
@@ -42,3 +42,14 @@ def test_remote_file_credentials_error(client):
     save(os.path.join(c.cache_folder, "credentials.json"), json.dumps(content))
     c.run("upload * -r=default -c", assert_error=True)
     assert "ERROR: Wrong user or password" in c.out
+
+
+def test_remote_file_credentials_bad_file(client):
+    c = client
+    save(os.path.join(c.cache_folder, "credentials.json"), "")
+    c.run("upload * -r=default -c", assert_error=True)
+    assert "ERROR: Error loading 'credentials.json'" in c.out
+    content = {"credentials": [{"remote": "default"}]}
+    save(os.path.join(c.cache_folder, "credentials.json"), json.dumps(content))
+    c.run("upload * -r=default -c", assert_error=True)
+    assert "ERROR: Error loading 'credentials.json'" in c.out

--- a/conans/test/integration/test_source_download_password.py
+++ b/conans/test/integration/test_source_download_password.py
@@ -41,9 +41,10 @@ def test_source_download_password():
     c.run("source .")
     assert "Content: hello world!" in c.out
 
-    # Errors
-    for invalid in [{"token": "mytoken"},
-                    {"url": server_url, "token": "mytoken2"},  # Unauthorized
+    # Errors loading file
+    for invalid in ["",
+                    "potato",
+                    {"token": "mytoken"},
                     {},
                     {"url": server_url},
                     {"auth": {}},
@@ -51,4 +52,10 @@ def test_source_download_password():
         content = {"credentials": [invalid]}
         save(os.path.join(c.cache_folder, "source_credentials.json"), json.dumps(content))
         c.run("source .", assert_error=True)
-        assert "Authentication" in c.out or "Unknown credentials" in c.out
+        assert "Error loading 'source_credentials.json'" in c.out
+
+    content = {"credentials": [{"url": server_url, "token": "mytoken2"}]}
+    save(os.path.join(c.cache_folder, "source_credentials.json"), json.dumps(content))
+    c.run("source .", assert_error=True)
+    assert "ERROR: conanfile.py: Error in source() method, line 6" in c.out
+    assert "Authentication" in c.out


### PR DESCRIPTION
Changelog: Fix: Improve UX and error messages when a remotes or credentials file in the cache is invalid/empty.
Docs: Omit

Close https://github.com/conan-io/conan/issues/16089