### PR TITLE
extend `conan version` to report current python and system for troubleshooting

### DIFF
--- a/conan/cli/commands/version.py
+++ b/conan/cli/commands/version.py
@@ -25,7 +25,8 @@ def version(conan_api, parser, *args):
             'system': {
                 'version': platform.version(),
                 'platform': platform.platform(),
-                'os': platform.system() + ' ' + platform.release(),
+                'system': platform.system(),
+                'release': platform.release(),
                 'cpu': platform.processor(),
                 }
             }

--- a/conan/cli/commands/version.py
+++ b/conan/cli/commands/version.py
@@ -14,7 +14,7 @@ def version(conan_api, parser, *args):
 
     return {
             'version': str(conan_version),
-            'conan_script_path': sys.argv[0],
+            'conan_path': sys.argv[0],
             'python': {
                 'version': platform.python_version().replace('\n', ''),
                 'sys_version': sys.version.replace('\n', ''),

--- a/conan/cli/commands/version.py
+++ b/conan/cli/commands/version.py
@@ -12,10 +12,21 @@ def version(conan_api, parser, *args):
     Give information about the Conan client version.
     """
 
-    return {'version': str(conan_version),
+    return {
+            'version': str(conan_version),
+            'conan_script_path': sys.argv[0],
             'python': {
                 'version': platform.python_version().replace('\n', ''),
                 'sys_version': sys.version.replace('\n', ''),
+                'sys_executable': sys.executable,
+                'is_frozen': getattr(sys, 'frozen', False),
+                'architecture': platform.machine(),
+                },
+            'system': {
+                'version': platform.version(),
+                'platform': platform.platform(),
+                'os': platform.system() + ' ' + platform.release(),
+                'cpu': platform.processor(),
                 }
             }
 

--- a/conans/test/integration/command_v2/test_version.py
+++ b/conans/test/integration/command_v2/test_version.py
@@ -21,16 +21,17 @@ def test_version_json():
     t.run("version --format=json")
     js = json.loads(t.stdout)
     assert js["version"] == __version__
-    assert js["conan_script_path"] == sys.argv[0]
+    assert js["conan_path"] == sys.argv[0]
     assert js["python"]["version"] == _python_version()
     assert js["python"]["sys_version"] == _sys_version()
     assert js["python"]["sys_executable"] == sys.executable
     assert js["python"]["is_frozen"] == getattr(sys, 'frozen', False)
     assert js["python"]["architecture"] == platform.machine()
     assert js["system"]["version"] == platform.version()
-    assert js["system"]["version"] == platform.platform()
-    assert js["system"]["version"] == platform.system() + ' ' + platform.release()
-    assert js["system"]["version"] == platform.processor()
+    assert js["system"]["platform"] == platform.platform()
+    assert js["system"]["system"] == platform.system()
+    assert js["system"]["release"] == platform.release()
+    assert js["system"]["cpu"] == platform.processor()
 
 
 def test_version_text():
@@ -55,7 +56,7 @@ def test_version_raw():
 def _validate_text_output(output):
     lines = output.splitlines()
     assert f'version: {__version__}' in lines
-    assert f'conan_script_path: {sys.argv[0]}' in lines
+    assert f'conan_path: {sys.argv[0]}' in lines
     assert 'python' in lines
     assert f'  version: {_python_version()}' in lines
     assert f'  sys_version: {_sys_version()}' in lines
@@ -65,5 +66,6 @@ def _validate_text_output(output):
     assert 'system' in lines
     assert f'  version: {platform.version()}' in lines
     assert f'  platform: {platform.platform()}' in lines
-    assert f'  os: {platform.system() + " " + platform.release()}' in lines
+    assert f'  system: {platform.system()}' in lines
+    assert f'  release: {platform.release()}' in lines
     assert f'  cpu: {platform.processor()}' in lines

--- a/conans/test/integration/command_v2/test_version.py
+++ b/conans/test/integration/command_v2/test_version.py
@@ -21,8 +21,16 @@ def test_version_json():
     t.run("version --format=json")
     js = json.loads(t.stdout)
     assert js["version"] == __version__
+    assert js["conan_script_path"] == sys.argv[0]
     assert js["python"]["version"] == _python_version()
     assert js["python"]["sys_version"] == _sys_version()
+    assert js["python"]["sys_executable"] == sys.executable
+    assert js["python"]["is_frozen"] == getattr(sys, 'frozen', False)
+    assert js["python"]["architecture"] == platform.machine()
+    assert js["system"]["version"] == platform.version()
+    assert js["system"]["version"] == platform.platform()
+    assert js["system"]["version"] == platform.system() + ' ' + platform.release()
+    assert js["system"]["version"] == platform.processor()
 
 
 def test_version_text():
@@ -47,6 +55,15 @@ def test_version_raw():
 def _validate_text_output(output):
     lines = output.splitlines()
     assert f'version: {__version__}' in lines
+    assert f'conan_script_path: {sys.argv[0]}' in lines
     assert 'python' in lines
     assert f'  version: {_python_version()}' in lines
     assert f'  sys_version: {_sys_version()}' in lines
+    assert f'  sys_executable: {sys.executable}' in lines
+    assert f'  is_frozen: {getattr(sys, "frozen", False)}' in lines
+    assert f'  architecture: {platform.machine()}' in lines
+    assert 'system' in lines
+    assert f'  version: {platform.version()}' in lines
+    assert f'  platform: {platform.platform()}' in lines
+    assert f'  os: {platform.system() + " " + platform.release()}' in lines
+    assert f'  cpu: {platform.processor()}' in lines


### PR DESCRIPTION
Changelog: Feature: Extend `conan version` to report current python and system for troubleshooting.
Docs: https://github.com/conan-io/docs/pull/3691

Close: #15974
