### PR TITLE
Show upload size for recipes and packages

### DIFF
--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -224,10 +224,7 @@ class UploadExecutor:
 
         cache_files = bundle["files"]
 
-        total_size = 0
-        for file in cache_files.values():
-            stat = os.stat(file)
-            total_size += stat.st_size
+        total_size = _total_size(cache_files)
 
         if total_size > 1000000:  # 1MB
             upload_msg += f" ({total_size / 100000} MB)"
@@ -247,10 +244,7 @@ class UploadExecutor:
         assert (pref.revision is not None), "Cannot upload a package without PREV"
         assert (pref.ref.revision is not None), "Cannot upload a package without RREV"
 
-        total_size = 0
-        for file in cache_files.values():
-            stat = os.stat(file)
-            total_size += stat.st_size
+        total_size = _total_size(cache_files)
 
         if total_size > 10000000:  # 10MB
             upload_msg += f" ({total_size / 1000000} MB)"
@@ -278,3 +272,11 @@ def compress_files(files, name, dest_dir, compresslevel=None, ref=None):
     duration = time.time() - t1
     ConanOutput().debug(f"{name} compressed in {duration} time")
     return tgz_path
+
+
+def _total_size(cache_files):
+    total_size = 0
+    for file in cache_files.values():
+        stat = os.stat(file)
+        total_size += stat.st_size
+    return total_size

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -221,15 +221,9 @@ class UploadExecutor:
 
     def upload_recipe(self, ref, bundle, remote):
         output = ConanOutput(scope=str(ref))
-        upload_msg = f"Uploading recipe '{ref.repr_notime()}'"
-
         cache_files = bundle["files"]
 
-        total_size = _total_size(cache_files)
-
-        if total_size > 1000000:  # 1MB
-            upload_msg += f" ({human_size(total_size)})"
-        output.info(upload_msg)
+        output.info(f"Uploading recipe '{ref.repr_notime()}' ({_total_size(cache_files)})")
 
         t1 = time.time()
         self._app.remote_manager.upload_recipe(ref, cache_files, remote)
@@ -240,16 +234,11 @@ class UploadExecutor:
 
     def upload_package(self, pref, prev_bundle, remote):
         output = ConanOutput(scope=str(pref.ref))
-        upload_msg = f"Uploading package '{pref.repr_notime()}'"
         cache_files = prev_bundle["files"]
         assert (pref.revision is not None), "Cannot upload a package without PREV"
         assert (pref.ref.revision is not None), "Cannot upload a package without RREV"
 
-        total_size = _total_size(cache_files)
-
-        if total_size > 10000000:  # 10MB
-            upload_msg += f" ({human_size(total_size)})"
-        output.info(upload_msg)
+        output.info(f"Uploading package '{pref.repr_notime()}' ({_total_size(cache_files)})")
 
         t1 = time.time()
         self._app.remote_manager.upload_package(pref, cache_files, remote)
@@ -280,4 +269,4 @@ def _total_size(cache_files):
     for file in cache_files.values():
         stat = os.stat(file)
         total_size += stat.st_size
-    return total_size
+    return human_size(total_size)

--- a/conans/client/cmd/uploader.py
+++ b/conans/client/cmd/uploader.py
@@ -9,7 +9,8 @@ from conans.errors import ConanException, NotFoundException
 from conans.paths import (CONAN_MANIFEST, CONANFILE, EXPORT_SOURCES_TGZ_NAME,
                           EXPORT_TGZ_NAME, PACKAGE_TGZ_NAME, CONANINFO)
 from conans.util.files import (clean_dirty, is_dirty, gather_files,
-                               gzopen_without_timestamps, set_dirty_context_manager, mkdir)
+                               gzopen_without_timestamps, set_dirty_context_manager, mkdir,
+                               human_size)
 
 UPLOAD_POLICY_FORCE = "force-upload"
 UPLOAD_POLICY_SKIP = "skip-upload"
@@ -227,7 +228,7 @@ class UploadExecutor:
         total_size = _total_size(cache_files)
 
         if total_size > 1000000:  # 1MB
-            upload_msg += f" ({total_size / 100000} MB)"
+            upload_msg += f" ({human_size(total_size)})"
         output.info(upload_msg)
 
         t1 = time.time()
@@ -247,7 +248,7 @@ class UploadExecutor:
         total_size = _total_size(cache_files)
 
         if total_size > 10000000:  # 10MB
-            upload_msg += f" ({total_size / 1000000} MB)"
+            upload_msg += f" ({human_size(total_size)})"
         output.info(upload_msg)
 
         t1 = time.time()

--- a/conans/test/integration/command/source_test.py
+++ b/conans/test/integration/command/source_test.py
@@ -1,4 +1,5 @@
 import os
+import re
 import textwrap
 import unittest
 from collections import OrderedDict
@@ -156,6 +157,9 @@ class ConanLib(ConanFile):
         client.run("create . --name=hello --version=0.1")
         rrev = client.exported_recipe_revision()
         client.run("upload hello/0.1 -r server0")
+        # Ensure we uploaded it
+        assert re.search(r"Uploading recipe 'hello/0.1#.*' \(.*\)", client.out)
+        assert re.search(r"Uploading package 'hello/0.1#.*' \(.*\)", client.out)
         client.run("remove * -c")
 
         # install from server0 that has the sources, upload to server1 (does not have the package)


### PR DESCRIPTION
Changelog: Feature: Show recipe and package sizes when running `conan upload`.
Docs: Omit

This is what it looks like now, note that it's almost imperceptible as most of the noise comes from the pkgid being logged:

<details>

```
$ conan upload "*" -r=origin -c
Found 26 pkg/version recipes matching * in local cache

======== Uploading to remote origin ========

-------- Checking server existing packages --------
autoconf/2.71: Checking which revisions exist in the remote server
brotli/1.1.0: Checking which revisions exist in the remote server
bzip2/1.0.8: Checking which revisions exist in the remote server
cairo/1.18.0: Checking which revisions exist in the remote server
expat/2.6.2: Checking which revisions exist in the remote server
fontconfig/2.15.0: Checking which revisions exist in the remote server
freetype/2.13.2: Checking which revisions exist in the remote server
glib/2.78.3: Checking which revisions exist in the remote server
gnu-config/cci.20210814: Checking which revisions exist in the remote server
gperf/3.1: Checking which revisions exist in the remote server
libelf/0.8.13: Checking which revisions exist in the remote server
libffi/3.4.4: Checking which revisions exist in the remote server
libgettext/0.22: Checking which revisions exist in the remote server
libiconv/1.17: Checking which revisions exist in the remote server
libpng/1.6.43: Checking which revisions exist in the remote server
lzo/2.10: Checking which revisions exist in the remote server
m4/1.4.19: Checking which revisions exist in the remote server
meson/1.2.2: Checking which revisions exist in the remote server
meson/1.4.0: Checking which revisions exist in the remote server
ninja/1.11.1: Checking which revisions exist in the remote server
openssl/3.2.1: Checking which revisions exist in the remote server
pcre2/10.42: Checking which revisions exist in the remote server
pixman/0.43.4: Checking which revisions exist in the remote server
pkgconf/2.0.3: Checking which revisions exist in the remote server
pkgconf/2.1.0: Checking which revisions exist in the remote server
zlib/1.3.1: Checking which revisions exist in the remote server

-------- Preparing artifacts for upload --------
autoconf/2.71: Sources downloaded from 'conancenter'
brotli/1.1.0:27c3eb48256dc5d2ec50ae887081dd85434e5755: Compressing conan_package.tgz
bzip2/1.0.8:bd47875fc25b97398a4030f4060ef8ef3539584a: Compressing conan_package.tgz
cairo/1.18.0: Sources downloaded from 'conancenter'
expat/2.6.2:10fd60dbb19c1c7b079fb35f1ca651920973f9ca: Compressing conan_package.tgz
fontconfig/2.15.0:eb3f1edd451de452fb0a262705e8171f26f76111: Compressing conan_package.tgz
freetype/2.13.2:b4870ffee4add54f8c0802d2f844e0b2960d8167: Compressing conan_package.tgz
gnu-config/cci.20210814: Sources downloaded from 'conancenter'
gperf/3.1: Sources downloaded from 'conancenter'
libelf/0.8.13:b117a9060cd3cd9e1fab132b9eda3173f84743bd: Compressing conan_package.tgz
libffi/3.4.4:2ee39e692ca4177b4b689b15bc1f2cfdf8f83706: Compressing conan_package.tgz
libgettext/0.22:50beeb0af7d06901e44de287d86534d4592f2583: Compressing conan_package.tgz
libiconv/1.17:2ee39e692ca4177b4b689b15bc1f2cfdf8f83706: Compressing conan_package.tgz
libpng/1.6.43:110170895f97fd2467430f5b1f7482bcfb6ba38b: Compressing conan_package.tgz
lzo/2.10:2ee39e692ca4177b4b689b15bc1f2cfdf8f83706: Compressing conan_package.tgz
m4/1.4.19: Sources downloaded from 'conancenter'
openssl/3.2.1:7833c7c48ca5681090256e36ed675b071307c45a: Compressing conan_package.tgz
pcre2/10.42:17867723f5118ac06c0e40c6780f191fc7f9489d: Compressing conan_package.tgz
pixman/0.43.4:2ee39e692ca4177b4b689b15bc1f2cfdf8f83706: Compressing conan_package.tgz
pkgconf/2.0.3: Sources downloaded from 'conancenter'
pkgconf/2.1.0: Sources downloaded from 'conancenter'
zlib/1.3.1:2ee39e692ca4177b4b689b15bc1f2cfdf8f83706: Compressing conan_package.tgz

-------- Uploading artifacts --------
autoconf/2.71: Uploading recipe 'autoconf/2.71#f9307992909d7fb3df459340f1932809' (8.6KB)
autoconf/2.71: Uploading package 'autoconf/2.71#f9307992909d7fb3df459340f1932809:da39a3ee5e6b4b0d3255bfef95601890afd80709#5b77f70c17ad1741f5845d4e468a347e' (607.1KB)
brotli/1.1.0: Uploading recipe 'brotli/1.1.0#d56d7bb9ca722942aba17369cb5c0519' (7.0KB)
brotli/1.1.0: Uploading package 'brotli/1.1.0#d56d7bb9ca722942aba17369cb5c0519:27c3eb48256dc5d2ec50ae887081dd85434e5755#687632d9760b0695a531e146f1481ae3' (411.7KB)
bzip2/1.0.8: Uploading recipe 'bzip2/1.0.8#457c272f7da34cb9c67456dd217d36c4' (5.3KB)
bzip2/1.0.8: Uploading package 'bzip2/1.0.8#457c272f7da34cb9c67456dd217d36c4:bd47875fc25b97398a4030f4060ef8ef3539584a#22c23032171c4b852ba2eafbe8e1593e' (89.8KB)
cairo/1.18.0: Uploading recipe 'cairo/1.18.0#6133b44d7bf4cf69c5361cbc864f6a58' (16.9KB)
expat/2.6.2: Uploading recipe 'expat/2.6.2#2d385d0d50eb5561006a7ff9e356656b' (4.3KB)
expat/2.6.2: Uploading package 'expat/2.6.2#2d385d0d50eb5561006a7ff9e356656b:10fd60dbb19c1c7b079fb35f1ca651920973f9ca#f32d30e1a3aea2fc31e0e41183b0e776' (93.0KB)
fontconfig/2.15.0: Uploading recipe 'fontconfig/2.15.0#b60b4b9d36807be37df93f84595d816e' (5.8KB)
fontconfig/2.15.0: Uploading package 'fontconfig/2.15.0#b60b4b9d36807be37df93f84595d816e:eb3f1edd451de452fb0a262705e8171f26f76111#bf26a5c99f81f77dde551013a0013c14' (184.3KB)
freetype/2.13.2: Uploading recipe 'freetype/2.13.2#dfa3d504cae4a08d5c72113bd6f28498' (13.3KB)
freetype/2.13.2: Uploading package 'freetype/2.13.2#dfa3d504cae4a08d5c72113bd6f28498:b4870ffee4add54f8c0802d2f844e0b2960d8167#7926c363406c325285893c00fa3ecc0c' (650.1KB)
glib/2.78.3: Uploading recipe 'glib/2.78.3#0cd1865c8603d90b3bc5858065e16d01' (13.4KB)
gnu-config/cci.20210814: Uploading recipe 'gnu-config/cci.20210814#dc430d754f465e8c74463019672fb97b' (3.8KB)
gnu-config/cci.20210814: Uploading package 'gnu-config/cci.20210814#dc430d754f465e8c74463019672fb97b:da39a3ee5e6b4b0d3255bfef95601890afd80709#22618e30bd9e326eb95e824dc90cc860' (26.5KB)
gperf/3.1: Uploading recipe 'gperf/3.1#1d622ad9717e9348ed3685c9994ad0b9' (4.9KB)
gperf/3.1: Uploading package 'gperf/3.1#1d622ad9717e9348ed3685c9994ad0b9:617cae191537b47386c088e07b1822d8606b7e67#97792284b5ff51a9003df58d87cfec75' (61.4KB)
libelf/0.8.13: Uploading recipe 'libelf/0.8.13#4f70a3555809ae50cc8add44f0f84288' (6.0KB)
libelf/0.8.13: Uploading package 'libelf/0.8.13#4f70a3555809ae50cc8add44f0f84288:b117a9060cd3cd9e1fab132b9eda3173f84743bd#966012b9b0d98adc0c7c0a0c18a31701' (68.8KB)
libffi/3.4.4: Uploading recipe 'libffi/3.4.4#35eb63842b505824b70aedc1baefc916' (10.6KB)
libffi/3.4.4: Uploading package 'libffi/3.4.4#35eb63842b505824b70aedc1baefc916:2ee39e692ca4177b4b689b15bc1f2cfdf8f83706#0565d70e65d03e649f35ff5fb626a4c4' (15.5KB)
libgettext/0.22: Uploading recipe 'libgettext/0.22#2c87563d7a69544dd9379f038aca3b0b' (10.4KB)
libgettext/0.22: Uploading package 'libgettext/0.22#2c87563d7a69544dd9379f038aca3b0b:50beeb0af7d06901e44de287d86534d4592f2583#4d78212afb5009171e7329b2a9fa6315' (82.9KB)
libiconv/1.17: Uploading recipe 'libiconv/1.17#73fefc1b696e069df90fd1d18aa63edd' (7.3KB)
libiconv/1.17: Uploading package 'libiconv/1.17#73fefc1b696e069df90fd1d18aa63edd:2ee39e692ca4177b4b689b15bc1f2cfdf8f83706#36b331c7978979259fbb8e379b4b9c9a' (1.4MB)
libpng/1.6.43: Uploading recipe 'libpng/1.6.43#c219d8f01983bac10c404fc613605eef' (7.8KB)
libpng/1.6.43: Uploading package 'libpng/1.6.43#c219d8f01983bac10c404fc613605eef:110170895f97fd2467430f5b1f7482bcfb6ba38b#a2bb4b92f21f0a27199197514a924331' (232.5KB)
lzo/2.10: Uploading recipe 'lzo/2.10#5725914235423c771cb1c6b607109b45' (2.5KB)
lzo/2.10: Uploading package 'lzo/2.10#5725914235423c771cb1c6b607109b45:2ee39e692ca4177b4b689b15bc1f2cfdf8f83706#34ee6b210dfbd7a1b2f40a6b0bf8e8d5' (93.0KB)
m4/1.4.19: Uploading recipe 'm4/1.4.19#b38ced39a01e31fef5435bc634461fd2' (10.2KB)
m4/1.4.19: Uploading package 'm4/1.4.19#b38ced39a01e31fef5435bc634461fd2:617cae191537b47386c088e07b1822d8606b7e67#af3bb664b82c4f616d3146625c5b4bd5' (158.8KB)
meson/1.2.2: Uploading recipe 'meson/1.2.2#04bdfb85d665c82b08a3510aee3ffd19' (3.0KB)
meson/1.2.2: Uploading package 'meson/1.2.2#04bdfb85d665c82b08a3510aee3ffd19:da39a3ee5e6b4b0d3255bfef95601890afd80709#97f4a23dd2d942f83e5344b1ca496ce7' (1.1MB)
meson/1.4.0: Uploading recipe 'meson/1.4.0#024dfac41ea5570cb1aec3ea6fe34d0a' (3.0KB)
meson/1.4.0: Uploading package 'meson/1.4.0#024dfac41ea5570cb1aec3ea6fe34d0a:da39a3ee5e6b4b0d3255bfef95601890afd80709#91b870cdcf4edb1a302a2ef7a0514791' (3.8MB)
ninja/1.11.1: Uploading recipe 'ninja/1.11.1#77587f8c8318662ac8e5a7867eb4be21' (2.3KB)
ninja/1.11.1: Uploading package 'ninja/1.11.1#77587f8c8318662ac8e5a7867eb4be21:617cae191537b47386c088e07b1822d8606b7e67#c91372a33f74405b60f9f71b2163a290' (134.8KB)
openssl/3.2.1: Uploading recipe 'openssl/3.2.1#c7b554068caae5eda12b735ea6f23d70' (30.6KB)
openssl/3.2.1: Uploading package 'openssl/3.2.1#c7b554068caae5eda12b735ea6f23d70:7833c7c48ca5681090256e36ed675b071307c45a#9ff3b7cad01e514b5973bb1dbf8a9e80' (9.3MB)
pcre2/10.42: Uploading recipe 'pcre2/10.42#a7a2c122056510509a7525c83d6a6695' (10.6KB)
pcre2/10.42: Uploading package 'pcre2/10.42#a7a2c122056510509a7525c83d6a6695:17867723f5118ac06c0e40c6780f191fc7f9489d#a0221164888f69f4927b9720ffa857c5' (626.8KB)
pixman/0.43.4: Uploading recipe 'pixman/0.43.4#17a592b79b264d61abeec594cc331e58' (3.8KB)
pixman/0.43.4: Uploading package 'pixman/0.43.4#17a592b79b264d61abeec594cc331e58:2ee39e692ca4177b4b689b15bc1f2cfdf8f83706#31ecec062ec2e5d220bfb07438cecac2' (247.1KB)
pkgconf/2.0.3: Uploading recipe 'pkgconf/2.0.3#f996677e96e61e6552d85e83756c328b' (6.5KB)
pkgconf/2.0.3: Uploading package 'pkgconf/2.0.3#f996677e96e61e6552d85e83756c328b:df7e47c8f0b96c79c977dd45ec51a050d8380273#525e4d2d8589922edbb7ec67d2bfe6ca' (40.7KB)
pkgconf/2.1.0: Uploading recipe 'pkgconf/2.1.0#27f44583701117b571307cf5b5fe5605' (6.5KB)
pkgconf/2.1.0: Uploading package 'pkgconf/2.1.0#27f44583701117b571307cf5b5fe5605:df7e47c8f0b96c79c977dd45ec51a050d8380273#0e4a349206e0319ddfe0a13932c26b03' (41.3KB)
zlib/1.3.1: Uploading recipe 'zlib/1.3.1#f52e03ae3d251dec704634230cd806a2' (6.2KB)
zlib/1.3.1: Uploading package 'zlib/1.3.1#f52e03ae3d251dec704634230cd806a2:2ee39e692ca4177b4b689b15bc1f2cfdf8f83706#abc795c85dad6e6d419cc292fe7c204a' (78.0KB)
Upload completed in 8s


-------- Upload summary --------
origin
  autoconf/2.71
    revisions
      f9307992909d7fb3df459340f1932809 (Uploaded)
        packages
          da39a3ee5e6b4b0d3255bfef95601890afd80709
            revisions
              5b77f70c17ad1741f5845d4e468a347e (Uploaded)
  brotli/1.1.0
    revisions
      d56d7bb9ca722942aba17369cb5c0519 (Uploaded)
        packages
          27c3eb48256dc5d2ec50ae887081dd85434e5755
            revisions
              687632d9760b0695a531e146f1481ae3 (Uploaded)
  bzip2/1.0.8
    revisions
      457c272f7da34cb9c67456dd217d36c4 (Uploaded)
        packages
          bd47875fc25b97398a4030f4060ef8ef3539584a
            revisions
              22c23032171c4b852ba2eafbe8e1593e (Uploaded)
  cairo/1.18.0
    revisions
      6133b44d7bf4cf69c5361cbc864f6a58 (Uploaded)
        packages
  expat/2.6.2
    revisions
      2d385d0d50eb5561006a7ff9e356656b (Uploaded)
        packages
          10fd60dbb19c1c7b079fb35f1ca651920973f9ca
            revisions
              f32d30e1a3aea2fc31e0e41183b0e776 (Uploaded)
  fontconfig/2.15.0
    revisions
      b60b4b9d36807be37df93f84595d816e (Uploaded)
        packages
          eb3f1edd451de452fb0a262705e8171f26f76111
            revisions
              bf26a5c99f81f77dde551013a0013c14 (Uploaded)
  freetype/2.13.2
    revisions
      dfa3d504cae4a08d5c72113bd6f28498 (Uploaded)
        packages
          b4870ffee4add54f8c0802d2f844e0b2960d8167
            revisions
              7926c363406c325285893c00fa3ecc0c (Uploaded)
  glib/2.78.3
    revisions
      0cd1865c8603d90b3bc5858065e16d01 (Uploaded)
        packages
  gnu-config/cci.20210814
    revisions
      dc430d754f465e8c74463019672fb97b (Uploaded)
        packages
          da39a3ee5e6b4b0d3255bfef95601890afd80709
            revisions
              22618e30bd9e326eb95e824dc90cc860 (Uploaded)
  gperf/3.1
    revisions
      1d622ad9717e9348ed3685c9994ad0b9 (Uploaded)
        packages
          617cae191537b47386c088e07b1822d8606b7e67
            revisions
              97792284b5ff51a9003df58d87cfec75 (Uploaded)
  libelf/0.8.13
    revisions
      4f70a3555809ae50cc8add44f0f84288 (Uploaded)
        packages
          b117a9060cd3cd9e1fab132b9eda3173f84743bd
            revisions
              966012b9b0d98adc0c7c0a0c18a31701 (Uploaded)
  libffi/3.4.4
    revisions
      35eb63842b505824b70aedc1baefc916 (Uploaded)
        packages
          2ee39e692ca4177b4b689b15bc1f2cfdf8f83706
            revisions
              0565d70e65d03e649f35ff5fb626a4c4 (Uploaded)
  libgettext/0.22
    revisions
      2c87563d7a69544dd9379f038aca3b0b (Uploaded)
        packages
          50beeb0af7d06901e44de287d86534d4592f2583
            revisions
              4d78212afb5009171e7329b2a9fa6315 (Uploaded)
  libiconv/1.17
    revisions
      73fefc1b696e069df90fd1d18aa63edd (Uploaded)
        packages
          2ee39e692ca4177b4b689b15bc1f2cfdf8f83706
            revisions
              36b331c7978979259fbb8e379b4b9c9a (Uploaded)
  libpng/1.6.43
    revisions
      c219d8f01983bac10c404fc613605eef (Uploaded)
        packages
          110170895f97fd2467430f5b1f7482bcfb6ba38b
            revisions
              a2bb4b92f21f0a27199197514a924331 (Uploaded)
  lzo/2.10
    revisions
      5725914235423c771cb1c6b607109b45 (Uploaded)
        packages
          2ee39e692ca4177b4b689b15bc1f2cfdf8f83706
            revisions
              34ee6b210dfbd7a1b2f40a6b0bf8e8d5 (Uploaded)
  m4/1.4.19
    revisions
      b38ced39a01e31fef5435bc634461fd2 (Uploaded)
        packages
          617cae191537b47386c088e07b1822d8606b7e67
            revisions
              af3bb664b82c4f616d3146625c5b4bd5 (Uploaded)
  meson/1.2.2
    revisions
      04bdfb85d665c82b08a3510aee3ffd19 (Uploaded)
        packages
          da39a3ee5e6b4b0d3255bfef95601890afd80709
            revisions
              97f4a23dd2d942f83e5344b1ca496ce7 (Uploaded)
  meson/1.4.0
    revisions
      024dfac41ea5570cb1aec3ea6fe34d0a (Uploaded)
        packages
          da39a3ee5e6b4b0d3255bfef95601890afd80709
            revisions
              91b870cdcf4edb1a302a2ef7a0514791 (Uploaded)
  ninja/1.11.1
    revisions
      77587f8c8318662ac8e5a7867eb4be21 (Uploaded)
        packages
          617cae191537b47386c088e07b1822d8606b7e67
            revisions
              c91372a33f74405b60f9f71b2163a290 (Uploaded)
  openssl/3.2.1
    revisions
      c7b554068caae5eda12b735ea6f23d70 (Uploaded)
        packages
          7833c7c48ca5681090256e36ed675b071307c45a
            revisions
              9ff3b7cad01e514b5973bb1dbf8a9e80 (Uploaded)
  pcre2/10.42
    revisions
      a7a2c122056510509a7525c83d6a6695 (Uploaded)
        packages
          17867723f5118ac06c0e40c6780f191fc7f9489d
            revisions
              a0221164888f69f4927b9720ffa857c5 (Uploaded)
  pixman/0.43.4
    revisions
      17a592b79b264d61abeec594cc331e58 (Uploaded)
        packages
          2ee39e692ca4177b4b689b15bc1f2cfdf8f83706
            revisions
              31ecec062ec2e5d220bfb07438cecac2 (Uploaded)
  pkgconf/2.0.3
    revisions
      f996677e96e61e6552d85e83756c328b (Uploaded)
        packages
          df7e47c8f0b96c79c977dd45ec51a050d8380273
            revisions
              525e4d2d8589922edbb7ec67d2bfe6ca (Uploaded)
  pkgconf/2.1.0
    revisions
      27f44583701117b571307cf5b5fe5605 (Uploaded)
        packages
          df7e47c8f0b96c79c977dd45ec51a050d8380273
            revisions
              0e4a349206e0319ddfe0a13932c26b03 (Uploaded)
  zlib/1.3.1
    revisions
      f52e03ae3d251dec704634230cd806a2 (Uploaded)
        packages
          2ee39e692ca4177b4b689b15bc1f2cfdf8f83706
            revisions
              abc795c85dad6e6d419cc292fe7c204a (Uploaded)
```

</details>

The test is in an unrelated one becuase there are no upload specific tests

Closes #9134