### PR TITLE
Allow wildcard in `rm_safe` call

### DIFF
--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -205,7 +205,7 @@ class Settings(object):
 
     def get_safe(self, name, default=None):
         """
-        Get the setting value avoiding
+        Get the setting value avoiding throwing if it does not exist or has been removed
         :param name:
         :param default:
         :return:
@@ -232,7 +232,10 @@ class Settings(object):
             except KeyError:
                 pass
         else:
-            self._data.pop(name, None)
+            if name == "*":
+                self.clear()
+            else:
+                self._data.pop(name, None)
 
     def copy(self):
         """ deepcopy, recursive

--- a/conans/test/unittests/model/settings_test.py
+++ b/conans/test/unittests/model/settings_test.py
@@ -465,6 +465,17 @@ def test_rm_safe():
     assert "'settings.compiler.libcxx' doesn't exist for 'clang'" in str(e.value)
 
 
+def test_rm_safe_wildcard():
+    settings = Settings.loads(default_settings_yml)
+    settings.compiler = "gcc"
+    settings.compiler.version = "4.8"
+    settings.compiler.libcxx = "libstdc++"
+    settings.rm_safe("compiler.*")
+    assert settings.compiler == "gcc"
+    assert settings.get_safe("compiler.version") is None
+    assert settings.get_safe("compiler.libcxx") is None
+
+
 def test_settings_intel_cppstd_03():
     settings = Settings.loads(default_settings_yml)
     settings.compiler = "intel-cc"


### PR DESCRIPTION
Changelog: Feature: Allow `*` wildcard as subsetting in in `rm_safe`.
Docs: https://github.com/conan-io/docs/pull/3697

To check with the team, came up in a conversation with @czoido when trying to debug the openjdk permission issues

Note that this is just a draft, because this is pretty similar to doing
```
 for subsetting in self.settings.compiler.fields:
     self.settings.compiler.rm_safe(subsetting)
```

so we might now want to have two ways of doing the same thing, even if the current syntaxt is a bit unknown (There's something to say from me just realizing about the `fields` property)