### PR TITLE
Use a clean, whitelisted environment with Popen (#16118)

### DIFF
--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -242,6 +242,54 @@ def _warn_python_version():
         ConanOutput().warning("Python 3.6 is end-of-life since 2021. "
                               "Conan future versions will drop support for it, "
                               "please upgrade Python", warn_tag="deprecated")
+def _clear_env():
+    if True: # if platform.system() == 'Windows':
+        whitelist_env_keys = [
+                'ALLUSERSPROFILE',
+                'APPDATA',
+                'COMMONPROGRAMFILES(X86)',
+                'COMMONPROGRAMFILES',
+                'COMMONPROGRAMW6432',
+                'COMPUTERNAME',
+                'COMSPEC',
+                'DRIVERDATA',
+                'HOMEDRIVE',
+                'HOMEPATH',
+                'LOCALAPPDATA',
+                'LOGONSERVER',
+                'NUMBER_OF_PROCESSORS',
+                'OS',
+                'PATHEXT',
+                'PROCESSOR_ARCHITECTURE',
+                'PROCESSOR_IDENTIFIER',
+                'PROCESSOR_LEVEL',
+                'PROCESSOR_REVISION',
+                'PROGRAMDATA',
+                'PROGRAMFILES(X86)',
+                'PROGRAMFILES',
+                'PROGRAMW6432',
+                'PSMODULEPATH',
+                'PUBLIC',
+                'SESSIONNAME',
+                'SYSTEMDRIVE',
+                'SYSTEMROOT',
+                'SYSTEMROOT',
+                'TEMP',
+                'TMP',
+                'USERDOMAIN',
+                'USERDOMAIN_ROAMINGPROFILE',
+                'USERNAME',
+                'USERPROFILE',
+                'WINDIR',
+                ]
+        for key in list(os.environ.keys()):
+            if key not in whitelist_env_keys:
+                del os.environ[key]
+        # Also get the path to conan's python, as some packages assume access to python
+        # eg dav1d
+        # This will also give access to ninja.exe and whatever else is installed in the devenv
+        python_path = os.path.dirname(sys.executable)
+        os.environ['PATH'] = f'C:\\WINDOWS\\system32;C:\\WINDOWS;C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0;{python_path}'
 
 
 def main(args):
@@ -284,6 +332,8 @@ def main(args):
 
     if sys.platform == 'win32':
         signal.signal(signal.SIGBREAK, ctrl_break_handler)
+
+    _clear_env()
 
     cli = Cli(conan_api)
     error = SUCCESS

--- a/conans/util/runners.py
+++ b/conans/util/runners.py
@@ -78,7 +78,11 @@ def _env_for_Popen():
                 'windir'
                 ]
         newenv = { key: os.environ[key] for key in whitelist_env_keys }
-        newenv['Path'] = 'C:\\WINDOWS\\system32;C:\\WINDOWS'
+        # Also get the path to conan's python, as some packages assume access to python
+        # eg dav1d
+        # This will also give access to ninja.exe and whatever else is installed in the devenv
+        python_path = os.path.dirname(sys.executable)
+        newenv['PATH'] = f'C:\\WINDOWS\\system32;C:\\WINDOWS;{python_path}'
     return newenv
 
 

--- a/conans/util/runners.py
+++ b/conans/util/runners.py
@@ -1,5 +1,4 @@
 import os
-import platform
 import subprocess
 import sys
 import tempfile
@@ -33,59 +32,6 @@ else:
         yield
 
 
-# Windows (and possibly other platforms) should have a clean environment,
-# unpolluted by anything in the user's environment.
-# Anything except the bare minimum should be added to the environment through
-# conan's environment mechanisms.
-# This whitelist could potentially be slimmed down further.
-def _env_for_Popen():
-    newenv = None
-    if platform.system() == 'Windows':
-        whitelist_env_keys = [
-                'ALLUSERSPROFILE',
-                'APPDATA',
-                'CommonProgramFiles',
-                'CommonProgramFiles(x86)',
-                'CommonProgramW6432',
-                'COMPUTERNAME',
-                'ComSpec',
-                'DriverData',
-                'HOMEDRIVE',
-                'HOMEPATH',
-                'LOCALAPPDATA',
-                'LOGONSERVER',
-                'NUMBER_OF_PROCESSORS',
-                'OS',
-                'PATHEXT',
-                'PROCESSOR_ARCHITECTURE',
-                'PROCESSOR_IDENTIFIER',
-                'PROCESSOR_LEVEL',
-                'PROCESSOR_REVISION',
-                'ProgramData',
-                'ProgramFiles',
-                'ProgramFiles(x86)',
-                'ProgramW6432',
-                'PUBLIC',
-                'SESSIONNAME',
-                'SystemDrive',
-                'SystemRoot',
-                'TEMP',
-                'TMP',
-                'USERDOMAIN',
-                'USERDOMAIN_ROAMINGPROFILE',
-                'USERNAME',
-                'USERPROFILE',
-                'windir'
-                ]
-        newenv = { key: os.environ[key] for key in whitelist_env_keys }
-        # Also get the path to conan's python, as some packages assume access to python
-        # eg dav1d
-        # This will also give access to ninja.exe and whatever else is installed in the devenv
-        python_path = os.path.dirname(sys.executable)
-        newenv['PATH'] = f'C:\\WINDOWS\\system32;C:\\WINDOWS;{python_path}'
-    return newenv
-
-
 def conan_run(command, stdout=None, stderr=None, cwd=None, shell=True):
     """
     @param shell:
@@ -102,7 +48,7 @@ def conan_run(command, stdout=None, stderr=None, cwd=None, shell=True):
 
     with pyinstaller_bundle_env_cleaned():
         try:
-            proc = subprocess.Popen(command, shell=shell, stdout=out, stderr=err, cwd=cwd, env=_env_for_Popen())
+            proc = subprocess.Popen(command, shell=shell, stdout=out, stderr=err, cwd=cwd)
         except Exception as e:
             raise ConanException("Error while running cmd\nError: %s" % (str(e)))
 
@@ -119,8 +65,7 @@ def conan_run(command, stdout=None, stderr=None, cwd=None, shell=True):
 def detect_runner(command):
     # Running detect.py automatic detection of profile
     proc = subprocess.Popen(command, shell=True, bufsize=1, universal_newlines=True,
-                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                            env=_env_for_Popen())
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
     output_buffer = []
     while True:
@@ -143,7 +88,7 @@ def check_output_runner(cmd, stderr=None, ignore_error=False):
         # We don't want stderr to print warnings that will mess the pristine outputs
         stderr = stderr or subprocess.PIPE
         command = '{} > "{}"'.format(cmd, tmp_file)
-        process = subprocess.Popen(command, shell=True, stderr=stderr, env=_env_for_Popen())
+        process = subprocess.Popen(command, shell=True, stderr=stderr)
         stdout, stderr = process.communicate()
 
         if process.returncode and not ignore_error:


### PR DESCRIPTION
Do not allow the user's shell environment to leak into the build environment. Instead, create a clean environment with just white-listed environment keys.

Changelog: Fix: Provide a create a clean environment to Popen() with white-listed environment keys.
Docs: Omit