### PR TITLE
fixed wrong servers 200 ok

### DIFF
--- a/conans/client/rest/rest_client_common.py
+++ b/conans/client/rest/rest_client_common.py
@@ -142,11 +142,16 @@ class RestCommonMethods(object):
             auth = self.auth
         ret = self.requester.get(url, auth=auth, headers=self.custom_headers, verify=self.verify_ssl)
 
-        server_capabilities = ret.headers.get('X-Conan-Server-Capabilities', "")
-        if not server_capabilities and not ret.ok:
-            # Old Artifactory might return 401/403 without capabilities, we don't want
-            # to cache them #5687, so raise the exception and force authentication
-            raise get_exception_from_error(ret.status_code)(response_to_str(ret))
+        server_capabilities = ret.headers.get('X-Conan-Server-Capabilities')
+        if server_capabilities is None:
+            # Any valid conan server should return some capabilities, specifically revisions,
+            # otherwise it will fail later with the "revisions not supported"
+            if not ret.ok:
+                # Old Artifactory might return 401/403 without capabilities, we don't want
+                # to cache them #5687, so raise the exception and force authentication
+                raise get_exception_from_error(ret.status_code)(response_to_str(ret))
+            else:  # Some servers returning 200-ok, even if not valid repo
+                raise ConanException(f"Remote {self.remote_url} doesn't seem a valid Conan remote")
 
         return [cap.strip() for cap in server_capabilities.split(",") if cap]
 

--- a/conans/client/rest/rest_client_common.py
+++ b/conans/client/rest/rest_client_common.py
@@ -151,7 +151,7 @@ class RestCommonMethods(object):
                 # to cache them #5687, so raise the exception and force authentication
                 raise get_exception_from_error(ret.status_code)(response_to_str(ret))
             else:  # Some servers returning 200-ok, even if not valid repo
-                raise ConanException(f"Remote {self.remote_url} doesn't seem a valid Conan remote")
+                raise ConanException(f"Remote {self.remote_url} doesn't seem like a valid Conan remote")
 
         return [cap.strip() for cap in server_capabilities.split(",") if cap]
 


### PR DESCRIPTION
Changelog: Fix: Improve error message when one URL is not a valid server but still returns 200-ok under a Conan "ping" API call.
Docs: Omit

Close https://github.com/conan-io/conan/issues/16104