### PR TITLE
Don't show a trace when `.conanrc`'s `conan_home` is invalid

### DIFF
--- a/conans/paths/__init__.py
+++ b/conans/paths/__init__.py
@@ -3,6 +3,8 @@ import os
 import platform
 from pathlib import Path
 
+from conans.errors import ConanException
+
 if platform.system() == "Windows":
     from conans.util.windows import conan_expand_user
 else:
@@ -46,7 +48,7 @@ def get_conan_user_home():
     else:  # Do an expansion, just in case the user is using ~/something/here
         user_home = conan_expand_user(user_home)
     if not os.path.isabs(user_home):
-        raise Exception("Invalid CONAN_HOME value '%s', "
+        raise ConanException("Invalid CONAN_HOME value '%s', "
                         "please specify an absolute or path starting with ~/ "
                         "(relative to user home)" % user_home)
     return user_home


### PR DESCRIPTION
Changelog: Bugfix: Don't show a trace when `.conanrc`'s `conan_home` is invalid.
Docs: Omit

Closes https://github.com/conan-io/conan/issues/12465