### PR TITLE
[Meson] Let users to change the default prefix

### DIFF
--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -48,8 +48,6 @@ class Meson(object):
 
         cmd += "".join([f'{cmd_param} "{meson_option}"' for meson_option in meson_filenames])
         cmd += ' "{}" "{}"'.format(build_folder, source_folder)
-        # Issue related: https://github.com/mesonbuild/meson/issues/12880
-        cmd += ' --prefix=/'  # this must be an absolute path, otherwise, meson complains
         self._conanfile.output.info("Meson configure cmd: {}".format(cmd))
         self._conanfile.run(cmd)
 
@@ -74,14 +72,17 @@ class Meson(object):
         self._conanfile.output.info("Meson build cmd: {}".format(cmd))
         self._conanfile.run(cmd)
 
-    def install(self):
+    def install(self, destdir=None):
         """
         Runs ``meson install -C "." --destdir`` in the build folder.
         """
         meson_build_folder = self._conanfile.build_folder.replace("\\", "/")
         meson_package_folder = self._conanfile.package_folder.replace("\\", "/")
+        destdir = meson_package_folder if destdir is None else destdir
         # Assuming meson >= 0.57.0
-        cmd = f'meson install -C "{meson_build_folder}" --destdir "{meson_package_folder}"'
+        cmd = f'meson install -C "{meson_build_folder}"'
+        if destdir:
+            cmd += f' --destdir "{destdir}"'
         verbosity = self._install_verbosity
         if verbosity:
             cmd += " " + verbosity

--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -75,6 +75,9 @@ class Meson(object):
     def install(self, destdir=None):
         """
         Runs ``meson install -C "." --destdir`` in the build folder.
+
+        :param destdir: ``str`` Specifies the destination folder. If ``None``, it will use
+                        the ``conanfile.package_folder`` value.
         """
         meson_build_folder = self._conanfile.build_folder.replace("\\", "/")
         meson_package_folder = self._conanfile.package_folder.replace("\\", "/")

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -89,7 +89,7 @@ class MesonToolchain(object):
     {% endfor %}
     """)
 
-    def __init__(self, conanfile, backend=None):
+    def __init__(self, conanfile, backend=None, prefix="/"):
         """
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         :param backend: ``str`` ``backend`` Meson variable value. By default, ``ninja``.
@@ -145,6 +145,8 @@ class MesonToolchain(object):
         self.preprocessor_definitions = {}
         # Add all the default dirs
         self.project_options.update(self._get_default_dirs())
+        # Issue related: https://github.com/mesonbuild/meson/issues/12880
+        self.project_options["prefix"] = prefix
 
         #: Defines the Meson ``pkg_config_path`` variable
         self.pkg_config_path = self._conanfile.generators_folder

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -93,6 +93,8 @@ class MesonToolchain(object):
         """
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         :param backend: ``str`` ``backend`` Meson variable value. By default, ``ninja``.
+        :param prefix: ``str`` ``prefix`` Meson project option value. By default, ``/``. Notice that
+                       this must be an absolute path, otherwise, meson complains.
         """
         raise_on_universal_arch(conanfile)
         self._conanfile = conanfile


### PR DESCRIPTION
Changelog: Feature: `MesonToolchain` accepts `prefix` param to change the default one `/`.
Changelog: Feature: `Meson.install()` accepts `destdir` param to change the default one `conanfile.package_folder`. Notice that setting `destdir=""` means to prune the `--destdir xxxx` param from the `meson install xxxx` command.
Docs: omit
