### PR TITLE
fix remove editables deleted

### DIFF
--- a/conan/api/subapi/local.py
+++ b/conan/api/subapi/local.py
@@ -1,5 +1,6 @@
 import os
 
+from conan.api.output import ConanOutput
 from conan.cli import make_abs_path
 from conan.internal.conan_app import ConanApp
 from conans.client.cache.editable import EditablePackages
@@ -60,7 +61,8 @@ class LocalAPI:
 
     def editable_remove(self, path=None, requires=None, cwd=None):
         if path:
-            path = self._conan_api.local.get_conanfile_path(path, cwd, py=True)
+            path = make_abs_path(path, cwd)
+            path = os.path.join(path, "conanfile.py")
         return self.editable_packages.remove(path, requires)
 
     def editable_list(self):

--- a/conans/test/integration/editable/editable_remove_test.py
+++ b/conans/test/integration/editable/editable_remove_test.py
@@ -48,8 +48,9 @@ class TestRemoveEditablePackageTest:
         c.save({'pkg/conanfile.py': GenConanfile()})
         c.run('editable add pkg --name=lib --version=version')
         shutil.rmtree(os.path.join(c.current_folder, "pkg"))
-        c.run("editable remove pkg", assert_error=True)
-        c.run("editable remove --refs=lib/version")
+        # https://github.com/conan-io/conan/issues/16164
+        # Making it possible, repeated issue
+        c.run("editable remove pkg")
         assert "Removed editable 'lib/version'" in c.out
         c.run("editable list")
         assert "lib" not in c.out


### PR DESCRIPTION
Changelog: Fix: Allowing ``conan editable remove <path>`` even when the path has been already deleted.
Docs: Omit

Close https://github.com/conan-io/conan/issues/16164
