### PR TITLE
MesonToolchain reads conf tools.build:defines

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -352,10 +352,12 @@ class MesonToolchain(object):
         exelinkflags = self._conanfile.conf.get("tools.build:exelinkflags", default=[], check_type=list)
         linker_scripts = self._conanfile.conf.get("tools.build:linker_scripts", default=[], check_type=list)
         linker_script_flags = ['-T"' + linker_script + '"' for linker_script in linker_scripts]
+        defines = [f"-D{d}" for d in self._conanfile.conf.get("tools.build:defines", default=[], check_type=list)]
         return {
             "cxxflags": cxxflags,
             "cflags": cflags,
-            "ldflags": sharedlinkflags + exelinkflags + linker_script_flags
+            "ldflags": sharedlinkflags + exelinkflags + linker_script_flags,
+            "defines": defines
         }
 
     @staticmethod
@@ -377,13 +379,13 @@ class MesonToolchain(object):
         apple_flags = self.apple_isysroot_flag + self.apple_arch_flag + self.apple_min_version_flag
         extra_flags = self._get_extra_flags()
 
-        self.c_args.extend(apple_flags + extra_flags["cflags"])
-        self.cpp_args.extend(apple_flags + extra_flags["cxxflags"])
+        self.c_args.extend(apple_flags + extra_flags["cflags"] + extra_flags["defines"])
+        self.cpp_args.extend(apple_flags + extra_flags["cxxflags"] + extra_flags["defines"])
         self.c_link_args.extend(apple_flags + extra_flags["ldflags"])
         self.cpp_link_args.extend(apple_flags + extra_flags["ldflags"])
         # Objective C/C++
-        self.objc_args.extend(self.c_args)
-        self.objcpp_args.extend(self.cpp_args)
+        self.objc_args.extend(self.c_args + extra_flags["defines"])
+        self.objcpp_args.extend(self.cpp_args + extra_flags["defines"])
         # These link_args have already the LDFLAGS env value so let's add only the new possible ones
         self.objc_link_args.extend(apple_flags + extra_flags["ldflags"])
         self.objcpp_link_args.extend(apple_flags + extra_flags["ldflags"])

--- a/conans/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/conans/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -87,6 +87,8 @@ def test_extra_flags_via_conf():
         tools.build:cflags=["-flag3", "-flag4"]
         tools.build:sharedlinkflags+=["-flag5"]
         tools.build:exelinkflags+=["-flag6"]
+        # Issue related: https://github.com/conan-io/conan/issues/16169
+        tools.build:defines=["_ITERATOR_DEBUG_LEVEL=0"]
    """)
     t = TestClient()
     t.save({"conanfile.txt": "[generators]\nMesonToolchain",
@@ -94,8 +96,8 @@ def test_extra_flags_via_conf():
 
     t.run("install . -pr:h=profile -pr:b=profile")
     content = t.load(MesonToolchain.native_filename)
-    assert "cpp_args = ['-flag0', '-other=val', '-flag1', '-flag2', '-D_GLIBCXX_USE_CXX11_ABI=0']" in content
-    assert "c_args = ['-flag0', '-other=val', '-flag3', '-flag4']" in content
+    assert "cpp_args = ['-flag0', '-other=val', '-flag1', '-flag2', '-D_ITERATOR_DEBUG_LEVEL=0', '-D_GLIBCXX_USE_CXX11_ABI=0']" in content
+    assert "c_args = ['-flag0', '-other=val', '-flag3', '-flag4', '-D_ITERATOR_DEBUG_LEVEL=0']" in content
     assert "c_link_args = ['-flag0', '-other=val', '-flag5', '-flag6']" in content
     assert "cpp_link_args = ['-flag0', '-other=val', '-flag5', '-flag6']" in content
 

--- a/conans/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/conans/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -88,7 +88,7 @@ def test_extra_flags_via_conf():
         tools.build:sharedlinkflags+=["-flag5"]
         tools.build:exelinkflags+=["-flag6"]
         # Issue related: https://github.com/conan-io/conan/issues/16169
-        tools.build:defines=["_ITERATOR_DEBUG_LEVEL=0"]
+        tools.build:defines=["define1=0"]
    """)
     t = TestClient()
     t.save({"conanfile.txt": "[generators]\nMesonToolchain",
@@ -96,8 +96,8 @@ def test_extra_flags_via_conf():
 
     t.run("install . -pr:h=profile -pr:b=profile")
     content = t.load(MesonToolchain.native_filename)
-    assert "cpp_args = ['-flag0', '-other=val', '-flag1', '-flag2', '-D_ITERATOR_DEBUG_LEVEL=0', '-D_GLIBCXX_USE_CXX11_ABI=0']" in content
-    assert "c_args = ['-flag0', '-other=val', '-flag3', '-flag4', '-D_ITERATOR_DEBUG_LEVEL=0']" in content
+    assert "cpp_args = ['-flag0', '-other=val', '-flag1', '-flag2', '-Ddefine1=0', '-D_GLIBCXX_USE_CXX11_ABI=0']" in content
+    assert "c_args = ['-flag0', '-other=val', '-flag3', '-flag4', '-Ddefine1=0']" in content
     assert "c_link_args = ['-flag0', '-other=val', '-flag5', '-flag6']" in content
     assert "cpp_link_args = ['-flag0', '-other=val', '-flag5', '-flag6']" in content
 


### PR DESCRIPTION
Changelog: Bugfix: Make MesonToolchain listen to `tools.build:defines` conf variable.
Docs: https://github.com/conan-io/docs/pull/3709
Closes: https://github.com/conan-io/conan/issues/16169
