### PR TITLE
fix CMake folder when running on drive

### DIFF
--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -85,10 +85,9 @@ class CMake(object):
         cmakelist_folder = self._conanfile.source_folder
         if build_script_folder:
             cmakelist_folder = os.path.join(self._conanfile.source_folder, build_script_folder)
+        cmakelist_folder = cmakelist_folder.replace("\\", "/")
 
         build_folder = self._conanfile.build_folder
-        generator_folder = self._conanfile.generators_folder
-
         mkdir(self._conanfile, build_folder)
 
         arg_list = [self._cmake_program]

--- a/conans/test/unittests/tools/cmake/test_cmake_presets_definitions.py
+++ b/conans/test/unittests/tools/cmake/test_cmake_presets_definitions.py
@@ -45,6 +45,7 @@ def test_cmake_make_program(conanfile):
         assert '-DCMAKE_MAKE_PROGRAM="C:/mymake.exe"' in command
 
     conanfile.run = run
+    conanfile.folders.set_base_source(temp_folder())
     conanfile.conf.define("tools.gnu:make_program", "C:\\mymake.exe")
 
     with mock.patch("platform.system", mock.MagicMock(return_value='Windows')):


### PR DESCRIPTION
Changelog: Fix: Use backslash in ``CMake`` helper for the CMakeLists.txt folder, fixes issue when project is in the drive root, like ``X:``
Docs: Omit

Close https://github.com/conan-io/conan/issues/16177

NOTE: I am not adding a test for this, because it is not failing in other places rather than the root ``X`` unit, and we are not going to run tests in CI for this, I have tested it manually on my computer.