### PR TITLE
new revision_mode

### DIFF
--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -149,6 +149,14 @@ class RequirementInfo:
         self.package_id = self._package_id
         self.recipe_revision = None
 
+    def revision_mode(self):
+        self.name = self._ref.name
+        self.version = self._ref.version
+        self.user = self._ref.user
+        self.channel = self._ref.channel
+        self.package_id = None
+        self.recipe_revision = self._ref.revision
+
     def full_mode(self):
         self.name = self._ref.name
         self.version = self._ref.version
@@ -223,6 +231,10 @@ class RequirementsInfo(UserRequirementsDict):
         for r in self._data.values():
             r.full_package_mode()
 
+    def revision_mode(self):
+        for r in self._data.values():
+            r.revision_mode()
+
     def full_mode(self):
         for r in self._data.values():
             r.full_mode()
@@ -284,6 +296,10 @@ class PythonRequiresInfo:
     def full_recipe_mode(self):
         for r in self._refs:
             r.full_recipe_mode()
+
+    def revision_mode(self):
+        for r in self._refs:
+            r.revision_mode()
 
     def full_mode(self):
         for r in self._refs:

--- a/conans/test/integration/package_id/test_config_package_id.py
+++ b/conans/test/integration/package_id/test_config_package_id.py
@@ -11,6 +11,7 @@ from conans.util.files import save
     ("myconfig/1.2.3#rev1:pid1#prev1", "minor_mode", "myconfig/1.2.Z"),
     ("myconfig/1.2.3#rev1:pid1#prev1", "patch_mode", "myconfig/1.2.3"),
     ("myconfig/1.2.3#rev1:pid1#prev1", "full_mode", "myconfig/1.2.3#rev1:pid1"),
+    ("myconfig/1.2.3#rev1:pid1#prev1", "revision_mode", "myconfig/1.2.3#rev1"),
     ("myconfig/1.2.3", "minor_mode", "myconfig/1.2.Z")])
 def test_config_package_id(config_version, mode, result):
     c = TestClient()
@@ -24,7 +25,8 @@ def test_config_package_id(config_version, mode, result):
     rrev = info["Local Cache"]["pkg/0.1"]["revisions"]["485dad6cb11e2fa99d9afbe44a57a164"]
     package_id = {"myconfig/1.2.Z": "c78b4d8224154390356fe04fe598d67aec930199",
                   "myconfig/1.2.3": "60005f5b11bef3ddd686b13f5c6bf576a9b882b8",
-                  "myconfig/1.2.3#rev1:pid1": "b1525975eb5420cef45b4ddd1544f87c29c773a5"}
+                  "myconfig/1.2.3#rev1:pid1": "b1525975eb5420cef45b4ddd1544f87c29c773a5",
+                  "myconfig/1.2.3#rev1": "aae875ae226416f177bf386a3e4ad6aaffce09e7"}
     package_id = package_id.get(result)
     pkg = rrev["packages"][package_id]
     assert pkg["info"] == {"config_version": [result]}


### PR DESCRIPTION
Changelog: Feature: Add new ``revision_mode`` including everything down to the ``recipe-revision``, but not the ``package_id``.
Docs: https://github.com/conan-io/docs/pull/3754

Close https://github.com/conan-io/conan/issues/16114