### PR TITLE
Fix/export pkg version pyrequire

### DIFF
--- a/conan/api/subapi/local.py
+++ b/conan/api/subapi/local.py
@@ -111,9 +111,10 @@ class LocalAPI:
             with chdir(conanfile.build_folder):
                 conanfile.test()
 
-    def inspect(self, conanfile_path, remotes, lockfile):
+    def inspect(self, conanfile_path, remotes, lockfile, name=None, version=None, user=None,
+                channel=None):
         app = ConanApp(self._conan_api)
-        conanfile = app.loader.load_named(conanfile_path, name=None, version=None,
-                                          user=None, channel=None, remotes=remotes, graph_lock=lockfile)
+        conanfile = app.loader.load_named(conanfile_path, name=name, version=version, user=user,
+                                          channel=channel, remotes=remotes, graph_lock=lockfile)
         return conanfile
 

--- a/conan/cli/commands/export_pkg.py
+++ b/conan/cli/commands/export_pkg.py
@@ -46,7 +46,8 @@ def export_pkg(conan_api, parser, *args):
     profile_host, profile_build = conan_api.profiles.get_profiles_from_args(args)
     remotes = conan_api.remotes.list(args.remote) if not args.no_remote else []
 
-    conanfile = conan_api.local.inspect(path, remotes, lockfile)
+    conanfile = conan_api.local.inspect(path, remotes, lockfile, name=args.name,
+                                        version=args.version, user=args.user, channel=args.channel)
     # The package_type is not fully processed at export
     if conanfile.package_type == "python-require":
         raise ConanException("export-pkg can only be used for binaries, not for 'python-require'")


### PR DESCRIPTION
Changelog: Bugfix: Allow ``export-pkg --version=xxx`` to be passed to recipes with ``python_requires`` inheriting ``set_version`` from base class.
Docs: Omit

Close https://github.com/conan-io/conan/issues/16223