### PR TITLE
Add property to change the CMake variable names generated with CMakeDeps

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -26,8 +26,8 @@ class CMakeDepsFileTemplate(object):
 
     @property
     def additional_variables_prefixes(self):
-        prefix_list = self.cmakedeps.get_property("cmake_additional_variables_prefixes", self.conanfile)
-        prefix_list = prefix_list if prefix_list else []
+        prefix_list = (
+            self.cmakedeps.get_property("cmake_additional_variables_prefixes", self.conanfile) or [])
         return list(set([self.file_name] + prefix_list))
 
     @property

--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -26,7 +26,7 @@ class CMakeDepsFileTemplate(object):
 
     @property
     def legacy_variable_prefix(self):
-        return self.cmakedeps.get_property("cmake_legacy_variable_prefix", self.conanfile)
+        return self.cmakedeps.get_property("cmake_legacy_variable_prefix", self.conanfile) or self.file_name
 
     @property
     def suffix(self):

--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -25,8 +25,10 @@ class CMakeDepsFileTemplate(object):
         return self.cmakedeps.get_cmake_package_name(self.conanfile, module_mode=self.generating_module) + self.suffix
 
     @property
-    def legacy_variable_prefix(self):
-        return self.cmakedeps.get_property("cmake_legacy_variable_prefix", self.conanfile) or self.file_name
+    def additional_variables_prefixes(self):
+        prefix_list = self.cmakedeps.get_property("cmake_additional_variables_prefixes", self.conanfile)
+        prefix_list = prefix_list if prefix_list else []
+        return list(set([self.file_name] + prefix_list))
 
     @property
     def suffix(self):

--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -25,6 +25,10 @@ class CMakeDepsFileTemplate(object):
         return self.cmakedeps.get_cmake_package_name(self.conanfile, module_mode=self.generating_module) + self.suffix
 
     @property
+    def legacy_variable_prefix(self):
+        return self.cmakedeps.get_property("cmake_legacy_variable_prefix", self.conanfile)
+
+    @property
     def suffix(self):
         if not self.require.build:
             return ""

--- a/conan/tools/cmake/cmakedeps/templates/config.py
+++ b/conan/tools/cmake/cmakedeps/templates/config.py
@@ -29,7 +29,7 @@ class ConfigTemplate(CMakeDepsFileTemplate):
         return {"is_module": self.generating_module,
                 "version": self.conanfile.ref.version,
                 "file_name":  self.file_name,
-                "legacy_variable_prefix": self.legacy_variable_prefix,
+                "additional_variables_prefixes": self.additional_variables_prefixes,
                 "pkg_name": self.pkg_name,
                 "config_suffix": self.config_suffix,
                 "check_components_exist": self.cmakedeps.check_components_exist,
@@ -68,11 +68,14 @@ class ConfigTemplate(CMakeDepsFileTemplate):
             endif()
         endforeach()
 
-        set({{ legacy_variable_prefix }}_VERSION_STRING "{{ version }}")
-        set({{ legacy_variable_prefix }}_INCLUDE_DIRS {{ pkg_var(pkg_name, 'INCLUDE_DIRS', config_suffix) }} )
-        set({{ legacy_variable_prefix }}_INCLUDE_DIR {{ pkg_var(pkg_name, 'INCLUDE_DIRS', config_suffix) }} )
-        set({{ legacy_variable_prefix }}_LIBRARIES {{ pkg_var(pkg_name, 'LIBRARIES', config_suffix) }} )
-        set({{ legacy_variable_prefix }}_DEFINITIONS {{ pkg_var(pkg_name, 'DEFINITIONS', config_suffix) }} )
+        {% for prefix in additional_variables_prefixes %}
+        set({{ prefix }}_VERSION_STRING "{{ version }}")
+        set({{ prefix }}_INCLUDE_DIRS {{ pkg_var(pkg_name, 'INCLUDE_DIRS', config_suffix) }} )
+        set({{ prefix }}_INCLUDE_DIR {{ pkg_var(pkg_name, 'INCLUDE_DIRS', config_suffix) }} )
+        set({{ prefix }}_LIBRARIES {{ pkg_var(pkg_name, 'LIBRARIES', config_suffix) }} )
+        set({{ prefix }}_DEFINITIONS {{ pkg_var(pkg_name, 'DEFINITIONS', config_suffix) }} )
+
+        {% endfor %}
 
         # Only the first installed configuration is included to avoid the collision
         foreach(_BUILD_MODULE {{ pkg_var(pkg_name, 'BUILD_MODULES_PATHS', config_suffix) }} )

--- a/conan/tools/cmake/cmakedeps/templates/config.py
+++ b/conan/tools/cmake/cmakedeps/templates/config.py
@@ -28,7 +28,7 @@ class ConfigTemplate(CMakeDepsFileTemplate):
         targets_include += "{}Targets.cmake".format(self.file_name)
         return {"is_module": self.generating_module,
                 "version": self.conanfile.ref.version,
-                "file_name": self.file_name,
+                "file_name": self.legacy_variable_prefix or self.file_name,
                 "pkg_name": self.pkg_name,
                 "config_suffix": self.config_suffix,
                 "check_components_exist": self.cmakedeps.check_components_exist,

--- a/conan/tools/cmake/cmakedeps/templates/config.py
+++ b/conan/tools/cmake/cmakedeps/templates/config.py
@@ -68,17 +68,11 @@ class ConfigTemplate(CMakeDepsFileTemplate):
             endif()
         endforeach()
 
-        {% if legacy_variable_prefix %}
-            {% set prefix_name = legacy_variable_prefix %}
-        {% else %}
-            {% set prefix_name = file_name %}
-        {% endif %}
-
-        set({{ prefix_name }}_VERSION_STRING "{{ version }}")
-        set({{ prefix_name }}_INCLUDE_DIRS {{ pkg_var(pkg_name, 'INCLUDE_DIRS', config_suffix) }} )
-        set({{ prefix_name }}_INCLUDE_DIR {{ pkg_var(pkg_name, 'INCLUDE_DIRS', config_suffix) }} )
-        set({{ prefix_name }}_LIBRARIES {{ pkg_var(pkg_name, 'LIBRARIES', config_suffix) }} )
-        set({{ prefix_name }}_DEFINITIONS {{ pkg_var(pkg_name, 'DEFINITIONS', config_suffix) }} )
+        set({{ legacy_variable_prefix }}_VERSION_STRING "{{ version }}")
+        set({{ legacy_variable_prefix }}_INCLUDE_DIRS {{ pkg_var(pkg_name, 'INCLUDE_DIRS', config_suffix) }} )
+        set({{ legacy_variable_prefix }}_INCLUDE_DIR {{ pkg_var(pkg_name, 'INCLUDE_DIRS', config_suffix) }} )
+        set({{ legacy_variable_prefix }}_LIBRARIES {{ pkg_var(pkg_name, 'LIBRARIES', config_suffix) }} )
+        set({{ legacy_variable_prefix }}_DEFINITIONS {{ pkg_var(pkg_name, 'DEFINITIONS', config_suffix) }} )
 
         # Only the first installed configuration is included to avoid the collision
         foreach(_BUILD_MODULE {{ pkg_var(pkg_name, 'BUILD_MODULES_PATHS', config_suffix) }} )

--- a/conan/tools/cmake/cmakedeps/templates/config.py
+++ b/conan/tools/cmake/cmakedeps/templates/config.py
@@ -69,18 +69,16 @@ class ConfigTemplate(CMakeDepsFileTemplate):
         endforeach()
 
         {% if legacy_variable_prefix %}
-        set({{ legacy_variable_prefix }}_VERSION_STRING "{{ version }}")
-        set({{ legacy_variable_prefix }}_INCLUDE_DIRS {{ pkg_var(pkg_name, 'INCLUDE_DIRS', config_suffix) }} )
-        set({{ legacy_variable_prefix }}_INCLUDE_DIR {{ pkg_var(pkg_name, 'INCLUDE_DIRS', config_suffix) }} )
-        set({{ legacy_variable_prefix }}_LIBRARIES {{ pkg_var(pkg_name, 'LIBRARIES', config_suffix) }} )
-        set({{ legacy_variable_prefix }}_DEFINITIONS {{ pkg_var(pkg_name, 'DEFINITIONS', config_suffix) }} )
+            {% set prefix_name = legacy_variable_prefix %}
         {% else %}
-        set({{ file_name }}_VERSION_STRING "{{ version }}")
-        set({{ file_name }}_INCLUDE_DIRS {{ pkg_var(pkg_name, 'INCLUDE_DIRS', config_suffix) }} )
-        set({{ file_name }}_INCLUDE_DIR {{ pkg_var(pkg_name, 'INCLUDE_DIRS', config_suffix) }} )
-        set({{ file_name }}_LIBRARIES {{ pkg_var(pkg_name, 'LIBRARIES', config_suffix) }} )
-        set({{ file_name }}_DEFINITIONS {{ pkg_var(pkg_name, 'DEFINITIONS', config_suffix) }} )
+            {% set prefix_name = file_name %}
         {% endif %}
+
+        set({{ prefix_name }}_VERSION_STRING "{{ version }}")
+        set({{ prefix_name }}_INCLUDE_DIRS {{ pkg_var(pkg_name, 'INCLUDE_DIRS', config_suffix) }} )
+        set({{ prefix_name }}_INCLUDE_DIR {{ pkg_var(pkg_name, 'INCLUDE_DIRS', config_suffix) }} )
+        set({{ prefix_name }}_LIBRARIES {{ pkg_var(pkg_name, 'LIBRARIES', config_suffix) }} )
+        set({{ prefix_name }}_DEFINITIONS {{ pkg_var(pkg_name, 'DEFINITIONS', config_suffix) }} )
 
         # Only the first installed configuration is included to avoid the collision
         foreach(_BUILD_MODULE {{ pkg_var(pkg_name, 'BUILD_MODULES_PATHS', config_suffix) }} )

--- a/conan/tools/cmake/cmakedeps/templates/config.py
+++ b/conan/tools/cmake/cmakedeps/templates/config.py
@@ -28,7 +28,8 @@ class ConfigTemplate(CMakeDepsFileTemplate):
         targets_include += "{}Targets.cmake".format(self.file_name)
         return {"is_module": self.generating_module,
                 "version": self.conanfile.ref.version,
-                "file_name": self.legacy_variable_prefix or self.file_name,
+                "file_name":  self.file_name,
+                "legacy_variable_prefix": self.legacy_variable_prefix,
                 "pkg_name": self.pkg_name,
                 "config_suffix": self.config_suffix,
                 "check_components_exist": self.cmakedeps.check_components_exist,
@@ -67,11 +68,19 @@ class ConfigTemplate(CMakeDepsFileTemplate):
             endif()
         endforeach()
 
+        {% if legacy_variable_prefix %}
+        set({{ legacy_variable_prefix }}_VERSION_STRING "{{ version }}")
+        set({{ legacy_variable_prefix }}_INCLUDE_DIRS {{ pkg_var(pkg_name, 'INCLUDE_DIRS', config_suffix) }} )
+        set({{ legacy_variable_prefix }}_INCLUDE_DIR {{ pkg_var(pkg_name, 'INCLUDE_DIRS', config_suffix) }} )
+        set({{ legacy_variable_prefix }}_LIBRARIES {{ pkg_var(pkg_name, 'LIBRARIES', config_suffix) }} )
+        set({{ legacy_variable_prefix }}_DEFINITIONS {{ pkg_var(pkg_name, 'DEFINITIONS', config_suffix) }} )
+        {% else %}
         set({{ file_name }}_VERSION_STRING "{{ version }}")
         set({{ file_name }}_INCLUDE_DIRS {{ pkg_var(pkg_name, 'INCLUDE_DIRS', config_suffix) }} )
         set({{ file_name }}_INCLUDE_DIR {{ pkg_var(pkg_name, 'INCLUDE_DIRS', config_suffix) }} )
         set({{ file_name }}_LIBRARIES {{ pkg_var(pkg_name, 'LIBRARIES', config_suffix) }} )
         set({{ file_name }}_DEFINITIONS {{ pkg_var(pkg_name, 'DEFINITIONS', config_suffix) }} )
+        {% endif %}
 
         # Only the first installed configuration is included to avoid the collision
         foreach(_BUILD_MODULE {{ pkg_var(pkg_name, 'BUILD_MODULES_PATHS', config_suffix) }} )

--- a/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/conans/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -718,10 +718,10 @@ def test_cmakedeps_set_legacy_variable_name():
                 version = "1.0"
 
                 def package_info(self):
-                    self.cpp_info.set_property("cmake_legacy_variable_prefix", "DEP")
+                    self.cpp_info.set_property("cmake_file_name", "lib")
     """)
-    client.save({"conanfile.py": conanfile})
-    client.run("create .")
+    client.save({"dep/conanfile.py": conanfile})
+    client.run("create dep")
     conanfile = textwrap.dedent("""\
         from conan import ConanFile
         from conan.tools.cmake import CMakeDeps
@@ -741,5 +741,22 @@ def test_cmakedeps_set_legacy_variable_name():
     """)
     client.save({"conanfile.py": conanfile})
     client.run("install .")
-    dep_config = client.load("dep-config.cmake")
+    dep_config = client.load("lib-config.cmake")
+    assert "lib_VERSION" in dep_config
+
+    conanfile = textwrap.dedent("""\
+            from conan import ConanFile
+
+            class libRecipe(ConanFile):
+                name = "dep"
+                version = "1.0"
+
+                def package_info(self):
+                    self.cpp_info.set_property("cmake_file_name", "lib2")
+                    self.cpp_info.set_property("cmake_legacy_variable_prefix", "DEP")
+    """)
+    client.save({"dep/conanfile.py": conanfile})
+    client.run("create dep")
+    client.run("install .")
+    dep_config = client.load("lib2-config.cmake")
     assert "DEP_VERSION" in dep_config


### PR DESCRIPTION
Changelog: Feature: Add `cmake_additional_variables_prefixes` variable to CMakeDeps generator to allow adding extra names for declared CMake variables.
Docs: https://github.com/conan-io/docs/pull/3721

Created new property for CMakeDeps generator: `cmake_legacy_variable_prefix` that can be set in `package_info()` of the conanfile.
It allows changing the prefix used when creating CMake variables instead of the package name that was currently being used.

Closes: https://github.com/conan-io/conan/issues/14788

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.