### PR TITLE
Fix msys ORIGINAL_PATH confusion

### DIFF
--- a/conans/client/subsystems.py
+++ b/conans/client/subsystems.py
@@ -82,6 +82,7 @@ def _windows_bash_wrapper(conanfile, command, env, envfiles_folder):
         # - CHERE_INVOKING is necessary to keep the CWD and not change automatically to the user home
         msys2_mode_env.define("MSYSTEM", _msystem)
         msys2_mode_env.define("MSYS2_PATH_TYPE", "inherit")
+        msys2_mode_env.unset("ORIGINAL_PATH")
         # So --login do not change automatically to the user home
         msys2_mode_env.define("CHERE_INVOKING", "1")
         path = os.path.join(conanfile.generators_folder, "msys2_mode.bat")

--- a/conans/util/windows.py
+++ b/conans/util/windows.py
@@ -19,6 +19,15 @@ def conan_expand_user(path):
         if home and (not os.path.exists(home) or
                      (os.getenv("MSYSTEM") and os.getenv("USERPROFILE"))):
             del os.environ["HOME"]
+        # Problematic cases of existing ORIGINAL_PATH variable
+        # - msys /etc/profile, for MSYS2_PATH_TYPE=inherit mode:
+        #   - If ORIGINAL_PATH is unset, then assign ORIGINAL_PATH=PATH
+        #   - Set PATH=some msys paths plus ORIGINAL_PATH
+        # - To ensure we keep PATH intact, we must ensure ORIGINAL_PATH is unset
+        # - A user running conan from an msys console typically has ORIGINAL_PATH already set
+        # - To ensure conan's build paths are correct, ORIGINAL_PATH must be unset
+        if os.getenv("ORIGINAL_PATH"):
+            del os.environ["ORIGINAL_PATH"]
         result = os.path.expanduser(path)
     finally:
         if home is not None:

--- a/conans/util/windows.py
+++ b/conans/util/windows.py
@@ -19,15 +19,6 @@ def conan_expand_user(path):
         if home and (not os.path.exists(home) or
                      (os.getenv("MSYSTEM") and os.getenv("USERPROFILE"))):
             del os.environ["HOME"]
-        # Problematic cases of existing ORIGINAL_PATH variable
-        # - msys /etc/profile, for MSYS2_PATH_TYPE=inherit mode:
-        #   - If ORIGINAL_PATH is unset, then assign ORIGINAL_PATH=PATH
-        #   - Set PATH=some msys paths plus ORIGINAL_PATH
-        # - To ensure we keep PATH intact, we must ensure ORIGINAL_PATH is unset
-        # - A user running conan from an msys console typically has ORIGINAL_PATH already set
-        # - To ensure conan's build paths are correct, ORIGINAL_PATH must be unset
-        if os.getenv("ORIGINAL_PATH"):
-            del os.environ["ORIGINAL_PATH"]
         result = os.path.expanduser(path)
     finally:
         if home is not None:


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Ensure ORIGINAL_PATH is unset,
so msys's /etc/profile will use the previous PATH as the future PATH.

Refer to #16268 