### PR TITLE
Fix 'compiler_executable' conf to work with Meson when path has spaces

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -254,15 +254,15 @@ class MesonToolchain(object):
         #: Sets the Meson ``c`` variable, defaulting to the ``CC`` build environment value.
         #: If provided as a blank-separated string, it will be transformed into a list.
         #: Otherwise, it remains a single string.
-        self.c = compilers_by_conf.get("c") or build_env.get("CC") or default_comp
+        self.c = compilers_by_conf.get("c") or self._sanitize_format(build_env.get("CC")) or default_comp
         #: Sets the Meson ``cpp`` variable, defaulting to the ``CXX`` build environment value.
         #: If provided as a blank-separated string, it will be transformed into a list.
         #: Otherwise, it remains a single string.
-        self.cpp = compilers_by_conf.get("cpp") or build_env.get("CXX") or default_comp_cpp
+        self.cpp = compilers_by_conf.get("cpp") or self._sanitize_format(build_env.get("CXX")) or default_comp_cpp
         #: Sets the Meson ``ld`` variable, defaulting to the ``LD`` build environment value.
         #: If provided as a blank-separated string, it will be transformed into a list.
         #: Otherwise, it remains a single string.
-        self.ld = build_env.get("LD")
+        self.ld = self._sanitize_format(build_env.get("LD"))
         # FIXME: Should we use the new tools.build:compiler_executables and avoid buildenv?
         # Issue related: https://github.com/mesonbuild/meson/issues/6442
         # PR related: https://github.com/mesonbuild/meson/pull/6457
@@ -420,12 +420,14 @@ class MesonToolchain(object):
     def _filter_list_empty_fields(v):
         return list(filter(bool, v))
 
+    @staticmethod
+    def _sanitize_format(v):
+        if v is None or isinstance(v, list):
+            return v
+        ret = [x.strip() for x in v.split() if x]
+        return f"{ret[0]}" if len(ret) == 1 else ret
+
     def _context(self):
-        def _sanitize_format(v):
-            if v is None or isinstance(v, list):
-                return v
-            ret = [x.strip() for x in v.split() if x]
-            return f"'{ret[0]}'" if len(ret) == 1 else ret
 
         apple_flags = self.apple_isysroot_flag + self.apple_arch_flag + self.apple_min_version_flag
         extra_flags = self._get_extra_flags()
@@ -464,9 +466,9 @@ class MesonToolchain(object):
             # https://mesonbuild.com/Builtin-options.html#directories
             # https://mesonbuild.com/Machine-files.html#binaries
             # https://mesonbuild.com/Reference-tables.html#compiler-and-linker-selection-variables
-            "c": _sanitize_format(self.c),
-            "cpp": _sanitize_format(self.cpp),
-            "ld": _sanitize_format(self.ld),
+            "c": to_meson_value(self.c),
+            "cpp": to_meson_value(self.cpp),
+            "ld": to_meson_value(self.ld),
             "objc": self.objc,
             "objcpp": self.objcpp,
             "c_ld": self.c_ld,

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -421,11 +421,11 @@ class MesonToolchain(object):
         return list(filter(bool, v))
 
     @staticmethod
-    def _sanitize_format(v):
-        if v is None or isinstance(v, list):
-            return v
-        ret = [x.strip() for x in v.split() if x]
-        return f"{ret[0]}" if len(ret) == 1 else ret
+    def _sanitize_env_format(value)
+        if value is None or isinstance(value, list):
+            return value
+        ret = [x.strip() for x in value.split() if x]
+        return ret[0] if len(ret) == 1 else ret
 
     def _context(self):
 

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -254,15 +254,15 @@ class MesonToolchain(object):
         #: Sets the Meson ``c`` variable, defaulting to the ``CC`` build environment value.
         #: If provided as a blank-separated string, it will be transformed into a list.
         #: Otherwise, it remains a single string.
-        self.c = compilers_by_conf.get("c") or self._sanitize_format(build_env.get("CC")) or default_comp
+        self.c = compilers_by_conf.get("c") or self._sanitize_env_format(build_env.get("CC")) or default_comp
         #: Sets the Meson ``cpp`` variable, defaulting to the ``CXX`` build environment value.
         #: If provided as a blank-separated string, it will be transformed into a list.
         #: Otherwise, it remains a single string.
-        self.cpp = compilers_by_conf.get("cpp") or self._sanitize_format(build_env.get("CXX")) or default_comp_cpp
+        self.cpp = compilers_by_conf.get("cpp") or self._sanitize_env_format(build_env.get("CXX")) or default_comp_cpp
         #: Sets the Meson ``ld`` variable, defaulting to the ``LD`` build environment value.
         #: If provided as a blank-separated string, it will be transformed into a list.
         #: Otherwise, it remains a single string.
-        self.ld = self._sanitize_format(build_env.get("LD"))
+        self.ld = self._sanitize_env_format(build_env.get("LD"))
         # FIXME: Should we use the new tools.build:compiler_executables and avoid buildenv?
         # Issue related: https://github.com/mesonbuild/meson/issues/6442
         # PR related: https://github.com/mesonbuild/meson/pull/6457
@@ -421,7 +421,7 @@ class MesonToolchain(object):
         return list(filter(bool, v))
 
     @staticmethod
-    def _sanitize_env_format(value)
+    def _sanitize_env_format(value):
         if value is None or isinstance(value, list):
             return value
         ret = [x.strip() for x in value.split() if x]

--- a/conans/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/conans/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -527,9 +527,9 @@ def test_compiler_path_with_spaces():
         tools.build:compiler_executables={"c":"c compiler path with spaces", "cpp":"cpp compiler path with spaces"}
     """)
     client = TestClient()
-    client.save({"conanfile.py": GenConanfile().with_name("lib").with_version("1.0")
-                .with_generator("MesonToolchain").with_settings("compiler"),
-                "meson-profile": profile})
+    client.save(
+        {"conanfile.py": GenConanfile().with_generator("MesonToolchain").with_settings("compiler"),
+         "meson-profile": profile})
     client.run("install . -pr:h=meson-profile")
     conan_meson_native = client.load("conan_meson_native.ini")
     assert "c = 'c compiler path with spaces'" in conan_meson_native

--- a/conans/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/conans/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -4,7 +4,7 @@ import textwrap
 
 import pytest
 
-from assets.genconanfile import GenConanfile
+from conans.test.assets.genconanfile import GenConanfile
 from conan.tools.files import load
 from conan.tools.meson import MesonToolchain
 from conans.test.utils.tools import TestClient
@@ -520,18 +520,11 @@ def test_native_attribute_error():
     assert "You can only pass native=True if you're cross-building" in client.out
 
 
-@pytest.mark.skipif(platform.system() != "Windows", reason="requires Win")
 def test_compiler_path_with_spaces():
     conanfile = (GenConanfile().with_name("lib").with_version("1.0").with_generator("MesonToolchain")
                  .with_settings("compiler"))
     profile = textwrap.dedent("""
-        [settings]
-        arch=x86
-        os=Windows
-        compiler=msvc
-        compiler.version=193
-        compiler.runtime=static
-        build_type=Release
+        include(default)
         [conf]
         tools.build:compiler_executables={"c":"c compiler path with spaces", "cpp":"cpp compiler path with spaces"}
     """)

--- a/conans/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/conans/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -521,15 +521,15 @@ def test_native_attribute_error():
 
 
 def test_compiler_path_with_spaces():
-    conanfile = GenConanfile().with_name("lib").with_version("1.0").with_generator("MesonToolchain")
-                .with_settings("compiler")
     profile = textwrap.dedent("""
         include(default)
         [conf]
         tools.build:compiler_executables={"c":"c compiler path with spaces", "cpp":"cpp compiler path with spaces"}
     """)
     client = TestClient()
-    client.save({"conanfile.py": conanfile, "meson-profile": profile})
+    client.save({"conanfile.py": GenConanfile().with_name("lib").with_version("1.0")
+                .with_generator("MesonToolchain").with_settings("compiler"),
+                "meson-profile": profile})
     client.run("install . -pr:h=meson-profile")
     conan_meson_native = client.load("conan_meson_native.ini")
     assert "c = 'c compiler path with spaces'" in conan_meson_native

--- a/conans/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/conans/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -521,8 +521,8 @@ def test_native_attribute_error():
 
 
 def test_compiler_path_with_spaces():
-    conanfile = (GenConanfile().with_name("lib").with_version("1.0").with_generator("MesonToolchain")
-                 .with_settings("compiler"))
+    conanfile = GenConanfile().with_name("lib").with_version("1.0").with_generator("MesonToolchain")
+                .with_settings("compiler")
     profile = textwrap.dedent("""
         include(default)
         [conf]


### PR DESCRIPTION
Changelog: Bugfix: Avoid sanitizing `tools.build:compiler_executables` value in MesonToolchain.
Docs: Omit

Close: https://github.com/conan-io/conan/issues/16212


