### PR TITLE
Fix conanvcvars in powershell

### DIFF
--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -169,7 +169,7 @@ class VCVars:
 
         is_ps1 = conanfile.conf.get("tools.env.virtualenv:powershell", check_type=bool, default=False)
         if is_ps1:
-            content_ps1 = textwrap.dedent(rf"""\
+            content_ps1 = textwrap.dedent(rf"""
             if (-not $env:VSCMD_ARG_VCVARS_VER){{
                 Push-Location "$PSScriptRoot"
                 cmd /c "conanvcvars.bat&set" |
@@ -180,7 +180,7 @@ class VCVars:
                 }}
                 Pop-Location
                 write-host conanvcvars.ps1: Activated environment}}
-            """)
+            """).strip()
             conan_vcvars_ps1 = f"{CONAN_VCVARS}.ps1"
             create_env_script(conanfile, content_ps1, conan_vcvars_ps1, scope)
             _create_deactivate_vcvars_file(conanfile, conan_vcvars_ps1)

--- a/conans/test/functional/toolchains/env/test_virtualenv_powershell.py
+++ b/conans/test/functional/toolchains/env/test_virtualenv_powershell.py
@@ -148,6 +148,10 @@ def test_vcvars():
     assert "conanvcvars.ps1: Activated environment" in client.out
     #check that the new env variables are set
     assert "VSCMD_ARG_VCVARS_VER" in client.out
+
+    client.run_command(r'powershell.exe ".\build\Release\generators\conanvcvars.ps1"')
+    assert client.out.strip() == "conanvcvars.ps1: Activated environment"
+
     conanbuild = client.load(r".\build\Release\generators\conanbuild.ps1")
     vcvars_ps1 = client.load(r".\build\Release\generators\conanvcvars.ps1")
     #check that the conanvcvars.ps1 is being added to the conanbuild.ps1


### PR DESCRIPTION
Changelog: Bugfix: Remove extra backslash in generated `conanvcvars.ps1`.
Docs: Omit

We could consider improving the ps1 so it handles the error and stops its execution when there's an error.
Current behavior:
![image](https://github.com/conan-io/conan/assets/35701596/7e94faa4-7d63-4bd8-9d36-1a9fe3e34cf9)


Fixed syntax of the generated conanvcvars.ps1 file.
Improved test to check for errors in the creation of the ps1 files.

Closes https://github.com/conan-io/conan/issues/16319
