### PR TITLE
Fix autodetect CMAKE_SYSTEM_VERSION to convert to Darwin version

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -528,13 +528,13 @@ class FindFiles(Block):
                 host_runtime_dirs = {}
                 for k, v in matches:
                     host_runtime_dirs.setdefault(k, []).append(v)
-
+        
         # Calculate the dirs for the current build_type
         runtime_dirs = []
         for req in host_req:
             cppinfo = req.cpp_info.aggregated_components()
             runtime_dirs.extend(cppinfo.bindirs if is_win else cppinfo.libdirs)
-        
+
         build_type = settings.get_safe("build_type")
         host_runtime_dirs[build_type] = [s.replace("\\", "/") for s in runtime_dirs]
 

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -18,6 +18,7 @@ from conan.tools.intel import IntelCC
 from conan.tools.microsoft.visual import msvc_version_to_toolset_version
 from conans.client.subsystems import deduce_subsystem, WINDOWS
 from conan.errors import ConanException
+from conans.model.version import Version
 from conans.util.files import load
 
 
@@ -919,6 +920,64 @@ class GenericSystemBlock(Block):
         return os_host in ('iOS', 'watchOS', 'tvOS', 'visionOS') or (
                 os_host == 'Macos' and (arch_host != arch_build or os_build != os_host))
 
+    def _get_darwin_version(self, system_name):
+        sdk_version = self._conanfile.settings.get_safe("os.sdk_version")
+        macos_minor_darwin_versions = {
+            "10.13": "17",
+            "10.14": "18",
+            "10.15": "19"
+        }
+        macos_major_darwin_versions = {
+            "11": "20",
+            "12": "21",
+            "13": "22",
+            "14": "23",
+        }
+        ios_darwin_versions = {
+            "11": "17",
+            "12": "18",
+            "13": "19",
+            "14": "20",
+            "15": "21",
+            "16": "22",
+            "17": "23"
+        }
+        watchos_darwin_versions = {
+            "4": "17",
+            "5": "18",
+            "6": "19",
+            "7": "20",
+            "8": "21",
+            "9": "22",
+            "10": "23"
+        }
+        tvos_darwin_versions = {
+            "11": "17",
+            "12": "18",
+            "13": "19",
+            "14": "20",
+            "15": "21",
+            "16": "22",
+            "17": "23"
+        }
+        if system_name == "Darwin":
+            if Version(sdk_version) < 11:
+                if sdk_version in macos_minor_darwin_versions:
+                    return macos_minor_darwin_versions.get(sdk_version)
+            elif sdk_version in macos_major_darwin_versions:
+                return macos_major_darwin_versions.get(sdk_version)
+        elif system_name == "iOS":
+            if sdk_version in ios_darwin_versions:
+                return ios_darwin_versions.get(sdk_version)
+        elif system_name == "watchOS":
+            if sdk_version in watchos_darwin_versions:
+                return watchos_darwin_versions.get(sdk_version)
+        elif system_name == "tvOS":
+            if sdk_version in tvos_darwin_versions:
+                return tvos_darwin_versions.get(sdk_version)
+        raise ConanException("Unsupported macOS version: %s" % sdk_version)
+
+
     def _get_cross_build(self):
         user_toolchain = self._conanfile.conf.get("tools.cmake.cmaketoolchain:user_toolchain")
 
@@ -941,7 +1000,7 @@ class GenericSystemBlock(Block):
                     # cross-build in Macos also for M1
                     system_name = {'Macos': 'Darwin'}.get(os_host, os_host)
                     #  CMAKE_SYSTEM_VERSION for Apple sets the sdk version, not the os version
-                    _system_version = self._conanfile.settings.get_safe("os.sdk_version")
+                    _system_version = self._get_darwin_version(system_name)
                     _system_processor = to_apple_arch(self._conanfile)
                 elif os_host != 'Android':
                     system_name = self._get_generic_system_name()

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -534,7 +534,7 @@ class FindFiles(Block):
         for req in host_req:
             cppinfo = req.cpp_info.aggregated_components()
             runtime_dirs.extend(cppinfo.bindirs if is_win else cppinfo.libdirs)
-
+        
         build_type = settings.get_safe("build_type")
         host_runtime_dirs[build_type] = [s.replace("\\", "/") for s in runtime_dirs]
 

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -922,12 +922,10 @@ class GenericSystemBlock(Block):
 
     def _get_darwin_version(self, system_name, os_version):
         darwin_versions = {
-            "macos_old": {
+            "Darwin": {
                 "10.13": "17",
                 "10.14": "18",
-                "10.15": "19"
-            },
-            "macos_new": {
+                "10.15": "19",
                 "11": "20",
                 "12": "21",
                 "13": "22",
@@ -967,17 +965,12 @@ class GenericSystemBlock(Block):
         if os_version is None:
             return None
         major_os_version = str(Version(os_version).major)
-        if system_name == "Darwin":
-            if Version(os_version) < 11:
-                if os_version in darwin_versions.get("macos_old"):
-                    return darwin_versions.get("macos_old").get(os_version)
-            else:
-                if major_os_version in darwin_versions.get("macos_new"):
-                    return darwin_versions.get("macos_new").get(major_os_version)
+        if system_name == "Darwin" and Version(os_version) < 11:
+            if os_version in darwin_versions.get("Darwin"):
+                return darwin_versions.get("Darwin").get(os_version)
         elif system_name in darwin_versions:
             if major_os_version in darwin_versions.get(system_name):
                 return darwin_versions.get(system_name).get(major_os_version)
-        raise ConanException("Unsupported macOS version: %s" % os_version)
 
     def _get_cross_build(self):
         user_toolchain = self._conanfile.conf.get("tools.cmake.cmaketoolchain:user_toolchain")

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -920,57 +920,32 @@ class GenericSystemBlock(Block):
         return os_host in ('iOS', 'watchOS', 'tvOS', 'visionOS') or (
                 os_host == 'Macos' and (arch_host != arch_build or os_build != os_host))
 
-    def _get_darwin_version(self, system_name, os_version):
-        darwin_versions = {
-            "Darwin": {
-                "10.13": "17",
-                "10.14": "18",
-                "10.15": "19",
-                "11": "20",
-                "12": "21",
-                "13": "22",
-                "14": "23",
+    def _get_darwin_version(self, os_name, os_version):
+        version_mapping = {
+            "Macos": {
+                "10.13": "17", "10.14": "18", "10.15": "19", "11": "20",
+                "12": "21", "13": "22", "14": "23",
             },
             "iOS": {
-                "11": "17",
-                "12": "18",
-                "13": "19",
-                "14": "20",
-                "15": "21",
-                "16": "22",
-                "17": "23"
+                "11": "17", "12": "18", "13": "19", "14": "20",
+                "15": "21", "16": "22", "17": "23"
             },
             "watchOS": {
-                "4": "17",
-                "5": "18",
-                "6": "19",
-                "7": "20",
-                "8": "21",
-                "9": "22",
-                "10": "23"
+                "4": "17", "5": "18", "6": "19", "7": "20",
+                "8": "21", "9": "22", "10": "23"
             },
             "tvOS": {
-                "11": "17",
-                "12": "18",
-                "13": "19",
-                "14": "20",
-                "15": "21",
-                "16": "22",
-                "17": "23"
+                "11": "17", "12": "18", "13": "19", "14": "20",
+                "15": "21", "16": "22", "17": "23"
             },
             "visionOS": {
                 "1": "23"
             }
         }
-        if os_version is None:
-            return None
-        major_os_version = str(Version(os_version).major)
-        if system_name == "Darwin" and Version(os_version) < 11:
-            if os_version in darwin_versions.get("Darwin"):
-                return darwin_versions.get("Darwin").get(os_version)
-        elif system_name in darwin_versions:
-            if major_os_version in darwin_versions.get(system_name):
-                return darwin_versions.get(system_name).get(major_os_version)
+        os_version = str(Version(os_version).major) \
+            if os_name != "Macos" or (os_name == "Macos" and Version(os_version) >= Version("11")) \
+            else str(os_version)
+        return version_mapping.get(os_name, {}).get(os_version)
 
     def _get_cross_build(self):
         user_toolchain = self._conanfile.conf.get("tools.cmake.cmaketoolchain:user_toolchain")
@@ -995,13 +970,8 @@ class GenericSystemBlock(Block):
                     system_name = {'Macos': 'Darwin'}.get(os_host, os_host)
                     #  CMAKE_SYSTEM_VERSION for Apple sets the sdk version, not the os version
                     sdk_version = self._conanfile.settings.get_safe("os.sdk_version")
-                    _system_version = self._get_darwin_version(system_name, sdk_version)
+                    _system_version = self._get_darwin_version(os_host, sdk_version)
                     _system_processor = to_apple_arch(self._conanfile)
-                elif os_host in ('Macos', 'iOS', 'watchOS', 'tvOS', 'visionOS'):
-                    system_name = self._get_generic_system_name()
-                    os_version = self._conanfile.settings.get_safe("os.version")
-                    _system_version = self._get_darwin_version(system_name, os_version)
-                    _system_processor = arch_host
                 elif os_host != 'Android':
                     system_name = self._get_generic_system_name()
                     _system_version = self._conanfile.settings.get_safe("os.version")

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -923,12 +923,13 @@ class GenericSystemBlock(Block):
     def _get_darwin_version(self, os_name, os_version):
         version_mapping = {
             "Macos": {
-                "10.13": "17", "10.14": "18", "10.15": "19", "11": "20",
-                "12": "21", "13": "22", "14": "23",
+                "10.6": "10", "10.7": "11", "10.8": "12", "10.9": "13", "10.10": "14", "10.11": "15",
+                "10.12": "16", "10.13": "17", "10.14": "18", "10.15": "19", "11": "20", "12": "21",
+                "13": "22", "14": "23",
             },
             "iOS": {
-                "11": "17", "12": "18", "13": "19", "14": "20",
-                "15": "21", "16": "22", "17": "23"
+                "7": "14", "8": "14", "9": "15", "10": "16", "11": "17", "12": "18", "13": "19",
+                "14": "20", "15": "21", "16": "22", "17": "23"
             },
             "watchOS": {
                 "4": "17", "5": "18", "6": "19", "7": "20",
@@ -968,9 +969,9 @@ class GenericSystemBlock(Block):
                 if self._is_apple_cross_building():
                     # cross-build in Macos also for M1
                     system_name = {'Macos': 'Darwin'}.get(os_host, os_host)
-                    #  CMAKE_SYSTEM_VERSION for Apple sets the sdk version, not the os version
-                    sdk_version = self._conanfile.settings.get_safe("os.sdk_version")
-                    _system_version = self._get_darwin_version(os_host, sdk_version)
+                    #  CMAKE_SYSTEM_VERSION for Apple sets the Darwin version, not the os version
+                    _system_version = self._get_darwin_version(os_host,
+                                                    self._conanfile.settings.get_safe("os.version"))
                     _system_processor = to_apple_arch(self._conanfile)
                 elif os_host != 'Android':
                     system_name = self._get_generic_system_name()

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -68,7 +68,7 @@ def test_cross_build_linux_to_macos():
     macos_profile = textwrap.dedent("""
         [settings]
         os=Macos
-        os.sdk_version=13.1
+        os.version=13.1
         arch=x86_64
         compiler=apple-clang
         compiler.version=13

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -85,7 +85,7 @@ def test_cross_build_linux_to_macos():
     toolchain = client.load("conan_toolchain.cmake")
 
     assert "set(CMAKE_SYSTEM_NAME Darwin)" in toolchain
-    assert "set(CMAKE_SYSTEM_VERSION 13.1)" in toolchain
+    assert "set(CMAKE_SYSTEM_VERSION 22)" in toolchain
     assert "set(CMAKE_SYSTEM_PROCESSOR x86_64)" in toolchain
 
 

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -437,7 +437,7 @@ def test_cmaketoolchain_cmake_system_processor_cross_apple():
     client.run("install hello.py -pr:h=./profile_ios -pr:b=default -g CMakeToolchain")
     toolchain = client.load("conan_toolchain.cmake")
     assert "set(CMAKE_SYSTEM_NAME iOS)" in toolchain
-    assert "set(CMAKE_SYSTEM_VERSION 15.0)" in toolchain
+    assert "set(CMAKE_SYSTEM_VERSION 21)" in toolchain
     assert "set(CMAKE_SYSTEM_PROCESSOR arm64)" in toolchain
 
 


### PR DESCRIPTION
Changelog: Fix: Change autodetect of `CMAKE_SYSTEM_VERSION` to use the Darwin version.
Docs: https://github.com/conan-io/docs/pull/3755

`CMAKE_SYSTEM_NAME` and `CMAKE_SYSTEM_VERSION` are required to be set when cross-compiling.
https://cmake.org/cmake/help/latest/variable/CMAKE_SYSTEM_VERSION.html
We recommend that users set them in the toolchain or through confs, but if they are not set we autodetect them based on the profile settings.
In the case of macOS systems, the `CMAKE_SYSTEM_VERSION` variable was set to the macOS version, but it needs to be the Darwin version. We need to set the Darwin version for each Apple system:  https://en.wikipedia.org/wiki/Darwin_(operating_system)#Darwin_20_onwards

This PR fixes it by converting the macOS versions to Darwin versions when the user doesn't set the variable.
Other option could be to stop autodetecting this variables and force users to set it themselves.

CMake states that the `CMAKE_SYSTEM_VERSION` is not usually set for Darwin systems and is not particularly meaningful, and users should be careful when making use of it in their projects.
It has almost no utility on the CMake side for Darwin systems
https://github.com/Kitware/CMake/blob/f0074159d75601145b6ab0a98d636ec4c17a4370/Modules/Platform/Darwin.cmake#L18

Closes: https://github.com/conan-io/conan/issues/16282
