### PR TITLE
Tools files rm: Exclude pattern to avoid removing everything

### DIFF
--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -74,7 +74,8 @@ def rm(conanfile, pattern, folder, recursive=False, excludes=None):
     :param pattern: Pattern that the files to be removed have to match (fnmatch).
     :param folder: Folder to search/remove the files.
     :param recursive: If ``recursive`` is specified it will search in the subfolders.
-    :param excludes: A tuple/list of fnmatch patterns or even a single one to be excluded from the remove.
+    :param excludes: (Optional, defaulted to None) A tuple/list of fnmatch patterns or even a
+                     single one to be excluded from the remove pattern.
     """
     if excludes and not isinstance(excludes, (tuple, list)):
         excludes = (excludes,)

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -66,7 +66,7 @@ def rmdir(conanfile, path):
     _internal_rmdir(path)
 
 
-def rm(conanfile, pattern, folder, recursive=False):
+def rm(conanfile, pattern, folder, recursive=False, excludes=None):
     """
     Utility functions to remove files matching a ``pattern`` in a ``folder``.
 
@@ -74,10 +74,11 @@ def rm(conanfile, pattern, folder, recursive=False):
     :param pattern: Pattern that the files to be removed have to match (fnmatch).
     :param folder: Folder to search/remove the files.
     :param recursive: If ``recursive`` is specified it will search in the subfolders.
+    :param excludes: Pattern to not be removed when matched with the pattern.
     """
     for root, _, filenames in os.walk(folder):
         for filename in filenames:
-            if fnmatch(filename, pattern):
+            if fnmatch(filename, pattern) and not (excludes and fnmatch(filename, excludes)):
                 fullname = os.path.join(root, filename)
                 os.unlink(fullname)
         if not recursive:

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -74,11 +74,16 @@ def rm(conanfile, pattern, folder, recursive=False, excludes=None):
     :param pattern: Pattern that the files to be removed have to match (fnmatch).
     :param folder: Folder to search/remove the files.
     :param recursive: If ``recursive`` is specified it will search in the subfolders.
-    :param excludes: Pattern to not be removed when matched with the pattern.
+    :param excludes: A tuple/list of fnmatch patterns or even a single one to be excluded from the remove.
     """
+    if excludes and not isinstance(excludes, (tuple, list)):
+        excludes = (excludes,)
+    elif not excludes:
+        excludes = []
+
     for root, _, filenames in os.walk(folder):
         for filename in filenames:
-            if fnmatch(filename, pattern) and not (excludes and fnmatch(filename, excludes)):
+            if fnmatch(filename, pattern) and not any(fnmatch(filename, it) for it in excludes):
                 fullname = os.path.join(root, filename)
                 os.unlink(fullname)
         if not recursive:

--- a/test/unittests/tools/files/test_rm.py
+++ b/test/unittests/tools/files/test_rm.py
@@ -67,9 +67,11 @@ def test_remove_files_by_mask_non_recursively():
 
 
 @pytest.mark.parametrize("recursive", [False, True])
-def test_rm_exclude_from_pattern(recursive):
+def test_exclude_pattern_from_remove_list(recursive):
     """ conan.tools.files.rm should not remove files that match the pattern but are excluded
-        by the excludes parameter
+        by the excludes parameter.
+        It should obey the recursive parameter, only excluding the files in the root folder in case
+        it is False.
     """
     temporary_folder = temp_folder()
     with chdir(None, temporary_folder):

--- a/test/unittests/tools/files/test_rm.py
+++ b/test/unittests/tools/files/test_rm.py
@@ -67,12 +67,19 @@ def test_remove_files_by_mask_non_recursively():
 
 
 @pytest.mark.parametrize("recursive", [False, True])
-def test_exclude_pattern_from_remove_list(recursive):
+@pytest.mark.parametrize("results", [
+    ["*.dll", ("foo.dll",)],
+    [("*.dll",), ("foo.dll",)],
+    [["*.dll"], ("foo.dll",)],
+    [("*.dll", "*.lib"), ("foo.dll", "foo.dll.lib")],
+])
+def test_exclude_pattern_from_remove_list(recursive, results):
     """ conan.tools.files.rm should not remove files that match the pattern but are excluded
         by the excludes parameter.
         It should obey the recursive parameter, only excluding the files in the root folder in case
         it is False.
     """
+    excludes, expected_files = results
     temporary_folder = temp_folder()
     with chdir(None, temporary_folder):
         os.makedirs("subdir")
@@ -85,15 +92,18 @@ def test_exclude_pattern_from_remove_list(recursive):
         "foo.dll.lib": "",
         os.path.join("subdir", "2.txt"): "",
         os.path.join("subdir", "2.pdb"): "",
-        os.path.join("subdir", "bar.dll"): "",
-        os.path.join("subdir", "bar.dll.lib"): "",
+        os.path.join("subdir", "foo.dll"): "",
+        os.path.join("subdir", "foo.dll.lib"): "",
         os.path.join("subdir", "2.pdb1"): ""})
 
-    rm(None, "*", temporary_folder, excludes="*.dll", recursive=recursive)
+    rm(None, "*", temporary_folder, excludes=excludes, recursive=recursive)
 
-    assert os.path.exists(os.path.join(temporary_folder, "foo.dll"))
-    assert not os.path.exists(os.path.join(temporary_folder, "foo.dll.lib"))
+    for it in expected_files:
+        assert os.path.exists(os.path.join(temporary_folder, it))
+    assert not os.path.exists(os.path.join(temporary_folder, "1.pdb"))
 
-    assert os.path.exists(os.path.join(temporary_folder, "subdir", "bar.dll"))
+    # Check the recursive parameter and subfolder
     condition = (lambda x: not x) if recursive else (lambda x: x)
-    condition(os.path.exists(os.path.join(temporary_folder, "subdir", "bar.dll.lib")))
+    assert condition(os.path.exists(os.path.join(temporary_folder, "subdir", "2.pdb")))
+    for it in expected_files:
+        assert os.path.exists(os.path.join(temporary_folder, "subdir", it))


### PR DESCRIPTION
Greetings!

Added the new parameter `excludes`, same used by `tools.files.copy`. This new parameter avoids removing the pattern listed that's also listed by removing pattern. For instance:

```python
def package(self):
    ...
    # Exclude everything from bin folder, except for any .dll file.
    tools.file.rm(self, "*", os.path.join(self.package_folder, "bin"), excludes="*.dll")
```


Changelog: Feature: Add excludes parameter to tools.files.rm to void removing pattern.
Docs: https://github.com/conan-io/docs/pull/3743

closes #16343

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
