### PR TITLE
[docs] Add more docstring to Version class

### DIFF
--- a/conans/model/version.py
+++ b/conans/model/version.py
@@ -48,10 +48,15 @@ class _VersionItem:
 @total_ordering
 class Version:
     """
-    This is NOT an implementation of semver, as users may use any pattern in their versions.
-    It is just a helper to parse "." or "-" and compare taking into account integers when possible
+    It exposes all the version components as properties and offers total ordering through compare operators.
+
+    NOTE: This is **NOT** an implementation of semver, as users may use any pattern in their versions.
     """
     def __init__(self, value, qualifier=False):
+        """"
+        :param value: The version string
+        :param qualifier: True if this is a pre-release or build version
+        """
         value = str(value)
         self._value = value
         self._build = None
@@ -114,18 +119,26 @@ class Version:
 
     @property
     def pre(self):
+        """Get the pre-release digit.
+        """
         return self._pre
 
     @property
     def build(self):
+        """Get the build digit.
+        """
         return self._build
 
     @property
     def main(self):
+        """Get all the main digits.
+        """
         return self._items
 
     @property
     def major(self):
+        """Get the major digit.
+        """
         try:
             return self.main[0]
         except IndexError:
@@ -133,6 +146,8 @@ class Version:
 
     @property
     def minor(self):
+        """Get the minor digit.
+        """
         try:
             return self.main[1]
         except IndexError:
@@ -140,6 +155,8 @@ class Version:
 
     @property
     def patch(self):
+        """Get the patch digit.
+        """
         try:
             return self.main[2]
         except IndexError:
@@ -147,6 +164,8 @@ class Version:
 
     @property
     def micro(self):
+        """Get the micro digit.
+        """
         try:
             return self.main[3]
         except IndexError:


### PR DESCRIPTION
In order to expose more Version() attributes in docs.conan.io, we actually need to write some information.

I collected the current data from Conan 1.x, it looks still updated.

The semver information I moved to looks more a note, like we usually have in docs.conan.io


Changelog: Omit
Docs: TODO (Need to list members in docs)

- [ ] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [X] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
