### PR TITLE
fix for vcvars for clang with msvc v144 backend

### DIFF
--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -131,7 +131,7 @@ class VCVars:
                           "v143": "17",
                           "v144": "17"}.get(toolset_version)
             if vs_version is None:
-                raise ConanException("Visual Studio Runtime version (v140-v143) not defined")
+                raise ConanException("Visual Studio Runtime version (v140-v144) not defined")
             vcvars_ver = {"v140": "14.0",
                           "v141": "14.1",
                           "v142": "14.2",

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -118,6 +118,7 @@ class VCVars:
         if vs_install_path == "":  # Empty string means "disable"
             return
 
+        msvc_update = conanfile.conf.get("tools.microsoft:msvc_update")
         if compiler == "clang":
             # The vcvars only needed for LLVM/Clang and VS ClangCL, who define runtime
             if not conanfile.settings.get_safe("compiler.runtime"):
@@ -127,20 +128,24 @@ class VCVars:
             vs_version = {"v140": "14",
                           "v141": "15",
                           "v142": "16",
-                          "v143": "17"}.get(toolset_version)
+                          "v143": "17",
+                          "v144": "17"}.get(toolset_version)
             if vs_version is None:
                 raise ConanException("Visual Studio Runtime version (v140-v143) not defined")
             vcvars_ver = {"v140": "14.0",
                           "v141": "14.1",
                           "v142": "14.2",
-                          "v143": "14.3"}.get(toolset_version)
+                          "v143": "14.3",
+                          "v144": "14.4"}.get(toolset_version)
+            if vcvars_ver and msvc_update is not None:
+                vcvars_ver += f"{msvc_update}"
         else:
             vs_version = vs_ide_version(conanfile)
             if int(vs_version) <= 14:
                 vcvars_ver = None
             else:
                 compiler_version = str(conanfile.settings.compiler.version)
-                compiler_update = conanfile.settings.get_safe("compiler.update", "")
+                compiler_update = msvc_update or conanfile.settings.get_safe("compiler.update", "")
                 # The equivalent of compiler 19.26 is toolset 14.26
                 vcvars_ver = "14.{}{}".format(compiler_version[-1], compiler_update)
 

--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -115,7 +115,7 @@ compiler:
         cppstd: [null, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23]
         runtime: [null, static, dynamic]
         runtime_type: [null, Debug, Release]
-        runtime_version: [null, v140, v141, v142, v143]
+        runtime_version: [null, v140, v141, v142, v143, v144]
     apple-clang:
         version: ["5.0", "5.1", "6.0", "6.1", "7.0", "7.3", "8.0", "8.1", "9.0", "9.1",
                   "10.0", "11.0", "12.0", "13", "13.0", "13.1", "14", "14.0", "15", "15.0"]


### PR DESCRIPTION
Changelog: Bugfix: Fix ``LLVM/Clang`` enablement of ``vcvars`` for latest ``v14.4`` toolset version after VS 17.10 update
Docs: https://github.com/conan-io/docs/pull/3752

Close https://github.com/conan-io/conan/issues/16373