### PR TITLE
[1.x] Update node-semver requirement to 0.9.0

### DIFF
--- a/conans/client/conf/required_version.py
+++ b/conans/client/conf/required_version.py
@@ -1,7 +1,7 @@
 import six
 
 from conans.client.cache.cache import ClientCache
-from semver import satisfies
+from nodesemver import satisfies
 from conans import __version__ as client_version
 from conans.errors import ConanException
 

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -56,7 +56,7 @@ def satisfying(list_versions, versionexpr, result):
     if some version cannot be converted to loose SemVer, it is discarded with a msg
     This provides some workaround for failing comparisons like "2.1" not matching "<=2.1"
     """
-    from semver import SemVer, Range, max_satisfying
+    from nodesemver import SemVer, Range, max_satisfying
     version_range, loose, include_prerelease = _parse_versionexpr(versionexpr, result)
 
     # Check version range expression

--- a/conans/client/tools/version.py
+++ b/conans/client/tools/version.py
@@ -2,7 +2,7 @@
 
 from functools import total_ordering
 
-from semver import SemVer
+from nodesemver import SemVer
 
 from conans.errors import ConanException
 

--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -5,7 +5,7 @@ PyYAML>=3.11, <6.1
 patch-ng>=1.17.4, <1.18
 fasteners>=0.14.1
 six>=1.10.0,<=1.16.0
-node-semver==0.6.1
+node-semver==0.9.0
 distro>=1.0.2, <=1.8.0; sys_platform == 'linux' or sys_platform == 'linux2'
 pygments>=2.0, <3.0
 tqdm>=4.28.1, <5


### PR DESCRIPTION
Conan 1.x has a requirement on [node-semver](https://pypi.org/project/node-semver/) that Conan 2.x removed. PyPI package node-semver 0.6.0 calls its Python package `semver`, the same as PyPI package [semver](https://pypi.org/project/semver/). Thus, Conan 1.x cannot coexist in the same environment with tools that depend on PyPI package semver.

PyPI package node-semver 0.9.0 instead calls its Python package `nodesemver`. This PR changes the requirement to that version and updates the imports.

I followed the instructions in the README, but I cannot reliably run the tests for Conan 1.x on my machine. Dozens fail, many are skipped (but clearly not enough), and some invoke `sudo` to test the system package manager (no, thank you). One of the tests appears to expect to find CMake versions 3.16, 3.17, _and_ 3.19 installed. Do you publish a container that I can use to run the tests? I am submitting this PR in the hopes that your CI can test whether this fix is compatible with the existing code.