### PR TITLE
[MesonToolchain] Added extra_xxxxx flags

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -194,6 +194,17 @@ class MesonToolchain(object):
             if vscrt:
                 self._b_vscrt = str(vscrt).lower()
 
+        # Extra flags
+        #: List of extra CXX flags. Added to cpp_args
+        self.extra_cxxflags = []
+        #: List of extra C flags. Added to c_args
+        self.extra_cflags = []
+        #: List of extra linker flags. Added to c_link_args and cpp_link_args
+        self.extra_ldflags = []
+        #: List of extra preprocessor definitions. Added to c_args and cpp_args with the
+        #: format -DFLAG1
+        self.extra_defines = []
+
         #: Dict-like object that defines Meson``properties`` with ``key=value`` format
         self.properties = {}
         #: Dict-like object that defines Meson ``project options`` with ``key=value`` format
@@ -408,13 +419,14 @@ class MesonToolchain(object):
         exelinkflags = self._conanfile_conf.get("tools.build:exelinkflags", default=[], check_type=list)
         linker_scripts = self._conanfile_conf.get("tools.build:linker_scripts", default=[], check_type=list)
         linker_script_flags = ['-T"' + linker_script + '"' for linker_script in linker_scripts]
-        defines = [f"-D{d}" for d in self._conanfile.conf.get("tools.build:defines", default=[], check_type=list)]
+        defines = self._conanfile.conf.get("tools.build:defines", default=[], check_type=list)
         sys_root = [f"--sysroot={self._sys_root}"] if self._sys_root else [""]
         return {
-            "cxxflags": cxxflags + sys_root,
-            "cflags": cflags + sys_root,
-            "ldflags": sharedlinkflags + exelinkflags + linker_script_flags + sys_root,
-            "defines": defines
+            "cxxflags": cxxflags + sys_root + self.extra_cxxflags,
+            "cflags": cflags + sys_root + self.extra_cflags,
+            "ldflags": sharedlinkflags + exelinkflags + linker_script_flags
+                       + sys_root + self.extra_ldflags,
+            "defines": [f"-D{d}" for d in (defines + self.extra_defines)]
         }
 
     @staticmethod


### PR DESCRIPTION
Changelog: Feature: Added `extra_xxxx` flags to MesonToolchain as done in other toolchains like AutotoolsToolchain, CMakeToolchain, etc.
Docs: omit
(docs for this should be autogenerated but I am keeping this just in case)
Related to: https://github.com/conan-io/conan/issues/16169
