### PR TITLE
Add missing `[replace_requires]` and `[platform_requires]` to serialization/dump of profiles

### DIFF
--- a/conans/model/profile.py
+++ b/conans/model/profile.py
@@ -37,19 +37,29 @@ class Profile:
         def _serialize_tool_requires():
             return {pattern: [repr(ref) for ref in refs]
                     for pattern, refs in self.tool_requires.items()}
-        return {
+        result = {
             "settings": self.settings,
             "package_settings": self.package_settings,
             "options": self.options.serialize(),
             "tool_requires": _serialize_tool_requires(),
-            "replace_requires": {str(pattern): str(replace) for pattern, replace in self.replace_requires.items()},
-            "replace_tool_requires": {str(pattern): str(replace) for pattern, replace in self.replace_tool_requires.items()},
-            "platform_tool_requires": [str(t) for t in self.platform_tool_requires],
-            "platform_requires": [str(t) for t in self.platform_requires],
             "conf": self.conf.serialize(),
             # FIXME: Perform a serialize method for ProfileEnvironment
             "build_env": self.buildenv.dumps()
         }
+
+        if self.replace_requires:
+            result["replace_requires"] = {str(pattern): str(replace) for pattern, replace in
+                                          self.replace_requires.items()}
+        if self.replace_tool_requires:
+            result["replace_tool_requires"] = {str(pattern): str(replace) for pattern, replace in
+                                               self.replace_tool_requires.items()}
+        if self.platform_tool_requires:
+            result["platform_tool_requires"] = [str(t) for t in self.platform_tool_requires]
+
+        if self.platform_requires:
+            result["platform_requires"] = [str(t) for t in self.platform_requires]
+
+        return result
 
     @property
     def package_settings_values(self):

--- a/conans/model/profile.py
+++ b/conans/model/profile.py
@@ -7,7 +7,7 @@ from conans.model.options import Options
 from conans.model.recipe_ref import RecipeReference
 
 
-class Profile(object):
+class Profile:
     """A profile contains a set of setting (with values), environment variables
     """
 
@@ -42,6 +42,10 @@ class Profile(object):
             "package_settings": self.package_settings,
             "options": self.options.serialize(),
             "tool_requires": _serialize_tool_requires(),
+            "replace_requires": {str(pattern): str(replace) for pattern, replace in self.replace_requires.items()},
+            "replace_tool_requires": {str(pattern): str(replace) for pattern, replace in self.replace_tool_requires.items()},
+            "platform_tool_requires": [str(t) for t in self.platform_tool_requires],
+            "platform_requires": [str(t) for t in self.platform_requires],
             "conf": self.conf.serialize(),
             # FIXME: Perform a serialize method for ProfileEnvironment
             "build_env": self.buildenv.dumps()
@@ -85,6 +89,16 @@ class Profile(object):
         if self.platform_requires:
             result.append("[platform_requires]")
             result.extend(str(t) for t in self.platform_requires)
+
+        if self.replace_requires:
+            result.append("[replace_requires]")
+            for pattern, ref in self.replace_requires.items():
+                result.append(f"{pattern}: {ref}")
+
+        if self.replace_tool_requires:
+            result.append("[replace_tool_requires]")
+            for pattern, ref in self.replace_tool_requires.items():
+                result.append(f"{pattern}: {ref}")
 
         if self.conf:
             result.append("[conf]")

--- a/test/integration/command/test_profile.py
+++ b/test/integration/command/test_profile.py
@@ -136,7 +136,9 @@ def test_profile_show_json():
     c.save({"myprofilewin": "[settings]\nos=Windows\n"
                             "[tool_requires]\nmytool/*:mytool/1.0\n"
                             "[conf]\nuser.conf:value=42\nlibiconv/*:tools.env.virtualenv:powershell=False\n"
-                            "[options]\n*:myoption=True",
+                            "[options]\n*:myoption=True\n"
+                            "[replace_requires]\ncmake/*: cmake/3.29.0\n"
+                            "[platform_requires]\ncmake/3.29.0\n",
             "myprofilelinux": "[settings]\nos=Linux"})
     c.run("profile show -pr:b=myprofilewin -pr:h=myprofilelinux --format=json")
 

--- a/test/integration/graph/test_replace_requires.py
+++ b/test/integration/graph/test_replace_requires.py
@@ -51,7 +51,10 @@ class TestReplaceRequires:
         channel = f"--channel={ref.channel}" if ref.channel else ""
         c.run(f"create dep --name={ref.name} --version={ref.version} {user} {channel}")
         rrev = c.exported_recipe_revision()
+        c.run("profile show -pr=profile")
+        assert profile_tag in c.out
         c.run("install pkg -pr=profile")
+        assert profile_tag in c.out
         c.assert_listed_require({f"{pkg}#{rrev}": "Cache"}, build=tool_require)
 
         # Check lockfile

--- a/test/unittests/model/profile_test.py
+++ b/test/unittests/model/profile_test.py
@@ -128,8 +128,17 @@ def test_profile_serialize():
     expected_json = {
         "settings": {"arch": "x86_64", "compiler": "Visual Studio", "compiler.version": "12"},
         "package_settings": {"MyPackage": {"os": "Windows"}}, "options": {},
-        'platform_requires': [], 'platform_tool_requires': [], 'replace_requires': {},
-        'replace_tool_requires': {},
+        "tool_requires": {"*": ["'zlib/1.2.8'"]}, "conf": {"user.myfield:value": "MyVal"},
+        "build_env": "VAR1=1\nVAR2=2\n"}
+    assert expected_json == profile.serialize()
+
+    profile.replace_requires.update({"cmake/*": "cmake/3.29.0"})
+    profile.platform_tool_requires = ["cmake/3.29.0"]
+    expected_json = {
+        "settings": {"arch": "x86_64", "compiler": "Visual Studio", "compiler.version": "12"},
+        "package_settings": {"MyPackage": {"os": "Windows"}}, "options": {},
+        "replace_requires": {"cmake/*": "cmake/3.29.0"},
+        "platform_tool_requires": ["cmake/3.29.0"],
         "tool_requires": {"*": ["'zlib/1.2.8'"]}, "conf": {"user.myfield:value": "MyVal"},
         "build_env": "VAR1=1\nVAR2=2\n"}
     assert expected_json == profile.serialize()

--- a/test/unittests/model/profile_test.py
+++ b/test/unittests/model/profile_test.py
@@ -128,6 +128,8 @@ def test_profile_serialize():
     expected_json = {
         "settings": {"arch": "x86_64", "compiler": "Visual Studio", "compiler.version": "12"},
         "package_settings": {"MyPackage": {"os": "Windows"}}, "options": {},
+        'platform_requires': [], 'platform_tool_requires': [], 'replace_requires': {},
+        'replace_tool_requires': {},
         "tool_requires": {"*": ["'zlib/1.2.8'"]}, "conf": {"user.myfield:value": "MyVal"},
         "build_env": "VAR1=1\nVAR2=2\n"}
     assert expected_json == profile.serialize()


### PR DESCRIPTION
Changelog: Fix: Add missing `[replace_requires]` and `[platform_requires]` to serialization/dump of profiles.
Docs: Omit
