### PR TITLE
fix back migration of default compatibility.py

### DIFF
--- a/conans/client/migrations.py
+++ b/conans/client/migrations.py
@@ -56,6 +56,22 @@ class ClientMigrator(Migrator):
         if old_version and old_version < "2.0.14-":
             _migrate_pkg_db_lru(self.cache_folder, old_version)
 
+        if old_version and old_version < "2.4":
+            _migrate_default_compatibility(self.cache_folder)
+
+
+def _migrate_default_compatibility(cache_folder):
+    # just the back migration
+    undo = textwrap.dedent("""\
+        import os
+
+        def migrate(home_folder):
+            from conans.client.graph.compatibility import migrate_compatibility_files
+            migrate_compatibility_files(home_folder)
+        """)
+    path = os.path.join(cache_folder, "migrations", "2.4_1-migrate.py")
+    save(path, undo)
+
 
 def _migrate_pkg_db_lru(cache_folder, old_version):
     config = ConfigAPI.load_config(cache_folder)


### PR DESCRIPTION
Changelog: Fix: Implement a back migration to <2.3 for default ``compatibility.py`` plugin.
Docs: Omit