### PR TITLE
allow empty_folders in packages

### DIFF
--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -306,12 +306,15 @@ def gather_files(folder):
     file_dict = {}
     symlinked_folders = {}
     for root, dirs, files in os.walk(folder):
+        if root != folder and not dirs and not files:  # empty folder
+            rel_path = root[len(folder) + 1:].replace("\\", "/")
+            symlinked_folders[rel_path] = root
+            continue
         for d in dirs:
             abs_path = os.path.join(root, d)
             if os.path.islink(abs_path):
                 rel_path = abs_path[len(folder) + 1:].replace("\\", "/")
                 symlinked_folders[rel_path] = abs_path
-                continue
         for f in files:
             if f == ".DS_Store":
                 continue


### PR DESCRIPTION
Changelog: Fix: Allow packages to have empty folders.
Docs: Omit

I haven't found a good place in the docs to describe this behavior, it is a ``Fix``, I think it doesn't need docs because it implements the expected behavior.

Close https://github.com/conan-io/conan/issues/16378