### PR TITLE
qbs: fix install

### DIFF
--- a/conan/tools/qbs/qbs.py
+++ b/conan/tools/qbs/qbs.py
@@ -73,7 +73,7 @@ class Qbs(object):
 
     def install(self):
         args = self._get_common_arguments()
-        args.append('--no-build')
+        args.extend(['--no-build', '--install-root', self._conanfile.package_folder])
 
         for name in self._configuration:
             args.append('config:%s' % name)


### PR DESCRIPTION
In the previous PR, the --install-root was accidentally removed. Bring it back now.

Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
