### PR TITLE
Qbs: Add test for multiple configurations

### DIFF
--- a/conan/tools/qbs/qbs.py
+++ b/conan/tools/qbs/qbs.py
@@ -73,7 +73,7 @@ class Qbs(object):
 
     def install(self):
         args = self._get_common_arguments()
-        args.append('--no-build')
+        args.extend(['--no-build', '--install-root', self._conanfile.package_folder])
 
         for name in self._configuration:
             args.append('config:%s' % name)

--- a/test/functional/toolchains/qbs/test_qbs.py
+++ b/test/functional/toolchains/qbs/test_qbs.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import textwrap
 
@@ -100,3 +101,46 @@ def test_qbs_specific_products():
 
     client.run("create .")
     assert "--products hello,hello" in client.out
+
+
+@pytest.mark.tool("qbs")
+def test_qbs_multiple_configurations():
+    client = TestClient()
+
+    context = {
+        "name": "hello",
+        "version": "2.0",
+        "package_name": "hello"
+    }
+
+    conanfile = textwrap.dedent('''
+    import os
+
+    from conan import ConanFile
+    from conan.tools.qbs import Qbs
+
+    class Recipe(ConanFile):
+        name = "hello"
+        version = "1.0"
+
+        exports_sources = "*.cpp", "*.h", "*.qbs"
+        settings = "os", "compiler", "arch", "build_type"
+
+        def build(self):
+            qbs = Qbs(self)
+            qbs.add_configuration("release", {"qbs.debugInformation": False})
+            qbs.add_configuration("debug", {"qbs.debugInformation": True})
+            qbs.build()
+        ''')
+
+    client.save({
+        "conanfile.py": conanfile,
+        "hello.cpp": gen_file(source_cpp, **context),
+        "hello.h": gen_file(source_h, **context),
+        "hello.qbs": gen_file(qbs_lib_file, **context),
+    }, clean_first=True)
+
+    client.run("create .")
+    build_folder = client.created_layout().build()
+    assert os.path.exists(os.path.join(build_folder, "release"))
+    assert os.path.exists(os.path.join(build_folder, "debug"))

--- a/test/functional/toolchains/qbs/test_qbs.py
+++ b/test/functional/toolchains/qbs/test_qbs.py
@@ -124,7 +124,7 @@ def test_qbs_multiple_configurations():
         version = "1.0"
 
         exports_sources = "*.cpp", "*.h", "*.qbs"
-        settings = "os", "compiler", "arch", "build_type"
+        settings = "os", "compiler", "arch"
 
         def build(self):
             qbs = Qbs(self)


### PR DESCRIPTION
Changelog: Omit
Docs: Omit


With Qbs, it is possible to build the project in multiple passes for different set of properties. While it is not very useful when creating Conan packages, since Conan only support one configuration, we expose this feature in API and it's good to be able to test it.

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
