### PR TITLE
#16427. Make MSBuildDeps generation with deployer relocatable

### DIFF
--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -8,9 +8,9 @@ from jinja2 import Template
 
 from conan.internal import check_duplicated_generator
 from conan.errors import ConanException
+from conans.client.generators import relativize_path
 from conans.model.dependencies import get_transitive_requires
 from conans.util.files import load, save
-from conans.client.generators import relativize_path
 
 VALID_LIB_EXTENSIONS = (".so", ".lib", ".a", ".dylib", ".bc")
 

--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -10,6 +10,7 @@ from conan.internal import check_duplicated_generator
 from conan.errors import ConanException
 from conans.model.dependencies import get_transitive_requires
 from conans.util.files import load, save
+from conans.client.generators import relativize_path
 
 VALID_LIB_EXTENSIONS = (".so", ".lib", ".a", ".dylib", ".bc")
 
@@ -178,6 +179,9 @@ class MSBuildDeps(object):
 
         root_folder = dep.recipe_folder if dep.package_folder is None else dep.package_folder
         root_folder = escape_path(root_folder)
+        # Make the root_folder relative to the generated conan_vars_xxx.props file
+        relative_root_folder = relativize_path(root_folder, self._conanfile,
+                                               "$(MSBuildThisFileDirectory)")
 
         bin_dirs = join_paths(cpp_info.bindirs)
         res_dirs = join_paths(cpp_info.resdirs)
@@ -205,7 +209,7 @@ class MSBuildDeps(object):
 
         fields = {
             'name': name,
-            'root_folder': root_folder,
+            'root_folder': relative_root_folder,
             'bin_dirs': bin_dirs,
             'res_dirs': res_dirs,
             'include_dirs': include_dirs,

--- a/test/integration/toolchains/microsoft/test_msbuilddeps.py
+++ b/test/integration/toolchains/microsoft/test_msbuilddeps.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import platform
 import textwrap
@@ -122,3 +123,52 @@ class TestMSBuildDepsSkips:
         assert "conan_liba" not in libb
         libb = c.load("app/conan_libb_mycomp_vars_release_x64.props")
         assert "conan_liba" not in libb
+
+
+def test_msbuilddeps_relocatable():
+    for withdepl in [False, True]:
+        c = TestClient()
+        c.save({
+            "libh/conanfile.py": GenConanfile("libh", "0.1")
+                .with_package_type("header-library"),
+            "libs/conanfile.py": GenConanfile("libs", "0.2")
+                .with_package_type("static-library")
+                .with_requires("libh/0.1"),
+            "libd/conanfile.py": GenConanfile("libd", "0.3")
+                .with_package_type("shared-library"),
+            "app/conanfile.py": GenConanfile()
+                .with_requires("libh/0.1")
+                .with_requires("libs/0.2")
+                .with_requires("libd/0.3")
+                .with_settings("arch", "build_type"),
+        })
+
+        c.run("create libh")
+        c.run("create libs")
+        c.run("create libd")
+        c.run("install app -g MSBuildDeps" + (" -d full_deploy" if withdepl else ""))
+
+        for dep in ["libh", "libs", "libd"]:
+            text = c.load(f"app/conan_{dep}_vars_release_x64.props")
+            marker = f"Conan{dep}RootFolder"
+            value = text.split(f"<{marker}>")[1].split(f"</{marker}>")[0]
+            if withdepl:
+                # path should be relative, since artifacts are moved along with project
+                prefix = '$(MSBuildThisFileDirectory)/'
+                assert value.startswith(prefix)
+                tail = value[len(prefix):]
+                assert not os.path.isabs(tail)
+            else:
+                # path should be absolute, since conan cache does not move with project
+                assert os.path.isabs(value)
+                assert '$(' not in value
+
+        if withdepl:
+            # extra checks: no absolute paths allowed anywhere in props
+            propsfiles = glob.glob(os.path.join(c.current_folder, "app/*.props"))
+            assert len(propsfiles) > 0
+            for fn in propsfiles:
+                text = c.load(fn)
+                text = text.replace('\\', '/')
+                dir = c.current_folder.replace('\\', '/')
+                assert dir not in text

--- a/test/integration/toolchains/microsoft/test_msbuilddeps.py
+++ b/test/integration/toolchains/microsoft/test_msbuilddeps.py
@@ -125,50 +125,51 @@ class TestMSBuildDepsSkips:
         assert "conan_liba" not in libb
 
 
-def test_msbuilddeps_relocatable():
-    for withdepl in [False, True]:
-        c = TestClient()
-        c.save({
-            "libh/conanfile.py": GenConanfile("libh", "0.1")
-                .with_package_type("header-library"),
-            "libs/conanfile.py": GenConanfile("libs", "0.2")
-                .with_package_type("static-library")
-                .with_requires("libh/0.1"),
-            "libd/conanfile.py": GenConanfile("libd", "0.3")
-                .with_package_type("shared-library"),
-            "app/conanfile.py": GenConanfile()
-                .with_requires("libh/0.1")
-                .with_requires("libs/0.2")
-                .with_requires("libd/0.3")
-                .with_settings("arch", "build_type"),
-        })
+@pytest.mark.skipif(platform.system() != "Windows", reason="MSBuildDeps broken with POSIX paths")
+@pytest.mark.parametrize("withdepl", [False, True])
+def test_msbuilddeps_relocatable(withdepl):
+    c = TestClient()
+    c.save({
+        "libh/conanfile.py": GenConanfile("libh", "0.1")
+            .with_package_type("header-library"),
+        "libs/conanfile.py": GenConanfile("libs", "0.2")
+            .with_package_type("static-library")
+            .with_requires("libh/0.1"),
+        "libd/conanfile.py": GenConanfile("libd", "0.3")
+            .with_package_type("shared-library"),
+        "app/conanfile.py": GenConanfile()
+            .with_requires("libh/0.1")
+            .with_requires("libs/0.2")
+            .with_requires("libd/0.3")
+            .with_settings("arch", "build_type"),
+    })
 
-        c.run("create libh")
-        c.run("create libs")
-        c.run("create libd")
-        c.run("install app -g MSBuildDeps" + (" -d full_deploy" if withdepl else ""))
+    c.run("create libh")
+    c.run("create libs")
+    c.run("create libd")
+    c.run("install app -g MSBuildDeps" + (" -d full_deploy" if withdepl else ""))
 
-        for dep in ["libh", "libs", "libd"]:
-            text = c.load(f"app/conan_{dep}_vars_release_x64.props")
-            marker = f"Conan{dep}RootFolder"
-            value = text.split(f"<{marker}>")[1].split(f"</{marker}>")[0]
-            if withdepl:
-                # path should be relative, since artifacts are moved along with project
-                prefix = '$(MSBuildThisFileDirectory)/'
-                assert value.startswith(prefix)
-                tail = value[len(prefix):]
-                assert not os.path.isabs(tail)
-            else:
-                # path should be absolute, since conan cache does not move with project
-                assert os.path.isabs(value)
-                assert '$(' not in value
-
+    for dep in ["libh", "libs", "libd"]:
+        text = c.load(f"app/conan_{dep}_vars_release_x64.props")
+        marker = f"Conan{dep}RootFolder"
+        value = text.split(f"<{marker}>")[1].split(f"</{marker}>")[0]
         if withdepl:
-            # extra checks: no absolute paths allowed anywhere in props
-            propsfiles = glob.glob(os.path.join(c.current_folder, "app/*.props"))
-            assert len(propsfiles) > 0
-            for fn in propsfiles:
-                text = c.load(fn)
-                text = text.replace('\\', '/')
-                dir = c.current_folder.replace('\\', '/')
-                assert dir not in text
+            # path should be relative, since artifacts are moved along with project
+            prefix = '$(MSBuildThisFileDirectory)/'
+            assert value.startswith(prefix)
+            tail = value[len(prefix):]
+            assert not os.path.isabs(tail)
+        else:
+            # path should be absolute, since conan cache does not move with project
+            assert os.path.isabs(value)
+            assert '$(' not in value
+
+    if withdepl:
+        # extra checks: no absolute paths allowed anywhere in props
+        propsfiles = glob.glob(os.path.join(c.current_folder, "app/*.props"))
+        assert len(propsfiles) > 0
+        for fn in propsfiles:
+            text = c.load(fn)
+            text = text.replace('\\', '/')
+            dir = c.current_folder.replace('\\', '/')
+            assert dir not in text


### PR DESCRIPTION
Changelog: Feature: Make ``MSBuildDeps`` generation with deployer relocatable.
Docs: Omit

Close https://github.com/conan-io/conan/issues/16427

- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.

I have copied the relativize_path logic from CMakeDeps, I can't say I fully understand its implementation though.

As far as I understand, paths should be relativized when deployer is present but kept absolute if package is in conan cache. I have not found in the code where this decision happens, but I have tested locally that paths are relative with deployer but absolute without it (even though everything is on the same disk letter).

Please advise where to add test if it is necessary. As far as I see, there are two tests which check that output with deployer is relocatable (`tests/functional/command/test_install_deploy.py`). If I should make a similar test for MSBuildDeps, where should I put it?
