### PR TITLE
Qbs: add explicit resolve method

### DIFF
--- a/conan/internal/api/new/qbs_lib.py
+++ b/conan/internal/api/new/qbs_lib.py
@@ -21,6 +21,7 @@ class {{package_name}}Recipe(ConanFile):
         qbs = Qbs(self)
         qbs_config = {"products.{{name}}.isShared": "true" if self.options.shared else "false"}
         qbs.add_configuration("default", qbs_config)
+        qbs.resolve()
         qbs.build()
 
     def package(self):
@@ -67,6 +68,7 @@ class {{package_name}}TestConan(ConanFile):
 
     def build(self):
         qbs = Qbs(self)
+        qbs.resolve()
         qbs.build()
         qbs.install()
 

--- a/conan/tools/qbs/qbs.py
+++ b/conan/tools/qbs/qbs.py
@@ -25,7 +25,6 @@ class Qbs(object):
         self._set_project_file(project_file)
         self.jobs = build_jobs(conanfile)
         self._configuration = dict()
-        self._resolved = False
 
     def _set_project_file(self, project_file):
         if not project_file:
@@ -63,12 +62,7 @@ class Qbs(object):
         cmd = 'qbs resolve %s' % cmd_args_to_string(args)
         self._conanfile.run(cmd)
 
-        self._resolved = True
-
     def _build(self, products, all_products):
-        # for backward compatibility when there was only build()
-        if not self._resolved:
-            self.resolve()
 
         args = self._get_common_arguments()
         args.append('--no-install')

--- a/test/functional/toolchains/qbs/test_qbs.py
+++ b/test/functional/toolchains/qbs/test_qbs.py
@@ -50,6 +50,7 @@ def test_qbs_all_products():
 
         def build(self):
             qbs = Qbs(self)
+            qbs.resolve()
             qbs.build_all()
         ''')
 
@@ -89,6 +90,7 @@ def test_qbs_specific_products():
 
         def build(self):
             qbs = Qbs(self)
+            qbs.resolve()
             qbs.build(products=["hello", "hello"])
         ''')
 
@@ -130,6 +132,7 @@ def test_qbs_multiple_configurations():
             qbs = Qbs(self)
             qbs.add_configuration("release", {"qbs.debugInformation": False})
             qbs.add_configuration("debug", {"qbs.debugInformation": True})
+            qbs.resolve()
             qbs.build()
         ''')
 


### PR DESCRIPTION
Changelog: Feature: Added `resolve()` method to the Qbs toolchain.
Docs: Omit


Most tools have a separate configuration step and Qbs is no different. It's strange that the API doesn't provide a separate method for this. Add it now so that users can understand better what went wrong during which stage.


- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
