### PR TITLE
Remove find_package generation on test_package of cmake_lib template

### DIFF
--- a/conan/internal/api/new/cmake_lib.py
+++ b/conan/internal/api/new/cmake_lib.py
@@ -32,7 +32,18 @@ class {{package_name}}Recipe(ConanFile):
 
     def layout(self):
         cmake_layout(self)
-
+    {% if requires is defined %}
+    def requirements(self):
+        {% for require in requires -%}
+        self.requires("{{ require }}")
+        {% endfor %}
+    {%- endif %}
+    {%- if tool_requires is defined %}
+    def build_requirements(self):
+        {% for require in tool_requires -%}
+        self.tool_requires("{{ require }}")
+        {% endfor %}
+    {%- endif %}
     def generate(self):
         deps = CMakeDeps(self)
         deps.generate()
@@ -50,20 +61,6 @@ class {{package_name}}Recipe(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = ["{{name}}"]
-
-    {% if requires is defined -%}
-    def requirements(self):
-        {% for require in requires -%}
-        self.requires("{{ require }}")
-        {% endfor %}
-    {%- endif %}
-
-    {% if tool_requires is defined -%}
-    def build_requirements(self):
-        {% for require in tool_requires -%}
-        self.tool_requires("{{ require }}")
-        {% endfor %}
-    {%- endif %}
 
 '''
 
@@ -269,12 +266,6 @@ test_cmake_v2 = """cmake_minimum_required(VERSION 3.15)
 project(PackageTest CXX)
 
 find_package({{name}} CONFIG REQUIRED)
-
-{% if requires is defined -%}
-{% for require in requires -%}
-find_package({{as_name(require)}} CONFIG REQUIRED)
-{% endfor %}
-{%- endif %}
 
 add_executable(example src/example.cpp)
 target_link_libraries(example {{name}}::{{name}})

--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -2,4 +2,4 @@ CHECKSUM_DEPLOY = "checksum_deploy"  # Only when v2
 REVISIONS = "revisions"  # Only when enabled in config, not by default look at server_launcher.py
 OAUTH_TOKEN = "oauth_token"
 
-__version__ = '2.4.0'
+__version__ = '2.4.1'


### PR DESCRIPTION
Changelog: Fix: Avoid `find_package`'s of transitive dependencies on `test_package` generated by `cmake_lib` template.
Docs: omit

Close #16450 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.

On test_package/CMakeLists.txt should not appear any find_package of transitive dependencies (dependencies of the currently tested package) Delegate on conan cmake generators to find dependencies.

Also, ordered optional requirements and build_requirement methods on template
