### PR TITLE
toolchain_file CMakeToolchain paths for deps

### DIFF
--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -55,8 +55,7 @@ class _CMakePresets:
                 cache_variables["BUILD_TESTING"] = "OFF"
 
         # In case user is injecting its own toolchain file, still need to locate generated CMakeDeps
-        toolchain_file = conanfile.conf.get("tools.cmake.cmaketoolchain:toolchain_file")
-        if toolchain_file:
+        if conanfile.conf.get("tools.cmake.cmaketoolchain:toolchain_file"):
             build_paths = [conanfile.generators_folder]
             for req in conanfile.dependencies.values():
                 cppinfo = req.cpp_info.aggregated_components()

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -54,6 +54,17 @@ class _CMakePresets:
             if conanfile.conf.get("tools.build:skip_test", check_type=bool):
                 cache_variables["BUILD_TESTING"] = "OFF"
 
+        # In case user is injecting its own toolchain file, still need to locate generated CMakeDeps
+        toolchain_file = conanfile.conf.get("tools.cmake.cmaketoolchain:toolchain_file")
+        if toolchain_file:
+            build_paths = [conanfile.generators_folder]
+            for req in conanfile.dependencies.values():
+                cppinfo = req.cpp_info.aggregated_components()
+                build_paths.extend(cppinfo.builddirs)
+            build_paths = ";".join(p.replace("\\", "/") for p in build_paths)
+            cache_variables["CMAKE_MODULE_PATH"] = build_paths
+            cache_variables["CMAKE_PREFIX_PATH"] = build_paths
+
         preset_path = os.path.join(conanfile.generators_folder, "CMakePresets.json")
         multiconfig = is_multi_configuration(generator)
         if os.path.exists(preset_path):


### PR DESCRIPTION
Changelog: Feature: Inject paths in CMake for ``tools.cmake.cmakettolchain:toolchain_file`` definition
Docs: https://github.com/conan-io/docs/pull/XXXX

Close https://github.com/conan-io/conan/issues/16376

I am not convinced of this approach, it seems it won't scale, there might be more and more things necessary. I think that going with the ``tools.cmake.cmaketoolchain:user_toolchain`` approach with maybe more control over the generated ``conan_toolchain.cmake`` file would be better.
