### PR TITLE
Qbs: pass provider args if QbsDeps was run

### DIFF
--- a/conan/tools/qbs/qbs.py
+++ b/conan/tools/qbs/qbs.py
@@ -55,6 +55,9 @@ class Qbs(object):
         if self.profile:
             args.append('profile:%s' % self.profile)
 
+        if os.path.exists(os.path.join(self._conanfile.source_folder, 'conan-qbs-deps')):
+            args.append('moduleProviders.conan.installDirectory:' + self._conanfile.source_folder)
+
         for name in self._configuration:
             config = self._configuration[name]
             args.extend(_configuration_dict_to_commandlist(name, config))

--- a/conan/tools/qbs/qbs.py
+++ b/conan/tools/qbs/qbs.py
@@ -55,8 +55,9 @@ class Qbs(object):
         if self.profile:
             args.append('profile:%s' % self.profile)
 
-        if os.path.exists(os.path.join(self._conanfile.source_folder, 'conan-qbs-deps')):
-            args.append('moduleProviders.conan.installDirectory:' + self._conanfile.source_folder)
+        generators_folder = self._conanfile.generators_folder
+        if os.path.exists(os.path.join(generators_folder, 'conan-qbs-deps')):
+            args.append('moduleProviders.conan.installDirectory:' + generators_folder)
 
         for name in self._configuration:
             config = self._configuration[name]

--- a/test/functional/toolchains/qbs/test_qbsdeps.py
+++ b/test/functional/toolchains/qbs/test_qbsdeps.py
@@ -111,6 +111,7 @@ def test_qbsdeps_with_qbs_toolchain():
             exports_sources = "*.cpp", "*.h", "*.qbs"
             settings = "os", "compiler", "build_type", "arch"
             generators = "QbsDeps"
+            generators_folder = "generators"
 
             def requirements(self):
                 self.requires("hello/1.0")

--- a/test/functional/toolchains/qbs/test_qbsdeps.py
+++ b/test/functional/toolchains/qbs/test_qbsdeps.py
@@ -111,10 +111,12 @@ def test_qbsdeps_with_qbs_toolchain():
             exports_sources = "*.cpp", "*.h", "*.qbs"
             settings = "os", "compiler", "build_type", "arch"
             generators = "QbsDeps"
-            generators_folder = "generators"
 
             def requirements(self):
                 self.requires("hello/1.0")
+
+            def layout(self):
+                self.folders.generators = "generators"
 
             def build(self):
                 qbs = Qbs(self)


### PR DESCRIPTION
Changelog: Feature: Qbs helper now invokes Conan provider automatically.
Docs: Omit



Now Qbs helper passes required arguments for the "conan" provider to qbs if QbsDeps was run.

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
