### PR TITLE
Fix `conan list ... --format=compact` for package revisions

### DIFF
--- a/conan/cli/commands/list.py
+++ b/conan/cli/commands/list.py
@@ -184,8 +184,9 @@ def prepare_pkglist_compact(pkglist):
             pkg_common_options = compute_common_options(prefs)
             pkg_common_options = pkg_common_options if len(pkg_common_options) > 4 else None
             for pref, pref_contents in prefs.items():
-                pref_info = pref_contents.pop("info")
-                pref_contents.update(compact_format_info(pref_info, pkg_common_options))
+                pref_info = pref_contents.pop("info", None)
+                if pref_info is not None:
+                    pref_contents.update(compact_format_info(pref_info, pkg_common_options))
                 diff_info = pref_contents.pop("diff", None)
                 if diff_info is not None:
                     pref_contents["diff"] = compact_diff(diff_info)

--- a/test/integration/command_v2/list_test.py
+++ b/test/integration/command_v2/list_test.py
@@ -812,6 +812,24 @@ class TestListCompact:
 
         assert expected == expected_output
 
+    @pytest.mark.parametrize("pattern", [
+        "pkg/*",
+        "pkg/1.0",
+        "pkg/1.0#*",
+        "pkg/1.0#*:*",
+        "pkg/1.0#*:*#*",
+        "pkg/1.0#a69a86bbd19ae2ef7eedc64ae645c531:*",
+        "pkg/1.0#a69a86bbd19ae2ef7eedc64ae645c531:*",
+        "pkg/1.0#a69a86bbd19ae2ef7eedc64ae645c531:*#*",
+        "pkg/1.0#a69a86bbd19ae2ef7eedc64ae645c531:da39a3ee5e6b4b0d3255bfef95601890afd80709#*",
+        "pkg/1.0#a69a86bbd19ae2ef7eedc64ae645c531:da39a3ee5e6b4b0d3255bfef95601890afd80709#0ba8627bd47edc3a501e8f0eb9a79e5e"
+    ])
+    def test_list_compact_patterns(self, pattern):
+        c = TestClient(light=True)
+        c.save({"pkg/conanfile.py": GenConanfile("pkg", "1.0")})
+        c.run("create pkg")
+        c.run(f"list {pattern} --format=compact")
+
 
 class TestListBinaryFilter:
 


### PR DESCRIPTION
Changelog: Bugfix: Fix `conan list ... --format=compact` for package revisions.
Docs: Omit

I might have gone a bit overboard with the test parametrization, the improtant few are the last ones, but they don't hurt either

Checking the code, I actually can't see where a package revision would get the `info` key, but I've left it instead of removing it in case I'm not finding it in some other part of the codebase
