### PR TITLE
[AutotoolsToolchain] Honoring `tools.android:ndk_path` conf

### DIFF
--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -116,22 +116,34 @@ class AutotoolsToolchain:
                                                " when tools.android:ndk_path is defined too.")
             arch = self._conanfile.settings.get_safe("arch")
             os_build = self._conanfile.settings_build.get_safe("os")
+            ndk_os_folder = {
+                'Macos': 'darwin',
+                'iOS': 'darwin',
+                'watchOS': 'darwin',
+                'tvOS': 'darwin',
+                'visionOS': 'darwin',
+                'FreeBSD': 'linux',
+                'Linux': 'linux',
+                'Windows': 'windows',
+                'WindowsCE': 'windows',
+                'WindowsStore': 'windows'
+            }.get(os_build, "linux")
             ndk_bin = os.path.join(ndk_path, "toolchains", "llvm", "prebuilt",
-                                   "{}-x86_64".format(os_build), "bin")
+                                   f"{ndk_os_folder}-x86_64", "bin")
             android_api_level = self._conanfile.settings.get_safe("os.api_level")
             android_target = {'armv7': 'armv7a-linux-androideabi',
                               'armv8': 'aarch64-linux-android',
                               'x86': 'i686-linux-android',
                               'x86_64': 'x86_64-linux-android'}.get(arch)
             os_build = self._conanfile.settings_build.get_safe('os')
-            compiler_extension = ".cmd" if os_build == "Windows" else ""
+            ext = ".cmd" if os_build == "Windows" else ""
             ret = {
-                "CC": os.path.join(ndk_bin, f"{android_target}{android_api_level}-clang{compiler_extension}"),
-                "CXX": os.path.join(ndk_bin, f"{android_target}{android_api_level}-clang++{compiler_extension}"),
+                "CC": os.path.join(ndk_bin, f"{android_target}{android_api_level}-clang{ext}"),
+                "CXX": os.path.join(ndk_bin, f"{android_target}{android_api_level}-clang++{ext}"),
                 "LD": os.path.join(ndk_bin, "ld"),
                 "STRIP": os.path.join(ndk_bin, "llvm-strip"),
                 "RANLIB": os.path.join(ndk_bin, "llvm-ranlib"),
-                "AS": os.path.join(ndk_bin, f"{android_target}{android_api_level}-clang{compiler_extension}"),
+                "AS": os.path.join(ndk_bin, f"{android_target}{android_api_level}-clang{ext}"),
                 "AR": os.path.join(ndk_bin, "llvm-ar"),
                 "host": android_target
             }

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -1,3 +1,5 @@
+import os
+
 from conan.errors import ConanException
 from conan.internal import check_duplicated_generator
 from conan.internal.internal_tools import raise_on_universal_arch
@@ -60,18 +62,24 @@ class AutotoolsToolchain:
         self._build = self._conanfile.conf.get("tools.gnu:build_triplet")
         self._target = None
 
+        self.android_cross_flags = {}
         self._is_cross_building = cross_building(self._conanfile)
         if self._is_cross_building:
-            os_host = conanfile.settings.get_safe("os")
-            arch_host = conanfile.settings.get_safe("arch")
-            os_build = conanfile.settings_build.get_safe('os')
-            arch_build = conanfile.settings_build.get_safe('arch')
-
             compiler = self._conanfile.settings.get_safe("compiler")
-            if not self._host:
+            # If cross-building and tools.android:ndk_path is defined, let's try to guess the Android
+            # cross-building flags
+            self.android_cross_flags = self._resolve_android_cross_compilation()
+            # Host triplet
+            if self.android_cross_flags:
+                self._host = self.android_cross_flags.pop("host")
+            elif not self._host:
+                os_host = conanfile.settings.get_safe("os")
+                arch_host = conanfile.settings.get_safe("arch")
                 self._host = _get_gnu_triplet(os_host, arch_host, compiler=compiler)["triplet"]
             # Build triplet
             if not self._build:
+                os_build = conanfile.settings_build.get_safe('os')
+                arch_build = conanfile.settings_build.get_safe('arch')
                 self._build = _get_gnu_triplet(os_build, arch_build, compiler=compiler)["triplet"]
 
         sysroot = self._conanfile.conf.get("tools.build:sysroot")
@@ -95,6 +103,39 @@ class AutotoolsToolchain:
         # -isysroot makes all includes for your library relative to the build directory
         self.apple_isysroot_flag = isysroot_flag
         self.apple_min_version_flag = min_flag
+
+    def _resolve_android_cross_compilation(self):
+        # Issue related: https://github.com/conan-io/conan/issues/13443
+        ret = {}
+        if not self._is_cross_building or not self._conanfile.settings.get_safe("os") == "Android":
+            return ret
+        ndk_path = self._conanfile.conf.get("tools.android:ndk_path", check_type=str)
+        if ndk_path:
+            if self._conanfile.conf.get("tools.build:compiler_executables"):
+                self._conanfile.output.warning("tools.build:compiler_executables conf has no effect"
+                                               " when tools.android:ndk_path is defined too.")
+            arch = self._conanfile.settings.get_safe("arch")
+            os_build = self._conanfile.settings_build.get_safe("os")
+            ndk_bin = os.path.join(ndk_path, "toolchains", "llvm", "prebuilt",
+                                   "{}-x86_64".format(os_build), "bin")
+            android_api_level = self._conanfile.settings.get_safe("os.api_level")
+            android_target = {'armv7': 'armv7a-linux-androideabi',
+                              'armv8': 'aarch64-linux-android',
+                              'x86': 'i686-linux-android',
+                              'x86_64': 'x86_64-linux-android'}.get(arch)
+            os_build = self._conanfile.settings_build.get_safe('os')
+            compiler_extension = ".cmd" if os_build == "Windows" else ""
+            ret = {
+                "CC": os.path.join(ndk_bin, f"{android_target}{android_api_level}-clang{compiler_extension}"),
+                "CXX": os.path.join(ndk_bin, f"{android_target}{android_api_level}-clang++{compiler_extension}"),
+                "LD": os.path.join(ndk_bin, "ld"),
+                "STRIP": os.path.join(ndk_bin, "llvm-strip"),
+                "RANLIB": os.path.join(ndk_bin, "llvm-ranlib"),
+                "AS": os.path.join(ndk_bin, f"{android_target}{android_api_level}-clang{compiler_extension}"),
+                "AR": os.path.join(ndk_bin, "llvm-ar"),
+                "host": android_target
+            }
+        return ret
 
     def _get_msvc_runtime_flag(self):
         flag = msvc_runtime_flag(self._conanfile)
@@ -159,17 +200,26 @@ class AutotoolsToolchain:
 
     def environment(self):
         env = Environment()
-        compilers_by_conf = self._conanfile.conf.get("tools.build:compiler_executables", default={},
-                                                     check_type=dict)
-        if compilers_by_conf:
-            compilers_mapping = {"c": "CC", "cpp": "CXX", "cuda": "NVCC", "fortran": "FC",
-                                 "rc": "RC"}
-            for comp, env_var in compilers_mapping.items():
-                if comp in compilers_by_conf:
-                    compiler = compilers_by_conf[comp]
-                    # https://github.com/conan-io/conan/issues/13780
-                    compiler = unix_path(self._conanfile, compiler)
-                    env.define(env_var, compiler)
+        # Setting Android cross-compilation flags (if exist)
+        if self.android_cross_flags:
+            for env_var, value in self.android_cross_flags.items():
+                compiler = unix_path(self._conanfile, value)
+                env.define(env_var, compiler)
+        else:
+            # Setting user custom compiler executables flags
+            compilers_by_conf = self._conanfile.conf.get("tools.build:compiler_executables",
+                                                         default={},
+                                                         check_type=dict)
+            if compilers_by_conf:
+                compilers_mapping = {"c": "CC", "cpp": "CXX", "cuda": "NVCC", "fortran": "FC",
+                                     "rc": "RC"}
+                for comp, env_var in compilers_mapping.items():
+                    if comp in compilers_by_conf:
+                        compiler = compilers_by_conf[comp]
+                        # https://github.com/conan-io/conan/issues/13780
+                        compiler = unix_path(self._conanfile, compiler)
+                        env.define(env_var, compiler)
+
         env.append("CPPFLAGS", ["-D{}".format(d) for d in self.defines])
         env.append("CXXFLAGS", self.cxxflags)
         env.append("CFLAGS", self.cflags)

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -214,9 +214,9 @@ class AutotoolsToolchain:
         env = Environment()
         # Setting Android cross-compilation flags (if exist)
         if self.android_cross_flags:
-            for env_var, value in self.android_cross_flags.items():
-                compiler = unix_path(self._conanfile, value)
-                env.define(env_var, compiler)
+            for env_var, env_value in self.android_cross_flags.items():
+                unix_env_value = unix_path(self._conanfile, env_value)
+                env.define(env_var, unix_env_value)
         else:
             # Setting user custom compiler executables flags
             compilers_by_conf = self._conanfile.conf.get("tools.build:compiler_executables",

--- a/test/functional/toolchains/gnu/autotools/test_android.py
+++ b/test/functional/toolchains/gnu/autotools/test_android.py
@@ -1,0 +1,45 @@
+import os
+import platform
+import textwrap
+
+import pytest
+
+from conan.test.assets.sources import gen_function_cpp, gen_function_h
+from conan.test.utils.tools import TestClient
+from test.conftest import tools_locations
+
+
+@pytest.mark.parametrize("arch, expected_arch", [('armv8', 'aarch64'),
+                                                 ('armv7', 'arm'),
+                                                 ('x86', 'i386'),
+                                                 ('x86_64', 'x86_64')
+                                                 ])
+@pytest.mark.tool("android_ndk")
+@pytest.mark.tool("autotools")
+@pytest.mark.skipif(platform.system() != "Darwin", reason="Android NDK only tested in MacOS for now")
+def test_android_meson_toolchain_cross_compiling(arch, expected_arch):
+    profile_host = textwrap.dedent("""
+    include(default)
+
+    [settings]
+    os = Android
+    os.api_level = 21
+    arch = {arch}
+
+    [conf]
+    tools.android:ndk_path={ndk_path}
+    """)
+    ndk_path = tools_locations["android_ndk"]["system"]["path"][platform.system()]
+    profile_host = profile_host.format(
+        arch=arch,
+        ndk_path=ndk_path
+    )
+
+    client = TestClient(path_with_spaces=False)
+    client.run("new autotools_lib -d name=hello -d version=1.0")
+    client.save({"profile_host": profile_host})
+    client.run("build . --profile:build=default --profile:host=profile_host")
+    libhello = os.path.join("build-release", "src", ".libs", "libhello.a")
+    # Check binaries architecture
+    client.run_command('objdump -f "%s"' % libhello)
+    assert "architecture: %s" % expected_arch in client.out

--- a/test/functional/toolchains/gnu/autotools/test_android.py
+++ b/test/functional/toolchains/gnu/autotools/test_android.py
@@ -16,7 +16,7 @@ from test.conftest import tools_locations
                                                  ])
 @pytest.mark.tool("android_ndk")
 @pytest.mark.tool("autotools")
-@pytest.mark.skipif(platform.system() != "Darwin", reason="Android NDK only tested in MacOS for now")
+@pytest.mark.skipif(platform.system() != "Darwin", reason="NDK only installed on MAC")
 def test_android_meson_toolchain_cross_compiling(arch, expected_arch):
     profile_host = textwrap.dedent("""
     include(default)


### PR DESCRIPTION
Changelog: Feature: Honoring `tools.android:ndk_path` conf. Setting the needed flags to cross-build for Android.
Docs: https://github.com/conan-io/docs/pull/3787
Closes: https://github.com/conan-io/conan/issues/13443
Closes: https://github.com/conan-io/conan/issues/16493
