### PR TITLE
new lock update subcommand

### DIFF
--- a/conan/api/subapi/lockfile.py
+++ b/conan/api/subapi/lockfile.py
@@ -64,11 +64,13 @@ class LockfileAPI:
         else:
             python_requires = []
         python_requires = python_requires + ([ref] if is_python_require else [])
-        lockfile = self.add_lockfile(lockfile,
+        new_lock = self.add_lockfile(lockfile,
                                      requires=[ref] if is_require else None,
                                      python_requires=python_requires,
                                      build_requires=[ref] if is_build_require else None)
-        return lockfile
+        if lockfile is None:  # If there was no lockfile, it is a partial one to lock export
+            new_lock.partial = True
+        return new_lock
 
     @staticmethod
     def update_lockfile(lockfile, graph, lock_packages=False, clean=False):
@@ -83,7 +85,6 @@ class LockfileAPI:
                      config_requires=None):
         if lockfile is None:
             lockfile = Lockfile()  # create a new lockfile
-            lockfile.partial = True
 
         lockfile.add(requires=requires, build_requires=build_requires,
                      python_requires=python_requires, config_requires=config_requires)

--- a/conan/cli/commands/lock.py
+++ b/conan/cli/commands/lock.py
@@ -11,7 +11,7 @@ from conans.model.recipe_ref import RecipeReference
 
 
 @conan_command(group="Consumer")
-def lock(conan_api, parser, *args):
+def lock(conan_api, parser, *args):  # noqa
     """
     Create or manage lockfiles.
     """
@@ -63,7 +63,7 @@ def lock_create(conan_api, parser, subparser, *args):
 
 
 @conan_subcommand()
-def lock_merge(conan_api, parser, subparser, *args):
+def lock_merge(conan_api, parser, subparser, *args): # noqa
     """
     Merge 2 or more lockfiles.
     """
@@ -132,7 +132,7 @@ def lock_add(conan_api, parser, subparser, *args):
 @conan_subcommand()
 def lock_remove(conan_api, parser, subparser, *args):
     """
-    Remove requires, build-requires or python-requires from an existing or new lockfile.
+    Remove requires, build-requires or python-requires from an existing lockfile.
     References can be supplied with and without revisions like "--requires=pkg/version",
     """
     subparser.add_argument('--requires', action="append", help='Remove references to lockfile.')
@@ -153,4 +153,29 @@ def lock_remove(conan_api, parser, subparser, *args):
                                                   python_requires=args.python_requires,
                                                   build_requires=args.build_requires,
                                                   config_requires=args.config_requires)
+    conan_api.lockfile.save_lockfile(lockfile, args.lockfile_out)
+
+
+@conan_subcommand()
+def lock_update(conan_api, parser, subparser, *args):
+    """
+    Update requires, build-requires or python-requires from an existing lockfile.
+    References that matches the arguments package names will be replaced by the arguments.
+    References can be supplied with and without revisions like "--requires=pkg/version",
+    """
+    subparser.add_argument('--requires', action="append", help='Update references to lockfile.')
+    subparser.add_argument('--build-requires', action="append",
+                           help='Update build-requires from lockfile')
+    subparser.add_argument('--python-requires', action="append",
+                           help='Update python-requires from lockfile')
+    subparser.add_argument('--config-requires', action="append",
+                           help='Update config-requires from lockfile')
+    subparser.add_argument("--lockfile-out", action=OnceArgument, default=LOCKFILE,
+                           help="Filename of the created lockfile")
+    subparser.add_argument("--lockfile", action=OnceArgument, help="Filename of the input lockfile")
+    args = parser.parse_args(*args)
+
+    lockfile = conan_api.lockfile.get_lockfile(lockfile=args.lockfile, partial=True)
+    lockfile.update(requires=args.requires, build_requires=args.build_requires,
+                    python_requires=args.python_requires, config_requires=args.config_requires)
     conan_api.lockfile.save_lockfile(lockfile, args.lockfile_out)

--- a/test/integration/lockfile/test_user_overrides.py
+++ b/test/integration/lockfile/test_user_overrides.py
@@ -327,3 +327,36 @@ class TestLockRemove:
                 "other/1.0@user", "pkg/1.0@team", "engine/1.0"}.difference(removed)
         for pkg in rest:
             assert pkg in lock
+
+
+class TestLockUpdate:
+    @pytest.mark.parametrize("kind, old, new", [
+        ("requires", "math/1.0", "math/1.1"),
+        ("build-requires", "cmake/1.0", "cmake/1.1"),
+        ("python-requires", "mytool/1.0", "mytool/1.1"),
+    ])
+    def test_lock_update(self, kind, old, new):
+        c = TestClient()
+        lock = textwrap.dedent("""\
+            {
+                "version": "0.5",
+                "requires": [
+                    "math/1.0#85d927a4a067a531b1a9c7619522c015%1702683583.3411012",
+                    "math/1.0#12345%1702683584.3411012",
+                    "engine/1.0#fd2b006646a54397c16a1478ac4111ac%1702683583.3544693"
+                ],
+                "build_requires": [
+                    "cmake/1.0#85d927a4a067a531b1a9c7619522c015%1702683583.3411012",
+                    "ninja/1.0#fd2b006646a54397c16a1478ac4111ac%1702683583.3544693"
+                ],
+                "python_requires": [
+                    "mytool/1.0#85d927a4a067a531b1a9c7619522c015%1702683583.3411012",
+                    "othertool/1.0#fd2b006646a54397c16a1478ac4111ac%1702683583.3544693"
+                ]
+            }
+            """)
+        c.save({"conan.lock": lock})
+        c.run(f"lock update --{kind}={new}")
+        lock = c.load("conan.lock")
+        assert old not in lock
+        assert new in lock


### PR DESCRIPTION
Changelog: Feature: New ``conan lock update`` subcommand to remove + add a reference in the same command.
Docs: https://github.com/conan-io/docs/pull/3784

Close https://github.com/conan-io/conan/issues/16377