### PR TITLE
set correct testpaths for pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ OK
 To run specific tests, you can specify the test name too, something like:
 
 ```bash
-$ python -m pytest conans/test/functional/command/export_test.py::TestRevisionModeSCM::test_revision_mode_scm -s
+$ python -m pytest test/functional/command/export_test.py::TestRevisionModeSCM::test_revision_mode_scm -s
 ```
 
 The `-s` argument can be useful to see some output that otherwise is captured by *pytest*.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 norecursedirs = '.*', 'dist', 'CVS', '_darcs', '{arch}', '*.egg', 'venv', 'assets'
-testpaths = 'conans/test'
+testpaths = 'test'

--- a/test/README.md
+++ b/test/README.md
@@ -3,18 +3,18 @@
 
 Conan tests fall into three categories:
 
-- **Unit tests** in `conans/test/unittests` folder. These tests should test small pieces of code like
+- **Unit tests** in `test/unittests` folder. These tests should test small pieces of code like
   functions, methods, or properties. As long as it's possible they should not rely on anything
   external like the file system or system configuration,  and in case they need to do it should be
   mocked.
 
-- **Integration tests** in `conans/test/integration` folder. We consider integration tests the ones that
+- **Integration tests** in `test/integration` folder. We consider integration tests the ones that
   only will need pure python to execute, but that may test the interaction between different Conan
   modules. They could test the result of the execution of one or several Conan commands, but shouldn't
   depend on any external tools like compilers, build systems, or version-control system
   tools.
 
-- **Functional tests** in `conans/test/functional` folder. Under this category, we add tests that are
+- **Functional tests** in `test/functional` folder. Under this category, we add tests that are
   testing the complete Conan functionality. They may call external tools (please read the section
   below to check the tools installed on the CI). These tests should be avoided as long as
   it's possible as they may take considerable CI time.
@@ -70,7 +70,7 @@ def test_vcvars_priority(self):
     ...
 ```
 
-If the test needs any of those tools to run it should be marked as using that tool and moved to the `conans/test/functional` folder.
+If the test needs any of those tools to run it should be marked as using that tool and moved to the `test/functional` folder.
 
 ### Parametrizing tests
 


### PR DESCRIPTION
Changelog: Fix: Set correct `testpaths` for pytest.
Docs: Omit

The tests were moved to a new location in c6748b1bc2cbc8aefa11264153da20545b06fa4a.
This updates `pytest`'s `testpaths` to the new path, and also corrects the documentation accordingly.

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.