### PR TITLE
Adding support for  `ar` and `ld` variables on `cmake-toolchain`

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -848,7 +848,13 @@ class CompilersBlock(Block):
     template = textwrap.dedent(r"""
         {% for lang, compiler_path in compilers.items() %}
         set(CMAKE_{{ lang }}_COMPILER "{{ compiler_path|replace('\\', '/') }}")
+        {% if cmake_cpp_link_executable %}
+        set(CMAKE_{{ lang }}_LINK_EXECUTABLE {{ cmake_cpp_link_executable }})
+        {% endif %}
         {% endfor %}
+        {% if cmake_ar %}
+        set(CMAKE_AR {{ cmake_ar }})
+        {% endif %}
     """)
 
     def context(self):
@@ -865,7 +871,9 @@ class CompilersBlock(Block):
             # To set CMAKE_<LANG>_COMPILER
             if comp in compilers_by_conf:
                 compilers[lang] = compilers_by_conf[comp]
-        return {"compilers": compilers}
+        return {"compilers": compilers,
+                "cmake_ar": compilers_by_conf["ar"] if "ar" in compilers_by_conf else None,
+                "cmake_cpp_link_executable": compilers_by_conf["ld"] if "ld" in compilers_by_conf else None}
 
 
 class GenericSystemBlock(Block):

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -289,12 +289,12 @@ class MesonToolchain(object):
         # PR related: https://github.com/mesonbuild/meson/pull/6457
         #: Defines the Meson ``c_ld`` variable. Defaulted to ``CC_LD``
         #: environment value
-        self.c_ld = build_env.get("CC_LD")
+        self.c_ld = compilers_by_conf.get("ld") or self._sanitize_env_format(build_env.get("CC_LD"))
         #: Defines the Meson ``cpp_ld`` variable. Defaulted to ``CXX_LD``
         #: environment value
-        self.cpp_ld = build_env.get("CXX_LD")
+        self.cpp_ld = compilers_by_conf.get("ld") or self._sanitize_env_format(build_env.get("CXX_LD"))
         #: Defines the Meson ``ar`` variable. Defaulted to ``AR`` build environment value
-        self.ar = build_env.get("AR")
+        self.ar = compilers_by_conf.get("ar") or self._sanitize_env_format(build_env.get("AR"))
         #: Defines the Meson ``strip`` variable. Defaulted to ``STRIP`` build environment value
         self.strip = build_env.get("STRIP")
         #: Defines the Meson ``as`` variable. Defaulted to ``AS`` build environment value

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -1046,6 +1046,28 @@ def test_set_cmake_lang_compilers_and_launchers():
     assert 'set(CMAKE_RC_COMPILER "C:/local/rc.exe")' in toolchain
 
 
+def test_set_cmake_ar_and_ld():
+    profile = textwrap.dedent(r"""
+    [settings]
+    os=Windows
+    arch=x86_64
+    compiler=clang
+    compiler.version=15
+    compiler.libcxx=libstdc++11
+    [conf]
+    tools.build:compiler_executables={"c": "/my/local/gcc", "ar": "/my/custom/ar", "ld": "/my/custom/ld"}
+    """)
+    client = TestClient(path_with_spaces=False)
+    conanfile = GenConanfile().with_settings("os", "arch", "compiler")\
+        .with_generator("CMakeToolchain")
+    client.save({"conanfile.py": conanfile,
+                "profile": profile})
+    client.run("install . -pr:b profile -pr:h profile")
+    toolchain = client.load("conan_toolchain.cmake")
+    assert 'set(CMAKE_C_LINK_EXECUTABLE /my/custom/ld)' in toolchain
+    assert 'set(CMAKE_AR /my/custom/ar)' in toolchain
+
+
 def test_cmake_layout_toolchain_folder():
     """ in single-config generators, the toolchain is a different file per configuration
     https://github.com/conan-io/conan/issues/12827

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -273,6 +273,28 @@ def test_clang_cl_vscrt(build_type, runtime, vscrt):
     assert f"b_vscrt = '{vscrt}'" in content
 
 
+def test_ar_ld_from_compiler_executables():
+    profile = textwrap.dedent("""
+        [settings]
+        os=Windows
+        arch=x86_64
+        compiler=clang
+        compiler.version=16
+
+        [conf]
+        tools.build:compiler_executables={"ar": "CUSTOM_AR", "ld": "CUSTOM_LD"}
+   """)
+    t = TestClient()
+    t.save({"conanfile.txt": "[generators]\nMesonToolchain",
+            "profile": profile})
+
+    t.run("install . -pr:h=profile -pr:b=profile")
+    content = t.load(MesonToolchain.native_filename)
+    assert "c_ld = 'CUSTOM_LD'" in content
+    assert "cpp_ld = 'CUSTOM_LD'" in content
+    assert "ar = 'CUSTOM_AR'" in content
+
+
 def test_env_vars_from_build_require():
     conanfile = textwrap.dedent("""
     from conan import ConanFile


### PR DESCRIPTION
Changelog: Fix: Fix ar and ld flags for cmake toolchain
Docs: https://github.com/conan-io/docs/pull/XXXX

Close: https://github.com/conan-io/conan/issues/16517

[CMAKE_<LANG>_LINK_EXECUTABLE](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_LINK_EXECUTABLE.html) 

[CMAKE_AR](https://cmake.org/cmake/help/latest/variable/CMAKE_AR.html)
