### PR TITLE
[deployers] Fix relative paths using`--deployer-folder` param

### DIFF
--- a/conan/api/subapi/install.py
+++ b/conan/api/subapi/install.py
@@ -1,3 +1,5 @@
+import os
+
 from conan.internal.conan_app import ConanApp
 from conan.internal.deploy import do_deploys
 from conans.client.generators import write_generators
@@ -70,7 +72,10 @@ class InstallAPI:
 
         # The previous .set_base_folders has already decided between the source_folder and output
         if deploy or deploy_package:
-            base_folder = deploy_folder or conanfile.folders.base_build
+            base_folder = conanfile.folders.base_build
+            # Issue related: https://github.com/conan-io/conan/issues/16543
+            if deploy_folder:
+                base_folder = os.path.join(base_folder, deploy_folder)
             do_deploys(self.conan_api, deps_graph, deploy, deploy_package, base_folder)
 
         final_generators = []

--- a/conan/api/subapi/install.py
+++ b/conan/api/subapi/install.py
@@ -72,10 +72,9 @@ class InstallAPI:
 
         # The previous .set_base_folders has already decided between the source_folder and output
         if deploy or deploy_package:
-            base_folder = conanfile.folders.base_build
             # Issue related: https://github.com/conan-io/conan/issues/16543
-            if deploy_folder:
-                base_folder = os.path.join(base_folder, deploy_folder)
+            base_folder = os.path.abspath(deploy_folder) if deploy_folder \
+                else conanfile.folders.base_build
             do_deploys(self.conan_api, deps_graph, deploy, deploy_package, base_folder)
 
         final_generators = []

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -78,12 +78,11 @@ class _PCContentGenerator:
         ret = {}
         for i, directory in enumerate(folders):
             directory = os.path.normpath(directory).replace("\\", "/")
-            prefix = ""
-            if not os.path.isabs(directory):
-                prefix = "${prefix}/"
-            elif directory.startswith(prefix_path_):
+            if directory.startswith(prefix_path_):
                 prefix = "${prefix}/"
                 directory = os.path.relpath(directory, prefix_path_).replace("\\", "/")
+            else:
+                prefix = "" if os.path.isabs(directory) else "${prefix}/"
             suffix = str(i) if i else ""
             var_name = f"{folder_name}{suffix}"
             ret[var_name] = f"{prefix}{directory}"

--- a/test/functional/toolchains/gnu/test_pkgconfigdeps_autotools.py
+++ b/test/functional/toolchains/gnu/test_pkgconfigdeps_autotools.py
@@ -110,5 +110,3 @@ def test_pkgconfigdeps_and_autotools():
         # Issue: https://github.com/conan-io/conan/issues/11867
         assert '-F/my/framework/file1' in client.out
         assert '-F/my/framework/file2' in client.out
-        assert "warning: directory not found for option '-F/my/framework/file1'" in client.out
-        assert "warning: directory not found for option '-F/my/framework/file2'" in client.out

--- a/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -779,11 +779,11 @@ def test_using_deployer_folder():
     os=Macos
     """)
     c.save({
-        "host": profile,
+        "profile": profile,
         "dep/conanfile.py": GenConanfile("dep")})
     c.run("create dep --version 1.0")
-    c.run("install --requires=dep/1.0 -pr host --deployer=direct_deploy "
+    c.run("install --requires=dep/1.0 -pr profile --deployer=direct_deploy "
           "--deployer-folder=mydeploy -g CMakeDeps")
-    content = c.load("DEP-release-x86_64-data.cmake")
+    content = c.load("dep-release-x86_64-data.cmake")
     assert ('set(dep_PACKAGE_FOLDER_RELEASE "${CMAKE_CURRENT_LIST_DIR}/mydeploy/direct_deploy/dep")'
             in content)

--- a/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -782,7 +782,7 @@ def test_using_deployer_folder():
         "host": profile,
         "dep/conanfile.py": GenConanfile("dep")})
     c.run("create dep --version 1.0")
-    c.run("install --requires=dep/1.0 --deployer=direct_deploy "
+    c.run("install --requires=dep/1.0 -pr host --deployer=direct_deploy "
           "--deployer-folder=mydeploy -g CMakeDeps")
     content = c.load("DEP-release-x86_64-data.cmake")
     assert ('set(dep_PACKAGE_FOLDER_RELEASE "${CMAKE_CURRENT_LIST_DIR}/mydeploy/direct_deploy/dep")'

--- a/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -1100,10 +1100,10 @@ def test_pkg_config_deps_and_private_deps():
     assert "Requires:" not in client.load("pkg.pc")
 
 
-def test_keep_prefix_path_deployers():
+def test_using_deployer_folder():
     """
-    Testing that there is no duplicated prefix path in relative folders when
-    dependency is deployed.
+    Testing that the absolute path is kept as the prefix instead of the
+    relative path.
 
     Issue related: https://github.com/conan-io/conan/issues/16543
     """

--- a/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -1113,7 +1113,8 @@ def test_using_deployer_folder():
     client.run("install --requires=dep/0.1 --deployer=direct_deploy "
                "--deployer-folder=mydeploy -g PkgConfigDeps")
     content = client.load("dep.pc")
-    assert f"prefix={client.current_folder}/mydeploy/direct_deploy/dep" in content
+    prefix_base = client.current_folder.replace('\\', '/')
+    assert f"prefix={prefix_base}/mydeploy/direct_deploy/dep" in content
     assert "libdir=${prefix}/lib" in content
     assert "includedir=${prefix}/include" in content
     assert "bindir=${prefix}/bin" in content

--- a/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -1110,10 +1110,10 @@ def test_keep_prefix_path_deployers():
     client = TestClient()
     client.save({"dep/conanfile.py": GenConanfile("dep", "0.1")})
     client.run("create dep/conanfile.py")
-    client.run("install --requires=dep/0.1 --output-folder=deploy  --deployer=direct_deploy"
-               " --deployer-folder=deploy -g PkgConfigDeps")
-    content = client.load(os.path.join("deploy", "dep.pc"))
-    assert "prefix=deploy/direct_deploy/dep" in content
+    client.run("install --requires=dep/0.1 --deployer=direct_deploy "
+               "--deployer-folder=mydeploy -g PkgConfigDeps")
+    content = client.load("dep.pc")
+    assert f"prefix={client.current_folder}/mydeploy/direct_deploy/dep" in content
     assert "libdir=${prefix}/lib" in content
     assert "includedir=${prefix}/include" in content
     assert "bindir=${prefix}/bin" in content

--- a/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -1098,3 +1098,22 @@ def test_pkg_config_deps_and_private_deps():
     # Now, it passes and creates the pc files correctly (the skipped one is not created)
     client.run("install .")
     assert "Requires:" not in client.load("pkg.pc")
+
+
+def test_keep_prefix_path_deployers():
+    """
+    Testing that there is no duplicated prefix path in relative folders when
+    dependency is deployed.
+
+    Issue related: https://github.com/conan-io/conan/issues/16543
+    """
+    client = TestClient()
+    client.save({"dep/conanfile.py": GenConanfile("dep", "0.1")})
+    client.run("create dep/conanfile.py")
+    client.run("install --requires=dep/0.1 --output-folder=deploy  --deployer=direct_deploy"
+               " --deployer-folder=deploy -g PkgConfigDeps")
+    content = client.load(os.path.join("deploy", "dep.pc"))
+    assert "prefix=deploy/direct_deploy/dep" in content
+    assert "libdir=${prefix}/lib" in content
+    assert "includedir=${prefix}/include" in content
+    assert "bindir=${prefix}/bin" in content


### PR DESCRIPTION
Changelog: Bugfix: `XXXDeps` generators did not include an absolute path in their generated files if `--deployer-folder=xxxx` param was used.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/16543