### PR TITLE
Add `constrain_possible_values` method to package options

### DIFF
--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -19,11 +19,8 @@ class _PackageOption:
         self._value = value  # Value None = not defined
         self.important = False
         # possible_values only possible origin is recipes
-        if possible_values is None:
-            self._possible_values = None
-        else:
-            # This can contain "ANY"
-            self._possible_values = [str(v) if v is not None else None for v in possible_values]
+        self._possible_values = None
+        self.constrain_possible_values(possible_values)
 
     def dumps(self, scope=None):
         if self._value is None:
@@ -94,6 +91,13 @@ class _PackageOption:
             return
         if None not in self._possible_values:
             raise ConanException("'options.%s' value not defined" % self._name)
+
+    def constrain_possible_values(self, possible_values):
+        if possible_values is None:
+            self._possible_values = None
+        else:
+            # This can contain "ANY"
+            self._possible_values = [str(v) if v is not None else None for v in possible_values]
 
 
 class _PackageOptions:
@@ -213,6 +217,13 @@ class _PackageOptions:
             if is_pattern and k not in self._data:
                 continue
             self._set(k, v)
+
+    def constrain_possible_values(self, field, possible_values):
+        self._ensure_exists(field)
+        if self._freeze:
+            raise ConanException(f"Cannot constrain option '{field}' possible values after it has "
+                                 f"been set to '{self._data[field].value}'")
+        self._data[field].constrain_possible_values(possible_values)
 
 
 class Options:

--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -20,7 +20,7 @@ class _PackageOption:
         self.important = False
         # possible_values only possible origin is recipes
         self._possible_values = None
-        self.constrain_possible_values(possible_values)
+        self._constrain_possible_values(possible_values)
 
     def dumps(self, scope=None):
         if self._value is None:
@@ -92,7 +92,7 @@ class _PackageOption:
         if None not in self._possible_values:
             raise ConanException("'options.%s' value not defined" % self._name)
 
-    def constrain_possible_values(self, possible_values):
+    def _constrain_possible_values(self, possible_values):
         if possible_values is None:
             self._possible_values = None
         else:
@@ -223,7 +223,7 @@ class _PackageOptions:
         if self._freeze:
             raise ConanException(f"Cannot constrain option '{field}' possible values after it has "
                                  f"been set to '{self._data[field].value}'")
-        self._data[field].constrain_possible_values(possible_values)
+        self._data[field]._constrain_possible_values(possible_values)
 
 
 class Options:


### PR DESCRIPTION
Changelog: Add `constrain_possible_values` to package options
Docs: TODO

Very early draft, some issues still remain, experimental and ee may not wanto to go this route, but wanted to push it to have something to show the team.

The most useful use-case for this would be something similar to [this CCI recipe PR](https://github.com/conan-io/conan-center-index/pull/24469), in which old versions deprecate option values in favour of new ones (As their value is directly passed to the build system)

The current solution goes the `validate()` route, which although it lets the recipe present nicer errors to the users, it could quickly grow unmanageable after a few changes like that.

There might be an alternative approach: The `init` method might run early enough to be able to redefine the `self.options` dict-like value before it gets converted to a `_PackageOptions` object