### PR TITLE
Ensure msvc cppstd compatibility fallback does not ignore 194 binaries

### DIFF
--- a/conans/client/graph/compatibility.py
+++ b/conans/client/graph/compatibility.py
@@ -55,8 +55,8 @@ def cppstd_compat(conanfile):
     if compiler == "msvc":
         msvc_fallback = {"194": "193"}.get(compiler_version)
         if msvc_fallback:
-            factors.append([{"compiler.version": msvc_fallback},
-                            {"compiler.version": compiler_version}])
+            factors.append([{"compiler.version": compiler_version},
+                            {"compiler.version": msvc_fallback}])
 
     combinations = []
     for factor in factors:

--- a/conans/client/graph/compatibility.py
+++ b/conans/client/graph/compatibility.py
@@ -55,7 +55,8 @@ def cppstd_compat(conanfile):
     if compiler == "msvc":
         msvc_fallback = {"194": "193"}.get(compiler_version)
         if msvc_fallback:
-            factors.append([{"compiler.version": msvc_fallback}])
+            factors.append([{"compiler.version": msvc_fallback},
+                            {"compiler.version": compiler_version}])
 
     combinations = []
     for factor in factors:

--- a/conans/client/graph/compatibility.py
+++ b/conans/client/graph/compatibility.py
@@ -65,9 +65,9 @@ def cppstd_compat(conanfile):
         new_combinations = []
         for comb in combinations:
             for f in factor:
-                comb = comb.copy()
-                comb.update(f)
-                new_combinations.append(comb)
+                new_comb = comb.copy()
+                new_comb.update(f)
+                new_combinations.append(new_comb)
         combinations.extend(new_combinations)
 
     ret = []

--- a/conans/client/graph/compatibility.py
+++ b/conans/client/graph/compatibility.py
@@ -55,8 +55,7 @@ def cppstd_compat(conanfile):
     if compiler == "msvc":
         msvc_fallback = {"194": "193"}.get(compiler_version)
         if msvc_fallback:
-            factors.append([{"compiler.version": compiler_version},
-                            {"compiler.version": msvc_fallback}])
+            factors.append([{"compiler.version": msvc_fallback}])
 
     combinations = []
     for factor in factors:
@@ -69,7 +68,7 @@ def cppstd_compat(conanfile):
                 comb = comb.copy()
                 comb.update(f)
                 new_combinations.append(comb)
-        combinations = new_combinations
+        combinations.extend(new_combinations)
 
     ret = []
     for comb in combinations:

--- a/test/integration/package_id/compatible_test.py
+++ b/test/integration/package_id/compatible_test.py
@@ -400,3 +400,12 @@ class TestNewCompatibility:
 
         c.run("install --requires=pdfium/2020.9 -pr=myprofile -s build_type=Debug")
         assert "missing. Using compatible package" in c.out
+
+    def test_compatibility_msvc_and_cppstd(self):
+        tc = TestClient()
+        tc.save({"dep/conanfile.py": GenConanfile("dep", "1.0").with_setting("compiler"),
+                 "conanfile.py": GenConanfile("app", "1.0").with_require("dep/1.0").with_setting("compiler")})
+
+        tc.run("create dep -s compiler=msvc -s compiler.version=194 -s compiler.cppstd=20 -s compiler.runtime=dynamic")
+        tc.run("create . -s compiler=msvc -s compiler.version=194 -s compiler.cppstd=17 -s compiler.runtime=dynamic")
+        tc.assert_listed_binary({"dep/1.0": ("b6d26a6bc439b25b434113982791edf9cab4d004", "Cache")})

--- a/test/integration/package_id/compatible_test.py
+++ b/test/integration/package_id/compatible_test.py
@@ -407,12 +407,9 @@ class TestNewCompatibility:
         tc = TestClient()
         profile = textwrap.dedent("""
                    [settings]
-                   os = Windows
                    compiler=msvc
                    compiler.version=194
                    compiler.runtime=dynamic
-                   build_type=Release
-                   arch=x86_64
                    """)
         tc.save({"dep/conanfile.py": GenConanfile("dep", "1.0").with_setting("compiler"),
                  "conanfile.py": GenConanfile("app", "1.0").with_require("dep/1.0").with_setting("compiler"),

--- a/test/integration/package_id/compatible_test.py
+++ b/test/integration/package_id/compatible_test.py
@@ -402,10 +402,22 @@ class TestNewCompatibility:
         assert "missing. Using compatible package" in c.out
 
     def test_compatibility_msvc_and_cppstd(self):
+        """msvc 194 would not find compatible packages built with same version but different cppstd
+        due to an issue in the msvc fallback compatibility rule."""
         tc = TestClient()
+        profile = textwrap.dedent("""
+                   [settings]
+                   os = Windows
+                   compiler=msvc
+                   compiler.version=194
+                   compiler.runtime=dynamic
+                   build_type=Release
+                   arch=x86_64
+                   """)
         tc.save({"dep/conanfile.py": GenConanfile("dep", "1.0").with_setting("compiler"),
-                 "conanfile.py": GenConanfile("app", "1.0").with_require("dep/1.0").with_setting("compiler")})
+                 "conanfile.py": GenConanfile("app", "1.0").with_require("dep/1.0").with_setting("compiler"),
+                 "profile": profile})
 
-        tc.run("create dep -s compiler=msvc -s compiler.version=194 -s compiler.cppstd=20 -s compiler.runtime=dynamic")
-        tc.run("create . -s compiler=msvc -s compiler.version=194 -s compiler.cppstd=17 -s compiler.runtime=dynamic")
+        tc.run("create dep -pr=profile -s compiler.cppstd=20")
+        tc.run("create . -pr=profile -s compiler.cppstd=17")
         tc.assert_listed_binary({"dep/1.0": ("b6d26a6bc439b25b434113982791edf9cab4d004", "Cache")})


### PR DESCRIPTION
Changelog: Bugfix: Ensure msvc cppstd compatibility fallback does not ignore 194 binaries.
Docs: Omit

This is one of the alternatives, another one might be to test each factor in isolation too?

Closes https://github.com/conan-io/conan/issues/16564