### PR TITLE
Add properties to MakeDeps generator

### DIFF
--- a/conan/tools/gnu/makedeps.py
+++ b/conan/tools/gnu/makedeps.py
@@ -131,6 +131,14 @@ def _jinja_format_list_values() -> str:
             {%- endif -%}
             {%- endmacro %}
 
+            {%- macro define_multiple_variable_value(var, values) -%}
+            {%- if values is not none -%}
+            {% for property_name, value in values.items() %}
+            {{ var }}_{{ property_name }} = {{ value }}
+            {% endfor %}
+            {%- endif -%}
+            {%- endmacro %}
+
             {%- macro define_variable_value(var, values) -%}
             {%- if values is not none -%}
             {%- if values|length > 0 -%}
@@ -397,6 +405,7 @@ class DepContentGenerator:
         {{- define_variable_value_safe("CONAN_REQUIRES_{}".format(name), cpp_info_flags, 'requires') -}}
         {{- define_variable_value_safe("CONAN_SYSTEM_LIBS_{}".format(name), cpp_info_flags, 'system_libs') -}}
         {{- define_variable_value("CONAN_COMPONENTS_{}".format(name), components) -}}
+        {{- define_multiple_variable_value("CONAN_PROPERTY_{}".format(name), properties) -}}
         """)
 
     def __init__(self, dependency, require, root: str, sysroot, dirs: dict, flags: dict):
@@ -420,6 +429,7 @@ class DepContentGenerator:
             "components": list(self._dep.cpp_info.get_sorted_components().keys()),
             "cpp_info_dirs": self._dirs,
             "cpp_info_flags": self._flags,
+            "properties": {_makefy(name): value for name, value in  self._dep.cpp_info._properties.items()},
         }
         template = Template(_jinja_format_list_values() + self.template, trim_blocks=True,
                             lstrip_blocks=True, undefined=StrictUndefined)

--- a/conan/tools/gnu/makedeps.py
+++ b/conan/tools/gnu/makedeps.py
@@ -32,6 +32,7 @@ import textwrap
 from jinja2 import Template, StrictUndefined
 from typing import Optional
 
+from conan.api.output import ConanOutput
 from conan.internal import check_duplicated_generator
 from conan.tools.files import save
 
@@ -669,8 +670,8 @@ class MakeDeps:
             # Require is not used at the moment, but its information could be used, and will be used in Conan 2.0
             if require.build:
                 continue
-
-            dep_gen = DepGenerator(dep, require, self._conanfile.output)
+            output = ConanOutput(scope=f"{self._conanfile} MakeDeps: {dep}:")
+            dep_gen = DepGenerator(dep, require, output)
             make_infos.append(dep_gen.makeinfo)
             deps_buffer += dep_gen.generate()
 

--- a/conan/tools/gnu/makedeps.py
+++ b/conan/tools/gnu/makedeps.py
@@ -74,7 +74,7 @@ def _makefy_properties(properties: Optional[dict]) -> dict:
     :param properties: The property dictionary to be converted (None is also accepted)
     :return: Modified property dictionary with keys not including bad characters that are not parsed correctly
     """
-    return {_makefy(name): value for name, value in  properties.items()} if properties else {}
+    return {_makefy(name): value for name, value in properties.items()} if properties else {}
 
 
 def _conan_prefix_flag(variable: str) -> str:

--- a/conan/tools/gnu/makedeps.py
+++ b/conan/tools/gnu/makedeps.py
@@ -30,6 +30,7 @@ import re
 import textwrap
 
 from jinja2 import Template, StrictUndefined
+from typing import Optional
 
 from conan.internal import check_duplicated_generator
 from conan.tools.files import save
@@ -65,6 +66,15 @@ def _makefy(name: str) -> str:
     :return: Safe makefile variable, not including bad characters that are not parsed correctly
     """
     return re.sub(r'[^0-9A-Z_]', '_', name.upper())
+
+
+def _makefy_properties(properties: dict) -> Optional[dict]:
+    """
+    Convert property dictionary keys to Make-variable-friendly syntax
+    :param properties: The property dictionary to be converted
+    :return: Modified property dictionary with keys not including bad characters that are not parsed correctly
+    """
+    return {_makefy(name): value for name, value in  properties.items()} if properties else None
 
 
 def _conan_prefix_flag(variable: str) -> str:
@@ -366,7 +376,7 @@ class DepComponentContentGenerator:
             "name": _makefy(self._name),
             "cpp_info_dirs": self._dirs,
             "cpp_info_flags": self._flags,
-            "properties": {_makefy(name): value for name, value in  self._dep.cpp_info.components[self._name]._properties.items()} if self._dep.cpp_info.components[self._name]._properties else None,
+            "properties": _makefy_properties(self._dep.cpp_info.components[self._name]._properties),
         }
         template = Template(_jinja_format_list_values() + self.template, trim_blocks=True,
                             lstrip_blocks=True, undefined=StrictUndefined)
@@ -431,7 +441,7 @@ class DepContentGenerator:
             "components": list(self._dep.cpp_info.get_sorted_components().keys()),
             "cpp_info_dirs": self._dirs,
             "cpp_info_flags": self._flags,
-            "properties": {_makefy(name): value for name, value in  self._dep.cpp_info._properties.items()} if self._dep.cpp_info._properties else None,
+            "properties": _makefy_properties(self._dep.cpp_info._properties),
         }
         template = Template(_jinja_format_list_values() + self.template, trim_blocks=True,
                             lstrip_blocks=True, undefined=StrictUndefined)

--- a/conan/tools/gnu/makedeps.py
+++ b/conan/tools/gnu/makedeps.py
@@ -340,6 +340,7 @@ class DepComponentContentGenerator:
         {{- define_variable_value_safe("CONAN_FRAMEWORKS_{}_{}".format(dep_name, name), cpp_info_flags, 'frameworks') -}}
         {{- define_variable_value_safe("CONAN_REQUIRES_{}_{}".format(dep_name, name), cpp_info_flags, 'requires') -}}
         {{- define_variable_value_safe("CONAN_SYSTEM_LIBS_{}_{}".format(dep_name, name), cpp_info_flags, 'system_libs') -}}
+        {{- define_multiple_variable_value("CONAN_PROPERTY_{}_{}".format(dep_name, name), properties) -}}
         """)
 
     def __init__(self, dependency, component_name: str, dirs: dict, flags: dict):
@@ -364,7 +365,8 @@ class DepComponentContentGenerator:
             "dep_name": _makefy(self._dep.ref.name),
             "name": _makefy(self._name),
             "cpp_info_dirs": self._dirs,
-            "cpp_info_flags": self._flags
+            "cpp_info_flags": self._flags,
+            "properties": {_makefy(name): value for name, value in  self._dep.cpp_info.components[self._name]._properties.items()} if self._dep.cpp_info.components[self._name]._properties else None,
         }
         template = Template(_jinja_format_list_values() + self.template, trim_blocks=True,
                             lstrip_blocks=True, undefined=StrictUndefined)
@@ -429,7 +431,7 @@ class DepContentGenerator:
             "components": list(self._dep.cpp_info.get_sorted_components().keys()),
             "cpp_info_dirs": self._dirs,
             "cpp_info_flags": self._flags,
-            "properties": {_makefy(name): value for name, value in  self._dep.cpp_info._properties.items()},
+            "properties": {_makefy(name): value for name, value in  self._dep.cpp_info._properties.items()} if self._dep.cpp_info._properties else None,
         }
         template = Template(_jinja_format_list_values() + self.template, trim_blocks=True,
                             lstrip_blocks=True, undefined=StrictUndefined)

--- a/conan/tools/gnu/makedeps.py
+++ b/conan/tools/gnu/makedeps.py
@@ -68,13 +68,13 @@ def _makefy(name: str) -> str:
     return re.sub(r'[^0-9A-Z_]', '_', name.upper())
 
 
-def _makefy_properties(properties: dict) -> Optional[dict]:
+def _makefy_properties(properties: Optional[dict]) -> dict:
     """
     Convert property dictionary keys to Make-variable-friendly syntax
-    :param properties: The property dictionary to be converted
+    :param properties: The property dictionary to be converted (None is also accepted)
     :return: Modified property dictionary with keys not including bad characters that are not parsed correctly
     """
-    return {_makefy(name): value for name, value in  properties.items()} if properties else None
+    return {_makefy(name): value for name, value in  properties.items()} if properties else {}
 
 
 def _conan_prefix_flag(variable: str) -> str:
@@ -142,11 +142,9 @@ def _jinja_format_list_values() -> str:
             {%- endmacro %}
 
             {%- macro define_multiple_variable_value(var, values) -%}
-            {%- if values is not none -%}
             {% for property_name, value in values.items() %}
             {{ var }}_{{ property_name }} = {{ value }}
             {% endfor %}
-            {%- endif -%}
             {%- endmacro %}
 
             {%- macro define_variable_value(var, values) -%}

--- a/test/integration/toolchains/gnu/test_makedeps.py
+++ b/test/integration/toolchains/gnu/test_makedeps.py
@@ -30,6 +30,7 @@ def test_make_dirs_with_abs_path():
                 lib_dir2 = os.path.join(self.package_folder, "lib2")
                 self.cpp_info.includedirs = [include_dir]
                 self.cpp_info.libdirs = [lib_dir, lib_dir2]
+                self.cpp_info.set_property("my_prop", "my prop value")
         """)
     client = TestClient()
     client.save({"conanfile.py": conanfile})
@@ -44,6 +45,7 @@ def test_make_dirs_with_abs_path():
     assert f'CONAN_LIB_DIRS_MYLIB = \\\n\t$(CONAN_LIB_DIR_FLAG){prefix}/my_absoulte_path/fake/mylib/lib \\\n\t$(CONAN_LIB_DIR_FLAG)$(CONAN_ROOT_MYLIB)/lib2' in makefile_content
     assert f'CONAN_INCLUDE_DIRS_MYLIB = $(CONAN_INCLUDE_DIR_FLAG){prefix}/my_absoulte_path/fake/mylib/include' in makefile_content
     assert 'CONAN_BIN_DIRS_MYLIB = $(CONAN_BIN_DIR_FLAG)$(CONAN_ROOT_MYLIB)/bin' in makefile_content
+    assert 'CONAN_PROPERTY_MYLIB_MY_PROP = my prop value' in makefile_content
 
     lines = makefile_content.splitlines()
     for line_no, line in enumerate(lines):
@@ -90,6 +92,7 @@ def test_make_empty_dirs():
     assert 'CONAN_BIN_DIRS' not in makefile_content
     assert 'CONAN_LIBS' not in makefile_content
     assert 'CONAN_FRAMEWORK_DIRS' not in makefile_content
+    assert 'CONAN_PROPERTY' not in makefile_content
 
 
 def test_libs_and_system_libs():
@@ -197,6 +200,7 @@ def test_make_with_public_deps_and_component_requires():
             def package_info(self):
                 self.cpp_info.components["mycomponent"].requires.append("lib::cmp1")
                 self.cpp_info.components["myfirstcomp"].requires.append("mycomponent")
+                self.cpp_info.components["myfirstcomp"].set_property("my_prop", "my prop value")
 
         """)
     client.save({"conanfile.py": conanfile}, clean_first=True)
@@ -235,6 +239,8 @@ def test_make_with_public_deps_and_component_requires():
     assert 'CONAN_LIBS_LIB_CMP1 = $(CONAN_LIB_FLAG)libcmp1\n' in makefile_content
     assert 'CONAN_REQUIRES = $(CONAN_REQUIRES_SECOND)\n' in makefile_content
     assert 'CONAN_LIBS = $(CONAN_LIBS_LIB)\n' in makefile_content
+
+    assert 'CONAN_PROPERTY_SECOND_MYFIRSTCOMP_MY_PROP = my prop value\n' in makefile_content
 
 
 def test_make_with_public_deps_and_component_requires_second():

--- a/test/integration/toolchains/gnu/test_makedeps.py
+++ b/test/integration/toolchains/gnu/test_makedeps.py
@@ -31,6 +31,7 @@ def test_make_dirs_with_abs_path():
                 self.cpp_info.includedirs = [include_dir]
                 self.cpp_info.libdirs = [lib_dir, lib_dir2]
                 self.cpp_info.set_property("my_prop", "my prop value")
+                self.cpp_info.set_property("my_prop_with_newline", "my\\nprop")
         """)
     client = TestClient()
     client.save({"conanfile.py": conanfile})
@@ -46,6 +47,8 @@ def test_make_dirs_with_abs_path():
     assert f'CONAN_INCLUDE_DIRS_MYLIB = $(CONAN_INCLUDE_DIR_FLAG){prefix}/my_absoulte_path/fake/mylib/include' in makefile_content
     assert 'CONAN_BIN_DIRS_MYLIB = $(CONAN_BIN_DIR_FLAG)$(CONAN_ROOT_MYLIB)/bin' in makefile_content
     assert 'CONAN_PROPERTY_MYLIB_MY_PROP = my prop value' in makefile_content
+    assert 'CONAN_PROPERTY_MYLIB_MY_PROP_WITH_NEWLINE' not in makefile_content
+    assert "WARN: Skipping propery 'my_prop_with_newline' because it contains newline" in client.stderr
 
     lines = makefile_content.splitlines()
     for line_no, line in enumerate(lines):
@@ -201,6 +204,7 @@ def test_make_with_public_deps_and_component_requires():
                 self.cpp_info.components["mycomponent"].requires.append("lib::cmp1")
                 self.cpp_info.components["myfirstcomp"].requires.append("mycomponent")
                 self.cpp_info.components["myfirstcomp"].set_property("my_prop", "my prop value")
+                self.cpp_info.components["myfirstcomp"].set_property("my_prop_with_newline", "my\\nprop")
 
         """)
     client.save({"conanfile.py": conanfile}, clean_first=True)
@@ -241,6 +245,8 @@ def test_make_with_public_deps_and_component_requires():
     assert 'CONAN_LIBS = $(CONAN_LIBS_LIB)\n' in makefile_content
 
     assert 'CONAN_PROPERTY_SECOND_MYFIRSTCOMP_MY_PROP = my prop value\n' in makefile_content
+    assert 'CONAN_PROPERTY_SECOND_MYFIRSTCOMP_MY_PROP_WITH_NEWLINE' not in makefile_content
+    assert "WARN: Skipping propery 'my_prop_with_newline' because it contains newline" in client2.stderr
 
 
 def test_make_with_public_deps_and_component_requires_second():


### PR DESCRIPTION
Changelog: Feature: MakeDeps generator generates make variables for dependencies and their components.
Docs: https://github.com/conan-io/docs/pull/3794

Fixes #16572
