### PR TITLE
simplify fasteners

### DIFF
--- a/conans/client/downloaders/download_cache.py
+++ b/conans/client/downloaders/download_cache.py
@@ -6,7 +6,7 @@ from threading import Lock
 from conans.errors import ConanException
 from conans.util.dates import timestamp_now
 from conans.util.files import load, save, remove_if_dirty
-from conans.util.locks import SimpleLock
+from conans.util.locks import simple_lock
 from conans.util.sha import sha256 as compute_sha256
 
 
@@ -35,7 +35,7 @@ class DownloadCache:
     @contextmanager
     def lock(self, lock_id):
         lock = os.path.join(self._path, self._LOCKS, lock_id)
-        with SimpleLock(lock):
+        with simple_lock(lock):
             # Once the process has access, make sure multithread is locked too
             # as SimpleLock doesn't work multithread
             thread_lock = self._thread_locks.setdefault(lock, Lock())

--- a/conans/util/locks.py
+++ b/conans/util/locks.py
@@ -1,120 +1,24 @@
-import os
-import time
+from contextlib import contextmanager
 
 import fasteners
 
-from conans.util.files import load, save
 
-logger = None
-
-class NoLock(object):
-
-    def __enter__(self):
-        pass
-
-    def __exit__(self, exc_type, exc_val, exc_tb):  # @UnusedVariable
-        pass
+@contextmanager
+def simple_lock(lock_path):
+    lock = fasteners.InterProcessLock(lock_path)
+    with lock:
+        yield
 
 
-class SimpleLock(object):
-
-    def __init__(self, filename):
-        self._lock = fasteners.InterProcessLock(filename, logger=logger)
-
-    def __enter__(self):
-        self._lock.acquire()
-
-    def __exit__(self, exc_type, exc_val, exc_tb):  # @UnusedVariable
-        self._lock.release()
+@contextmanager
+def read_lock(lock_path):
+    rw_lock = fasteners.InterProcessReaderWriterLock(lock_path)
+    with rw_lock.read_lock():
+        yield
 
 
-READ_BUSY_DELAY = 0.5
-WRITE_BUSY_DELAY = 0.25
-
-
-class Lock(object):
-
-    @staticmethod
-    def clean(folder):
-        if os.path.exists(folder + ".count"):
-            os.remove(folder + ".count")
-        if os.path.exists(folder + ".count.lock"):
-            os.remove(folder + ".count.lock")
-
-    def __init__(self, folder, locked_item, output):
-        self._count_file = folder + ".count"
-        self._count_lock_file = folder + ".count.lock"
-        self._locked_item = locked_item
-        self._output = output
-        self._first_lock = True
-
-    @property
-    def files(self):
-        return self._count_file, self._count_lock_file
-
-    def _info_locked(self):
-        if self._first_lock:
-            self._first_lock = False
-            self._output.info("%s is locked by another concurrent conan process, wait..."
-                              % str(self._locked_item))
-            self._output.info("If not the case, quit, and do 'conan remove --locks'")
-
-    def _readers(self):
-        try:
-            return int(load(self._count_file))
-        except IOError:
-            return 0
-        except (UnicodeEncodeError, ValueError):
-            self._output.warning("%s does not contain a number!" % self._count_file)
-            return 0
-
-
-class ReadLock(Lock):
-
-    def __enter__(self):
-        while True:
-            with fasteners.InterProcessLock(self._count_lock_file, logger=logger):
-                readers = self._readers()
-                if readers >= 0:
-                    save(self._count_file, str(readers + 1))
-                    break
-            self._info_locked()
-            time.sleep(READ_BUSY_DELAY)
-
-    def __exit__(self, exc_type, exc_val, exc_tb):   # @UnusedVariable
-        with fasteners.InterProcessLock(self._count_lock_file, logger=logger):
-            readers = self._readers()
-            save(self._count_file, str(readers - 1))
-
-
-class WriteLock(Lock):
-
-    def __enter__(self):
-        while True:
-            with fasteners.InterProcessLock(self._count_lock_file, logger=logger):
-                readers = self._readers()
-                if readers == 0:
-                    save(self._count_file, "-1")
-                    break
-            self._info_locked()
-            time.sleep(WRITE_BUSY_DELAY)
-
-    def __exit__(self, exc_type, exc_val, exc_tb):  # @UnusedVariable
-        with fasteners.InterProcessLock(self._count_lock_file, logger=logger):
-            save(self._count_file, "0")
-
-        if exc_type is not None:
-            # If there was an exception while locking this, might be empty
-            # Try to clean up the trailing filelocks
-            try:
-                os.remove(self._count_file)
-                os.remove(self._count_lock_file)
-                path = os.path.dirname(self._count_file)
-                for _ in range(3):
-                    try:  # Take advantage that os.rmdir does not delete non-empty dirs
-                        os.rmdir(path)
-                    except Exception:
-                        break  # not empty
-                    path = os.path.dirname(path)
-            except Exception:
-                pass
+@contextmanager
+def write_lock(lock_path):
+    rw_lock = fasteners.InterProcessReaderWriterLock(lock_path)
+    with rw_lock.write_lock():
+        yield


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Fasteners code is very old and dead, modernizing.
In theory fasteners 0.19, the latest one and used one does not support Python 3.6 or Python 3.7, but it is "not tested", nothing specific has been banned so far apparently. So it keeps working for our case in Python 3.6.

I have tested the new Readers-Writers lock separately with success, very promising, the current context managers here should work safely