### PR TITLE
[new templates][bazel] Added `.bazelrc` to new templates

### DIFF
--- a/conan/cli/commands/new.py
+++ b/conan/cli/commands/new.py
@@ -68,7 +68,7 @@ def new(conan_api, parser, *args):
                 template_vars.extend(meta.find_undeclared_variables(ast))
 
             injected_vars = {"conan_version", "package_name", "as_name"}
-            optional_vars = {"requires", "tool_requires"}
+            optional_vars = {"requires", "tool_requires", "outputRootDir"}
             template_vars = list(set(template_vars) - injected_vars - optional_vars)
             template_vars.sort()
             return template_vars

--- a/conan/cli/commands/new.py
+++ b/conan/cli/commands/new.py
@@ -68,7 +68,7 @@ def new(conan_api, parser, *args):
                 template_vars.extend(meta.find_undeclared_variables(ast))
 
             injected_vars = {"conan_version", "package_name", "as_name"}
-            optional_vars = {"requires", "tool_requires", "outputRootDir"}
+            optional_vars = {"requires", "tool_requires", "output_root_dir"}
             template_vars = list(set(template_vars) - injected_vars - optional_vars)
             template_vars.sort()
             return template_vars

--- a/conan/internal/api/new/bazel_7_exe.py
+++ b/conan/internal/api/new/bazel_7_exe.py
@@ -59,7 +59,7 @@ cc_binary(
 
 _bazel_workspace = " "  # Important not empty, so template doesn't discard it
 _bazel_rc = """\
-{% if outputRootDir is defined %}startup --output_user_root={{outputRootDir}}{% endif %}
+{% if output_root_dir is defined %}startup --output_user_root={{output_root_dir}}{% endif %}
 """
 
 bazel_exe_files_7 = {"conanfile.py": conanfile_exe,

--- a/conan/internal/api/new/bazel_7_exe.py
+++ b/conan/internal/api/new/bazel_7_exe.py
@@ -17,7 +17,7 @@ class {{package_name}}Recipe(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
 
     # Sources are located in the same place as this recipe, copy them to the recipe
-    exports_sources = "main/*", "MODULE.bazel"
+    exports_sources = "main/*", "MODULE.bazel", ".bazelrc"
 
     generators = "BazelToolchain"
 
@@ -58,7 +58,9 @@ cc_binary(
 """
 
 _bazel_workspace = " "  # Important not empty, so template doesn't discard it
-
+_bazel_rc = """\
+{% if outputRootDir is defined %}startup --output_user_root={{outputRootDir}}{% endif %}
+"""
 
 bazel_exe_files_7 = {"conanfile.py": conanfile_exe,
                      "main/{{name}}.cpp": source_cpp,
@@ -66,5 +68,6 @@ bazel_exe_files_7 = {"conanfile.py": conanfile_exe,
                      "main/main.cpp": test_main,
                      "main/BUILD": _bazel_build_exe,
                      "MODULE.bazel": _bazel_workspace,
+                     ".bazelrc": _bazel_rc,
                      "test_package/conanfile.py": test_conanfile_exe_v2
                    }

--- a/conan/internal/api/new/bazel_7_lib.py
+++ b/conan/internal/api/new/bazel_7_lib.py
@@ -17,7 +17,7 @@ class {{package_name}}Recipe(ConanFile):
     default_options = {"shared": False, "fPIC": True}
 
     # Sources are located in the same place as this recipe, copy them to the recipe
-    exports_sources = "main/*", "MODULE.bazel"
+    exports_sources = "main/*", "MODULE.bazel", ".bazelrc"
     generators = "BazelToolchain"
 
     def config_options(self):
@@ -116,6 +116,9 @@ cc_shared_library(
 """
 
 _bazel_workspace = " "  # Important not empty, so template doesn't discard it
+_bazel_rc = """\
+{% if outputRootDir is defined %}startup --output_user_root={{outputRootDir}}{% endif %}
+"""
 _test_bazel_module_bazel = """\
 load_conan_dependencies = use_extension("//conan:conan_deps_module_extension.bzl", "conan_extension")
 use_repo(load_conan_dependencies, "{{name}}")
@@ -136,7 +139,9 @@ bazel_lib_files_7 = {"conanfile.py": conanfile_sources_v2,
                      "main/{{name}}.h": source_h,
                      "main/BUILD": _get_bazel_build(),
                      "MODULE.bazel": _bazel_workspace,
+                     ".bazelrc": _bazel_rc,
                      "test_package/conanfile.py": test_conanfile_v2,
                      "test_package/main/example.cpp": test_main,
                      "test_package/main/BUILD": _bazel_build_test,
-                     "test_package/MODULE.bazel": _test_bazel_module_bazel}
+                     "test_package/MODULE.bazel": _test_bazel_module_bazel,
+                     "test_package/.bazelrc": _bazel_rc}

--- a/conan/internal/api/new/bazel_7_lib.py
+++ b/conan/internal/api/new/bazel_7_lib.py
@@ -117,7 +117,7 @@ cc_shared_library(
 
 _bazel_workspace = " "  # Important not empty, so template doesn't discard it
 _bazel_rc = """\
-{% if outputRootDir is defined %}startup --output_user_root={{outputRootDir}}{% endif %}
+{% if output_root_dir is defined %}startup --output_user_root={{output_root_dir}}{% endif %}
 """
 _test_bazel_module_bazel = """\
 load_conan_dependencies = use_extension("//conan:conan_deps_module_extension.bzl", "conan_extension")

--- a/conan/internal/api/new/bazel_exe.py
+++ b/conan/internal/api/new/bazel_exe.py
@@ -17,7 +17,7 @@ class {{package_name}}Recipe(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
 
     # Sources are located in the same place as this recipe, copy them to the recipe
-    exports_sources = "main/*", "WORKSPACE"
+    exports_sources = "main/*", "WORKSPACE", ".bazelrc"
     generators = "BazelToolchain"
 
     def layout(self):
@@ -61,7 +61,9 @@ cc_binary(
 """
 
 _bazel_workspace = " "  # Important not empty, so template doesn't discard it
-
+_bazel_rc = """\
+{% if outputRootDir is defined %}startup --output_user_root={{outputRootDir}}{% endif %}
+"""
 
 bazel_exe_files = {"conanfile.py": conanfile_exe,
                    "main/{{name}}.cpp": source_cpp,
@@ -69,5 +71,6 @@ bazel_exe_files = {"conanfile.py": conanfile_exe,
                    "main/main.cpp": test_main,
                    "main/BUILD": _bazel_build_exe,
                    "WORKSPACE": _bazel_workspace,
+                   ".bazelrc": _bazel_rc,
                    "test_package/conanfile.py": test_conanfile_exe_v2
                    }

--- a/conan/internal/api/new/bazel_exe.py
+++ b/conan/internal/api/new/bazel_exe.py
@@ -62,7 +62,7 @@ cc_binary(
 
 _bazel_workspace = " "  # Important not empty, so template doesn't discard it
 _bazel_rc = """\
-{% if outputRootDir is defined %}startup --output_user_root={{outputRootDir}}{% endif %}
+{% if output_root_dir is defined %}startup --output_user_root={{output_root_dir}}{% endif %}
 """
 
 bazel_exe_files = {"conanfile.py": conanfile_exe,

--- a/conan/internal/api/new/bazel_lib.py
+++ b/conan/internal/api/new/bazel_lib.py
@@ -121,7 +121,7 @@ cc_shared_library(
 
 _bazel_workspace = " "  # Important not empty, so template doesn't discard it
 _bazel_rc = """\
-{% if outputRootDir is defined %}startup --output_user_root={{outputRootDir}}{% endif %}
+{% if output_root_dir is defined %}startup --output_user_root={{output_root_dir}}{% endif %}
 """
 _test_bazel_workspace = """
 load("@//conan:dependencies.bzl", "load_conan_dependencies")

--- a/conan/internal/api/new/bazel_lib.py
+++ b/conan/internal/api/new/bazel_lib.py
@@ -17,7 +17,7 @@ class {{package_name}}Recipe(ConanFile):
     default_options = {"shared": False, "fPIC": True}
 
     # Sources are located in the same place as this recipe, copy them to the recipe
-    exports_sources = "main/*", "WORKSPACE"
+    exports_sources = "main/*", "WORKSPACE", ".bazelrc"
     generators = "BazelToolchain"
 
     def config_options(self):
@@ -120,6 +120,9 @@ cc_shared_library(
 """
 
 _bazel_workspace = " "  # Important not empty, so template doesn't discard it
+_bazel_rc = """\
+{% if outputRootDir is defined %}startup --output_user_root={{outputRootDir}}{% endif %}
+"""
 _test_bazel_workspace = """
 load("@//conan:dependencies.bzl", "load_conan_dependencies")
 load_conan_dependencies()
@@ -140,7 +143,9 @@ bazel_lib_files = {"conanfile.py": conanfile_sources_v2,
                    "main/{{name}}.h": source_h,
                    "main/BUILD": _get_bazel_build(),
                    "WORKSPACE": _bazel_workspace,
+                   ".bazelrc": _bazel_rc,
                    "test_package/conanfile.py": test_conanfile_v2,
                    "test_package/main/example.cpp": test_main,
                    "test_package/main/BUILD": _bazel_build_test,
-                   "test_package/WORKSPACE": _test_bazel_workspace}
+                   "test_package/WORKSPACE": _test_bazel_workspace,
+                   "test_package/.bazelrc": _bazel_rc}

--- a/test/functional/toolchains/google/test_bazel.py
+++ b/test/functional/toolchains/google/test_bazel.py
@@ -9,7 +9,7 @@ from conan.test.utils.tools import TestClient
 
 @pytest.fixture(scope="module")
 def bazel_output_root_dir():
-    return temp_folder(path_with_spaces=False)
+    return temp_folder(path_with_spaces=False).replace("\\", "/")
 
 
 @pytest.fixture(scope="module")

--- a/test/functional/toolchains/google/test_bazel.py
+++ b/test/functional/toolchains/google/test_bazel.py
@@ -3,7 +3,13 @@ import textwrap
 
 import pytest
 
+from conan.test.utils.test_files import temp_folder
 from conan.test.utils.tools import TestClient
+
+
+@pytest.fixture(scope="module")
+def bazel_output_root_dir():
+    return temp_folder(path_with_spaces=False)
 
 
 @pytest.fixture(scope="module")
@@ -33,9 +39,9 @@ def base_profile():
 
 @pytest.mark.parametrize("build_type", ["Debug", "Release", "RelWithDebInfo", "MinSizeRel"])
 @pytest.mark.tool("bazel", "6.3.2")
-def test_basic_exe_6x(bazelrc, build_type, base_profile):
+def test_basic_exe_6x(bazelrc, build_type, base_profile, bazel_output_root_dir):
     client = TestClient(path_with_spaces=False)
-    client.run("new bazel_exe -d name=myapp -d version=1.0")
+    client.run(f"new bazel_exe -d name=myapp -d version=1.0 -d outputRootDir={bazel_output_root_dir}")
     # The build:<config> define several configurations that can be activated by passing
     # the bazel config with tools.google.bazel:configs
     client.save({"mybazelrc": bazelrc})
@@ -51,9 +57,9 @@ def test_basic_exe_6x(bazelrc, build_type, base_profile):
 
 @pytest.mark.parametrize("build_type", ["Debug", "Release", "RelWithDebInfo", "MinSizeRel"])
 @pytest.mark.tool("bazel", "7.1.2")
-def test_basic_exe(bazelrc, build_type, base_profile):
+def test_basic_exe(bazelrc, build_type, base_profile, bazel_output_root_dir):
     client = TestClient(path_with_spaces=False)
-    client.run("new bazel_7_exe -d name=myapp -d version=1.0")
+    client.run(f"new bazel_7_exe -d name=myapp -d version=1.0 -d outputRootDir={bazel_output_root_dir}")
     # The build:<config> define several configurations that can be activated by passing
     # the bazel config with tools.google.bazel:configs
     client.save({"mybazelrc": bazelrc})
@@ -69,7 +75,7 @@ def test_basic_exe(bazelrc, build_type, base_profile):
 
 @pytest.mark.parametrize("shared", [False, True])
 @pytest.mark.tool("bazel", "6.3.2")
-def test_transitive_libs_consuming_6x(shared):
+def test_transitive_libs_consuming_6x(shared, bazel_output_root_dir):
     """
     Testing the next dependencies structure for shared/static libs
 
@@ -98,7 +104,7 @@ def test_transitive_libs_consuming_6x(shared):
     client = TestClient(path_with_spaces=False)
     # A regular library made with Bazel
     with client.chdir("myfirstlib"):
-        client.run("new bazel_lib -d name=myfirstlib -d version=1.2.11")
+        client.run(f"new bazel_lib -d name=myfirstlib -d version=1.2.11 -d outputRootDir={bazel_output_root_dir}")
         conanfile = client.load("conanfile.py")
         conanfile += """
         self.cpp_info.defines.append("MY_DEFINE=\\"MY_VALUE\\"")
@@ -115,7 +121,7 @@ def test_transitive_libs_consuming_6x(shared):
         # We prepare a consumer with Bazel (library mysecondlib using myfirstlib)
         # and a test_package with an example executable
         os_ = platform.system()
-        client.run("new bazel_lib -d name=mysecondlib -d version=1.0")
+        client.run(f"new bazel_lib -d name=mysecondlib -d version=1.0 -d outputRootDir={bazel_output_root_dir}")
         conanfile = client.load("conanfile.py")
         conanfile = conanfile.replace('generators = "BazelToolchain"',
                                       'generators = "BazelToolchain", "BazelDeps"\n'
@@ -195,7 +201,7 @@ def test_transitive_libs_consuming_6x(shared):
 
 @pytest.mark.parametrize("shared", [False, True])
 @pytest.mark.tool("bazel", "7.1.2")
-def test_transitive_libs_consuming(shared):
+def test_transitive_libs_consuming(shared, bazel_output_root_dir):
     """
     Testing the next dependencies structure for shared/static libs
 
@@ -224,7 +230,7 @@ def test_transitive_libs_consuming(shared):
     client = TestClient(path_with_spaces=False)
     # A regular library made with Bazel
     with client.chdir("myfirstlib"):
-        client.run("new bazel_7_lib -d name=myfirstlib -d version=1.2.11")
+        client.run(f"new bazel_7_lib -d name=myfirstlib -d version=1.2.11 -d outputRootDir={bazel_output_root_dir}")
         conanfile = client.load("conanfile.py")
         conanfile += """
         self.cpp_info.defines.append("MY_DEFINE=\\"MY_VALUE\\"")
@@ -241,7 +247,7 @@ def test_transitive_libs_consuming(shared):
         # We prepare a consumer with Bazel (library mysecondlib using myfirstlib)
         # and a test_package with an example executable
         os_ = platform.system()
-        client.run("new bazel_7_lib -d name=mysecondlib -d version=1.0")
+        client.run(f"new bazel_7_lib -d name=mysecondlib -d version=1.0 -d outputRootDir={bazel_output_root_dir}")
         conanfile = client.load("conanfile.py")
         conanfile = conanfile.replace('generators = "BazelToolchain"',
                                       'generators = "BazelToolchain", "BazelDeps"\n'

--- a/test/functional/toolchains/google/test_bazel.py
+++ b/test/functional/toolchains/google/test_bazel.py
@@ -41,7 +41,7 @@ def base_profile():
 @pytest.mark.tool("bazel", "6.3.2")
 def test_basic_exe_6x(bazelrc, build_type, base_profile, bazel_output_root_dir):
     client = TestClient(path_with_spaces=False)
-    client.run(f"new bazel_exe -d name=myapp -d version=1.0 -d outputRootDir={bazel_output_root_dir}")
+    client.run(f"new bazel_exe -d name=myapp -d version=1.0 -d output_root_dir={bazel_output_root_dir}")
     # The build:<config> define several configurations that can be activated by passing
     # the bazel config with tools.google.bazel:configs
     client.save({"mybazelrc": bazelrc})
@@ -59,7 +59,7 @@ def test_basic_exe_6x(bazelrc, build_type, base_profile, bazel_output_root_dir):
 @pytest.mark.tool("bazel", "7.1.2")
 def test_basic_exe(bazelrc, build_type, base_profile, bazel_output_root_dir):
     client = TestClient(path_with_spaces=False)
-    client.run(f"new bazel_7_exe -d name=myapp -d version=1.0 -d outputRootDir={bazel_output_root_dir}")
+    client.run(f"new bazel_7_exe -d name=myapp -d version=1.0 -d output_root_dir={bazel_output_root_dir}")
     # The build:<config> define several configurations that can be activated by passing
     # the bazel config with tools.google.bazel:configs
     client.save({"mybazelrc": bazelrc})
@@ -104,7 +104,7 @@ def test_transitive_libs_consuming_6x(shared, bazel_output_root_dir):
     client = TestClient(path_with_spaces=False)
     # A regular library made with Bazel
     with client.chdir("myfirstlib"):
-        client.run(f"new bazel_lib -d name=myfirstlib -d version=1.2.11 -d outputRootDir={bazel_output_root_dir}")
+        client.run(f"new bazel_lib -d name=myfirstlib -d version=1.2.11 -d output_root_dir={bazel_output_root_dir}")
         conanfile = client.load("conanfile.py")
         conanfile += """
         self.cpp_info.defines.append("MY_DEFINE=\\"MY_VALUE\\"")
@@ -121,7 +121,7 @@ def test_transitive_libs_consuming_6x(shared, bazel_output_root_dir):
         # We prepare a consumer with Bazel (library mysecondlib using myfirstlib)
         # and a test_package with an example executable
         os_ = platform.system()
-        client.run(f"new bazel_lib -d name=mysecondlib -d version=1.0 -d outputRootDir={bazel_output_root_dir}")
+        client.run(f"new bazel_lib -d name=mysecondlib -d version=1.0 -d output_root_dir={bazel_output_root_dir}")
         conanfile = client.load("conanfile.py")
         conanfile = conanfile.replace('generators = "BazelToolchain"',
                                       'generators = "BazelToolchain", "BazelDeps"\n'
@@ -230,7 +230,7 @@ def test_transitive_libs_consuming(shared, bazel_output_root_dir):
     client = TestClient(path_with_spaces=False)
     # A regular library made with Bazel
     with client.chdir("myfirstlib"):
-        client.run(f"new bazel_7_lib -d name=myfirstlib -d version=1.2.11 -d outputRootDir={bazel_output_root_dir}")
+        client.run(f"new bazel_7_lib -d name=myfirstlib -d version=1.2.11 -d output_root_dir={bazel_output_root_dir}")
         conanfile = client.load("conanfile.py")
         conanfile += """
         self.cpp_info.defines.append("MY_DEFINE=\\"MY_VALUE\\"")
@@ -247,7 +247,7 @@ def test_transitive_libs_consuming(shared, bazel_output_root_dir):
         # We prepare a consumer with Bazel (library mysecondlib using myfirstlib)
         # and a test_package with an example executable
         os_ = platform.system()
-        client.run(f"new bazel_7_lib -d name=mysecondlib -d version=1.0 -d outputRootDir={bazel_output_root_dir}")
+        client.run(f"new bazel_7_lib -d name=mysecondlib -d version=1.0 -d output_root_dir={bazel_output_root_dir}")
         conanfile = client.load("conanfile.py")
         conanfile = conanfile.replace('generators = "BazelToolchain"',
                                       'generators = "BazelToolchain", "BazelDeps"\n'

--- a/test/functional/toolchains/google/test_bazeltoolchain_cross_compilation.py
+++ b/test/functional/toolchains/google/test_bazeltoolchain_cross_compilation.py
@@ -61,12 +61,13 @@ def test_bazel_simple_cross_compilation():
     )
     """)
     client = TestClient(path_with_spaces=False)
+    bazel_root_dir = temp_folder(path_with_spaces=False).replace("\\", "/")
     client.save({
         "profile": profile,
         "profile_host": profile_host,
         "conanfile.py": conanfile,
         "WORKSPACE": "",
-        ".bazelrc": f"startup --output_user_root={temp_folder(path_with_spaces=False)}",
+        ".bazelrc": f"startup --output_user_root={bazel_root_dir}",
         "main/BUILD": BUILD,
         "main/myapp.cpp": gen_function_cpp(name="myapp"),
         "main/myapp.h": gen_function_h(name="myapp"),

--- a/test/functional/toolchains/google/test_bazeltoolchain_cross_compilation.py
+++ b/test/functional/toolchains/google/test_bazeltoolchain_cross_compilation.py
@@ -5,6 +5,7 @@ import textwrap
 import pytest
 
 from conan.test.assets.sources import gen_function_cpp, gen_function_h
+from conan.test.utils.test_files import temp_folder
 from conan.test.utils.tools import TestClient
 
 
@@ -65,6 +66,7 @@ def test_bazel_simple_cross_compilation():
         "profile_host": profile_host,
         "conanfile.py": conanfile,
         "WORKSPACE": "",
+        ".bazelrc": f"startup --output_user_root={temp_folder(path_with_spaces=False)}",
         "main/BUILD": BUILD,
         "main/myapp.cpp": gen_function_cpp(name="myapp"),
         "main/myapp.h": gen_function_h(name="myapp"),


### PR DESCRIPTION
Changelog: Feature: Added `outputRootDir` as an optional definition in Bazel new templates.
Docs: Omit

Actually, this is meant to avoid filling the disk due to the Bazel cache. Now, passing an `outputRootDir` value, we ensure that cache deletion.