### PR TITLE
Fix handling of `tools.build:defines` for (Ninja) multi-config CMake CMake (#15921)

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -724,7 +724,7 @@ class ExtraFlagsBlock(Block):
         {% if defines %}
         {% if config %}
         {% for define in defines %}
-        add_compile_definitions($<$<CONFIG:{{config}}>:"{{ define }}">)
+        add_compile_definitions("$<$<CONFIG:{{config}}>:{{ define }}>")
         {% endfor %}
         {% else %}
         add_compile_definitions({% for define in defines %} "{{ define }}"{% endfor %})

--- a/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1916,7 +1916,7 @@ def test_cmake_toolchain_cxxflags_multi_config():
 
 
 @pytest.mark.tool("ninja")
-@pytest.mark.tool("cmake")
+@pytest.mark.tool("cmake", "3.23")
 def test_cmake_toolchain_ninja_multi_config():
     c = TestClient()
     profile_release = textwrap.dedent(r"""

--- a/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1989,28 +1989,29 @@ def test_cmake_toolchain_ninja_multi_config():
             "profile_debug": profile_debug,
             "profile_relwithdebinfo": profile_relwithdebinfo,
             "src/main.cpp": main,
-            "CMakeLists.txt": cmakelists}, clean_first=True)
+            "CMakeLists.txt": cmakelists})
     c.run("install . -pr=./profile_release")
     c.run("install . -pr=./profile_debug")
     c.run("install . -pr=./profile_relwithdebinfo")
 
     with c.chdir("build"):
-        c.run_command("cmake .. -G \"Ninja Multi-Config\" -DCMAKE_TOOLCHAIN_FILE=generators/conan_toolchain.cmake")
+        c.run_command(f"cmake .. -G \"Ninja Multi-Config\" "
+                      "-DCMAKE_TOOLCHAIN_FILE=generators/conan_toolchain.cmake")
         c.run_command("cmake --build . --config Release")
         c.run_command("cmake --build . --config Debug")
         c.run_command("cmake --build . --config RelWithDebInfo")
 
-    c.run_command(r"build/Release/example")
+    c.run_command(os.sep.join([".", "build", "Release", "example"]))
     assert 'DEFINE conan_test_answer=42!' in c.out
     assert 'DEFINE conan_test_other=24!' in c.out
     assert 'complex=' not in c.out
 
-    c.run_command(r"build/Debug/example")
+    c.run_command(os.sep.join([".", "build", "Debug", "example"]))
     assert 'DEFINE conan_test_answer=123' in c.out
     assert 'other=' not in c.out
     assert 'complex=' not in c.out
 
-    c.run_command(r"build/RelWithDebInfo/example")
+    c.run_command(os.sep.join([".", "build", "RelWithDebInfo", "example"]))
     assert 'DEFINE conan_test_answer=456!' in c.out
     assert 'DEFINE conan_test_other=abc!' in c.out
     assert 'DEFINE conan_test_complex="1 2"!' in c.out

--- a/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1995,11 +1995,12 @@ def test_cmake_toolchain_ninja_multi_config():
     c.run("install . -pr=./profile_relwithdebinfo")
 
     with c.chdir("build"):
-        c.run_command(f"cmake .. -G \"Ninja Multi-Config\" "
+        env = r".\generators\conanbuild.bat &&" if platform.system() == "Windows" else ""
+        c.run_command(f"{env} cmake .. -G \"Ninja Multi-Config\" "
                       "-DCMAKE_TOOLCHAIN_FILE=generators/conan_toolchain.cmake")
-        c.run_command("cmake --build . --config Release")
-        c.run_command("cmake --build . --config Debug")
-        c.run_command("cmake --build . --config RelWithDebInfo")
+        c.run_command(f"{env} cmake --build . --config Release")
+        c.run_command(f"{env} cmake --build . --config Debug")
+        c.run_command(f"{env} cmake --build . --config RelWithDebInfo")
 
     c.run_command(os.sep.join([".", "build", "Release", "example"]))
     assert 'DEFINE conan_test_answer=42!' in c.out


### PR DESCRIPTION
Changelog: Bugfix: Fix handling of `tools.build:defines` for Ninja Multi-Config CMake.
Docs: Omit
Fixes: #15921 

The CMake generator-expressions that results from the values given to Conan's `tools.build:defines` configuration will now properly be put into quotes to form a CMake string. (_Note: CMake's generator-expressions should never contain any (non-escaped) quotes._)

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
