### PR TITLE
[settings] subsettings from fake settings 

### DIFF
--- a/conans/client/graph/compatibility.py
+++ b/conans/client/graph/compatibility.py
@@ -146,12 +146,12 @@ class BinaryCompatibility:
                 compat_info = conanfile.original_info.clone()
                 settings = elem.get("settings")
                 if settings:
-                    compat_info.settings.update_values(settings)
+                    compat_info.settings.update_values(settings, raise_error=False)
                 options = elem.get("options")
                 if options:
                     compat_info.options.update(options_values=OrderedDict(options))
                 result.append(compat_info)
                 settings_target = elem.get("settings_target")
                 if settings_target and compat_info.settings_target:
-                    compat_info.settings_target.update_values(settings_target)
+                    compat_info.settings_target.update_values(settings_target, raise_error=False)
         return result

--- a/conans/client/graph/compatibility.py
+++ b/conans/client/graph/compatibility.py
@@ -146,12 +146,12 @@ class BinaryCompatibility:
                 compat_info = conanfile.original_info.clone()
                 settings = elem.get("settings")
                 if settings:
-                    compat_info.settings.update_values(settings, raise_error=False)
+                    compat_info.settings.update_values(settings, raise_undefined=False)
                 options = elem.get("options")
                 if options:
                     compat_info.options.update(options_values=OrderedDict(options))
                 result.append(compat_info)
                 settings_target = elem.get("settings_target")
                 if settings_target and compat_info.settings_target:
-                    compat_info.settings_target.update_values(settings_target, raise_error=False)
+                    compat_info.settings_target.update_values(settings_target, raise_undefined=False)
         return result

--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -302,24 +302,24 @@ class Settings(object):
     def items(self):
         return self.values_list
 
-    def update_values(self, vals, raise_error=True):
-        """ receives a list of tuples (compiler.version, value)
-        This is more an updated than a setter
+    def update_values(self, values, raise_error=True):
+        """
+        Receives a list of tuples (compiler.version, value)
+        This is more an updater than a setter.
         """
         self._frozen = False  # Could be restored at the end, but not really necessary
-        assert isinstance(vals, (list, tuple)), vals
-        for (name, value) in vals:
+        assert isinstance(values, (list, tuple)), values
+        for (name, value) in values:
             list_settings = name.split(".")
             attr = self
             try:
                 for setting in list_settings[:-1]:
                     attr = getattr(attr, setting)
+                value = str(value) if value is not None else None
+                setattr(attr, list_settings[-1], value)
             except ConanException:  # fails if receiving settings doesn't have it defined
                 if raise_error:
                     raise
-            else:
-                value = str(value) if value is not None else None
-                setattr(attr, list_settings[-1], value)
 
     def constrained(self, constraint_def):
         """ allows to restrict a given Settings object with the input of another Settings object

--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -315,7 +315,7 @@ class Settings(object):
                 for setting in list_settings[:-1]:
                     attr = getattr(attr, setting)
             except ConanException:  # fails if receiving settings doesn't have it defined
-                pass
+                raise
             else:
                 value = str(value) if value is not None else None
                 setattr(attr, list_settings[-1], value)

--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -302,7 +302,7 @@ class Settings(object):
     def items(self):
         return self.values_list
 
-    def update_values(self, values, raise_error=True):
+    def update_values(self, values, raise_undefined=True):
         """
         Receives a list of tuples (compiler.version, value)
         This is more an updater than a setter.
@@ -318,7 +318,7 @@ class Settings(object):
                 value = str(value) if value is not None else None
                 setattr(attr, list_settings[-1], value)
             except ConanException:  # fails if receiving settings doesn't have it defined
-                if raise_error:
+                if raise_undefined:
                     raise
 
     def constrained(self, constraint_def):

--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -302,7 +302,7 @@ class Settings(object):
     def items(self):
         return self.values_list
 
-    def update_values(self, vals):
+    def update_values(self, vals, raise_error=True):
         """ receives a list of tuples (compiler.version, value)
         This is more an updated than a setter
         """
@@ -315,7 +315,8 @@ class Settings(object):
                 for setting in list_settings[:-1]:
                     attr = getattr(attr, setting)
             except ConanException:  # fails if receiving settings doesn't have it defined
-                raise
+                if raise_error:
+                    raise
             else:
                 value = str(value) if value is not None else None
                 setattr(attr, list_settings[-1], value)

--- a/test/integration/settings/test_non_defining_settings.py
+++ b/test/integration/settings/test_non_defining_settings.py
@@ -1,5 +1,6 @@
 import textwrap
 
+from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
 
 
@@ -29,3 +30,15 @@ def test_settings_not_defined_consuming():
     # It doesn't fail, even if settings not defined
     c.run("install --requires=pkg/1.0 -pr=profile -s os=Linux -s arch=x86")
     # It doesn't fail, even if settings different value
+
+
+def test_settings_undefined():
+    client = TestClient()
+    client.save({
+        "conanfile.py": GenConanfile(name="hello", version="1.0")
+    })
+    # Undefined settings field
+    client.run("install . -s foo=None", assert_error=True)
+    assert "'settings.foo' doesn't exist for 'settings'" in client.out
+    client.run("install . -s foo.bar=None", assert_error=True)
+    assert "'settings.foo' doesn't exist for 'settings'" in client.out

--- a/test/unittests/model/settings_test.py
+++ b/test/unittests/model/settings_test.py
@@ -481,3 +481,25 @@ def test_settings_intel_cppstd_03():
     settings.compiler = "intel-cc"
     # This doesn't crash, it used to crash due to "03" not quoted in setting.yml
     settings.compiler.cppstd = "03"
+
+
+def test_set_value_non_existing_values():
+    data = {
+        "compiler": {
+            "gcc": {
+                "version": ["4.8", "4.9"],
+                "arch": {"x86": {"speed": ["A", "B"]},
+                         "x64": {"speed": ["C", "D"]}}}
+        },
+        "os": ["Windows", "Linux"]
+    }
+    settings = Settings(data)
+    with pytest.raises(ConanException) as cm:
+        settings.update_values([("foo", "A")])
+    assert "'settings.foo' doesn't exist for 'settings'" in str(cm.value)
+    with pytest.raises(ConanException) as cm:
+        settings.update_values([("foo.bar", "A")])
+    assert "'settings.foo' doesn't exist for 'settings'" in str(cm.value)
+    # it does not raise any error
+    settings.update_values([("foo", "A")], raise_error=False)
+    settings.update_values([("foo.bar", "A")], raise_error=False)

--- a/test/unittests/model/settings_test.py
+++ b/test/unittests/model/settings_test.py
@@ -501,5 +501,5 @@ def test_set_value_non_existing_values():
         settings.update_values([("foo.bar", "A")])
     assert "'settings.foo' doesn't exist for 'settings'" in str(cm.value)
     # it does not raise any error
-    settings.update_values([("foo", "A")], raise_error=False)
-    settings.update_values([("foo.bar", "A")], raise_error=False)
+    settings.update_values([("foo", "A")], raise_undefined=False)
+    settings.update_values([("foo.bar", "A")], raise_undefined=False)


### PR DESCRIPTION
Changelog: Bugfix: Avoid `settings.update_values()` failing when deducing compatibility.
Docs: omit

cc @AbrilRBS 