### PR TITLE
Add message when unzipping files

### DIFF
--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -281,6 +281,7 @@ def unzip(conanfile, filename, destination=".", keep_permissions=False, pattern=
     """
 
     output = conanfile.output
+    output.info(f"Unzipping {filename} to {destination}")
     if (filename.endswith(".tar.gz") or filename.endswith(".tgz") or
             filename.endswith(".tbz2") or filename.endswith(".tar.bz2") or
             filename.endswith(".tar")):


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Adding because I got bitten a bit by this

For cases of very large files, Conan will get stuck for a while, and the user might not know what is actually going on (This is specially visible in things like QT etc)

This adds the last line to outputs like this, to let the user know Conan did not actually hang while downloading - we might want to skip the final folder as that's inferred from the source() method title output, but I thought it could be useful elsewhere
![image](https://github.com/user-attachments/assets/610f27cd-e47c-4551-b826-5508763bd2e1)
