### PR TITLE
better errors for pkg-list files loading

### DIFF
--- a/conan/api/model.py
+++ b/conan/api/model.py
@@ -1,6 +1,7 @@
 import fnmatch
 import json
 import os
+from json import JSONDecodeError
 
 from conans.client.graph.graph import RECIPE_EDITABLE, RECIPE_CONSUMER, RECIPE_PLATFORM, \
     RECIPE_VIRTUAL, BINARY_SKIP, BINARY_MISSING, BINARY_INVALID
@@ -73,7 +74,12 @@ class MultiPackagesList:
 
     @staticmethod
     def load(file):
-        content = json.loads(load(file))
+        try:
+            content = json.loads(load(file))
+        except JSONDecodeError as e:
+            raise ConanException(f"Package list file invalid JSON: {file}\n{e}")
+        except Exception as e:
+            raise ConanException(f"Package list file missing or broken: {file}\n{e}")
         result = {}
         for remote, pkglist in content.items():
             if "error" in pkglist:

--- a/test/integration/command_v2/test_combined_pkglist_flows.py
+++ b/test/integration/command_v2/test_combined_pkglist_flows.py
@@ -259,6 +259,15 @@ class TestPkgListMerge:
         settings = rev["packages"]["9e186f6d94c008b544af1569d1a6368d8339efc5"]["info"]["settings"]
         assert settings == {"build_type": "Debug"}
 
+    def test_pkglist_file_error(self):
+        # This can happen when reusing the same file in input and output
+        c = TestClient(light=True)
+        c.run("pkglist merge -l mylist.json", assert_error=True)
+        assert "ERROR: Package list file missing or broken:" in c.out
+        c.save({"mylist.json": ""})
+        c.run("pkglist merge -l mylist.json", assert_error=True)
+        assert "ERROR: Package list file invalid JSON:" in c.out
+
 
 class TestDownloadUpload:
     @pytest.fixture()


### PR DESCRIPTION
Changelog: Fix: Better error messages when loading an inexistent or broken "package list" file.
Docs: Omit

Coming from the review in https://github.com/conan-io/docs/pull/3799
