### PR TITLE
improve error message for deploy folder

### DIFF
--- a/conan/internal/deploy.py
+++ b/conan/internal/deploy.py
@@ -40,7 +40,10 @@ def _find_deployer(d, cache_deploy_folder):
 
 
 def do_deploys(conan_api, graph, deploy, deploy_package, deploy_folder):
-    mkdir(deploy_folder)
+    try:
+        mkdir(deploy_folder)
+    except Exception as e:
+        raise ConanException(f"Deployer folder cannot be created '{deploy_folder}':\n{e}")
     # handle the recipe deploy()
     if deploy_package:
         # Similar processing as BuildMode class

--- a/test/functional/command/test_install_deploy.py
+++ b/test/functional/command/test_install_deploy.py
@@ -443,8 +443,10 @@ def test_deploy_incorrect_folder():
     c.save({"conanfile.txt": ""})
     c.run('install . --deployer=full_deploy --deployer-folder="mydep fold"')
     assert os.path.exists(os.path.join(c.current_folder, "mydep fold"))
-    c.run(r'install . --deployer=full_deploy --deployer-folder="\"mydep fold\""', assert_error=True)
-    assert "ERROR: Deployer folder cannot be created" in c.out
+    if platform.system() == "Windows":  # This only fails in Windows
+        c.run(r'install . --deployer=full_deploy --deployer-folder="\"mydep fold\""',
+              assert_error=True)
+        assert "ERROR: Deployer folder cannot be created" in c.out
 
 
 class TestRuntimeDeployer:

--- a/test/functional/command/test_install_deploy.py
+++ b/test/functional/command/test_install_deploy.py
@@ -437,6 +437,16 @@ def test_not_deploy_absolute_paths():
     assert f'export MYPATH="{some_abs_path}/mypath"' in env
 
 
+def test_deploy_incorrect_folder():
+    # https://github.com/conan-io/cmake-conan/issues/658
+    c = TestClient()
+    c.save({"conanfile.txt": ""})
+    c.run('install . --deployer=full_deploy --deployer-folder="mydep fold"')
+    assert os.path.exists(os.path.join(c.current_folder, "mydep fold"))
+    c.run(r'install . --deployer=full_deploy --deployer-folder="\"mydep fold\""', assert_error=True)
+    assert "ERROR: Deployer folder cannot be created" in c.out
+
+
 class TestRuntimeDeployer:
     def test_runtime_deploy(self):
         c = TestClient()


### PR DESCRIPTION
Changelog: Fix: Improve error message when passing a ``--deployer-folder=xxx`` argument of an incorrect folder.
Docs: Omit

Related to https://github.com/conan-io/cmake-conan/issues/658