### PR TITLE
Add possibility to enforce return value of cross_building via conf

### DIFF
--- a/conan/tools/build/cross_building.py
+++ b/conan/tools/build/cross_building.py
@@ -1,5 +1,8 @@
 
 def cross_building(conanfile=None, skip_x64_x86=False):
+    cross_build = conanfile.conf.get("tools.build.cross_building:cross_build", check_type=bool)
+    if cross_build is not None:
+        return cross_build
 
     build_os, build_arch, host_os, host_arch = get_cross_building_settings(conanfile)
 


### PR DESCRIPTION
Changelog: Feature: Add possibility to enforce return value of cross_building via conf.
Docs: Omit

No associated issue. This is a backport of functionality on develop2, to help me ease migration of our components.