### PR TITLE
Test to show that yml anchors work with `trim_conandata`

### DIFF
--- a/test/integration/conanfile/conan_data_test.py
+++ b/test/integration/conanfile/conan_data_test.py
@@ -467,3 +467,10 @@ def test_trim_conandata_anchors():
              """)})
     tc.run("create . --version=2.0")
     assert "x: foo" in tc.out
+    pkg_layout = tc.exported_layout()
+    conandata = tc.load(pkg_layout.conandata())
+    assert conandata == textwrap.dedent("""\
+        mapping:
+          '2.0':
+            x: foo
+        """)


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Just a new test to ensure approaches like https://github.com/conan-io/conan-center-index/pull/22421/files keep working