### PR TITLE
Add newly released gcc 14.2

### DIFF
--- a/conans/client/conf/__init__.py
+++ b/conans/client/conf/__init__.py
@@ -97,7 +97,7 @@ compiler:
                     "11", "11.1", "11.2", "11.3", "11.4",
                     "12", "12.1", "12.2", "12.3",  "12.4",
                     "13", "13.1", "13.2", "13.3",
-                    "14", "14.1"]
+                    "14", "14.1", "14.2"]
         libcxx: [libstdc++, libstdc++11]
         threads: [null, posix, win32]  # Windows MinGW
         exception: [null, dwarf2, sjlj, seh]  # Windows MinGW


### PR DESCRIPTION
Changelog: Feature: Add support for gcc 14.2.
Docs: https://github.com/conan-io/docs/pull/3851

Nothing important in this release beside bugfixes and regression fixes https://gcc.gnu.org/gcc-14/