### PR TITLE
[fix] Conan 2.x: Avoid SyntaxWarning spam by updating Patch-NG to 1.18.0

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -2,7 +2,7 @@ requests>=2.25, <3.0.0
 urllib3>=1.26.6, <1.27
 colorama>=0.4.3, <0.5.0
 PyYAML>=6.0, <7.0
-patch-ng>=1.17.4, <1.18
+patch-ng>=1.18.0, <1.19
 fasteners>=0.15
 distro>=1.4.0, <=1.8.0; platform_system == 'Linux' or platform_system == 'FreeBSD'
 Jinja2>=3.0, <4.0.0


### PR DESCRIPTION
Update `patch-ng` minor version to be able to fix https://github.com/conan-io/conan/issues/16759

The release 1.18.0 (https://github.com/conan-io/python-patch-ng/releases/tag/1.18.0) has a proper fix (https://github.com/conan-io/python-patch-ng/pull/29) to avoid warnings in Python 3.12

Changelog: Fix: Update patch-ng 1.18.0 to avoid SyntaxWarning spam.
Docs: Omit

fixes #16759


- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.