### PR TITLE
Issue with 'automatic' compatible packages and custom package ids

### DIFF
--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -394,6 +394,17 @@ class GraphBinariesAnalyzer(object):
                                           default_python_requires_id_mode=
                                           default_python_requires_id_mode)
         conanfile.original_info = conanfile.info.clone()
+
+        # Call the package id before any compatibility, as the other way around
+        # compatibile packages will be cloned from a wrong info set. How?
+        # If the package id erases a few options / settings and it is done AFTER
+        # compatibility, the compatible packages will still look for packages 
+        # containing those - later erased - options, settings
+        with conanfile_exception_formatter(str(conanfile), "package_id"):
+            with conan_v2_property(conanfile, 'cpp_info',
+                                   "'self.cpp_info' access in package_id() method is deprecated"):
+                conanfile.package_id()
+
         if not self._cache.new_config["core.package_id:msvc_visual_incompatible"]:
             msvc_compatible = conanfile.info.msvc_compatible()
             if msvc_compatible:
@@ -402,12 +413,6 @@ class GraphBinariesAnalyzer(object):
         apple_clang_compatible = conanfile.info.apple_clang_compatible()
         if apple_clang_compatible:
             conanfile.compatible_packages.append(apple_clang_compatible)
-
-        # Once we are done, call package_id() to narrow and change possible values
-        with conanfile_exception_formatter(str(conanfile), "package_id"):
-            with conan_v2_property(conanfile, 'cpp_info',
-                                   "'self.cpp_info' access in package_id() method is deprecated"):
-                conanfile.package_id()
 
         if hasattr(conanfile, "validate") and callable(conanfile.validate):
             with conanfile_exception_formatter(str(conanfile), "validate"):

--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -600,12 +600,15 @@ class ConanInfo(object):
             compatible.settings.compiler.cppstd = cppstd
 
         from conan.tools.microsoft.visual import msvc_version_to_vs_ide_version
-        visual_version = msvc_version_to_vs_ide_version(version)
-        compatible.settings.compiler.version = visual_version
-        runtime = "MT" if runtime == "static" else "MD"
-        if runtime_type == "Debug":
-            runtime = "{}d".format(runtime)
-        compatible.settings.compiler.runtime = runtime
+        if version is not None:
+            visual_version = msvc_version_to_vs_ide_version(version)
+            compatible.settings.compiler.version = visual_version
+
+        if runtime is not None and runtime_type is not None:
+            runtime = "MT" if runtime == "static" else "MD"
+            if runtime_type == "Debug":
+                runtime = "{}d".format(runtime)
+            compatible.settings.compiler.runtime = runtime
 
         # Some 'final adjustment'
         # In case the cppstd is the 'default' for the compiler, it will actually be erased

--- a/conans/test/integration/package_id/compatible_test.py
+++ b/conans/test/integration/package_id/compatible_test.py
@@ -771,3 +771,27 @@ class TestNewCompatibility:
         client.run("install . -o pkg/*:optimized=3")
         assert "pkg/0.1@user/stable: Already installed!" in client.out
         assert f"pkg/0.1@user/stable:{package_id} - Cache" in client.out
+
+
+def test_crash():
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+       from conans import ConanFile
+
+       class Pkg(ConanFile):
+           settings = "os", "compiler"
+           def package_id(self):
+               del self.info.settings.compiler.version
+       """)
+    profile = textwrap.dedent("""
+       [settings]
+       os = Windows
+       compiler=msvc
+       compiler.version=192
+       compiler.runtime=dynamic
+       compiler.cppstd=14
+       build_type=Release
+       """)
+    client.save({"conanfile.py": conanfile,
+                 "myprofile": profile})
+    client.run("create . pkg/0.1@ -pr=myprofile")


### PR DESCRIPTION
ISSUE-16785: Issue with 'automatic' compatible packages and custom package ids

In case the recipe uses its own package_id() and compatible packages are generated automatically (e.g. Visual Studio vs msvc), then the compatible packages will use wrong 'base' info set for the compatible package id generation.

In case the recipe's own package_id() erases a few options / settings, the compatible packages will not know about it, as those are generated prior the recipe's package_id() is being called.

The change makes sure that first the recipe's package_id() is called, then the compatible packages are generated, so that they pick up the updated info set.

Changelog: Bugfix: Automatically generated compatible packages are wrong in case of custom package_id().
Docs: Omit

- [X] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
