### PR TITLE
Add `set_property` for PkgConfigDeps

### DIFF
--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -417,13 +417,13 @@ class PkgConfigDeps:
 
     def set_property(self, dep, prop, value):
         """
-        Using this method you can overwrite the :ref:`property<CMakeDeps Properties>` values set by
+        Using this method you can overwrite the :ref:`property<PkgConfigDeps Properties>` values set by
         the Conan recipes from the consumer. This can be done for `pkg_config_name`,
         `pkg_config_aliases` and `pkg_config_custom_content` properties.
 
-        :param dep: Name of the dependency to set the :ref:`property<CMakeDeps Properties>`. For
+        :param dep: Name of the dependency to set the :ref:`property<PkgConfigDeps Properties>`. For
          components use the syntax: ``dep_name::component_name``.
-        :param prop: Name of the :ref:`property<CMakeDeps Properties>`.
+        :param prop: Name of the :ref:`property<PkgConfigDeps Properties>`.
         :param value: Value of the property. Use ``None`` to invalidate any value set by the
          upstream recipe.
         """

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -416,19 +416,16 @@ class PkgConfigDeps:
         for generator_file, content in generator_files.items():
             save(generator_file, content)
 
-    def set_property(self, dep, prop, value, build_context=False):
+    def set_property(self, dep, prop, value):
         """
         Using this method you can overwrite the :ref:`property<CMakeDeps Properties>` values set by
-        the Conan recipes from the consumer. This can be done for `cmake_file_name`, `cmake_target_name`,
-        `cmake_find_mode`, `cmake_module_file_name` and `cmake_module_target_name` properties.
+        the Conan recipes from the consumer. This can be done for `pkg_config_name`,
+        `pkg_config_aliases` and `pkg_config_custom_content` properties.
 
         :param dep: Name of the dependency to set the :ref:`property<CMakeDeps Properties>`. For
          components use the syntax: ``dep_name::component_name``.
         :param prop: Name of the :ref:`property<CMakeDeps Properties>`.
         :param value: Value of the property. Use ``None`` to invalidate any value set by the
          upstream recipe.
-        :param build_context: Set to ``True`` if you want to set the property for a dependency that
-         belongs to the build context (``False`` by default).
         """
-        build_suffix = "&build" if build_context else ""
-        self._properties.setdefault(f"{dep}{build_suffix}", {}).update({prop: value})
+        self._properties.setdefault(dep, {}).update({prop: value})

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -398,9 +398,8 @@ class PkgConfigDeps:
             # Filter the build_requires not activated with PkgConfigDeps.build_context_activated
             if require.build and dep.ref.name not in self.build_context_activated:
                 continue
-            if dep.ref.name in self._properties:
-                for prop, value in self._properties[dep.ref.name].items():
-                    dep.cpp_info.set_property(prop, value)
+            for prop, value in self._properties.get(dep.ref.name, {}).items():
+                dep.cpp_info.set_property(prop, value)
 
             # Save all the *.pc files and their contents
             pc_files.update(_PCGenerator(self, require, dep).pc_files)

--- a/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -1197,12 +1197,7 @@ def test_pkg_config_deps_set_property():
     c.run("create dep")
     c.run("create other")
     c.run("install app")
-    try:
-        # This file shouldn't exist
-        c.load("app/dep.pc")
-        assert False
-    except FileNotFoundError:
-        pass
+    assert not os.path.exists(os.path.join(c.current_folder, "app", "dep.pc"))
 
     dep = c.load("app/depx264.pc")
     assert 'Name: depx264' in dep


### PR DESCRIPTION
Changelog: Feature: Add `set_property` for PkgConfigDeps to set properties for requirements from consumer recipes.
Docs: Omit

close: #13076
