### PR TITLE
Fix traceback when graph build-order-merge gets missing packages without node entries

### DIFF
--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -133,7 +133,6 @@ def graph_build_order(conan_api, parser, subparser, *args):
             "conan_error": install_graph.get_errors()}
 
 
-
 @conan_subcommand(formatters={"text": cli_build_order, "json": json_build_order,
                               "html": format_build_order_html})
 def graph_build_order_merge(conan_api, parser, subparser, *args):

--- a/conans/client/graph/install_graph.py
+++ b/conans/client/graph/install_graph.py
@@ -492,7 +492,7 @@ class InstallGraph:
                     binary, reason = "Invalid", node.conanfile.info.invalid
                 errors.append(f"{tab}- {node.ref}: {binary}: {reason}")
         if missing:
-            missing_prefs = set(n.nodes[0].pref for n in missing)  # avoid duplicated
+            missing_prefs = set(n.nodes[0].pref if n.nodes else n.pref for n in missing)  # avoid duplicated
             for pref in list(sorted([str(pref) for pref in missing_prefs])):
                 errors.append(f"{tab}- {pref}: Missing binary")
         if errors:

--- a/conans/client/graph/install_graph.py
+++ b/conans/client/graph/install_graph.py
@@ -485,14 +485,9 @@ class InstallGraph:
             errors.append("There are some error(s) in the graph:")
         if invalid:
             for package in invalid:
-                node = package.nodes[0]
-                if node.cant_build and node.should_build:
-                    binary, reason = "Cannot build for this configuration", node.cant_build
-                else:
-                    binary, reason = "Invalid", node.conanfile.info.invalid
-                errors.append(f"{tab}- {node.ref}: {binary}: {reason}")
+                errors.append(f"{tab}- {package.pref}: Invalid configuration")
         if missing:
-            missing_prefs = set(n.nodes[0].pref if n.nodes else n.pref for n in missing)  # avoid duplicated
+            missing_prefs = set(n.pref for n in missing)  # avoid duplicated
             for pref in list(sorted([str(pref) for pref in missing_prefs])):
                 errors.append(f"{tab}- {pref}: Missing binary")
         if errors:

--- a/test/integration/command_v2/test_info_build_order.py
+++ b/test/integration/command_v2/test_info_build_order.py
@@ -717,3 +717,14 @@ class TestBuildOrderReduce:
         # different order
         c.run(f"graph build-order-merge --file=bo3.json --file=bo2.json", assert_error=True)
         assert "ERROR: Cannot merge build-orders of configuration!=recipe" in c.out
+
+    def test_merge_same_no_stacktrace(self):
+        tc = TestClient(light=True)
+        tc.save({"dep/conanfile.py": GenConanfile("dep", "1.0"),
+                 "pkg/conanfile.py": GenConanfile("pkg", "1.0").with_requires("dep/1.0")})
+        tc.run("export dep")
+        tc.run("export pkg")
+        tc.run("graph build-order --order=recipe --requires=pkg/1.0 --format=json", assert_error=True, redirect_stdout="order.json")
+        tc.run("graph build-order-merge --file=order.json --file=order.json --format=json", assert_error=True)
+        assert "dep/1.0:da39a3ee5e6b4b0d3255bfef95601890afd80709: Missing binary" in tc.out
+        assert "IndexError: list index out of range" not in tc.out


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Not quite sure that this is the best approach, but it bit me when trying to find missing binaries and their corresponding build-order