### PR TITLE
Add test to show users about `compiler.cppstd` when it's hardcoded in the CmakeLists

### DIFF
--- a/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -2018,13 +2018,15 @@ def test_cmake_toolchain_ninja_multi_config():
     assert 'DEFINE conan_test_complex="1 2"!' in c.out
 
 
-def test_cxx_version_not_overriden_if_foced():
+@pytest.mark.tool("cmake")
+@pytest.mark.skipif(platform.system() != "Darwin", reason="Only needs to run once, no need for extra platforms")
+def test_cxx_version_not_overriden_if_hardcoded():
     """Any C++ standard set in the CMakeLists.txt will have priority even if the
     compiler.cppstd is set in the profile"""
     tc = TestClient()
     tc.run("new cmake_exe -dname=foo -dversion=1.0")
 
-    cml_contents = tc.load("CMakelists.txt")
+    cml_contents = tc.load("CMakeLists.txt")
     cml_contents = cml_contents.replace("project(foo CXX)\n", "project(foo CXX)\nset(CMAKE_CXX_STANDARD 17)\n")
     tc.save({"CMakeLists.txt": cml_contents})
 

--- a/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -2019,13 +2019,17 @@ def test_cmake_toolchain_ninja_multi_config():
 
 
 def test_cxx_version_not_overriden_if_foced():
+    """Any C++ standard set in the CMakeLists.txt will have priority even if the
+    compiler.cppstd is set in the profile"""
     tc = TestClient()
     tc.run("new cmake_exe -dname=foo -dversion=1.0")
+
     cml_contents = tc.load("CMakelists.txt")
     cml_contents = cml_contents.replace("project(foo CXX)\n", "project(foo CXX)\nset(CMAKE_CXX_STANDARD 17)\n")
     tc.save({"CMakeLists.txt": cml_contents})
 
+    # The compiler.cppstd will not override the CXX_STANDARD variable
     tc.run("create . -s=compiler.cppstd=11")
     assert "Conan toolchain: C++ Standard 11 with extensions OFF" in tc.out
-    ## Conan says yes! But alas
+    # Conan says yes! But alas, the compiled code is C++17
     assert "foo/1.0: __cplusplus2017" in tc.out

--- a/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -2016,3 +2016,16 @@ def test_cmake_toolchain_ninja_multi_config():
     assert 'DEFINE conan_test_answer=456!' in c.out
     assert 'DEFINE conan_test_other=abc!' in c.out
     assert 'DEFINE conan_test_complex="1 2"!' in c.out
+
+
+def test_cxx_version_not_overriden_if_foced():
+    tc = TestClient()
+    tc.run("new cmake_exe -dname=foo -dversion=1.0")
+    cml_contents = tc.load("CMakelists.txt")
+    cml_contents = cml_contents.replace("project(foo CXX)\n", "project(foo CXX)\nset(CMAKE_CXX_STANDARD 17)\n")
+    tc.save({"CMakeLists.txt": cml_contents})
+
+    tc.run("create . -s=compiler.cppstd=11")
+    assert "Conan toolchain: C++ Standard 11 with extensions OFF" in tc.out
+    ## Conan says yes! But alas
+    assert "foo/1.0: __cplusplus2017" in tc.out


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

To be able to show to users why we would ask to remove that line in upstream cmakelists in CCI