### PR TITLE
`get_property` with `check_type` for CMakeDeps

### DIFF
--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -149,7 +149,7 @@ class CMakeDeps(object):
         build_suffix = "&build" if build_context else ""
         self._properties.setdefault(f"{dep}{build_suffix}", {}).update({prop: value})
 
-    def get_property(self, prop, dep, comp_name=None):
+    def get_property(self, prop, dep, comp_name=None, check_type=None):
         dep_name = dep.ref.name
         build_suffix = "&build" if str(
             dep_name) in self.build_context_activated and dep.context == "build" else ""
@@ -157,8 +157,8 @@ class CMakeDeps(object):
         try:
             return self._properties[f"{dep_comp}{build_suffix}"][prop]
         except KeyError:
-            return dep.cpp_info.get_property(prop) if not comp_name else dep.cpp_info.components[
-                comp_name].get_property(prop)
+            return dep.cpp_info.get_property(prop, check_type=check_type) if not comp_name \
+                else dep.cpp_info.components[comp_name].get_property(prop, check_type=check_type)
 
     def get_cmake_package_name(self, dep, module_mode=None):
         """Get the name of the file for the find_package(XXX)"""

--- a/conan/tools/cmake/cmakedeps/templates/config.py
+++ b/conan/tools/cmake/cmakedeps/templates/config.py
@@ -25,7 +25,7 @@ class ConfigTemplate(CMakeDepsFileTemplate):
     @property
     def additional_variables_prefixes(self):
         prefix_list = (
-            self.cmakedeps.get_property("cmake_additional_variables_prefixes", self.conanfile) or [])
+            self.cmakedeps.get_property("cmake_additional_variables_prefixes", self.conanfile, check_type=list) or [])
         return list(set([self.file_name] + prefix_list))
 
     @property

--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -28,7 +28,7 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
 
         is_win = self.conanfile.settings.get_safe("os") == "Windows"
         auto_link = self.cmakedeps.get_property("cmake_set_interface_link_directories",
-                                                self.conanfile)
+                                                self.conanfile, check_type=bool)
         return {"pkg_name": self.pkg_name,
                 "root_target_name": self.root_target_name,
                 "config_suffix": self.config_suffix,

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -356,8 +356,8 @@ class _TargetDataContext(object):
         if require and not require.run:
             self.bin_paths = ""
 
-        build_modules = cmakedeps.get_property("cmake_build_modules", conanfile) or []
+        build_modules = cmakedeps.get_property("cmake_build_modules", conanfile, check_type=list) or []
         self.build_modules_paths = join_paths(build_modules)
         # SONAME flag only makes sense for SHARED libraries
-        nosoname = cmakedeps.get_property("nosoname", conanfile, comp_name)
+        nosoname = cmakedeps.get_property("nosoname", conanfile, comp_name, check_type=bool)
         self.no_soname = str((nosoname if self.library_type == "SHARED" else False) or False).upper()


### PR DESCRIPTION
Changelog: Feature: Add `check_type` to `get_property`  for CMakeDeps.
Docs: https://github.com/conan-io/docs/pull/3815

This is the second part of this #16848
