### PR TITLE
Add confs to control default automatic generation of virtualenvs

### DIFF
--- a/conan/api/subapi/config.py
+++ b/conan/api/subapi/config.py
@@ -51,8 +51,8 @@ class ConfigAPI:
 
         # Computation of a very simple graph that requires "ref"
         conanfile = app.loader.load_virtual(requires=[RecipeReference.loads(ref)])
-        consumer_definer(conanfile, profile_build, profile_host)
         root_node = Node(ref=None, conanfile=conanfile, context=CONTEXT_HOST, recipe=RECIPE_VIRTUAL)
+        consumer_definer(conanfile, profile_build, profile_host)
         root_node.is_conf = True
         update = ["*"]
         builder = DepsGraphBuilder(app.proxy, app.loader, app.range_resolver, app.cache, remotes,

--- a/conan/api/subapi/graph.py
+++ b/conan/api/subapi/graph.py
@@ -32,18 +32,18 @@ class GraphAPI:
             ref = RecipeReference(conanfile.name, conanfile.version,
                                   conanfile.user, conanfile.channel)
             context = CONTEXT_BUILD if is_build_require else CONTEXT_HOST
-            # Here, it is always the "host" context because it is the base, not the current node one
-            initialize_conanfile_profile(conanfile, profile_build, profile_host, CONTEXT_HOST,
-                                         is_build_require, ref)
             if ref.name:
                 profile_host.options.scope(ref)
             root_node = Node(ref, conanfile, context=context, recipe=RECIPE_CONSUMER, path=path)
             root_node.should_build = True  # It is a consumer, this is something we are building
+            # Here, it is always the "host" context because it is the base, not the current node one
+            initialize_conanfile_profile(conanfile, profile_build, profile_host, CONTEXT_HOST,
+                                         is_build_require, ref)
         else:
             conanfile = app.loader.load_conanfile_txt(path)
-            consumer_definer(conanfile, profile_host, profile_build)
             root_node = Node(None, conanfile, context=CONTEXT_HOST, recipe=RECIPE_CONSUMER,
                              path=path)
+            consumer_definer(conanfile, profile_host, profile_build)
         return root_node
 
     def load_root_test_conanfile(self, path, tested_reference, profile_host, profile_build,
@@ -95,8 +95,8 @@ class GraphAPI:
                                             graph_lock=lockfile, remotes=remotes,
                                             update=update, check_updates=check_updates)
 
-        consumer_definer(conanfile, profile_host, profile_build)
         root_node = Node(ref=None, conanfile=conanfile, context=CONTEXT_HOST, recipe=RECIPE_VIRTUAL)
+        consumer_definer(conanfile, profile_host, profile_build)
         return root_node
 
     @staticmethod

--- a/conan/api/subapi/graph.py
+++ b/conan/api/subapi/graph.py
@@ -32,13 +32,13 @@ class GraphAPI:
             ref = RecipeReference(conanfile.name, conanfile.version,
                                   conanfile.user, conanfile.channel)
             context = CONTEXT_BUILD if is_build_require else CONTEXT_HOST
-            if ref.name:
-                profile_host.options.scope(ref)
             root_node = Node(ref, conanfile, context=context, recipe=RECIPE_CONSUMER, path=path)
             root_node.should_build = True  # It is a consumer, this is something we are building
             # Here, it is always the "host" context because it is the base, not the current node one
             initialize_conanfile_profile(conanfile, profile_build, profile_host, CONTEXT_HOST,
                                          is_build_require, ref)
+            if ref.name:
+                profile_host.options.scope(ref)
         else:
             conanfile = app.loader.load_conanfile_txt(path)
             root_node = Node(None, conanfile, context=CONTEXT_HOST, recipe=RECIPE_CONSUMER,

--- a/conan/internal/api/install/generators.py
+++ b/conan/internal/api/install/generators.py
@@ -116,6 +116,9 @@ def write_generators(conanfile, app):
             with conanfile_exception_formatter(conanfile, "generate"):
                 conanfile.generate()
 
+    assert conanfile.virtualbuildenv is not None
+    assert conanfile.virtualrunenv is not None
+
     if conanfile.virtualbuildenv:
         mkdir(new_gen_folder)
         with chdir(new_gen_folder):

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -357,13 +357,13 @@ class DepsGraphBuilder(object):
         is_test_package = getattr(node.conanfile, "tested_reference_str", False)
         if node.conanfile._conan_is_consumer and (node.recipe == RECIPE_VIRTUAL or is_test_package):
             dep_conanfile._conan_is_consumer = True
-        initialize_conanfile_profile(dep_conanfile, profile_build, profile_host, node.context,
-                                     require.build, new_ref, parent=node.conanfile)
 
         context = CONTEXT_BUILD if require.build else node.context
         new_node = Node(new_ref, dep_conanfile, context=context, test=require.test or node.test)
         new_node.recipe = recipe_status
         new_node.remote = remote
+        initialize_conanfile_profile(dep_conanfile, profile_build, profile_host, node.context,
+                                     require.build, new_ref, parent=node.conanfile)
 
         down_options = self._compute_down_options(node, require, new_ref)
 

--- a/conans/client/graph/profile_node_definer.py
+++ b/conans/client/graph/profile_node_definer.py
@@ -73,12 +73,14 @@ def _per_package_settings(conanfile, profile, ref):
 def _initialize_virtualenv_generation(conanfile):
     # This only applies to consumers and editable recipes, else builds would break by disabling
     # generation for build tools like cmake, etc for example
-    if conanfile._conan_node.recipe not in (RECIPE_CONSUMER, RECIPE_EDITABLE):
-        return
+    try:
+        is_consumer = conanfile._conan_node.recipe not in (RECIPE_CONSUMER, RECIPE_EDITABLE)
+    except Exception as e:
+        raise e
     if conanfile.virtualbuildenv is None:  # Allow the user to override it with True or False
-        conanfile.virtualbuildenv = conanfile.conf.get("tools.env.virtualbuildenv:autogenerate", True, check_type=bool)
+        conanfile.virtualbuildenv = True if not is_consumer else conanfile.conf.get("tools.env.virtualbuildenv:autogenerate", True, check_type=bool)
     if conanfile.virtualrunenv is None:  # Allow the user to override it with True or False
-        conanfile.virtualrunenv = conanfile.conf.get("tools.env.virtualrunenv:autogenerate", True, check_type=bool)
+        conanfile.virtualrunenv = True if not is_consumer else conanfile.conf.get("tools.env.virtualrunenv:autogenerate", True, check_type=bool)
 
 
 def _initialize_conanfile(conanfile, profile, settings, ref):
@@ -93,6 +95,7 @@ def _initialize_conanfile(conanfile, profile, settings, ref):
     conanfile._conan_runenv = profile.runenv
     conanfile.conf = profile.conf.get_conanfile_conf(ref, conanfile._conan_is_consumer)  # Maybe this can be done lazy too
     _initialize_virtualenv_generation(conanfile)
+
 
 def consumer_definer(conanfile, profile_host, profile_build):
     """ conanfile.txt does not declare settings, but it assumes it uses all the profile settings

--- a/conans/client/graph/profile_node_definer.py
+++ b/conans/client/graph/profile_node_definer.py
@@ -1,4 +1,4 @@
-from conans.client.graph.graph import CONTEXT_BUILD
+from conans.client.graph.graph import CONTEXT_BUILD, RECIPE_CONSUMER, RECIPE_EDITABLE
 from conans.errors import ConanException
 from conans.model.recipe_ref import ref_matches
 
@@ -71,6 +71,10 @@ def _per_package_settings(conanfile, profile, ref):
 
 
 def _initialize_virtualenv_generation(conanfile):
+    # This only applies to consumers and editable recipes, else builds would break by disabling
+    # generation for build tools like cmake, etc for example
+    if conanfile._conan_node.recipe not in (RECIPE_CONSUMER, RECIPE_EDITABLE):
+        return
     if conanfile.virtualbuildenv is None:  # Allow the user to override it with True or False
         conanfile.virtualbuildenv = conanfile.conf.get("tools.env.virtualbuildenv:autogenerate", True, check_type=bool)
     if conanfile.virtualrunenv is None:  # Allow the user to override it with True or False

--- a/conans/client/graph/profile_node_definer.py
+++ b/conans/client/graph/profile_node_definer.py
@@ -73,7 +73,7 @@ def _per_package_settings(conanfile, profile, ref):
 def _initialize_virtualenv_generation(conanfile):
     # This only applies to consumers and editable recipes, else builds would break by disabling
     # generation for build tools like cmake, etc for example
-    is_consumer = conanfile._conan_node.recipe not in (RECIPE_CONSUMER, RECIPE_EDITABLE)
+    is_consumer = conanfile._conan_node.recipe in (RECIPE_CONSUMER, RECIPE_EDITABLE)
     if conanfile.virtualbuildenv is None:  # Allow the user to override it with True or False
         conanfile.virtualbuildenv = True if not is_consumer else conanfile.conf.get("tools.env.virtualbuildenv:autogenerate", True, check_type=bool)
     if conanfile.virtualrunenv is None:  # Allow the user to override it with True or False

--- a/conans/client/graph/profile_node_definer.py
+++ b/conans/client/graph/profile_node_definer.py
@@ -73,10 +73,7 @@ def _per_package_settings(conanfile, profile, ref):
 def _initialize_virtualenv_generation(conanfile):
     # This only applies to consumers and editable recipes, else builds would break by disabling
     # generation for build tools like cmake, etc for example
-    try:
-        is_consumer = conanfile._conan_node.recipe not in (RECIPE_CONSUMER, RECIPE_EDITABLE)
-    except Exception as e:
-        raise e
+    is_consumer = conanfile._conan_node.recipe not in (RECIPE_CONSUMER, RECIPE_EDITABLE)
     if conanfile.virtualbuildenv is None:  # Allow the user to override it with True or False
         conanfile.virtualbuildenv = True if not is_consumer else conanfile.conf.get("tools.env.virtualbuildenv:autogenerate", True, check_type=bool)
     if conanfile.virtualrunenv is None:  # Allow the user to override it with True or False

--- a/conans/client/graph/profile_node_definer.py
+++ b/conans/client/graph/profile_node_definer.py
@@ -70,6 +70,13 @@ def _per_package_settings(conanfile, profile, ref):
     return tmp_settings
 
 
+def _initialize_virtualenv_generation(conanfile):
+    if conanfile.virtualbuildenv is None:  # Allow the user to override it with True or False
+        conanfile.virtualbuildenv = conanfile.conf.get("tools.env.virtualbuildenv:autogenerate", True, check_type=bool)
+    if conanfile.virtualrunenv is None:  # Allow the user to override it with True or False
+        conanfile.virtualrunenv = conanfile.conf.get("tools.env.virtualrunenv:autogenerate", True, check_type=bool)
+
+
 def _initialize_conanfile(conanfile, profile, settings, ref):
     try:
         settings.constrained(conanfile.settings)
@@ -81,7 +88,7 @@ def _initialize_conanfile(conanfile, profile, settings, ref):
     conanfile._conan_buildenv = profile.buildenv
     conanfile._conan_runenv = profile.runenv
     conanfile.conf = profile.conf.get_conanfile_conf(ref, conanfile._conan_is_consumer)  # Maybe this can be done lazy too
-
+    _initialize_virtualenv_generation(conanfile)
 
 def consumer_definer(conanfile, profile_host, profile_build):
     """ conanfile.txt does not declare settings, but it assumes it uses all the profile settings
@@ -108,3 +115,4 @@ def consumer_definer(conanfile, profile_host, profile_build):
     conanfile._conan_buildenv = profile_host.buildenv
     conanfile._conan_runenv = profile_host.runenv
     conanfile.conf = profile_host.conf.get_conanfile_conf(None, is_consumer=True)
+    _initialize_virtualenv_generation(conanfile)

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -111,10 +111,12 @@ class ConanFile:
         self.env_info = MockInfoProperty("env_info")
         self._conan_dependencies = None
 
-        if not hasattr(self, "virtualbuildenv"):  # Allow the user to override it with True or False
-            self.virtualbuildenv = True
-        if not hasattr(self, "virtualrunenv"):  # Allow the user to override it with True or False
-            self.virtualrunenv = True
+        # Allow the user to override them with True or False
+        # If not, value will be given in profile_node_definer based on confs
+        if not hasattr(self, "virtualbuildenv"):
+            self.virtualbuildenv = None
+        if not hasattr(self, "virtualrunenv"):
+            self.virtualrunenv = None
 
         self.env_scripts = {}  # Accumulate the env scripts generated in order
         self.system_requires = {}  # Read only, internal {"apt": []}

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -117,8 +117,8 @@ BUILT_IN_CONFS = {
     "tools.apple:enable_arc": "(boolean) Enable/Disable ARC Apple Clang flags",
     "tools.apple:enable_visibility": "(boolean) Enable/Disable Visibility Apple Clang flags",
     "tools.env.virtualenv:powershell": "If it is set to True it will generate powershell launchers if os=Windows",
-    "tools.env.virtualrunenv:autogenerate": "Whether to autogenerate virtualrunenv launchers (True by default)",
-    "tools.env.virtualbuildenv:autogenerate": "Whether to autogenerate virtualbuildenv launchers (True by default)",
+    "tools.env.virtualrunenv:autogenerate": "Whether to autogenerate virtualrunenv launchers for consumer recipes (True by default)",
+    "tools.env.virtualbuildenv:autogenerate": "Whether to autogenerate virtualbuildenv launchers for consumer recipes (True by default)",
     # Compilers/Flags configurations
     "tools.build:compiler_executables": "Defines a Python dict-like with the compilers path to be used. Allowed keys {'c', 'cpp', 'cuda', 'objc', 'objcxx', 'rc', 'fortran', 'asm', 'hip', 'ispc'}",
     "tools.build:cxxflags": "List of extra CXX flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -117,6 +117,8 @@ BUILT_IN_CONFS = {
     "tools.apple:enable_arc": "(boolean) Enable/Disable ARC Apple Clang flags",
     "tools.apple:enable_visibility": "(boolean) Enable/Disable Visibility Apple Clang flags",
     "tools.env.virtualenv:powershell": "If it is set to True it will generate powershell launchers if os=Windows",
+    "tools.env.virtualrunenv:autogenerate": "Whether to autogenerate virtualrunenv launchers (True by default)",
+    "tools.env.virtualbuildenv:autogenerate": "Whether to autogenerate virtualbuildenv launchers (True by default)",
     # Compilers/Flags configurations
     "tools.build:compiler_executables": "Defines a Python dict-like with the compilers path to be used. Allowed keys {'c', 'cpp', 'cuda', 'objc', 'objcxx', 'rc', 'fortran', 'asm', 'hip', 'ispc'}",
     "tools.build:cxxflags": "List of extra CXX flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",


### PR DESCRIPTION
Changelog: Feature: Add confs to control default automatic generation of virtualenvs
Docs: TODO

As part of the work to support ROS by @danimtb, this need arose

It was a bit tricky to cover all the cases, as losing the choice in the constructor meant having to track down where after the conf was properly defined this needed to be setup. The final decision seems reasonable to me, but happy to discuss other possibilities I might have missed!


Close https://github.com/conan-io/conan/issues/16117
