### PR TITLE
Add variable_watch for `CMAKE_{C,CXX}_STANDARD` in `conan_toolchain.cmake`

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -274,13 +274,14 @@ class CppStdBlock(Block):
         # Define the C++ and C standards from 'compiler.cppstd' and 'compiler.cstd'
 
         function(conan_modify_std_watch variable access value current_list_file stack)
-            set(watched_variable {{ cppstd }})
+            set(conan_watched_std_variable {{ cppstd }})
             if (${variable} STREQUAL "CMAKE_C_STANDARD")
-                set(watched_variable {{ cstd }})
+                set(conan_watched_std_variable {{ cstd }})
             endif()
-            if (${access} STREQUAL "MODIFIED_ACCESS" AND NOT ${value} STREQUAL ${watched_variable})
-                message(STATUS "Warning: Standard ${variable} value defined in conan_toolchain.cmake to ${watched_variable} has been modified to ${value} by ${current_list_file}")
+            if (${access} STREQUAL "MODIFIED_ACCESS" AND NOT ${value} STREQUAL ${conan_watched_std_variable})
+                message(STATUS "Warning: Standard ${variable} value defined in conan_toolchain.cmake to ${conan_watched_std_variable} has been modified to ${value} by ${current_list_file}")
             endif()
+            unset(conan_watched_std_variable)
         endfunction()
 
         {% if cppstd %}

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -273,17 +273,33 @@ class CppStdBlock(Block):
     template = textwrap.dedent("""\
         # Define the C++ and C standards from 'compiler.cppstd' and 'compiler.cstd'
 
+        function(conan_modify_std_watch variable access value current_list_file original_value)
+            if (${access} STREQUAL "MODIFIED_ACCESS" AND NOT ${value} STREQUAL ${original_value})
+                message(STATUS "Warning: Standard ${variable} value defined in conan_toolchain.cmake to ${original_value} has been modified to ${value} by ${current_list_file}")
+            endif()
+        endfunction()
+
         {% if cppstd %}
         message(STATUS "Conan toolchain: C++ Standard {{ cppstd }} with extensions {{ cppstd_extensions }}")
         set(CMAKE_CXX_STANDARD {{ cppstd }})
         set(CMAKE_CXX_EXTENSIONS {{ cppstd_extensions }})
         set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+        function(conan_modify_cppstd_watch variable access value current_list_file stack)
+            conan_modify_std_watch(${variable} ${access} ${value} ${current_list_file} {{ cppstd }})
+        endfunction()
+        variable_watch(CMAKE_CXX_STANDARD conan_modify_cppstd_watch)
         {% endif %}
         {% if cstd %}
         message(STATUS "Conan toolchain: C Standard {{ cstd }} with extensions {{ cstd_extensions }}")
         set(CMAKE_C_STANDARD {{ cstd }})
         set(CMAKE_C_EXTENSIONS {{ cstd_extensions }})
         set(CMAKE_C_STANDARD_REQUIRED ON)
+
+        function(conan_modify_cstd_watch variable access value current_list_file stack)
+            conan_modify_std_watch(${variable} ${access} ${value} ${current_list_file} {{ cstd }})
+        endfunction()
+        variable_watch(CMAKE_C_STANDARD conan_modify_cstd_watch)
         {% endif %}
         """)
 

--- a/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -2037,3 +2037,7 @@ def test_cxx_version_not_overriden_if_hardcoded():
 
     # Even though Conan warns, the compiled code is C++17
     assert "foo/1.0: __cplusplus2017" in tc.out
+
+    tc.run("create . -s=compiler.cppstd=17")
+    assert "Conan toolchain: C++ Standard 17 with extensions OFF" in tc.out
+    assert "Warning: Standard CMAKE_CXX_STANDARD value defined in conan_toolchain.cmake to 17 has been modified to 17" not in tc.out

--- a/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -2033,5 +2033,7 @@ def test_cxx_version_not_overriden_if_hardcoded():
     # The compiler.cppstd will not override the CXX_STANDARD variable
     tc.run("create . -s=compiler.cppstd=11")
     assert "Conan toolchain: C++ Standard 11 with extensions OFF" in tc.out
-    # Conan says yes! But alas, the compiled code is C++17
+    assert "Warning: Standard CMAKE_CXX_STANDARD value defined in conan_toolchain.cmake to 11 has been modified to 17" in tc.out
+
+    # Even though Conan warns, the compiled code is C++17
     assert "foo/1.0: __cplusplus2017" in tc.out


### PR DESCRIPTION
Changelog: Feature: Add variable_watch for `CMAKE_{C,CXX}_STANDARD` in `conan_toolchain.cmake`.
Docs: Omit

[`variable_watch`](https://cmake.org/cmake/help/v3.30/command/variable_watch.html) has been supported since CMake 3.0 https://cmake.org/cmake/help/v3.0/command/variable_watch.html