### PR TITLE
Better error message when previous detect function found no compiler and version is thus none

### DIFF
--- a/conan/internal/api/detect_api.py
+++ b/conan/internal/api/detect_api.py
@@ -571,7 +571,7 @@ def default_compiler_version(compiler, version):
     output = ConanOutput(scope="detect_api")
     if not version:
         raise ConanException(
-            f"No version provided to default_compiler_version for {compiler} compiler")
+            f"No version provided to 'detect_api.default_compiler_version()' for {compiler} compiler")
     tokens = version.main
     major = tokens[0]
     minor = tokens[1] if len(tokens) > 1 else 0

--- a/conan/internal/api/detect_api.py
+++ b/conan/internal/api/detect_api.py
@@ -5,7 +5,7 @@ import tempfile
 import textwrap
 
 from conan.api.output import ConanOutput
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.version import Version
 from conans.util.files import load, save
 from conans.util.runners import check_output_runner, detect_runner

--- a/conan/internal/api/detect_api.py
+++ b/conan/internal/api/detect_api.py
@@ -5,6 +5,7 @@ import tempfile
 import textwrap
 
 from conan.api.output import ConanOutput
+from conans.errors import ConanException
 from conans.model.version import Version
 from conans.util.files import load, save
 from conans.util.runners import check_output_runner, detect_runner
@@ -568,6 +569,9 @@ def default_compiler_version(compiler, version):
     of the minor or patch digits, that do not affect binary compatibility
     """
     output = ConanOutput(scope="detect_api")
+    if not version:
+        raise ConanException(
+            f"No version provided to default_compiler_version for {compiler} compiler")
     tokens = version.main
     major = tokens[0]
     minor = tokens[1] if len(tokens) > 1 else 0

--- a/test/integration/configuration/test_profile_jinja.py
+++ b/test/integration/configuration/test_profile_jinja.py
@@ -208,7 +208,7 @@ class TestProfileDetectAPI:
 
         client.save({"profile1": tpl1})
         client.run("profile show -pr=profile1", assert_error=True)
-        assert "No version provided to default_compiler_version for None compiler" in client.out
+        assert "No version provided to 'detect_api.default_compiler_version' for None compiler" in client.out
 
 
 def test_profile_jinja_error():

--- a/test/integration/configuration/test_profile_jinja.py
+++ b/test/integration/configuration/test_profile_jinja.py
@@ -199,6 +199,17 @@ class TestProfileDetectAPI:
             """)
         assert expected in client.out
 
+    def test_profile_detect_compiler_missing_error(self):
+        client = TestClient(light=True)
+        tpl1 = textwrap.dedent("""
+                    {% set compiler, version, compiler_exe = detect_api.detect_clang_compiler(compiler_exe="not-existing-compiler") %}
+                    {% set version = detect_api.default_compiler_version(compiler, version) %}
+                    """)
+
+        client.save({"profile1": tpl1})
+        client.run("profile show -pr=profile1", assert_error=True)
+        assert "No version provided to default_compiler_version for None compiler" in client.out
+
 
 def test_profile_jinja_error():
     c = TestClient(light=True)

--- a/test/integration/configuration/test_profile_jinja.py
+++ b/test/integration/configuration/test_profile_jinja.py
@@ -208,7 +208,7 @@ class TestProfileDetectAPI:
 
         client.save({"profile1": tpl1})
         client.run("profile show -pr=profile1", assert_error=True)
-        assert "No version provided to 'detect_api.default_compiler_version' for None compiler" in client.out
+        assert "No version provided to 'detect_api.default_compiler_version()' for None compiler" in client.out
 
 
 def test_profile_jinja_error():


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Before this, the error message was not helpful and finding the issue was quite a trial and error process. This at least gives some info into what is actually failing
