### PR TITLE
Fix mapping of Meson system when settings.os is None i.e. bare metal

### DIFF
--- a/conan/tools/meson/helpers.py
+++ b/conan/tools/meson/helpers.py
@@ -75,7 +75,7 @@ def to_meson_machine(machine_os, machine_arch):
     :param machine_arch: ``str`` OS arch.
     :return: ``dict`` Meson machine context.
     """
-    system = _meson_system_map.get(machine_os, machine_os.lower())
+    system = _meson_system_map.get(machine_os, 'none' if machine_os is None else machine_os.lower())
     default_cpu_tuple = (machine_arch.lower(), machine_arch.lower(), 'little')
     cpu_tuple = _meson_cpu_family_map.get(machine_arch, default_cpu_tuple)
     cpu_family, cpu, endian = cpu_tuple[0], cpu_tuple[1], cpu_tuple[2]

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -338,7 +338,7 @@ class MesonToolchain(object):
 
         if self._is_apple_system:
             self._resolve_apple_flags_and_variables(build_env, compilers_by_conf)
-        if native is False and self.cross_build and self.cross_build["host"]["system"] == "android":
+        if native is False and self.cross_build and self.cross_build["host"].get("system") == "android":
             self._resolve_android_cross_compilation()
 
     def _get_default_dirs(self):


### PR DESCRIPTION
Changelog: Fix mapping of Meson system when settings.os is None i.e. bare metal

https://github.com/conan-io/conan/issues/16893

- [X] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
