### PR TITLE
Prepare build compatibles refactor

### DIFF
--- a/conan/api/subapi/install.py
+++ b/conan/api/subapi/install.py
@@ -64,8 +64,8 @@ class InstallAPI:
             msg = "{}: Invalid ID: {}: {}".format(conanfile, binary, reason)
             raise ConanInvalidConfiguration(msg)
 
-        if root_node.cant_build and root_node.should_build:
-            binary, reason = "Cannot build for this configuration", root_node.cant_build
+        if conanfile.info is not None and conanfile.info.cant_build and root_node.should_build:
+            binary, reason = "Cannot build for this configuration", conanfile.info.cant_build
             msg = "{}: {}: {}".format(conanfile, binary, reason)
             raise ConanInvalidConfiguration(msg)
 

--- a/conans/client/graph/compute_pid.py
+++ b/conans/client/graph/compute_pid.py
@@ -65,7 +65,7 @@ def compute_package_id(node, new_config, config_version):
                     conanfile.validate_build()
                 except ConanInvalidConfiguration as e:
                     # This 'cant_build' will be ignored if we don't have to build the node.
-                    node.cant_build = str(e)
+                    conanfile.info.cant_build = str(e)
 
     run_validate_package_id(conanfile)
 

--- a/conans/client/graph/graph.py
+++ b/conans/client/graph/graph.py
@@ -64,7 +64,6 @@ class Node(object):
         self.dependencies = []  # Ordered Edges
         self.dependants = []  # Edges
         self.error = None
-        self.cant_build = False  # It will set to a str with a reason if the validate_build() fails
         self.should_build = False  # If the --build or policy wants to build this binary
         self.build_allowed = False
         self.is_conf = False
@@ -238,7 +237,7 @@ class Node(object):
         result["build_id"] = build_id(self.conanfile)
         result["binary"] = self.binary
         # TODO: This doesn't match the model, check it
-        result["invalid_build"] = self.cant_build
+        result["invalid_build"] = getattr(getattr(self.conanfile, "info", None), "cant_build", False)
         result["info_invalid"] = getattr(getattr(self.conanfile, "info", None), "invalid", None)
         # Adding the conanfile information: settings, options, etc
         result.update(self.conanfile.serialize())

--- a/conans/client/graph/install_graph.py
+++ b/conans/client/graph/install_graph.py
@@ -498,8 +498,8 @@ class InstallGraph:
         msg = ["There are invalid packages:"]
         for package in invalid:
             node = package.nodes[0]
-            if node.cant_build and node.should_build:
-                binary, reason = "Cannot build for this configuration", node.cant_build
+            if node.conanfile.info.cant_build and node.should_build:
+                binary, reason = "Cannot build for this configuration", node.conanfile.info.cant_build
             else:
                 binary, reason = "Invalid", node.conanfile.info.invalid
             msg.append("{}: {}: {}".format(node.conanfile, binary, reason))

--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -328,6 +328,7 @@ class ConanInfo:
     def __init__(self, settings=None, options=None, reqs_info=None, build_requires_info=None,
                  python_requires=None, conf=None, config_version=None):
         self.invalid = None
+        self.cant_build = False  # It will set to a str with a reason if the validate_build() fails
         self.settings = settings
         self.settings_target = None  # needs to be explicitly defined by recipe package_id()
         self.options = options


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

This should be a pure refactor.
In preparation for https://github.com/conan-io/conan/pull/16871

- Move from ``root_node.cant_build`` => ``root_node.conanfile.info.cant_build``, so the ``cant_build`` information belongs per ``info``, so multiple "compatible" packages can be analyzed if they can be built or not.
- Split the ``def _process_compatible_packages(self, node, remotes, update):`` into ``_get_compatibles`` and ``_compatible_found()`` so they can be reused