### PR TITLE
improve error messages for broken 'list --graph' arguments

### DIFF
--- a/conan/api/model.py
+++ b/conan/api/model.py
@@ -99,8 +99,13 @@ class MultiPackagesList:
     def load_graph(graphfile, graph_recipes=None, graph_binaries=None):
         if not os.path.isfile(graphfile):
             raise ConanException(f"Graph file not found: {graphfile}")
-        graph = json.loads(load(graphfile))
-        return MultiPackagesList._define_graph(graph, graph_recipes, graph_binaries)
+        try:
+            graph = json.loads(load(graphfile))
+            return MultiPackagesList._define_graph(graph, graph_recipes, graph_binaries)
+        except JSONDecodeError as e:
+            raise ConanException(f"Graph file invalid JSON: {graphfile}\n{e}")
+        except Exception as e:
+            raise ConanException(f"Graph file broken: {graphfile}\n{e}")
 
     @staticmethod
     def _define_graph(graph, graph_recipes=None, graph_binaries=None):

--- a/test/integration/command_v2/list_test.py
+++ b/test/integration/command_v2/list_test.py
@@ -43,6 +43,20 @@ class TestParamErrors:
         c.run("list * -p os=Linux", assert_error=True)
         assert "--package-query and --filter-xxx can only be done for binaries" in c.out
 
+    def test_graph_file_error(self):
+        # This can happen when reusing the same file in input and output
+        c = TestClient(light=True)
+        c.run("list --graph=graph.json", assert_error=True)
+        assert "ERROR: Graph file not found" in c.out
+        c.save({"graph.json": ""})
+        c.run("list --graph=graph.json", assert_error=True)
+        assert "ERROR: Graph file invalid JSON:" in c.out
+        text = b'\x2b\x2f\x76\x38J\xe2nis\xa7'
+        with open(os.path.join(c.current_folder, "graph.json"), 'wb') as handle:
+            handle.write(text)
+        c.run("list --graph=graph.json", assert_error=True)
+        assert "ERROR: Graph file broken" in c.out
+
 
 @pytest.fixture(scope="module")
 def client():


### PR DESCRIPTION
Changelog: Fix: Better error messages when ``conan list --graph=<graph-json-file>`` file has issues.
Docs: Omit

Close https://github.com/conan-io/conan/issues/16921
