### PR TITLE
Fix c++23 flag for apple-clang 16

### DIFF
--- a/conan/tools/build/flags.py
+++ b/conan/tools/build/flags.py
@@ -264,7 +264,10 @@ def _cppstd_apple_clang(clang_version, cppstd):
         v20 = "c++2a"
         vgnu20 = "gnu++2a"
 
-    if clang_version >= "13.0":
+    if clang_version >= "16.0":
+        v23 = "c++23"
+        vgnu23 = "gnu++23"
+    elif clang_version >= "13.0":
         v23 = "c++2b"
         vgnu23 = "gnu++2b"
 


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

As per `apple-clang` output:

```
note: use 'c++98' or 'c++03' for 'ISO C++ 1998 with amendments' standard
note: use 'gnu++98' or 'gnu++03' for 'ISO C++ 1998 with amendments and GNU extensions' standard
note: use 'c++11' for 'ISO C++ 2011 with amendments' standard
note: use 'gnu++11' for 'ISO C++ 2011 with amendments and GNU extensions' standard
note: use 'c++14' for 'ISO C++ 2014 with amendments' standard
note: use 'gnu++14' for 'ISO C++ 2014 with amendments and GNU extensions' standard
note: use 'c++17' for 'ISO C++ 2017 with amendments' standard
note: use 'gnu++17' for 'ISO C++ 2017 with amendments and GNU extensions' standard
note: use 'c++20' for 'ISO C++ 2020 DIS' standard
note: use 'gnu++20' for 'ISO C++ 2020 DIS with GNU extensions' standard
note: use 'c++23' for 'ISO C++ 2023 DIS' standard
note: use 'gnu++23' for 'ISO C++ 2023 DIS with GNU extensions' standard
note: use 'c++2c' or 'c++26' for 'Working draft for C++2c' standard
note: use 'gnu++2c' or 'gnu++26' for 'Working draft for C++2c with GNU extensions' standard
```

This PR only adds the `c++23` flag, leaving c++2c inclusion for 2.8.0