### PR TITLE
Add test to show that you need to pass skip_binaries conf to build

### DIFF
--- a/test/integration/graph/test_skip_binaries.py
+++ b/test/integration/graph/test_skip_binaries.py
@@ -206,7 +206,7 @@ def test_skip_tool_requires_context():
     tc.run("export lib")
 
     # Suprising behaviour if not passing the conf to the build context too, cmake CAN get skipped
-    tc.run("graph info app -c=t:tools.graph:skip_binaries=False")
+    tc.run("graph info app -c=tools.graph:skip_binaries=False")
     assert "binary: Skip" in tc.out
 
     # Fixing the behaviour by passing the conf to the build context


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

As part of the investigation for https://github.com/conan-io/conan/issues/16957, this only adds a test to document behaviopru that while consistent with respect to the whole codebase and context separation, can be a bit suprising for users