### PR TITLE
Make conf.get with a check_type=bool raise exception if invalid value

### DIFF
--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -320,9 +320,10 @@ class Conf:
             if choices is not None and v not in choices:
                 raise ConanException(f"Unknown value '{v}' for '{conf_name}'")
             # Some smart conversions
-            if check_type is bool and not isinstance(v, bool):
-                # Perhaps, user has introduced a "false", "0" or even "off"
-                return str(v).lower() not in Conf.boolean_false_expressions
+            if check_type is bool and not (isinstance(v, bool) or str(v).lower() not in
+                                           Conf.boolean_false_expressions):
+                raise ConanException(f"[conf] {conf_name} must be a boolean-like object "
+                                     f"(false, 0, off, etc) and value '{v}' does not match it.")
             elif check_type is str and not isinstance(v, str):
                 return str(v)
             elif v is None:  # value was unset

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -272,6 +272,7 @@ class _ConfValue(object):
 class Conf:
     # Putting some default expressions to check that any value could be false
     boolean_false_expressions = ("0", '"0"', "false", '"false"', "off")
+    boolean_true_expressions = ("1", '"1"', "true", '"true"', "on")
 
     def __init__(self):
         # It being ordered allows for Windows case-insensitive composition
@@ -320,10 +321,13 @@ class Conf:
             if choices is not None and v not in choices:
                 raise ConanException(f"Unknown value '{v}' for '{conf_name}'")
             # Some smart conversions
-            if check_type is bool and not (isinstance(v, bool) or str(v).lower() not in
-                                           Conf.boolean_false_expressions):
+            if check_type is bool and not isinstance(v, bool):
+                if str(v).lower() in Conf.boolean_false_expressions:
+                    return False
+                if str(v).lower() in Conf.boolean_true_expressions:
+                    return True
                 raise ConanException(f"[conf] {conf_name} must be a boolean-like object "
-                                     f"(false, 0, off, etc) and value '{v}' does not match it.")
+                                     f"(true/false, 1/0, on/off) and value '{v}' does not match it.")
             elif check_type is str and not isinstance(v, str):
                 return str(v)
             elif v is None:  # value was unset

--- a/test/unittests/model/test_conf.py
+++ b/test/unittests/model/test_conf.py
@@ -221,10 +221,15 @@ def test_conf_get_check_type_and_default():
         zlib:user.company.check:static_str=off
         user.company.list:newnames+=myname
         core.download:parallel=True
+        user:bad_value_0=Fasle
+        user:bad_value_1=ture
+        user:bad_value_2=10
+        user:bad_value_3='00'
     """)
     c = ConfDefinition()
     c.loads(text)
     assert c.get("user.company.cpu:jobs", check_type=int) == 5
+    assert c.get("user.company.cpu:jobs", check_type=None) == 5
     assert c.get("user.company.cpu:jobs", check_type=str) == "5"  # smart conversion
     with pytest.raises(ConanException) as exc_info:
         c.get("user.company.cpu:jobs", check_type=list)
@@ -243,6 +248,18 @@ def test_conf_get_check_type_and_default():
         c.get("core.download:parallel", check_type=int)
     assert ("[conf] core.download:parallel must be a int-like object. "
             "The value 'True' introduced is a bool object") in str(exc_info.value)
+    with pytest.raises(ConanException) as exc_info:
+        c.get("user:bad_value_0", check_type=bool)
+    assert ("[conf] user:bad_value_0 must be a boolean-like object (true/false, 1/0, on/off) and value 'Fasle' does not match it.") in str(exc_info.value)
+    with pytest.raises(ConanException) as exc_info:
+        c.get("user:bad_value_1", check_type=bool)
+    assert ("[conf] user:bad_value_1 must be a boolean-like object (true/false, 1/0, on/off) and value 'ture' does not match it.") in str(exc_info.value)
+    with pytest.raises(ConanException) as exc_info:
+        c.get("user:bad_value_2", check_type=bool)
+    assert ("[conf] user:bad_value_2 must be a boolean-like object (true/false, 1/0, on/off) and value '10' does not match it.") in str(exc_info.value)
+    with pytest.raises(ConanException) as exc_info:
+        c.get("user:bad_value_3", check_type=bool)
+    assert ("[conf] user:bad_value_3 must be a boolean-like object (true/false, 1/0, on/off) and value '\'00\'' does not match it.") in str(exc_info.value)
 
 
 def test_conf_pop():


### PR DESCRIPTION
Changelog: Bugfix: Raise error if invalid value passed to conf.get(check_type=bool).
Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
