### PR TITLE
Think about the possibility of passing the context to profile_plugin

### DIFF
--- a/conan/test/utils/tools.py
+++ b/conan/test/utils/tools.py
@@ -32,6 +32,7 @@ from conan.api.conan_api import ConanAPI
 from conan.api.model import Remote
 from conan.cli.cli import Cli, _CONAN_INTERNAL_CUSTOM_COMMANDS_PATH
 from conan.test.utils.env import environment_update
+from conans.client.graph.graph import CONTEXT_BUILD, CONTEXT_HOST
 from conans.errors import NotFoundException, ConanException
 from conans.model.manifest import FileTreeManifest
 from conans.model.package_ref import PkgReference
@@ -731,11 +732,11 @@ class TestClient:
 
     def get_default_host_profile(self):
         api = ConanAPI(cache_folder=self.cache_folder)
-        return api.profiles.get_profile([api.profiles.get_default_host()])
+        return api.profiles.get_profile([api.profiles.get_default_host()], context=CONTEXT_HOST)
 
     def get_default_build_profile(self):
         api = ConanAPI(cache_folder=self.cache_folder)
-        return api.profiles.get_profile([api.profiles.get_default_build()])
+        return api.profiles.get_profile([api.profiles.get_default_build()], context=CONTEXT_BUILD)
 
     def recipe_exists(self, ref):
         rrev = self.cache.get_recipe_revisions_references(ref)

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -160,6 +160,7 @@ class CMake:
         arg_list = ['"{}"'.format(bf), build_config, cmd_args_to_string(args)]
         arg_list = " ".join(filter(None, arg_list))
         command = "%s --build %s" % (self._cmake_program, arg_list)
+        self._conanfile.run(f"{self._cmake_program} --version", stdout=stdout, stderr=stderr)
         self._conanfile.run(command, env=env, stdout=stdout, stderr=stderr)
 
     def build(self, build_type=None, target=None, cli_args=None, build_tool_args=None,

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -160,7 +160,6 @@ class CMake:
         arg_list = ['"{}"'.format(bf), build_config, cmd_args_to_string(args)]
         arg_list = " ".join(filter(None, arg_list))
         command = "%s --build %s" % (self._cmake_program, arg_list)
-        self._conanfile.run(f"{self._cmake_program} --version", stdout=stdout, stderr=stderr)
         self._conanfile.run(command, env=env, stdout=stdout, stderr=stderr)
 
     def build(self, build_type=None, target=None, cli_args=None, build_tool_args=None,


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX


probably won't get merged

This is a small sketch with a possible idea as to how the profile plugin could benefit from getting the context where it's feasible/makes sense to do so, and how it could be useful

Other use-case (The one I was actually looking into): What happens when you specify a compiler.version that does not actually match the final compiler version being used. Having a warning in the profile plugin sounded like a nice idea, but actually quite hard because the executable can be set in the confs! But as a basic idea
