### PR TITLE
Fix/bash path slash

### DIFF
--- a/conans/client/subsystems.py
+++ b/conans/client/subsystems.py
@@ -72,6 +72,7 @@ def _windows_bash_wrapper(conanfile, command, env, envfiles_folder):
     if not shell_path:
         raise ConanException("The config 'tools.microsoft.bash:path' is "
                              "needed to run commands in a Windows subsystem")
+    shell_path = shell_path.replace("\\", "/")  # Should work in all terminals
     env = env or []
     if subsystem == MSYS2:
         # Configure MSYS2 to inherith the PATH

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -132,7 +132,7 @@ tools_locations = {
         "platform": "Windows",
         "default": "system",
         "exe": "make",
-        "system": {"path": {'Windows': "C:/msys64/usr/bin"}},
+        "system": {"path": {'Windows': r"C:\msys64\usr\bin"}},
     },
     'msys2_clang64': {
         "disabled": True,

--- a/test/functional/toolchains/gnu/autotools/test_win_bash.py
+++ b/test/functional/toolchains/gnu/autotools/test_win_bash.py
@@ -121,7 +121,7 @@ def test_conf_inherited_in_test_package():
 
             def package_info(self):
                 self.conf_info.define("tools.microsoft.bash:subsystem", "msys2")
-                self.conf_info.define("tools.microsoft.bash:path", "{}")
+                self.conf_info.define("tools.microsoft.bash:path", r"{}")
     """.format(bash_path))
     client.save({"conanfile.py": conanfile})
     client.run("create .")


### PR DESCRIPTION
Changelog: Fix: Use always forward slashes in Windows subsystems ``bash`` path.
Docs: Omit

Related to https://github.com/conan-io/conan/issues/16963 (not a full fix)
