### PR TITLE
Test for universal binaries macOS using Ninja

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -23,7 +23,8 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
         if self.arch:
             data_fname += "-{}".format(self.arch)
         data_fname += "-data.cmake"
-        return data_fname
+        # https://github.com/conan-io/conan/issues/17009
+        return data_fname.replace("|", "-")
 
     @property
     def _build_modules_activated(self):

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -24,7 +24,7 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
             data_fname += "-{}".format(self.arch)
         data_fname += "-data.cmake"
         # https://github.com/conan-io/conan/issues/17009
-        return data_fname.replace("|", "-")
+        return data_fname.replace("|", "_")
 
     @property
     def _build_modules_activated(self):

--- a/conan/tools/env/virtualbuildenv.py
+++ b/conan/tools/env/virtualbuildenv.py
@@ -34,7 +34,7 @@ class VirtualBuildEnv:
         if configuration:
             f += "-" + configuration.replace(".", "_")
         if arch:
-            f += "-" + arch.replace(".", "_")
+            f += "-" + arch.replace(".", "_").replace("|", "_")
         return f
 
     def environment(self):

--- a/conan/tools/env/virtualrunenv.py
+++ b/conan/tools/env/virtualrunenv.py
@@ -52,7 +52,7 @@ class VirtualRunEnv:
         if self.configuration:
             f += "-" + self.configuration.replace(".", "_")
         if self.arch:
-            f += "-" + self.arch.replace(".", "_")
+            f += "-" + self.arch.replace(".", "_").replace("|", "_")
         return f
 
     def environment(self):

--- a/test/functional/toolchains/cmake/test_universal_binaries.py
+++ b/test/functional/toolchains/cmake/test_universal_binaries.py
@@ -139,7 +139,7 @@ def test_create_universal_binary_ninja():
                            "-DCMAKE_POLICY_DEFAULT_CMP0091=NEW "
                            "-DCMAKE_BUILD_TYPE=Release")
 
-    assert "ninja: error: build.ninja:87: expected newline, got '|'" not in client.out
+    assert "expected newline, got '|'" not in client.out
     assert "Build files have been written to:" in client.out
     # test that there are no files with the "|" character in the build folder
     assert not any("|" in f for f in os.listdir(os.path.join(client.current_folder, "build")))

--- a/test/functional/toolchains/cmake/test_universal_binaries.py
+++ b/test/functional/toolchains/cmake/test_universal_binaries.py
@@ -136,4 +136,6 @@ def test_create_universal_binary_ninja():
                            "-DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake "
                            "-DCMAKE_POLICY_DEFAULT_CMP0091=NEW "
                            "-DCMAKE_BUILD_TYPE=Release")
+
     assert "ninja: error: build.ninja:87: expected newline, got '|'" not in client.out
+    assert "Build files have been written to:" in client.out

--- a/test/functional/toolchains/cmake/test_universal_binaries.py
+++ b/test/functional/toolchains/cmake/test_universal_binaries.py
@@ -116,6 +116,8 @@ def test_create_universal_binary_ninja():
         [generators]
         CMakeToolchain
         CMakeDeps
+        VirtualBuildEnv
+        VirtualRunEnv
         """)
 
     cmake = textwrap.dedent("""
@@ -139,3 +141,5 @@ def test_create_universal_binary_ninja():
 
     assert "ninja: error: build.ninja:87: expected newline, got '|'" not in client.out
     assert "Build files have been written to:" in client.out
+    # test that there are no files with the "|" character in the build folder
+    assert not any("|" in f for f in os.listdir(os.path.join(client.current_folder, "build")))

--- a/test/functional/toolchains/cmake/test_universal_binaries.py
+++ b/test/functional/toolchains/cmake/test_universal_binaries.py
@@ -126,8 +126,8 @@ def test_create_universal_binary_ninja():
         """)
 
     client.save({"conanfile.txt": conanfile,
-                      "CMakeLists.txt": cmake},
-               clean_first=True)
+                 "CMakeLists.txt": cmake},
+                 clean_first=True)
 
     client.run('install . -s=arch="armv8|x86_64" --build=missing -of=build')
 


### PR DESCRIPTION
Changelog: Fix: Replace `|` character in generated CMake and Environment files.
Docs: Omit

Closes: https://github.com/conan-io/conan/issues/17009
