### PR TITLE
[BazelDeps][bugfix] Windows and shared libraries

### DIFF
--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -115,9 +115,7 @@ def _get_libs(dep, cpp_info=None, reference_name=None) -> list:
         if ext == "dll" or ext.endswith(".dll"):
             if lib_name:
                 shared_windows_libs[lib_name] = formatted_path
-            elif total_libs_number == 1:
-                shared_windows_libs[libs[0]] = formatted_path
-            elif len(libs) == 1 and ref_name in name and libs[0] not in shared_windows_libs:
+            elif total_libs_number == 1 and libs[0] not in shared_windows_libs:
                 shared_windows_libs[libs[0]] = formatted_path
             else:  # let's cross the fingers... This is the last chance.
                 for lib in libs:

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -80,7 +80,7 @@ def _get_libs(dep, cpp_info=None, reference_name=None) -> list:
     :param cpp_info: <CppInfo obj> of the component.
     :param reference_name: <str> Package/Component's reference name. ``None`` by default.
     :return: list of tuples per static/shared library ->
-             [(lib_name, is_shared, library_path, import_library_path)]
+             [(name, is_shared, lib_path, import_lib_path)]
              Note: ``library_path`` could be both static and shared ones in case of UNIX systems.
                     Windows would have:
                         * shared: library_path as DLL, and import_library_path as LIB
@@ -155,15 +155,15 @@ def _get_libs(dep, cpp_info=None, reference_name=None) -> list:
                 _save_lib_path(f, full_path)
 
     libraries = []
-    for lib_name, library_path in lib_paths.items():
-        import_library_path = None
-        if is_shared and os.path.splitext(library_path)[1] == ".lib":
-            if lib_name not in shared_windows_libs:
+    for name, lib_path in lib_paths.items():
+        import_lib_path = None
+        if is_shared and os.path.splitext(lib_path)[1] == ".lib":
+            if name not in shared_windows_libs:
                 raise ConanException(f"Windows needs a .lib for link-time and .dll for runtime."
-                                     f" Only found {library_path}")
-            import_library_path = library_path  # .lib
-            library_path = shared_windows_libs.pop(lib_name)  # .dll
-        libraries.append((lib_name, is_shared, library_path, import_library_path))
+                                     f" Only found {lib_path}")
+            import_lib_path = lib_path  # .lib
+            lib_path = shared_windows_libs.pop(name)  # .dll
+        libraries.append((name, is_shared, lib_path, import_lib_path))
     # TODO: Would we want to manage the cases where DLLs are provided by the system?
     return libraries
 

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -103,6 +103,9 @@ def _get_libs(dep, cpp_info=None) -> list:
             lib_paths[lib_] = formatted_path
 
     cpp_info = cpp_info or dep.cpp_info
+    if hasattr(cpp_info, "aggregated_components"):
+        # Global cpp_info
+        cpp_info = cpp_info.aggregated_components()
     is_shared = _is_shared()
     libdirs = cpp_info.libdirs
     bindirs = cpp_info.bindirs if is_shared else []  # just want to get shared libraries

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -155,15 +155,15 @@ def _get_libs(dep, cpp_info=None, reference_name=None) -> list:
                 _save_lib_path(f, full_path)
 
     libraries = []
-    for lib, lib_path in lib_paths.items():
-        import_lib_path = None
-        if is_shared and os.path.splitext(lib_path)[1] == ".lib":
-            if lib not in shared_windows_libs:
+    for lib_name, library_path in lib_paths.items():
+        import_library_path = None
+        if is_shared and os.path.splitext(library_path)[1] == ".lib":
+            if lib_name not in shared_windows_libs:
                 raise ConanException(f"Windows needs a .lib for link-time and .dll for runtime."
-                                     f" Only found {lib_path}")
-            import_lib_path = lib_path  # .lib
-            lib_path = shared_windows_libs.pop(lib)  # .dll
-        libraries.append((lib, is_shared, lib_path, import_lib_path))
+                                     f" Only found {library_path}")
+            import_library_path = library_path  # .lib
+            library_path = shared_windows_libs.pop(lib_name)  # .dll
+        libraries.append((lib_name, is_shared, library_path, import_library_path))
     # TODO: Would we want to manage the cases where DLLs are provided by the system?
     return libraries
 

--- a/test/integration/toolchains/google/test_bazeldeps.py
+++ b/test/integration/toolchains/google/test_bazeldeps.py
@@ -983,3 +983,25 @@ class TestBazelGenerationBuildContext:
         # Now make sure we can actually build with build!=host context
         c.run("install app -s:h build_type=Debug --build=missing")
         assert "Install finished successfully" in c.out  # the asserts in build() didn't fail
+
+
+
+def test_shared_windows_find_libraries():
+    """
+    Testing the ``_get_libs`` mechanism in Windows, the shared libraries and their
+    import ones are correctly found.
+
+    Note: simulating dependencies with openssl, libcurl, and zlib packages:
+
+    zlib:
+        - (zlib package) bin/zlib1.dll AND lib/zdll.lib
+    libcurl:
+        - (curl component) bin/libcurl.dll AND lib/libcurl_imp.lib
+    openssl:
+        - (crypto component) bin/libcrypto-3-x64.dll AND lib/libcrypto.lib
+        - (ssl component) bin/libssl-3-x64.dll AND lib/libssl.lib
+
+
+    Issue: https://github.com/conan-io/conan/issues/16691
+    """
+    pass

--- a/test/integration/toolchains/google/test_bazeldeps.py
+++ b/test/integration/toolchains/google/test_bazeldeps.py
@@ -4,6 +4,7 @@ import textwrap
 
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
+from conan.tools.files import load
 
 
 def test_bazel():
@@ -1004,4 +1005,111 @@ def test_shared_windows_find_libraries():
 
     Issue: https://github.com/conan-io/conan/issues/16691
     """
-    pass
+    c = TestClient()
+    zlib = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+        from conan.tools.files import save
+        class Example(ConanFile):
+            name = "zlib"
+            version = "1.0"
+            options = {"shared": [True, False]}
+            default_options = {"shared": False}
+            def package(self):
+                bindirs = os.path.join(self.package_folder, "bin")
+                libdirs = os.path.join(self.package_folder, "lib")
+                save(self, os.path.join(bindirs, "zlib1.dll"), "")
+                save(self, os.path.join(libdirs, "zdll.lib"), "")
+            def package_info(self):
+                self.cpp_info.libs = ["zdll"]
+            """)
+    openssl = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+        from conan.tools.files import save
+        class Pkg(ConanFile):
+            name = "openssl"
+            version = "1.0"
+            options = {"shared": [True, False]}
+            default_options = {"shared": False}
+            def package(self):
+                bindirs = os.path.join(self.package_folder, "bin")
+                libdirs = os.path.join(self.package_folder, "lib")
+                save(self, os.path.join(bindirs, "libcrypto-3-x64.dll"), "")
+                save(self, os.path.join(bindirs, "libssl-3-x64.dll"), "")
+                save(self, os.path.join(libdirs, "libcrypto.lib"), "")
+                save(self, os.path.join(libdirs, "libssl.lib"), "")
+            def package_info(self):
+                self.cpp_info.components["crypto"].libs = ["libcrypto"]
+                self.cpp_info.components["ssl"].libs = ["libssl"]
+        """)
+    libcurl = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+        from conan.tools.files import save
+        class Example(ConanFile):
+            name = "libcurl"
+            version = "1.0"
+            options = {"shared": [True, False]}
+            default_options = {"shared": False}
+            def package(self):
+                bindirs = os.path.join(self.package_folder, "bin")
+                libdirs = os.path.join(self.package_folder, "lib")
+                save(self, os.path.join(bindirs, "libcurl.dll"), "")
+                save(self, os.path.join(libdirs, "libcurl_imp.lib"), "")
+            def package_info(self):
+                self.cpp_info.components["curl"].libs = ["libcurl_imp"]
+            """)
+    consumer = textwrap.dedent("""
+        [requires]
+        zlib/1.0
+        openssl/1.0
+        libcurl/1.0
+        [options]
+        *:shared=True
+    """)
+    c.save({"conanfile.txt": consumer,
+            "zlib/conanfile.py": zlib,
+            "openssl/conanfile.py": openssl,
+            "libcurl/conanfile.py": libcurl})
+    c.run("export-pkg zlib -o:a shared=True")
+    c.run("export-pkg openssl -o:a shared=True")
+    c.run("export-pkg libcurl -o:a shared=True")
+    c.run("install . -g BazelDeps")
+    libcurl_bazel_build = load(None, os.path.join(c.current_folder, "libcurl", "BUILD.bazel"))
+    zlib_bazel_build = load(None, os.path.join(c.current_folder, "zlib", "BUILD.bazel"))
+    openssl_bazel_build = load(None, os.path.join(c.current_folder, "openssl", "BUILD.bazel"))
+    libcurl_expected = textwrap.dedent("""\
+    # Components precompiled libs
+    cc_import(
+        name = "libcurl_imp_precompiled",
+        shared_library = "bin/libcurl.dll",
+        interface_library = "lib/libcurl_imp.lib",
+    )
+    """)
+    openssl_expected = textwrap.dedent("""\
+    # Components precompiled libs
+    cc_import(
+        name = "libcrypto_precompiled",
+        shared_library = "bin/libcrypto-3-x64.dll",
+        interface_library = "lib/libcrypto.lib",
+    )
+
+    cc_import(
+        name = "libssl_precompiled",
+        shared_library = "bin/libcrypto-3-x64.dll",
+        interface_library = "lib/libssl.lib",
+    )
+    """)
+    zlib_expected = textwrap.dedent("""\
+    # Components precompiled libs
+    # Root package precompiled libs
+    cc_import(
+        name = "zdll_precompiled",
+        shared_library = "bin/zlib1.dll",
+        interface_library = "lib/zdll.lib",
+    )
+    """)
+    assert libcurl_expected in libcurl_bazel_build
+    assert zlib_expected in zlib_bazel_build
+    assert openssl_expected in openssl_bazel_build

--- a/test/unittests/tools/google/test_bazel.py
+++ b/test/unittests/tools/google/test_bazel.py
@@ -83,15 +83,11 @@ def test_bazeldeps_relativize_path(path, pattern, expected):
     # Win + shared
     (["mylibwin"], True, [('mylibwin', True, '{base_folder}/bin/mylibwin.dll', '{base_folder}/lib/mylibwin.lib')]),
     # Win + shared (interface with another ext)
-    (["mylibwin2"], True,
-     [('mylibwin2', True, '{base_folder}/bin/mylibwin2.dll', '{base_folder}/lib/mylibwin2.if.lib')]),
-    # Win + Mac + shared
-    (["mylibwin", "mylibmac"], True, [('mylibmac', True, '{base_folder}/bin/mylibmac.dylib', None),
-                                      ('mylibwin', True, '{base_folder}/bin/mylibwin.dll',
-                                       '{base_folder}/lib/mylibwin.lib')]),
-    # Linux + Mac + static
-    (["myliblin", "mylibmac"], False, [('mylibmac', False, '{base_folder}/lib/mylibmac.a', None),
-                                       ('myliblin', False, '{base_folder}/lib/myliblin.a', None)]),
+    (["mylibwin2"], True, [('mylibwin2', True, '{base_folder}/bin/mylibwin2.dll', '{base_folder}/lib/mylibwin2.if.lib')]),
+    # Mac + shared
+    (["mylibmac"], True, [('mylibmac', True, '{base_folder}/bin/mylibmac.dylib', None)]),
+    # Mac + static
+    (["mylibmac"], False, [('mylibmac', False, '{base_folder}/lib/mylibmac.a', None)]),
     # mylib + shared (saved as libmylib.so) -> removing the leading "lib" if it matches
     (["mylib"], True, [('mylib', True, '{base_folder}/lib/libmylib.so', None)]),
     # mylib + static (saved in a subfolder subfolder/libmylib.a) -> non-recursive at this moment
@@ -114,30 +110,10 @@ def test_bazeldeps_get_libs(cpp_info, libs, is_shared, expected):
         if interface_lib_path:
             interface_lib_path = interface_lib_path.format(base_folder=cpp_info._base_folder)
         ret.append((lib, is_shared, lib_path, interface_lib_path))
-    options = MagicMock(get_safe=Mock(return_value=is_shared))
-    found_libs = _get_libs(ConanFileMock(options=options),
-                           cpp_info)
+    dep = MagicMock()
+    dep.options.get_safe.return_value = is_shared
+    dep.ref.name = "my_pkg"
+    found_libs = _get_libs(dep, cpp_info)
     found_libs.sort()
     ret.sort()
     assert found_libs == ret
-
-
-def test_shared_windows_libs_with_different_names():
-    folder = temp_folder(path_with_spaces=False)
-    bindirs = os.path.join(folder, "bin")
-    libdirs = os.path.join(folder, "lib")
-    save(ConanFileMock(), os.path.join(bindirs, "libcurl.dll"), "")
-    save(ConanFileMock(), os.path.join(libdirs, "libcurl_imp.lib"), "")
-    cpp_info_mock = MagicMock(_base_folder=folder.replace("\\", "/"),
-                              libdirs=None, bindirs=None, libs=None)
-    cpp_info_mock.libdirs = [libdirs]
-    cpp_info_mock.bindirs = [bindirs]
-    cpp_info_mock.libs = ["libcurl_imp"]
-    cpp_info_mock.aggregated_components.return_value = cpp_info_mock
-    options = MagicMock(get_safe=Mock(return_value=True))
-    found_libs = _get_libs(ConanFileMock(options=options), cpp_info_mock)
-    found_libs.sort()
-    base_folder = folder.replace("\\", "/")
-    assert found_libs == [('libcurl_imp', True,
-                           f'{base_folder}/bin/libcurl.dll',
-                           f'{base_folder}/lib/libcurl_imp.lib')]

--- a/test/unittests/tools/google/test_bazel.py
+++ b/test/unittests/tools/google/test_bazel.py
@@ -1,6 +1,6 @@
 import os
 import platform
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock
 
 import pytest
 


### PR DESCRIPTION
Changelog: Bugfix: BazelDeps did not find DLL files as Conan does not model them in the Windows platform.
Docs: omit
Close: https://github.com/conan-io/conan/issues/16691
