### PR TITLE
fix --build=compatible for graph build-order

### DIFF
--- a/conans/client/graph/compatibility.py
+++ b/conans/client/graph/compatibility.py
@@ -35,7 +35,6 @@ def cppstd_compat(conanfile):
     cppstd = conanfile.settings.get_safe("compiler.cppstd")
     if not compiler or not compiler_version:
         return []
-    base = dict(conanfile.settings.values_list)
     factors = []  # List of list, each sublist is a potential combination
     if cppstd is not None and extension_properties.get("compatibility_cppstd") is not False:
         cppstd_possible_values = supported_cppstd(conanfile)
@@ -72,9 +71,7 @@ def cppstd_compat(conanfile):
 
     ret = []
     for comb in combinations:
-        configuration = base.copy()
-        configuration.update(comb)
-        ret.append({"settings": [(k, v) for k, v in configuration.items()]})
+        ret.append({"settings": [(k, v) for k, v in comb.items()]})
     return ret
 """
 
@@ -144,6 +141,7 @@ class BinaryCompatibility:
         if compatibles:
             for elem in compatibles:
                 compat_info = conanfile.original_info.clone()
+                compat_info.compatibility_delta = elem
                 settings = elem.get("settings")
                 if settings:
                     compat_info.settings.update_values(settings, raise_undefined=False)

--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -382,6 +382,8 @@ class ConanInfo:
         config_version_dumps = self.config_version.serialize() if self.config_version else None
         if config_version_dumps:
             result["config_version"] = config_version_dumps
+        if self.compatibility_delta:
+            result["compatibility_delta"] = self.compatibility_delta
         return result
 
     def dumps(self):

--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -338,6 +338,7 @@ class ConanInfo:
         self.python_requires = python_requires
         self.conf = conf
         self.config_version = config_version
+        self.compatibility_delta = None
 
     def clone(self):
         """ Useful for build_id implementation and for compatibility()

--- a/test/integration/command_v2/test_info_build_order.py
+++ b/test/integration/command_v2/test_info_build_order.py
@@ -28,6 +28,7 @@ def test_info_build_order():
                         "package_id": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
                         'prev': None,
                         'filenames': [],
+                        'info': {},
                         "context": "host",
                         'depends': [],
                         "binary": "Build",
@@ -49,6 +50,7 @@ def test_info_build_order():
                         "package_id": "59205ba5b14b8f4ebc216a6c51a89553021e82c1",
                         'prev': None,
                         'filenames': [],
+                        'info': {'requires': ['dep/0.1']},
                         "context": "host",
                         'depends': [],
                         "binary": "Build",
@@ -102,6 +104,7 @@ def test_info_build_order_configuration():
                 "package_id": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
                 'prev': None,
                 'filenames': [],
+                'info': {},
                 "context": "host",
                 "binary": "Build",
                 'build_args': '--requires=dep/0.1 --build=dep/0.1',
@@ -119,6 +122,7 @@ def test_info_build_order_configuration():
                 "package_id": "59205ba5b14b8f4ebc216a6c51a89553021e82c1",
                 'prev': None,
                 'filenames': [],
+                'info': {'requires': ['dep/0.1']},
                 "context": "host",
                 "binary": "Build",
                 'build_args': '--requires=pkg/0.1 --build=pkg/0.1',
@@ -170,6 +174,7 @@ def test_info_build_order_build_require():
                         "package_id": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
                         'prev': None,
                         'filenames': [],
+                        'info': {},
                         "context": "build",
                         'depends': [],
                         "binary": "Build",
@@ -191,6 +196,7 @@ def test_info_build_order_build_require():
                         "package_id": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
                         'prev': None,
                         'filenames': [],
+                        'info': {},
                         "context": "host",
                         'depends': [],
                         "binary": "Build",
@@ -230,9 +236,11 @@ def test_info_build_order_options():
                  {'package_id': '1124b99dc8cd3c8bbf79121c7bf86ce40c725a40', 'prev': None,
                   'context': 'build', 'depends': [], "overrides": {},
                   'binary': 'Build', 'options': ['tool/0.1:myopt=2'], 'filenames': [],
+                  'info': {'options': {'myopt': '2'}},
                   'build_args': '--tool-requires=tool/0.1 --build=tool/0.1 -o tool/0.1:myopt=2'},
                  {'package_id': 'a9035d84c5880b26c4b44acf70078c9a7dd37412', 'prev': None,
                   'context': 'build', 'depends': [], "overrides": {},
+                  'info': {'options': {'myopt': '1'}},
                   'binary': 'Build', 'options': ['tool/0.1:myopt=1'],
                   'filenames': [],
                   'build_args': '--tool-requires=tool/0.1 --build=tool/0.1 -o tool/0.1:myopt=1'}
@@ -244,7 +252,7 @@ def test_info_build_order_options():
              'packages': [[
                  {'package_id': 'da39a3ee5e6b4b0d3255bfef95601890afd80709', 'prev': None,
                   'context': 'host', 'depends': [], 'binary': 'Build', 'options': [],
-                  'filenames': [], "overrides": {},
+                  'filenames': [], 'info': {}, "overrides": {},
                   'build_args': '--requires=dep1/0.1 --build=dep1/0.1'}
              ]]},
             {'ref': 'dep2/0.1#23c789d2b36f0461e52cd6f139f97f5e',
@@ -252,7 +260,7 @@ def test_info_build_order_options():
              'packages': [[
                  {'package_id': 'da39a3ee5e6b4b0d3255bfef95601890afd80709', 'prev': None,
                   'context': 'host', 'depends': [], 'binary': 'Build', 'options': [],
-                  'filenames': [], "overrides": {},
+                  'filenames': [], 'info': {}, "overrides": {},
                   'build_args': '--requires=dep2/0.1 --build=dep2/0.1'}
              ]]}
         ]
@@ -286,6 +294,7 @@ def test_info_build_order_merge_multi_product():
                         "package_id": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
                         'prev': None,
                         'filenames': ["bo1", "bo2"],
+                        'info': {},
                         "context": "host",
                         'depends': [],
                         "binary": "Build",
@@ -307,6 +316,7 @@ def test_info_build_order_merge_multi_product():
                         "package_id": "59205ba5b14b8f4ebc216a6c51a89553021e82c1",
                         'prev': None,
                         'filenames': ["bo1"],
+                        'info': {'requires': ['dep/0.1']},
                         "context": "host",
                         'depends': [],
                         "binary": "Build",
@@ -326,6 +336,7 @@ def test_info_build_order_merge_multi_product():
                         "package_id": "59205ba5b14b8f4ebc216a6c51a89553021e82c1",
                         'prev': None,
                         'filenames': ["bo2"],
+                        'info': {'requires': ['dep/0.1']},
                         "context": "host",
                         'depends': [],
                         "binary": "Build",
@@ -343,7 +354,6 @@ def test_info_build_order_merge_multi_product():
     # test that html format for build-order-merge generates something
     c.run("graph build-order-merge --file=bo1.json --file=bo2.json --format=html")
     assert "<body>" in c.stdout
-
 
 
 def test_info_build_order_merge_multi_product_configurations():
@@ -378,6 +388,7 @@ def test_info_build_order_merge_multi_product_configurations():
                     "bo1",
                     "bo2"
                 ],
+                'info': {},
                 "depends": [],
                 "overrides": {},
                 "build_args": "--requires=dep/0.1 --build=dep/0.1"
@@ -395,6 +406,7 @@ def test_info_build_order_merge_multi_product_configurations():
                 "filenames": [
                     "bo1"
                 ],
+                'info': {'requires': ['dep/0.1']},
                 "depends": [
                     "dep/0.1#4d670581ccb765839f2239cc8dff8fbd:da39a3ee5e6b4b0d3255bfef95601890afd80709"
                 ],
@@ -412,6 +424,7 @@ def test_info_build_order_merge_multi_product_configurations():
                 "filenames": [
                     "bo2"
                 ],
+                'info': {'requires': ['dep/0.1']},
                 "depends": [
                     "dep/0.1#4d670581ccb765839f2239cc8dff8fbd:da39a3ee5e6b4b0d3255bfef95601890afd80709"
                 ],
@@ -461,6 +474,7 @@ def test_info_build_order_merge_conditionals():
                         "package_id": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
                         'prev': None,
                         'filenames': ["bo_win"],
+                        'info': {},
                         "context": "host",
                         'depends': [],
                         "binary": "Build",
@@ -478,6 +492,7 @@ def test_info_build_order_merge_conditionals():
                         "package_id": "da39a3ee5e6b4b0d3255bfef95601890afd80709",
                         'prev': None,
                         'filenames': ["bo_nix"],
+                        'info': {},
                         "context": "host",
                         'depends': [],
                         "binary": "Build",
@@ -500,6 +515,8 @@ def test_info_build_order_merge_conditionals():
                         "package_id": "b23846b9b10455081d89a9dfacd01f7712d04b95",
                         'prev': None,
                         'filenames': ["bo_win"],
+                        'info': {'requires': ['depwin/0.1'],
+                                 'settings': {'os': 'Windows'}},
                         "context": "host",
                         'depends': [],
                         "binary": "Build",
@@ -511,6 +528,8 @@ def test_info_build_order_merge_conditionals():
                         "package_id": "dc29fa55ec82fab6bd820398c7a152ae5f7d4e28",
                         'prev': None,
                         'filenames': ["bo_nix"],
+                        'info': {'requires': ['depnix/0.1'],
+                                 'settings': {'os': 'Linux'}},
                         "context": "host",
                         'depends': [],
                         "binary": "Build",
@@ -565,6 +584,7 @@ def test_build_order_missing_package_check_error():
                 "binary": "Missing",
                 "options": [],
                 "filenames": [],
+                'info': {},
                 "depends": [],
                 "overrides": {},
                 "build_args": None,
@@ -580,6 +600,7 @@ def test_build_order_missing_package_check_error():
                 "binary": "Build",
                 "options": [],
                 "filenames": [],
+                'info': {'requires': ['dep/0.1']},
                 "depends": [
                     "dep/0.1#4d670581ccb765839f2239cc8dff8fbd:da39a3ee5e6b4b0d3255bfef95601890afd80709"
                 ],

--- a/test/integration/package_id/compatible_test.py
+++ b/test/integration/package_id/compatible_test.py
@@ -652,13 +652,13 @@ class TestCompatibleBuild:
         bo = json.loads(c.load("build_order.json"))
         liba = bo["order"][0][0]
         assert liba["ref"] == "liba/0.1#c1459d256a9c2d3c49d149fd7c43310c"
-        assert liba["compatibility_delta"] == {"settings": [["compiler.cppstd", "14"]]}
+        assert liba["info"]["compatibility_delta"] == {"settings": [["compiler.cppstd", "14"]]}
         assert liba["build_args"] == "--requires=liba/0.1 --build=compatible:liba/0.1"
         # Lets make sure the build works too
         c.run(f"install {settings} {liba['build_args']}")
         libb = bo["order"][1][0]
         assert libb["ref"] == "libb/0.1#62bb167aaa5306d1ac757bb817797f9e"
-        assert libb["compatibility_delta"] == {"settings": [["compiler.cppstd", "17"]]}
+        assert libb["info"]["compatibility_delta"] == {"settings": [["compiler.cppstd", "17"]]}
         assert libb["build_args"] == "--requires=libb/0.1 --build=compatible:libb/0.1"
         # Lets make sure the build works too
         c.run(f"install {settings} {libb['build_args']}")
@@ -674,7 +674,7 @@ class TestCompatibleBuild:
         for pkg_index in (0, 1):
             liba = bo["order"][0][pkg_index]
             assert liba["ref"] == "liba/0.1#c1459d256a9c2d3c49d149fd7c43310c"
-            assert liba["compatibility_delta"] == {"settings": [["compiler.cppstd", "14"]]}
+            assert liba["info"]["compatibility_delta"] == {"settings": [["compiler.cppstd", "14"]]}
             assert liba["build_args"] == "--requires=liba/0.1 --build=compatible:liba/0.1"
 
         # By recipe also works
@@ -685,12 +685,12 @@ class TestCompatibleBuild:
         liba = bo["order"][0][0]
         assert liba["ref"] == "liba/0.1#c1459d256a9c2d3c49d149fd7c43310c"
         pkga = liba["packages"][0][0]
-        assert pkga["compatibility_delta"] == {"settings": [["compiler.cppstd", "14"]]}
+        assert pkga["info"]["compatibility_delta"] == {"settings": [["compiler.cppstd", "14"]]}
         assert pkga["build_args"] == "--requires=liba/0.1 --build=compatible:liba/0.1"
         libb = bo["order"][1][0]
         assert libb["ref"] == "libb/0.1#62bb167aaa5306d1ac757bb817797f9e"
         pkgb = libb["packages"][0][0]
-        assert pkgb["compatibility_delta"] == {"settings": [["compiler.cppstd", "17"]]}
+        assert pkgb["info"]["compatibility_delta"] == {"settings": [["compiler.cppstd", "17"]]}
         assert pkgb["build_args"] == "--requires=libb/0.1 --build=compatible:libb/0.1"
 
         # Now lets make sure that build-order-merge works too
@@ -704,5 +704,5 @@ class TestCompatibleBuild:
         assert liba["ref"] == "liba/0.1#c1459d256a9c2d3c49d149fd7c43310c"
         for pkg_index in (0, 1):
             pkga = liba["packages"][0][pkg_index]
-            assert pkga["compatibility_delta"] == {"settings": [["compiler.cppstd", "14"]]}
+            assert pkga["info"]["compatibility_delta"] == {"settings": [["compiler.cppstd", "14"]]}
             assert pkga["build_args"] == "--requires=liba/0.1 --build=compatible:liba/0.1"


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Complements the ``--build=compatible`` for ``conan graph build-order``