### PR TITLE
Add `hook_name` and `hook_method` variables in `conanfile`

### DIFF
--- a/conans/client/hook_manager.py
+++ b/conans/client/hook_manager.py
@@ -30,11 +30,16 @@ class HookManager:
             try:
                 conanfile.display_name = "%s: [HOOK - %s] %s()" % (conanfile.display_name, name,
                                                                    method_name)
+                conanfile.hook_name = name
+                conanfile.hook_method = method_name
+
                 method(conanfile)
             except Exception as e:
                 raise ConanException("[HOOK - %s] %s(): %s" % (name, method_name, str(e)))
             finally:
                 conanfile.display_name = display_name
+                conanfile.hook_name = None
+                conanfile.hook_method = None
 
     def _load_hooks(self):
         hooks = {}

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -75,6 +75,10 @@ class ConanFile:
     runenv_info = None
     conf_info = None
 
+    # Hook data
+    hook_name = None
+    hook_method = None
+
     def __init__(self, display_name=""):
         self.display_name = display_name
         # something that can run commands, as os.sytem


### PR DESCRIPTION
Changelog: Feature: Add `hook_name` and `hook_method` variables in `conanfile`
Docs: https://github.com/conan-io/docs/pull/XXXX

In order to improve the traceability and control of the data generated by hooks in Conan, it would be beneficial to add these two variables, which would only be written to and kept alive during the execution of a hook. Currently, to obtain this data, we would need to parse the display_name that the hook manager assigns to the Conanfile."


