### PR TITLE
Fix example usage for scoped options help string

### DIFF
--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -96,7 +96,7 @@ def add_profiles_args(parser):
                             help="")
 
     create_config("pr", "profile")
-    create_config("o", "options", "-o pkg:with_qt=true")
+    create_config("o", "options", "-o pkg/*:with_qt=True")
     create_config("s", "settings", "-s compiler=gcc")
     create_config("c", "conf", "-c tools.cmake.cmaketoolchain:generator=Xcode")
 

--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -48,7 +48,7 @@ def add_common_install_arguments(parser):
                        help='Do not use remote, resolve exclusively in the cache')
 
     update_help = ("Will install newer versions and/or revisions in the local cache "
-                   "for the given pattern, or all references in the graph if no argument is supplied. "
+                   "for the given reference name, or all references in the graph if no argument is supplied. "
                    "When using version ranges, it will install the latest version that "
                    "satisfies the range. It will update to the "
                    "latest revision for the resolved version range.")

--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -48,9 +48,9 @@ def add_common_install_arguments(parser):
                        help='Do not use remote, resolve exclusively in the cache')
 
     update_help = ("Will install newer versions and/or revisions in the local cache "
-                   "for the given reference, or all in case no argument is supplied. "
+                   "for the given pattern, or all references in the graph if no argument is supplied. "
                    "When using version ranges, it will install the latest version that "
-                   "satisfies the range. Also, if using revisions, it will update to the "
+                   "satisfies the range. It will update to the "
                    "latest revision for the resolved version range.")
 
     parser.add_argument("-u", "--update", action="append", nargs="?", help=update_help, const="*")
@@ -96,9 +96,9 @@ def add_profiles_args(parser):
                             help="")
 
     create_config("pr", "profile")
-    create_config("o", "options", "-o pkg/*:with_qt=True")
-    create_config("s", "settings", "-s compiler=gcc")
-    create_config("c", "conf", "-c tools.cmake.cmaketoolchain:generator=Xcode")
+    create_config("o", "options", '-o="pkg/*:with_qt=True"')
+    create_config("s", "settings", '-s="compiler=gcc"')
+    create_config("c", "conf", '-c="tools.cmake.cmaketoolchain:generator=Xcode"')
 
 
 def add_reference_args(parser):


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Minor change to reflect that the `pkg:option=Value` syntax has been deprecated for a bit now

This would error out with 
> The usage of package names `pkg:with_qt` in options is deprecated, use a pattern like `pkg/*:with_qt` instead