### PR TITLE
Fix RuntimeLibrary deduced from profile in MSBuildToolchain

### DIFF
--- a/conan/tools/microsoft/toolchain.py
+++ b/conan/tools/microsoft/toolchain.py
@@ -7,7 +7,7 @@ from jinja2 import Template
 from conan.internal import check_duplicated_generator
 from conan.tools.build import build_jobs
 from conan.tools.intel.intel_cc import IntelCC
-from conan.tools.microsoft.visual import VCVars, msvs_toolset
+from conan.tools.microsoft.visual import VCVars, msvs_toolset, msvc_runtime_flag
 from conan.errors import ConanException
 from conans.util.files import save, load
 
@@ -67,7 +67,7 @@ class MSBuildToolchain(object):
         #: The build type. By default, the ``conanfile.settings.build_type`` value
         self.configuration = conanfile.settings.build_type
         #: The runtime flag. By default, it'll be based on the `compiler.runtime` setting.
-        self.runtime_library = self._runtime_library(conanfile.settings)
+        self.runtime_library = self._runtime_library()
         #: cppstd value. By default, ``compiler.cppstd`` one.
         self.cppstd = conanfile.settings.get_safe("compiler.cppstd")
         self.cstd = conanfile.settings.get_safe("compiler.cstd")
@@ -107,24 +107,13 @@ class MSBuildToolchain(object):
         else:
             VCVars(self._conanfile).generate()
 
-    @staticmethod
-    def _runtime_library(settings):
-        compiler = settings.compiler
-        runtime = settings.get_safe("compiler.runtime")
-        if compiler == "msvc" or compiler == "intel-cc":
-            build_type = settings.get_safe("build_type")
-            if build_type != "Debug":
-                runtime_library = {"static": "MultiThreaded",
-                                   "dynamic": "MultiThreadedDLL"}.get(runtime, "")
-            else:
-                runtime_library = {"static": "MultiThreadedDebug",
-                                   "dynamic": "MultiThreadedDebugDLL"}.get(runtime, "")
-        else:
-            runtime_library = {"MT": "MultiThreaded",
-                               "MTd": "MultiThreadedDebug",
-                               "MD": "MultiThreadedDLL",
-                               "MDd": "MultiThreadedDebugDLL"}.get(runtime, "")
-        return runtime_library
+    def _runtime_library(self):
+        return {
+            "MT": "MultiThreaded",
+            "MTd": "MultiThreadedDebug",
+            "MD": "MultiThreadedDLL",
+            "MDd": "MultiThreadedDebugDLL",
+        }.get(msvc_runtime_flag(self), "")
 
     @property
     def context_config_toolchain(self):

--- a/conan/tools/microsoft/toolchain.py
+++ b/conan/tools/microsoft/toolchain.py
@@ -113,7 +113,7 @@ class MSBuildToolchain(object):
             "MTd": "MultiThreadedDebug",
             "MD": "MultiThreadedDLL",
             "MDd": "MultiThreadedDebugDLL",
-        }.get(msvc_runtime_flag(self), "")
+        }.get(msvc_runtime_flag(self._conanfile), "")
 
     @property
     def context_config_toolchain(self):

--- a/test/integration/toolchains/microsoft/test_msbuild_toolchain.py
+++ b/test/integration/toolchains/microsoft/test_msbuild_toolchain.py
@@ -6,7 +6,6 @@ import pytest
 from conan.test.utils.tools import TestClient
 
 
-
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
 @pytest.mark.tool("visual_studio")
 @pytest.mark.parametrize(

--- a/test/integration/toolchains/microsoft/test_msbuild_toolchain.py
+++ b/test/integration/toolchains/microsoft/test_msbuild_toolchain.py
@@ -8,11 +8,13 @@ from conan.test.utils.tools import TestClient
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
 @pytest.mark.tool("visual_studio")
+@pytest.mark.tool("clang", "16")
 @pytest.mark.parametrize(
     "compiler, version",
     [
         ("msvc", "190"),
         ("msvc", "191"),
+        ("clang", "16")
     ],
 )
 @pytest.mark.parametrize("runtime", ["dynamic", "static"])
@@ -45,10 +47,13 @@ def test_toolchain_win(compiler, version, runtime, runtime_type):
     props = client.load("conantoolchain_release_x64.props")
     assert "<IncludeExternals>true</IncludeExternals>" in props
     assert "<LanguageStandard>stdcpp14</LanguageStandard>" in props
-    if version == "190":
-        assert "<PlatformToolset>v140</PlatformToolset>" in props
-    else:
-        assert "<PlatformToolset>v141</PlatformToolset>" in props
+    if compiler == "msvc":
+        if version == "190":
+            assert "<PlatformToolset>v140</PlatformToolset>" in props
+        elif version == "191":
+            assert "<PlatformToolset>v141</PlatformToolset>" in props
+    elif compiler == "clang":
+        assert "<PlatformToolset>ClangCl</PlatformToolset>" in props
     if runtime == "dynamic":
         if runtime_type == "Release":
             assert "<RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>" in props


### PR DESCRIPTION
Changelog: Fix: Properly deduce RuntimeLibrary from profile in MSBuildToolchain.
Docs: Omit

closes https://github.com/conan-io/conan/issues/17099

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
