### PR TITLE
fixing pacman used for msys2 win_bash

### DIFF
--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -37,7 +37,7 @@ class _SystemPackageManagerTool(object):
         if os_name in ["Linux", "FreeBSD"]:
             import distro
             os_name = distro.id() or os_name
-        elif os_name == "Windows" and self._conanfile.conf.get("tools.microsoft.bash:subsystem") == "msys2":
+        elif os_name == "Windows" and self._conanfile.settings.get_safe("os.subsystem") == "msys2":
             os_name = "msys2"
         manager_mapping = {"apt-get": ["Linux", "ubuntu", "debian", "raspbian", "linuxmint", 'astra', 'elbrus', 'altlinux', 'pop'],
                            "apk": ["alpine"],

--- a/test/integration/tools/system/package_manager_test.py
+++ b/test/integration/tools/system/package_manager_test.py
@@ -36,8 +36,13 @@ def test_msys2():
         with mock.patch('conan.ConanFile.context', new_callable=PropertyMock) as context_mock:
             context_mock.return_value = "host"
             conanfile = ConanFileMock()
-            conanfile.settings = Settings()
+            conanfile.settings = Settings({"os": {"Windows": {"subsystem": ["msys2"]}}})
             conanfile.conf.define("tools.microsoft.bash:subsystem", "msys2")
+            manager = _SystemPackageManagerTool(conanfile)
+            assert manager.get_default_tool() == "choco"
+
+            conanfile.settings.os = "Windows"
+            conanfile.settings.os.subsystem = "msys2"
             manager = _SystemPackageManagerTool(conanfile)
             assert manager.get_default_tool() == "pacman"
 
@@ -240,6 +245,7 @@ def test_tools_install_mode_install_different_archs(tool_class, arch_host, resul
 
     assert tool._conanfile.command == result
 
+
 @pytest.mark.parametrize("tool_class, arch_host, result", [
     # Install build machine package and not cross-compile -> do not add host architecture
     (Apk, 'x86_64', 'apk add --no-cache package1 package2'),
@@ -280,6 +286,7 @@ def test_tools_install_mode_install_to_build_machine_arch(tool_class, arch_host,
             tool.install(["package1", "package2"], host_package=False)
 
     assert tool._conanfile.command == result
+
 
 @pytest.mark.parametrize("tool_class, result", [
     # cross-compile but arch_names=None -> do not add host architecture


### PR DESCRIPTION
Changelog: Fix: ``Pacman`` as package manager shouldn't be used for ``tools.microsoft.bash:subsystem=msys2``, but when the target platform is actually msys2 ``os.subsystem=msys2`` (as a setting).
Docs: Omit

Close https://github.com/conan-io/conan/issues/17025
