### PR TITLE
[feature] Add ROSEnv generator integration for ROS2 builds

### DIFF
--- a/conan/internal/api/install/generators.py
+++ b/conan/internal/api/install/generators.py
@@ -32,7 +32,8 @@ _generators = {"CMakeToolchain": "conan.tools.cmake",
                "SConsDeps": "conan.tools.scons",
                "QbsDeps": "conan.tools.qbs",
                "QbsProfile": "conan.tools.qbs",
-               "CPSDeps": "conan.tools.cps"
+               "CPSDeps": "conan.tools.cps",
+               "ROSEnv": "conan.tools.ros"
                }
 
 

--- a/conan/tools/ros/__init__.py
+++ b/conan/tools/ros/__init__.py
@@ -1,0 +1,1 @@
+from conan.tools.ros.rosenv import ROSEnv

--- a/conan/tools/ros/rosenv.py
+++ b/conan/tools/ros/rosenv.py
@@ -1,0 +1,38 @@
+import os
+from conan.api.output import Color
+from conan.tools.files import save
+
+
+class ROSEnv(object):
+    """
+    Generator to serve as integration for Robot Operating System 2 development workspaces.
+    It generates a conanrosenv.bash file that when sources sets variables so the Conan
+    dependencies are found by CMake and the run environment is also set.
+
+    IMPORTANT: This generator should be used together with CMakeDeps and CMakeToolchain generators.
+    """
+
+    def __init__(self, conanfile):
+        self._conanfile = conanfile
+        self.filename = "conanrosenv.bash"
+        self.variables = {}
+
+    def generate(self):
+        output_folder = self._conanfile.generators_folder
+        self.variables["CMAKE_TOOLCHAIN_FILE"] = os.path.join(output_folder, "conan_toolchain.cmake")
+        build_type = self._conanfile.settings.get_safe("build_type")
+        if build_type:
+            self.variables["CMAKE_BUILD_TYPE"] = build_type
+
+        content = []
+        for key, value in self.variables.items():
+            line = f"export {key}=\"{value}\""
+            content.append(line)
+        conanrun_path = os.path.join(output_folder, "conanrun.sh")
+        content.append(f". \"{conanrun_path}\"")
+        conanrosenv_path = os.path.join(output_folder, self.filename)
+        save(self, conanrosenv_path, "\n".join(content))
+
+        msg = f"Generated ROSEnv Conan file: {self.filename}\n" + \
+              f"Use 'source {conanrosenv_path}' to set the ROSEnv Conan before 'colcon build'"
+        self._conanfile.output.info(msg, fg=Color.CYAN)

--- a/conan/tools/ros/rosenv.py
+++ b/conan/tools/ros/rosenv.py
@@ -14,25 +14,28 @@ class ROSEnv(object):
 
     def __init__(self, conanfile):
         self._conanfile = conanfile
-        self.filename = "conanrosenv.bash"
+        self.filename = "conanrosenv"
         self.variables = {}
 
     def generate(self):
         output_folder = self._conanfile.generators_folder
-        self.variables["CMAKE_TOOLCHAIN_FILE"] = os.path.join(output_folder, "conan_toolchain.cmake")
+        self.variables.setdefault("CMAKE_TOOLCHAIN_FILE",
+                                  os.path.join(output_folder, "conan_toolchain.cmake"))
         build_type = self._conanfile.settings.get_safe("build_type")
         if build_type:
-            self.variables["CMAKE_BUILD_TYPE"] = build_type
+            self.variables.setdefault("CMAKE_BUILD_TYPE", build_type)
 
         content = []
+        # TODO: Support ps1 and zsh script generation for Windows/Macos
         for key, value in self.variables.items():
             line = f"export {key}=\"{value}\""
             content.append(line)
         conanrun_path = os.path.join(output_folder, "conanrun.sh")
         content.append(f". \"{conanrun_path}\"")
-        conanrosenv_path = os.path.join(output_folder, self.filename)
+        filename = f"{self.filename}.bash"
+        conanrosenv_path = os.path.join(output_folder, filename)
         save(self, conanrosenv_path, "\n".join(content))
 
-        msg = f"Generated ROSEnv Conan file: {self.filename}\n" + \
+        msg = f"Generated ROSEnv Conan file: {filename}\n" + \
               f"Use 'source {conanrosenv_path}' to set the ROSEnv Conan before 'colcon build'"
         self._conanfile.output.info(msg, fg=Color.CYAN)

--- a/conan/tools/ros/rosenv.py
+++ b/conan/tools/ros/rosenv.py
@@ -1,23 +1,12 @@
 import os
 from conan.api.output import Color
 from conan.tools.env import VirtualBuildEnv, VirtualRunEnv, Environment
-from conan.tools.files import save
-from conan.errors import ConanException
-
-
-cmake_toolchain_exists_bash = """\
-if [ ! -e "$CMAKE_TOOLCHAIN_FILE" ]; then
-    echo "Error: CMAKE_TOOLCHAIN_FILE path not found at '$CMAKE_TOOLCHAIN_FILE'."
-    echo "Make sure you are using CMakeToolchain and CMakeDeps generators too."
-    exit 1
-fi
-"""
 
 
 class ROSEnv(object):
     """
     Generator to serve as integration for Robot Operating System 2 development workspaces.
-    It generates a conanrosenv.bash file that when sources sets variables so the Conan
+    It generates a conanrosenv.sh file that when sources sets variables so the Conan
     dependencies are found by CMake and the run environment is also set.
 
     IMPORTANT: This generator should be used together with CMakeDeps and CMakeToolchain generators.
@@ -44,7 +33,7 @@ class ROSEnv(object):
         self._virtualbuildenv._buildenv = rosbuildenv
         # Add VirtualRunEnv variables to VirtualBuildEnv
         self._virtualbuildenv._buildenv.compose_env(self._virtualrunenv.environment())
-        self._virtualbuildenv.generate()
+        self._virtualbuildenv.generate(scope="rosenv")  # Create new scope to generate conanrosenv.sh
         conanrosenv_path = os.path.join(self._conanfile.generators_folder, "conanrosenv.sh")
         msg = f"Generated ROSEnv Conan file: conanrosenv.sh\n" + \
               f"Use 'source {conanrosenv_path}' to set the ROSEnv Conan before 'colcon build'"

--- a/conan/tools/ros/rosenv.py
+++ b/conan/tools/ros/rosenv.py
@@ -1,6 +1,7 @@
 import os
 from conan.api.output import Color
 from conan.tools.env import VirtualBuildEnv, Environment
+from conan.tools.env.environment import create_env_script
 from conan.tools.files import save
 
 
@@ -15,35 +16,33 @@ class ROSEnv:
 
     def __init__(self, conanfile):
         self._conanfile = conanfile
-        self._variables = {}
         self.variables = {}
-        self._virtualbuildenv = VirtualBuildEnv(self._conanfile, auto_generate=True)
-        self._virtualbuildenv.basename = "conanrosenv"
-        self._rosenv_wrapper = "conanrosenv.sh"
+        self._build_script_file = "conanrosenv-build.sh"
+        self._wrapper_script_file = "conanrosenv.sh"
 
     def generate(self):
-        output_folder = self._conanfile.generators_folder
-        self._variables["CMAKE_TOOLCHAIN_FILE"] = os.path.join(output_folder, "conan_toolchain.cmake")
+        cmake_toolchain_path = os.path.join(self._conanfile.generators_folder,
+                                            "conan_toolchain.cmake")
+        self.variables["CMAKE_TOOLCHAIN_FILE"] = f"\"{cmake_toolchain_path}\""
         build_type = self._conanfile.settings.get_safe("build_type")
         if build_type:
-            self._variables["CMAKE_BUILD_TYPE"] = build_type
-        self.variables.update(self._variables)
+            self.variables["CMAKE_BUILD_TYPE"] = build_type
 
         # Add ROS required variables to VirtualBuildEnv
         rosbuildenv = Environment()
         for k, v in self.variables.items():
             rosbuildenv.define(k, v)
-        self._virtualbuildenv._buildenv = rosbuildenv
-        self._virtualbuildenv.generate()
+        rosbuildenv.vars(self._conanfile, "build").save_script(self._build_script_file)
 
         # Generate conanrosenv.sh script wrapper that calls conanbuild.sh and conanrun.sh
         # TODO: Windows .bat/.ps1 files still not supported for the wrapper
         conanbuild_path = os.path.join(self._conanfile.generators_folder, "conanbuild.sh")
         conanrun_path = os.path.join(self._conanfile.generators_folder, "conanrun.sh")
         rosenv_wrapper_content = [f". \"{conanbuild_path}\"", f". \"{conanrun_path}\""]
-        conanrosenv_path = os.path.join(self._conanfile.generators_folder, self._rosenv_wrapper)
-        save(self._conanfile, conanrosenv_path, "\n".join(rosenv_wrapper_content))
+        create_env_script(self._conanfile, "\n".join(rosenv_wrapper_content),
+                          self._wrapper_script_file, None)
 
-        msg = f"Generated ROSEnv Conan file: conanrosenv.sh\n" + \
+        conanrosenv_path = os.path.join(self._conanfile.generators_folder, self._wrapper_script_file)
+        msg = f"Generated ROSEnv Conan file: {self._wrapper_script_file}\n" + \
               f"Use 'source {conanrosenv_path}' to set the ROSEnv Conan before 'colcon build'"
         self._conanfile.output.info(msg, fg=Color.CYAN)

--- a/conan/tools/ros/rosenv.py
+++ b/conan/tools/ros/rosenv.py
@@ -38,10 +38,10 @@ class ROSEnv:
 
         # Generate conanrosenv.sh script wrapper that calls conanbuild.sh and conanrun.sh
         conanbuild_path = os.path.join(self._conanfile.generators_folder, "conanbuild.sh")
-        cmd_wrapper = [f". {conanbuild_path}"]
+        cmd_wrapper = [f". \"{conanbuild_path}\""]
         conanrun_path = os.path.join(self._conanfile.generators_folder, "conanrun.sh")
         if os.path.exists(conanrun_path):
-            cmd_wrapper.append(f". {conanrun_path}")
+            cmd_wrapper.append(f". \"{conanrun_path}\"")
         conanrosenv_path = os.path.join(self._conanfile.generators_folder, self._rosenv_wrapper)
         save(self._conanfile, conanrosenv_path, "\n".join(cmd_wrapper))
 

--- a/conan/tools/ros/rosenv.py
+++ b/conan/tools/ros/rosenv.py
@@ -1,9 +1,10 @@
 import os
 from conan.api.output import Color
-from conan.tools.env import VirtualBuildEnv, VirtualRunEnv, Environment
+from conan.tools.env import VirtualBuildEnv, Environment
+from conan.tools.files import save
 
 
-class ROSEnv(object):
+class ROSEnv:
     """
     Generator to serve as integration for Robot Operating System 2 development workspaces.
     It generates a conanrosenv.sh file that when sources sets variables so the Conan
@@ -14,27 +15,36 @@ class ROSEnv(object):
 
     def __init__(self, conanfile):
         self._conanfile = conanfile
+        self._variables = {}
         self.variables = {}
-        self._virtualbuildenv = VirtualBuildEnv(conanfile)
+        self._virtualbuildenv = VirtualBuildEnv(self._conanfile, auto_generate=True)
         self._virtualbuildenv.basename = "conanrosenv"
-        self._virtualrunenv = VirtualRunEnv(conanfile)
+        self._rosenv_wrapper = "conanrosenv.sh"
 
     def generate(self):
         output_folder = self._conanfile.generators_folder
-        self.variables.setdefault("CMAKE_TOOLCHAIN_FILE",
-                                  os.path.join(output_folder, "conan_toolchain.cmake"))
+        self._variables["CMAKE_TOOLCHAIN_FILE"] = os.path.join(output_folder, "conan_toolchain.cmake")
         build_type = self._conanfile.settings.get_safe("build_type")
         if build_type:
-            self.variables.setdefault("CMAKE_BUILD_TYPE", build_type)
+            self._variables["CMAKE_BUILD_TYPE"] = build_type
+        self.variables.update(self._variables)
+
         # Add ROS required variables to VirtualBuildEnv
         rosbuildenv = Environment()
-        for k, v in self.variables.items():
+        for k, v in self._variables.items():
             rosbuildenv.define(k, v)
         self._virtualbuildenv._buildenv = rosbuildenv
-        # Add VirtualRunEnv variables to VirtualBuildEnv
-        self._virtualbuildenv._buildenv.compose_env(self._virtualrunenv.environment())
-        self._virtualbuildenv.generate(scope="rosenv")  # Create new scope to generate conanrosenv.sh
-        conanrosenv_path = os.path.join(self._conanfile.generators_folder, "conanrosenv.sh")
+        self._virtualbuildenv.generate()
+
+        # Generate conanrosenv.sh script wrapper that calls conanbuild.sh and conanrun.sh
+        conanbuild_path = os.path.join(self._conanfile.generators_folder, "conanbuild.sh")
+        cmd_wrapper = [f". {conanbuild_path}"]
+        conanrun_path = os.path.join(self._conanfile.generators_folder, "conanrun.sh")
+        if os.path.exists(conanrun_path):
+            cmd_wrapper.append(f". {conanrun_path}")
+        conanrosenv_path = os.path.join(self._conanfile.generators_folder, self._rosenv_wrapper)
+        save(self._conanfile, conanrosenv_path, "\n".join(cmd_wrapper))
+
         msg = f"Generated ROSEnv Conan file: conanrosenv.sh\n" + \
               f"Use 'source {conanrosenv_path}' to set the ROSEnv Conan before 'colcon build'"
         self._conanfile.output.info(msg, fg=Color.CYAN)

--- a/conan/tools/ros/rosenv.py
+++ b/conan/tools/ros/rosenv.py
@@ -31,12 +31,13 @@ class ROSEnv:
 
         # Add ROS required variables to VirtualBuildEnv
         rosbuildenv = Environment()
-        for k, v in self._variables.items():
+        for k, v in self.variables.items():
             rosbuildenv.define(k, v)
         self._virtualbuildenv._buildenv = rosbuildenv
         self._virtualbuildenv.generate()
 
         # Generate conanrosenv.sh script wrapper that calls conanbuild.sh and conanrun.sh
+        # TODO: Windows .bat/.ps1 files still not supported for the wrapper
         conanbuild_path = os.path.join(self._conanfile.generators_folder, "conanbuild.sh")
         conanrun_path = os.path.join(self._conanfile.generators_folder, "conanrun.sh")
         rosenv_wrapper_content = [f". \"{conanbuild_path}\"", f". \"{conanrun_path}\""]

--- a/conan/tools/ros/rosenv.py
+++ b/conan/tools/ros/rosenv.py
@@ -38,12 +38,10 @@ class ROSEnv:
 
         # Generate conanrosenv.sh script wrapper that calls conanbuild.sh and conanrun.sh
         conanbuild_path = os.path.join(self._conanfile.generators_folder, "conanbuild.sh")
-        cmd_wrapper = [f". \"{conanbuild_path}\""]
         conanrun_path = os.path.join(self._conanfile.generators_folder, "conanrun.sh")
-        if os.path.exists(conanrun_path):
-            cmd_wrapper.append(f". \"{conanrun_path}\"")
+        rosenv_wrapper_content = [f". \"{conanbuild_path}\"", f". \"{conanrun_path}\""]
         conanrosenv_path = os.path.join(self._conanfile.generators_folder, self._rosenv_wrapper)
-        save(self._conanfile, conanrosenv_path, "\n".join(cmd_wrapper))
+        save(self._conanfile, conanrosenv_path, "\n".join(rosenv_wrapper_content))
 
         msg = f"Generated ROSEnv Conan file: conanrosenv.sh\n" + \
               f"Use 'source {conanrosenv_path}' to set the ROSEnv Conan before 'colcon build'"

--- a/test/integration/tools/ros/test_rosenv.py
+++ b/test/integration/tools/ros/test_rosenv.py
@@ -81,21 +81,17 @@ def test_error_when_rosenv_not_used_with_cmake_generators():
     ROSEnv generator should be used with CMake and CMakeToolchain generators
     """
     client = TestClient()
-    c1 = GenConanfile("lib1", "1.0")
     c2 = textwrap.dedent('''
            [requires]
-           lib1/1.0
            [generators]
            ROSEnv
            ''')
     client.save({
-        "conanfile1.py": c1,
         "conanfile2.txt": c2
     })
 
-    client.run("create conanfile1.py")
     client.run("install conanfile2.txt --output-folder install/conan")
     conanrosenv_path = os.path.join(client.current_folder, "install", "conan", "conanrosenv.bash")
-    print("CONTENT: ", client.load(conanrosenv_path))
-    client.run_command(f". \"{conanrosenv_path}\" && env")
-    assert "kk" in client.out
+    client.run_command(f". \"{conanrosenv_path}\"", assert_error=True)
+    assert "CMAKE_TOOLCHAIN_FILE path not found" in client.out
+    assert "Make sure you are using CMakeToolchain and CMakeDeps generators too" in client.out

--- a/test/integration/tools/ros/test_rosenv.py
+++ b/test/integration/tools/ros/test_rosenv.py
@@ -96,5 +96,5 @@ def test_error_when_rosenv_not_used_with_cmake_generators():
     client.run("create conanfile1.py")
     client.run("install conanfile2.txt --output-folder install/conan")
     conanrosenv_path = os.path.join(client.current_folder, "install", "conan", "conanrosenv.bash")
-    client.run_command(f". \"{conanrosenv_path}\" && env", assert_error=True)
+    client.run_command(f". \"{conanrosenv_path}\" && env")
     assert "kk" in client.out

--- a/test/integration/tools/ros/test_rosenv.py
+++ b/test/integration/tools/ros/test_rosenv.py
@@ -1,0 +1,68 @@
+import os
+import textwrap
+from sys import platform
+
+import pytest
+
+from conan.test.utils.tools import TestClient
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Uses UNIX commands")
+def test_rosenv():
+    """
+    Test that the amentdeps generator generates conan_<name> folders and place CMake files
+    in the correct path
+    """
+    client = TestClient()
+    conanfile1 = textwrap.dedent('''
+        import os
+        from conan import ConanFile
+        from conan.tools.files import save
+        class Recipe(ConanFile):
+            name = "lib1"
+            version = "1.0"
+            settings = "os", "compiler", "build_type", "arch"
+
+            def package(self):
+                save(self, os.path.join(self.package_folder, "lib", "lib1"), "")
+        ''')
+    conanfile2 = textwrap.dedent('''
+        import os
+        from conan import ConanFile
+        from conan.tools.files import save
+
+        class Recipe(ConanFile):
+            name = "lib2"
+            version = "1.0"
+            settings = "os", "compiler", "build_type", "arch"
+
+            def requirements(self):
+                self.requires('lib1/1.0')
+
+            def package(self):
+                save(self, os.path.join(self.package_folder, "lib", "lib2"), "")
+        ''')
+    conanfile3 = textwrap.dedent('''
+        [requires]
+        lib2/1.0
+        [generators]
+        CMakeDeps
+        CMakeToolchain
+        ROSEnv
+        ''')
+    client.save({
+        "conanfile1.py": conanfile1,
+        "conanfile2.py": conanfile2,
+        "conanfile3.txt": conanfile3
+    })
+
+    client.run("create conanfile1.py")
+    client.run("create conanfile2.py")
+    client.run("install conanfile3.txt --output-folder install/conan")
+    assert "Generated ROSEnv Conan file: conanrosenv.bash" in client.out
+    conanrosenv_path = os.path.join(client.current_folder, "install", "conan", "conanrosenv.bash")
+    assert os.path.exists(conanrosenv_path)
+    client.run_command(f"source \"{conanrosenv_path}\" && env")
+    toolchain_path = os.path.join(client.current_folder, "install", "conan", "conan_toolchain.cmake")
+    assert f"CMAKE_TOOLCHAIN_FILE={toolchain_path}" in client.out
+    #TODO: Assert LD_LIBRARY_PATH/DYLD_LIBRARY_PATH/PATH paths are set in the environment

--- a/test/integration/tools/ros/test_rosenv.py
+++ b/test/integration/tools/ros/test_rosenv.py
@@ -11,8 +11,7 @@ from conan.test.utils.tools import TestClient
 @pytest.mark.skipif(platform.system() == "Windows", reason="Uses UNIX commands")
 def test_rosenv():
     """
-    Test that the amentdeps generator generates conan_<name> folders and place CMake files
-    in the correct path
+    Test that the ROSEnv generator generates the environment files and that the environment variables are correctly set
     """
     client = TestClient()
     conanfile3 = textwrap.dedent('''

--- a/test/integration/tools/ros/test_rosenv.py
+++ b/test/integration/tools/ros/test_rosenv.py
@@ -62,7 +62,7 @@ def test_rosenv():
     assert "Generated ROSEnv Conan file: conanrosenv.bash" in client.out
     conanrosenv_path = os.path.join(client.current_folder, "install", "conan", "conanrosenv.bash")
     assert os.path.exists(conanrosenv_path)
-    client.run_command(f"source \"{conanrosenv_path}\" && env")
+    client.run_command(f". \"{conanrosenv_path}\" && env")
     toolchain_path = os.path.join(client.current_folder, "install", "conan", "conan_toolchain.cmake")
     assert f"CMAKE_TOOLCHAIN_FILE={toolchain_path}" in client.out
     #TODO: Assert LD_LIBRARY_PATH/DYLD_LIBRARY_PATH/PATH paths are set in the environment

--- a/test/integration/tools/ros/test_rosenv.py
+++ b/test/integration/tools/ros/test_rosenv.py
@@ -96,5 +96,6 @@ def test_error_when_rosenv_not_used_with_cmake_generators():
     client.run("create conanfile1.py")
     client.run("install conanfile2.txt --output-folder install/conan")
     conanrosenv_path = os.path.join(client.current_folder, "install", "conan", "conanrosenv.bash")
+    print("CONTENT: ", client.load(conanrosenv_path))
     client.run_command(f". \"{conanrosenv_path}\" && env")
     assert "kk" in client.out

--- a/test/integration/tools/ros/test_rosenv.py
+++ b/test/integration/tools/ros/test_rosenv.py
@@ -15,50 +15,17 @@ def test_rosenv():
     in the correct path
     """
     client = TestClient()
-    conanfile1 = textwrap.dedent('''
-        import os
-        from conan import ConanFile
-        from conan.tools.files import save
-        class Recipe(ConanFile):
-            name = "lib1"
-            version = "1.0"
-            settings = "os", "compiler", "build_type", "arch"
-
-            def package(self):
-                save(self, os.path.join(self.package_folder, "lib", "lib1"), "")
-        ''')
-    conanfile2 = textwrap.dedent('''
-        import os
-        from conan import ConanFile
-        from conan.tools.files import save
-
-        class Recipe(ConanFile):
-            name = "lib2"
-            version = "1.0"
-            settings = "os", "compiler", "build_type", "arch"
-
-            def requirements(self):
-                self.requires('lib1/1.0')
-
-            def package(self):
-                save(self, os.path.join(self.package_folder, "lib", "lib2"), "")
-        ''')
     conanfile3 = textwrap.dedent('''
         [requires]
-        lib2/1.0
         [generators]
         CMakeDeps
         CMakeToolchain
         ROSEnv
         ''')
     client.save({
-        "conanfile1.py": conanfile1,
-        "conanfile2.py": conanfile2,
         "conanfile3.txt": conanfile3
     })
 
-    client.run("create conanfile1.py")
-    client.run("create conanfile2.py")
     client.run("install conanfile3.txt --output-folder install/conan")
     assert "Generated ROSEnv Conan file: conanrosenv.bash" in client.out
     conanrosenv_path = os.path.join(client.current_folder, "install", "conan", "conanrosenv.bash")
@@ -117,7 +84,7 @@ def test_error_when_rosenv_not_used_with_cmake_generators():
     c1 = GenConanfile("lib1", "1.0")
     c2 = textwrap.dedent('''
            [requires]
-           lib2/1.0
+           lib1/1.0
            [generators]
            ROSEnv
            ''')

--- a/test/integration/tools/ros/test_rosenv.py
+++ b/test/integration/tools/ros/test_rosenv.py
@@ -4,6 +4,7 @@ import platform
 
 import pytest
 
+from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
 
 
@@ -65,4 +66,68 @@ def test_rosenv():
     client.run_command(f". \"{conanrosenv_path}\" && env")
     toolchain_path = os.path.join(client.current_folder, "install", "conan", "conan_toolchain.cmake")
     assert f"CMAKE_TOOLCHAIN_FILE={toolchain_path}" in client.out
-    #TODO: Assert LD_LIBRARY_PATH/DYLD_LIBRARY_PATH/PATH paths are set in the environment
+    assert "CMAKE_BUILD_TYPE=Release" in client.out
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="Uses UNIX commands")
+def test_rosenv_shared_libraries():
+    """
+    Test that the library paths env vars are set up correctly so that the executables built with
+    colcon can found the shared libraries of conan packages
+    """
+    client = TestClient()
+    c1 = GenConanfile("lib1", "1.0").with_shared_option(False).with_package_file("lib/lib2", "lib-content")
+    c2 = GenConanfile("lib2", "1.0").with_shared_option(False).with_requirement("lib1/1.0").with_package_file("lib/lib2", "lib-content")
+    c3 = textwrap.dedent('''
+           [requires]
+           lib2/1.0
+           [generators]
+           CMakeDeps
+           CMakeToolchain
+           ROSEnv
+           ''')
+    client.save({
+        "conanfile1.py": c1,
+        "conanfile2.py": c2,
+        "conanfile3.txt": c3
+    })
+
+    client.run("create conanfile1.py -o *:shared=True")
+    client.run("create conanfile2.py -o *:shared=True")
+    client.run("install conanfile3.txt -o *:shared=True --output-folder install/conan")
+    conanrosenv_path = os.path.join(client.current_folder, "install", "conan", "conanrosenv.bash")
+    client.run_command(f". \"{conanrosenv_path}\" && env")
+    environment_content = client.out
+    client.run(
+        "cache path lib1/1.0#a77a22ae2a9a8dba9b408d95db4e9880:1744785cb24e3bdca70e27041dc5abd20476f947")
+    lib1_lib_path = os.path.join(client.out.strip(), "lib")
+    assert lib1_lib_path in environment_content
+    client.run(
+        "cache path lib2/1.0#4b7a6063ba107d770458ce10385beb52:5c3c2e56259489f7ffbc8e494921eda4b747ef21")
+    lib2_lib_path = os.path.join(client.out.strip(), "lib")
+    assert lib2_lib_path in environment_content
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="Uses UNIX commands")
+def test_error_when_rosenv_not_used_with_cmake_generators():
+    """
+    ROSEnv generator should be used with CMake and CMakeToolchain generators
+    """
+    client = TestClient()
+    c1 = GenConanfile("lib1", "1.0")
+    c2 = textwrap.dedent('''
+           [requires]
+           lib2/1.0
+           [generators]
+           ROSEnv
+           ''')
+    client.save({
+        "conanfile1.py": c1,
+        "conanfile2.txt": c2
+    })
+
+    client.run("create conanfile1.py")
+    client.run("install conanfile2.txt --output-folder install/conan")
+    conanrosenv_path = os.path.join(client.current_folder, "install", "conan", "conanrosenv.bash")
+    client.run_command(f". \"{conanrosenv_path}\" && env", assert_error=True)
+    assert "kk" in client.out

--- a/test/integration/tools/ros/test_rosenv.py
+++ b/test/integration/tools/ros/test_rosenv.py
@@ -27,9 +27,8 @@ def test_rosenv():
     })
 
     client.run("install conanfile3.txt --output-folder install/conan")
-    # assert "Generated ROSEnv Conan file: conanrosenv.sh" in client.out
-    # FIXME: This file should be conanrosenv.sh, without configuration, but conanbuild.sh is generated instead
-    conanrosenv_path = os.path.join(client.current_folder, "install", "conan", "conanrosenv-release-x86_64.sh")
+    assert "Generated ROSEnv Conan file: conanrosenv.sh" in client.out
+    conanrosenv_path = os.path.join(client.current_folder, "install", "conan", "conanrosenv.sh")
     assert os.path.exists(conanrosenv_path)
     client.run_command(f". \"{conanrosenv_path}\" && env")
     toolchain_path = os.path.join(client.current_folder, "install", "conan", "conan_toolchain.cmake")
@@ -63,8 +62,7 @@ def test_rosenv_shared_libraries():
     client.run("create conanfile1.py -o *:shared=True")
     client.run("create conanfile2.py -o *:shared=True")
     client.run("install conanfile3.txt -o *:shared=True --output-folder install/conan")
-    # FIXME: This file should be conanrosenv.sh, without configuration, but conanbuild.sh is generated instead
-    conanrosenv_path = os.path.join(client.current_folder, "install", "conan", "conanrosenv-release-x86_64.sh")
+    conanrosenv_path = os.path.join(client.current_folder, "install", "conan", "conanrosenv.sh")
     client.run_command(f". \"{conanrosenv_path}\" && env")
     environment_content = client.out
     client.run(

--- a/test/integration/tools/ros/test_rosenv.py
+++ b/test/integration/tools/ros/test_rosenv.py
@@ -1,13 +1,13 @@
 import os
 import textwrap
-from sys import platform
+import platform
 
 import pytest
 
 from conan.test.utils.tools import TestClient
 
 
-@pytest.mark.skipif(platform.system() != "Windows", reason="Uses UNIX commands")
+@pytest.mark.skipif(platform.system() == "Windows", reason="Uses UNIX commands")
 def test_rosenv():
     """
     Test that the amentdeps generator generates conan_<name> folders and place CMake files

--- a/test/integration/tools/ros/test_rosenv.py
+++ b/test/integration/tools/ros/test_rosenv.py
@@ -27,11 +27,14 @@ def test_rosenv():
 
     client.run("install conanfile3.txt --output-folder install/conan")
     assert "Generated ROSEnv Conan file: conanrosenv.sh" in client.out
-    conanrosenv_path = os.path.join(client.current_folder, "install", "conan", "conanrosenv.sh")
+    install_folder = os.path.join(client.current_folder, "install", "conan")
+    conanrosenv_path = os.path.join(install_folder, "conanrosenv.sh")
     assert os.path.exists(conanrosenv_path)
+    conanrosenvbuild_path = os.path.join(install_folder, "conanrosenv-build.sh")
+    assert os.path.exists(conanrosenvbuild_path)
     client.run_command(f". \"{conanrosenv_path}\" && env")
     toolchain_path = os.path.join(client.current_folder, "install", "conan", "conan_toolchain.cmake")
-    assert f"CMAKE_TOOLCHAIN_FILE={toolchain_path}" in client.out
+    assert f"CMAKE_TOOLCHAIN_FILE=\"{toolchain_path}\"" in client.out
     assert "CMAKE_BUILD_TYPE=Release" in client.out
 
 


### PR DESCRIPTION
Changelog: Feature: Add ROSEnv generator integration for ROS2 (Robot Operating System).
Docs: Omit

Related to #17055 

This a generator with a new approach: Set the build and run environment before a colcon build in ROS.

The generator should be used together with CMakeDeps and CMaketoolchain generators as it uses the files generated by those as well.

The ROSEnv generator generates a file called 'conanrosenv.bash' that should be _sourced_ before the build.

Example:

```sh
$ conan install conanfile.txt --output-folder install/conan
$ source install/conan/conanrosenv.sh
$ colcon build
...
$ source install/setup.bash
$ ros2 run <pkg> <executable>
```

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
