### PR TITLE
Empty version range results in empty condition set

### DIFF
--- a/conans/model/version_range.py
+++ b/conans/model/version_range.py
@@ -66,6 +66,10 @@ class _ConditionSet:
 
     def __init__(self, expression, prerelease):
         expressions = expression.split()
+        if not expressions:
+            # Guarantee at least one expression
+            expressions = [""]
+
         self.prerelease = prerelease
         self.conditions = []
         for e in expressions:

--- a/test/unittests/model/version/test_version_range.py
+++ b/test/unittests/model/version/test_version_range.py
@@ -33,6 +33,7 @@ values = [
     # pre-releases
     ['',                             [[[">=", "0.0.0-"]]],    ["1.0"],                ["1.0-pre.1"]],
     ['*, include_prerelease=True',   [[[">=", "0.0.0-"]]],    ["1.0", "1.0-pre.1", "0.0.0", "0.0.0-pre.1"],   []],
+    [', include_prerelease=True',   [[[">=", "0.0.0-"]]],    ["1.0", "1.0-pre.1", "0.0.0", "0.0.0-pre.1"],   []],
     ['>1- <2.0',                     [[['>', '1-'], ['<', '2.0-']]],
                                      ["1.0", "1.1", "1.9"],   ["1-pre.1", "1.5.1-pre1", "2.1-pre1"]],
     ['>1- <2.0 || ^3.2 ',  [[['>', '1-'], ['<', '2.0-']], [['>=', '3.2-'], ['<', '4.0-']]],
@@ -53,14 +54,19 @@ values = [
     ['>=2.0-pre.0, include_prerelease', [[['>=', '2.0-pre.0']]], ["2.1", "2.0-pre.1"], ["1.5"]],
     # Build metadata
     ['>=1.0.0+2', [[['>=', '1.0.0+2']]], ["1.0.0+2", "1.0.0+3"], ["1.0.0+1"]],
-    ['>=2.2.0+build.en.305 <2.2.0+build.en.306', [], ["2.2.0+build.en.305", "2.2.0+build.en.305.1", "2.2.0+build.en.305.2"], ["2.2.0+build.en.306"]]
+    ['>=2.2.0+build.en.305 <2.2.0+build.en.306', [[['>=', '2.2.0+build.en.305'], ['<', '2.2.0+build.en.306']]],
+                                                 ["2.2.0+build.en.305", "2.2.0+build.en.305.1", "2.2.0+build.en.305.2"], ["2.2.0+build.en.306"]]
 ]
 
 
 @pytest.mark.parametrize("version_range, conditions, versions_in, versions_out", values)
 def test_range(version_range, conditions, versions_in, versions_out):
     r = VersionRange(version_range)
+    assert len(r.condition_sets) == len(conditions), \
+        f"Expected {r} to have {len(conditions)} condition sets, but got {len(r.condition_sets)}"
     for condition_set, expected_condition_set in zip(r.condition_sets, conditions):
+        assert len(condition_set.conditions) == len(expected_condition_set), \
+            f"Expected {r} to have {len(expected_condition_set)} conditions, but got {len(condition_set.conditions)}"
         for condition, expected_condition in zip(condition_set.conditions, expected_condition_set):
             assert condition.operator == expected_condition[0], f"Expected {r} condition operator to be {expected_condition[0]}, but got {condition.operator}"
             assert condition.version == expected_condition[1], f"Expected {r} condition version to be {expected_condition[1]}, but got {condition.version}"
@@ -80,6 +86,10 @@ def test_range(version_range, conditions, versions_in, versions_out):
     ['*, include_prerelease', True, ["1.5.1", "1.5.1-pre1", "2.1-pre1"], []],
     ['*, include_prerelease', False, ["1.5.1"], ["1.5.1-pre1", "2.1-pre1"]],
     ['*, include_prerelease', None, ["1.5.1", "1.5.1-pre1", "2.1-pre1"], []],
+
+    [', include_prerelease', True, ["1.5.1", "1.5.1-pre1", "2.1-pre1"], []],
+    [', include_prerelease', False, ["1.5.1"], ["1.5.1-pre1", "2.1-pre1"]],
+    [', include_prerelease', None, ["1.5.1", "1.5.1-pre1", "2.1-pre1"], []],
 
     ['>1 <2.0', True, ["1.5.1", "1.5.1-pre1"], ["2.1-pre1"]],
     ['>1 <2.0', False, ["1.5.1"], ["1.5.1-pre1", "2.1-pre1"]],

--- a/test/unittests/model/version/test_version_range_intersection.py
+++ b/test/unittests/model/version/test_version_range_intersection.py
@@ -3,18 +3,25 @@ import pytest
 from conans.model.version_range import VersionRange
 
 values = [
+    # empty / any ranges
+    ['', "", ">=0.0.0"],
+    ['*', "*", ">=0.0.0"],
     # single lower limits bounds
     ['>1.0', ">1.0", ">1.0"],
     ['>=1.0', ">1.0", ">1.0"],
     ['>1.0', ">1.1", ">1.1"],
     ['>1.0', ">=1.1", ">=1.1"],
     ['>=1.0', ">=1.1", ">=1.1"],
+    ['', ">1.0", ">1.0"],
+    ['>1.0', "", ">1.0"],
     # single upper limits bounds
     ['<2.0', "<2.0", "<2.0"],
     ['<=1.0', "<1.0", "<1.0"],
     ['<2.0', "<2.1", "<2.0"],
     ['<2.0', "<=1.1", "<=1.1"],
     ['<=1.0', "<=1.1", "<=1.0"],
+    ['', "<2.0", ">=0.0.0 <2.0"],
+    ['<2.0', "", ">=0.0.0 <2.0"],
     # One lower limit, one upper
     ['>=1.0', "<2.0", ">=1.0 <2.0"],
     ['>=1', '<=1', ">=1 <=1"],
@@ -83,6 +90,9 @@ def test_range_intersection_incompatible(range1, range2):
 
 
 prerelease_values = [
+    [", include_prerelease",
+     ">=1.0-pre.1 <1.0-pre.99, include_prerelease",
+     ">=1.0-pre.1 <1.0-pre.99, include_prerelease"],
     [">=1.0-pre.1 <1.0-pre.99, include_prerelease",
      ">=1.0-pre.1 <1.0-pre.99, include_prerelease",
      ">=1.0-pre.1 <1.0-pre.99, include_prerelease"],


### PR DESCRIPTION
Changelog: Bugfix: Empty version range results in empty condition set.
Docs: Omit

This PR fixes a bug that occurs when an empty version range is supplied.
Previously an empty version range would result in a `_ConditionSet`, with an empty list of `conditions`.
This can lead to issues, when comparing two version ranges created from an empty version string. Meaning `VersionRange('').intersection(VersionRange('')) == None`, which is wrong.
This PR fixes this behavior and makes sure this is also properly checked for in the tests.

- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
