### PR TITLE
moved exceptions conans->conan

### DIFF
--- a/conan/api/conan_api.py
+++ b/conan/api/conan_api.py
@@ -19,7 +19,7 @@ from conan.api.subapi.search import SearchAPI
 from conan.api.subapi.upload import UploadAPI
 from conans.client.migrations import ClientMigrator
 from conans.client.userio import init_colorama
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.version import Version
 from conan.internal.paths import get_conan_user_home
 from conans.model.version_range import validate_conan_version

--- a/conan/api/model.py
+++ b/conan/api/model.py
@@ -5,7 +5,8 @@ from json import JSONDecodeError
 
 from conans.client.graph.graph import RECIPE_EDITABLE, RECIPE_CONSUMER, RECIPE_PLATFORM, \
     RECIPE_VIRTUAL, BINARY_SKIP, BINARY_MISSING, BINARY_INVALID
-from conans.errors import ConanException, NotFoundException
+from conan.internal.errors import NotFoundException
+from conan.errors import ConanException
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
 from conans.util.files import load

--- a/conan/api/output.py
+++ b/conan/api/output.py
@@ -7,7 +7,7 @@ from threading import Lock
 from colorama import Fore, Style
 
 from conans.client.userio import color_enabled
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 LEVEL_QUIET = 80  # -q
 LEVEL_ERROR = 70  # Errors

--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -11,7 +11,7 @@ from conan.internal.cache.home_paths import HomePaths
 from conan.internal.conan_app import ConanApp
 from conan.internal.cache.integrity_check import IntegrityChecker
 from conans.client.downloaders.download_cache import DownloadCache
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
 from conans.util.dates import revision_timestamp_now

--- a/conan/api/subapi/command.py
+++ b/conan/api/subapi/command.py
@@ -1,4 +1,4 @@
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 class CommandAPI:

--- a/conan/api/subapi/config.py
+++ b/conan/api/subapi/config.py
@@ -15,7 +15,7 @@ from conan.internal.default_settings import default_settings_yml
 from conans.client.graph.graph import CONTEXT_HOST, RECIPE_VIRTUAL, Node
 from conans.client.graph.graph_builder import DepsGraphBuilder
 from conans.client.graph.profile_node_definer import consumer_definer
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.conf import ConfDefinition, BUILT_IN_CONFS
 from conans.model.pkg_type import PackageType
 from conans.model.recipe_ref import RecipeReference

--- a/conan/api/subapi/download.py
+++ b/conan/api/subapi/download.py
@@ -5,7 +5,7 @@ from typing import Optional, List
 from conan.api.model import Remote, PackagesList
 from conan.api.output import ConanOutput
 from conan.internal.conan_app import ConanApp
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
 

--- a/conan/api/subapi/graph.py
+++ b/conan/api/subapi/graph.py
@@ -5,7 +5,7 @@ from conans.client.graph.graph import Node, RECIPE_CONSUMER, CONTEXT_HOST, RECIP
 from conans.client.graph.graph_binaries import GraphBinariesAnalyzer
 from conans.client.graph.graph_builder import DepsGraphBuilder
 from conans.client.graph.profile_node_definer import initialize_conanfile_profile, consumer_definer
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.recipe_ref import RecipeReference
 
 

--- a/conan/api/subapi/install.py
+++ b/conan/api/subapi/install.py
@@ -6,7 +6,7 @@ from conan.internal.deploy import do_deploys
 
 from conans.client.graph.install_graph import InstallGraph
 from conans.client.installer import BinaryInstaller
-from conans.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration
 
 
 class InstallAPI:

--- a/conan/api/subapi/list.py
+++ b/conan/api/subapi/list.py
@@ -7,7 +7,8 @@ from conan.api.output import ConanOutput, TimedOutput
 from conan.internal.api.list.query_parse import filter_package_configs
 from conan.internal.conan_app import ConanApp
 from conan.internal.paths import CONANINFO
-from conans.errors import ConanException, NotFoundException
+from conan.internal.errors import NotFoundException
+from conan.errors import ConanException
 from conans.model.info import load_binary_info
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference, ref_matches

--- a/conan/api/subapi/local.py
+++ b/conan/api/subapi/local.py
@@ -7,7 +7,8 @@ from conans.client.conanfile.build import run_build_method
 from conans.client.graph.graph import CONTEXT_HOST
 from conans.client.graph.profile_node_definer import initialize_conanfile_profile
 from conans.client.source import run_source_method
-from conans.errors import ConanException, conanfile_exception_formatter
+from conan.internal.errors import conanfile_exception_formatter
+from conan.errors import ConanException
 from conans.model.recipe_ref import RecipeReference
 from conans.util.files import chdir
 

--- a/conan/api/subapi/lockfile.py
+++ b/conan/api/subapi/lockfile.py
@@ -3,7 +3,7 @@ import os
 from conan.api.output import ConanOutput
 from conan.cli import make_abs_path
 from conans.client.graph.graph import Overrides
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.graph_lock import Lockfile, LOCKFILE
 
 

--- a/conan/api/subapi/new.py
+++ b/conan/api/subapi/new.py
@@ -3,7 +3,7 @@ import os
 
 from jinja2 import Template, StrictUndefined
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.util.files import load
 from conans import __version__
 

--- a/conan/api/subapi/profiles.py
+++ b/conan/api/subapi/profiles.py
@@ -5,7 +5,8 @@ from conan.internal.cache.home_paths import HomePaths
 
 from conans.client.loader import load_python_file
 from conan.internal.api.profile.profile_loader import ProfileLoader
-from conans.errors import ConanException, scoped_traceback
+from conan.internal.errors import scoped_traceback
+from conan.errors import ConanException
 from conans.model.profile import Profile
 
 DEFAULT_PROFILE_NAME = "default"

--- a/conan/api/subapi/remotes.py
+++ b/conan/api/subapi/remotes.py
@@ -10,7 +10,7 @@ from conan.internal.conan_app import ConanApp
 from conans.client.rest_client_local_recipe_index import add_local_recipes_index_remote, \
     remove_local_recipes_index_remote
 from conan.internal.api.remotes.localdb import LocalDB
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.util.files import save, load
 
 CONAN_CENTER_REMOTE_NAME = "conancenter"

--- a/conan/api/subapi/upload.py
+++ b/conan/api/subapi/upload.py
@@ -8,7 +8,8 @@ from conan.internal.api.uploader import PackagePreparator, UploadExecutor, Uploa
     gather_metadata
 from conans.client.pkg_sign import PkgSignaturesPlugin
 from conans.client.rest.file_uploader import FileUploader
-from conans.errors import ConanException, AuthenticationException, ForbiddenException
+from conan.internal.errors import AuthenticationException, ForbiddenException
+from conan.errors import ConanException
 
 
 class UploadAPI:

--- a/conan/cli/commands/download.py
+++ b/conan/cli/commands/download.py
@@ -4,7 +4,7 @@ from conan.api.output import ConanOutput
 from conan.cli import make_abs_path
 from conan.cli.command import conan_command, OnceArgument
 from conan.cli.commands.list import print_list_text, print_list_json
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 @conan_command(group="Creator", formatters={"text": print_list_text,

--- a/conan/cli/commands/export_pkg.py
+++ b/conan/cli/commands/export_pkg.py
@@ -7,7 +7,7 @@ from conan.cli.command import conan_command, OnceArgument
 from conan.cli.commands.create import _get_test_conanfile_path
 from conan.cli.formatters.graph import format_graph_json
 from conan.cli.printers.graph import print_graph_basic
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 @conan_command(group="Creator", formatters={"json": format_graph_json})

--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -15,7 +15,7 @@ from conan.errors import ConanException
 from conan.internal.deploy import do_deploys
 from conans.client.graph.graph import BINARY_MISSING
 from conans.client.graph.install_graph import InstallGraph
-from conans.errors import NotFoundException
+from conan.internal.errors import NotFoundException
 from conans.model.recipe_ref import ref_matches, RecipeReference
 
 

--- a/conan/cli/commands/list.py
+++ b/conan/cli/commands/list.py
@@ -6,7 +6,7 @@ from conan.api.output import Color, cli_out_write
 from conan.cli import make_abs_path
 from conan.cli.command import conan_command, OnceArgument
 from conan.cli.formatters.list import list_packages_html
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.util.dates import timestamp_to_str
 
 

--- a/conan/cli/commands/pkglist.py
+++ b/conan/cli/commands/pkglist.py
@@ -6,7 +6,7 @@ from conan.cli import make_abs_path
 from conan.cli.command import conan_command, conan_subcommand
 from conan.cli.commands.list import print_list_text, print_list_json
 from conan.cli.formatters.list import list_packages_html
-from conans.errors import NotFoundException
+from conan.internal.errors import NotFoundException
 
 
 @conan_command(group="Consumer")

--- a/conan/cli/commands/remove.py
+++ b/conan/cli/commands/remove.py
@@ -5,7 +5,7 @@ from conan.cli import make_abs_path
 from conan.cli.command import conan_command, OnceArgument
 from conan.cli.commands.list import print_list_json, print_serial
 from conans.client.userio import UserInput
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 def summary_remove_list(results):

--- a/conan/errors.py
+++ b/conan/errors.py
@@ -1,3 +1,22 @@
-from conans.errors import ConanException
-from conans.errors import ConanInvalidConfiguration
-from conans.errors import ConanMigrationError
+class ConanException(Exception):
+    """ Generic conan exception """
+    def __init__(self, msg=None, remote=None):
+        self.remote = remote
+        super().__init__(msg)
+
+    def __str__(self):
+        msg = super().__str__()
+        if self.remote:
+            return f"{msg}. [Remote: {self.remote.name}]"
+        return msg
+
+
+class ConanInvalidConfiguration(ConanException):
+    """
+    This binary, for the requested configuration and package-id cannot be built
+    """
+    pass
+
+
+class ConanMigrationError(ConanException):
+    pass

--- a/conan/internal/api/config/config_installer.py
+++ b/conan/internal/api/config/config_installer.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 
 from conan.api.output import ConanOutput
 from conans.client.downloaders.file_downloader import FileDownloader
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.util.files import mkdir, rmdir, remove, unzip, chdir
 from conans.util.runners import detect_runner
 

--- a/conan/internal/api/detect/detect_vs.py
+++ b/conan/internal/api/detect/detect_vs.py
@@ -3,7 +3,7 @@ import os
 from shutil import which
 
 from conan.tools.build import cmd_args_to_string
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 def vs_installation_path(version):

--- a/conan/internal/api/export.py
+++ b/conan/internal/api/export.py
@@ -4,7 +4,8 @@ import shutil
 from conan.tools.files import copy
 from conan.api.output import ConanOutput
 from conan.tools.scm import Git
-from conans.errors import ConanException, conanfile_exception_formatter
+from conan.internal.errors import conanfile_exception_formatter
+from conan.errors import ConanException
 from conans.model.manifest import FileTreeManifest
 from conans.model.recipe_ref import RecipeReference
 from conan.internal.paths import DATA_YML

--- a/conan/internal/api/install/generators.py
+++ b/conan/internal/api/install/generators.py
@@ -5,7 +5,8 @@ import importlib
 
 from conan.internal.cache.home_paths import HomePaths
 from conans.client.subsystems import deduce_subsystem, subsystem_path
-from conans.errors import ConanException, conanfile_exception_formatter
+from conan.internal.errors import conanfile_exception_formatter
+from conan.errors import ConanException
 from conans.util.files import save, mkdir, chdir
 
 _generators = {"CMakeToolchain": "conan.tools.cmake",

--- a/conan/internal/api/profile/profile_loader.py
+++ b/conan/internal/api/profile/profile_loader.py
@@ -9,7 +9,7 @@ from conan.api.output import ConanOutput
 from conan.internal.api.detect import detect_api
 from conan.internal.cache.home_paths import HomePaths
 from conan.tools.env.environment import ProfileEnvironment
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.conf import ConfDefinition, CORE_CONF_PATTERN
 from conans.model.options import Options
 from conans.model.profile import Profile

--- a/conan/internal/api/uploader.py
+++ b/conan/internal/api/uploader.py
@@ -6,7 +6,8 @@ import time
 from conan.internal.conan_app import ConanApp
 from conan.api.output import ConanOutput
 from conans.client.source import retrieve_exports_sources
-from conans.errors import ConanException, NotFoundException
+from conan.internal.errors import NotFoundException
+from conan.errors import ConanException
 from conan.internal.paths import (CONAN_MANIFEST, CONANFILE, EXPORT_SOURCES_TGZ_NAME,
                                   EXPORT_TGZ_NAME, PACKAGE_TGZ_NAME, CONANINFO)
 from conans.util.files import (clean_dirty, is_dirty, gather_files,

--- a/conan/internal/cache/cache.py
+++ b/conan/internal/cache/cache.py
@@ -10,7 +10,8 @@ from conan.internal.cache.conan_reference_layout import RecipeLayout, PackageLay
 # TODO: Random folders are no longer accessible, how to get rid of them asap?
 # TODO: We need the workflow to remove existing references.
 from conan.internal.cache.db.cache_database import CacheDatabase
-from conans.errors import ConanReferenceAlreadyExistsInDB, ConanException
+from conan.internal.errors import ConanReferenceAlreadyExistsInDB
+from conan.errors import ConanException
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
 from conans.util.dates import revision_timestamp_now

--- a/conan/internal/cache/db/packages_table.py
+++ b/conan/internal/cache/db/packages_table.py
@@ -1,7 +1,7 @@
 import sqlite3
 
 from conan.internal.cache.db.table import BaseDbTable
-from conans.errors import ConanReferenceDoesNotExistInDB, ConanReferenceAlreadyExistsInDB
+from conan.internal.errors import ConanReferenceDoesNotExistInDB, ConanReferenceAlreadyExistsInDB
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
 from conans.util.dates import timestamp_now

--- a/conan/internal/cache/db/recipes_table.py
+++ b/conan/internal/cache/db/recipes_table.py
@@ -1,7 +1,7 @@
 import sqlite3
 
 from conan.internal.cache.db.table import BaseDbTable
-from conans.errors import ConanReferenceDoesNotExistInDB, ConanReferenceAlreadyExistsInDB
+from conan.internal.errors import ConanReferenceDoesNotExistInDB, ConanReferenceAlreadyExistsInDB
 from conans.model.recipe_ref import RecipeReference
 from conans.util.dates import timestamp_now
 

--- a/conan/internal/cache/integrity_check.py
+++ b/conan/internal/cache/integrity_check.py
@@ -1,7 +1,7 @@
 import os
 
 from conan.api.output import ConanOutput
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
 

--- a/conan/internal/deploy.py
+++ b/conan/internal/deploy.py
@@ -5,7 +5,8 @@ import shutil
 from conan.internal.cache.home_paths import HomePaths
 from conan.api.output import ConanOutput
 from conans.client.loader import load_python_file
-from conans.errors import ConanException, conanfile_exception_formatter
+from conan.internal.errors import conanfile_exception_formatter
+from conan.errors import ConanException
 from conans.util.files import rmdir, mkdir
 
 

--- a/conan/internal/errors.py
+++ b/conan/internal/errors.py
@@ -1,14 +1,7 @@
-"""
-    Exceptions raised and handled in Conan
-    These exceptions are mapped between server (as an HTTP response) and client
-    through the REST API. When an error happens in server its translated to an HTTP
-    error code that its sent to client. Client reads the server code and raise the
-    matching exception.
-
-    see return_plugin.py
-"""
 import traceback
 from contextlib import contextmanager
+
+from conan.errors import ConanException, ConanInvalidConfiguration
 
 
 @contextmanager
@@ -88,19 +81,6 @@ def scoped_traceback(header_msg, exception, scope):
     return ret
 
 
-class ConanException(Exception):
-    """ Generic conan exception """
-    def __init__(self, msg=None, remote=None):
-        self.remote = remote
-        super().__init__(msg)
-
-    def __str__(self):
-        msg = super().__str__()
-        if self.remote:
-            return f"{msg}. [Remote: {self.remote.name}]"
-        return msg
-
-
 class ConanReferenceDoesNotExistInDB(ConanException):
     """ Reference does not exist in cache db """
     pass
@@ -115,18 +95,6 @@ class ConanConnectionError(ConanException):
     pass
 
 
-class ConanInvalidConfiguration(ConanException):
-    """
-    This binary, for the requested configuration and package-id cannot be built
-    """
-    pass
-
-
-class ConanMigrationError(ConanException):
-    pass
-
-
-# Remote exceptions #
 class InternalErrorException(ConanException):
     """
          Generic 500 error

--- a/conan/internal/internal_tools.py
+++ b/conan/internal/internal_tools.py
@@ -1,4 +1,4 @@
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 universal_arch_separator = '|'
 

--- a/conan/internal/runner/docker.py
+++ b/conan/internal/runner/docker.py
@@ -9,7 +9,7 @@ from conan.api.output import Color, ConanOutput
 from conan.api.conan_api import ConfigAPI
 from conan.cli import make_abs_path
 from conan.internal.runner import RunnerException
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.version import Version
 
 

--- a/conan/internal/runner/ssh.py
+++ b/conan/internal/runner/ssh.py
@@ -3,7 +3,7 @@ import pathlib
 import tempfile
 
 from conan.api.output import Color, ConanOutput
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 import os
 from io import BytesIO

--- a/conan/internal/runner/wsl.py
+++ b/conan/internal/runner/wsl.py
@@ -1,6 +1,6 @@
 from pathlib import PurePosixPath, PureWindowsPath, Path
 from conan.api.output import Color, ConanOutput
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.util.runners import conan_run
 from conans.client.subsystems import subsystem_path
 from conan.tools.files import save
@@ -61,7 +61,7 @@ class WSLRunner:
                 create_json_wsl = subsystem_path("wsl", create_json)
                 pkglist_json = PureWindowsPath(tmp_dir).joinpath("pkglist.json").as_posix()
                 pkglist_json_wsl = subsystem_path("wsl", pkglist_json)
-                
+
                 saved_cache = PureWindowsPath(tmp_dir).joinpath("saved_cache.tgz").as_posix()
                 saved_cache_wsl = subsystem_path("wsl", saved_cache)
                 conan_run(f"wsl.exe --cd {tmp_dir_wsl} -- CONAN_RUNNER_ENVIRONMENT=1 CONAN_HOME={self.remote_conan_home} {self.remote_conan} list --graph={create_json_wsl} --format=json > {pkglist_json}")
@@ -89,7 +89,7 @@ class WSLRunner:
         self.remote_conan_home = conan_home
 
         has_conan = conan_run(f"wsl.exe CONAN_HOME={conan_home.as_posix()} {remote_conan} --version", stdout=stdout, stderr=stderr) == 0
-        
+
         if not has_conan:
             wsl_info("Bootstrapping Conan in remote")
             conan_run(f"wsl.exe mkdir -p {remote_home}/.conan2remote")
@@ -109,7 +109,7 @@ class WSLRunner:
         # If this command succeeds, great - if not because it already exists, ignore
         conan_run(f"wsl.exe CONAN_HOME={conan_home.as_posix()} {remote_conan} profile detect", stdout=stdout, stderr=stderr)
 
-       
+
         conf_content = f"core.cache:storage_path={self.remote_conan_cache}\n"  if self.shared_cache else ""
         with tempfile.TemporaryDirectory() as tmp:
             global_conf = os.path.join(tmp, "global.conf")
@@ -117,7 +117,7 @@ class WSLRunner:
             global_conf_wsl = subsystem_path("wsl", global_conf)
             remote_global_conf = self.remote_conan_home.joinpath("global.conf")
             conan_run(f"wsl.exe cp {global_conf_wsl} {remote_global_conf}")
- 
+
         self._copy_profiles()
 
     def _copy_profiles(self):
@@ -137,7 +137,7 @@ class WSLRunner:
                 save(None, path=outfile, content=contents)
                 outfile_wsl = subsystem_path("wsl", outfile)
                 remote_profile = self.remote_conan_home.joinpath("profiles").as_posix() + "/"
-                
+
                 # This works but copies the file with executable attribute
                 conan_run(f"wsl.exe cp {outfile_wsl} {remote_profile}")
 

--- a/conan/test/utils/artifactory.py
+++ b/conan/test/utils/artifactory.py
@@ -4,7 +4,7 @@ import uuid
 
 import requests
 
-from conans.errors import RecipeNotFoundException, PackageNotFoundException
+from conan.internal.errors import RecipeNotFoundException, PackageNotFoundException
 from conans.server.revision_list import _RevisionEntry
 
 ARTIFACTORY_DEFAULT_USER = os.getenv("ARTIFACTORY_DEFAULT_USER", "admin")

--- a/conan/test/utils/mocks.py
+++ b/conan/test/utils/mocks.py
@@ -3,7 +3,7 @@ from io import StringIO
 
 from conan import ConanFile
 from conan.internal.conan_app import ConanFileHelpers
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.conf import Conf
 from conans.model.layout import Folders, Infos
 from conans.model.options import Options

--- a/conan/test/utils/test_files.py
+++ b/conan/test/utils/test_files.py
@@ -10,7 +10,7 @@ from io import BytesIO
 
 from conan.tools.files.files import untargz
 from conans.client.subsystems import get_cased_path
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conan.internal.paths import PACKAGE_TGZ_NAME
 from conans.util.files import gzopen_without_timestamps
 

--- a/conan/test/utils/tools.py
+++ b/conan/test/utils/tools.py
@@ -32,7 +32,8 @@ from conan.api.conan_api import ConanAPI
 from conan.api.model import Remote
 from conan.cli.cli import Cli, _CONAN_INTERNAL_CUSTOM_COMMANDS_PATH
 from conan.test.utils.env import environment_update
-from conans.errors import NotFoundException, ConanException
+from conan.internal.errors import NotFoundException
+from conan.errors import ConanException
 from conans.model.manifest import FileTreeManifest
 from conans.model.package_ref import PkgReference
 from conans.model.profile import Profile

--- a/conan/tools/cmake/cmakedeps/templates/config_version.py
+++ b/conan/tools/cmake/cmakedeps/templates/config_version.py
@@ -1,7 +1,7 @@
 import textwrap
 
 from conan.tools.cmake.cmakedeps.templates import CMakeDepsFileTemplate
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 """
     foo-config-version.cmake

--- a/conan/tools/files/copy_pattern.py
+++ b/conan/tools/files/copy_pattern.py
@@ -3,7 +3,7 @@ import fnmatch
 import os
 import shutil
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.util.files import mkdir
 
 

--- a/conan/tools/gnu/gnutoolchain.py
+++ b/conan/tools/gnu/gnutoolchain.py
@@ -11,7 +11,7 @@ from conan.tools.build.flags import architecture_flag, build_type_flags, cppstd_
 from conan.tools.env import Environment
 from conan.tools.gnu.get_gnu_triplet import _get_gnu_triplet
 from conan.tools.microsoft import VCVars, msvc_runtime_flag, unix_path, check_min_vs, is_msvc
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.pkg_type import PackageType
 
 

--- a/conans/client/conanfile/build.py
+++ b/conans/client/conanfile/build.py
@@ -1,4 +1,4 @@
-from conans.errors import conanfile_exception_formatter
+from conan.internal.errors import conanfile_exception_formatter
 from conans.util.files import chdir, mkdir
 
 

--- a/conans/client/conanfile/configure.py
+++ b/conans/client/conanfile/configure.py
@@ -1,4 +1,4 @@
-from conans.errors import conanfile_exception_formatter
+from conan.internal.errors import conanfile_exception_formatter
 from conans.model.pkg_type import PackageType
 from conans.model.requires import BuildRequirements, TestRequirements, ToolRequirements
 from conans.client.conanfile.implementations import auto_shared_fpic_config_options, \

--- a/conans/client/conanfile/package.py
+++ b/conans/client/conanfile/package.py
@@ -1,7 +1,8 @@
 import os
 
 from conan.api.output import ConanOutput
-from conans.errors import ConanException, conanfile_exception_formatter, conanfile_remove_attr
+from conan.internal.errors import conanfile_remove_attr, conanfile_exception_formatter
+from conan.errors import ConanException
 from conans.model.manifest import FileTreeManifest
 from conans.model.package_ref import PkgReference
 from conan.internal.paths import CONANINFO

--- a/conans/client/downloaders/caching_file_downloader.py
+++ b/conans/client/downloaders/caching_file_downloader.py
@@ -8,8 +8,8 @@ from conan.api.output import ConanOutput
 from conan.internal.cache.home_paths import HomePaths
 from conans.client.downloaders.file_downloader import FileDownloader
 from conans.client.downloaders.download_cache import DownloadCache
-from conans.errors import NotFoundException, ConanException, AuthenticationException, \
-    ForbiddenException
+from conan.internal.errors import AuthenticationException, ForbiddenException, NotFoundException
+from conan.errors import ConanException
 from conans.util.files import mkdir, set_dirty_context_manager, remove_if_dirty, human_size
 
 

--- a/conans/client/downloaders/download_cache.py
+++ b/conans/client/downloaders/download_cache.py
@@ -4,7 +4,7 @@ import os
 from contextlib import contextmanager
 from threading import Lock
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.util.dates import timestamp_now
 from conans.util.files import load, save, remove_if_dirty
 from conans.util.locks import simple_lock

--- a/conans/client/downloaders/file_downloader.py
+++ b/conans/client/downloaders/file_downloader.py
@@ -5,8 +5,9 @@ import time
 
 from conan.api.output import ConanOutput, TimedOutput
 from conans.client.rest import response_to_str
-from conans.errors import ConanException, NotFoundException, AuthenticationException, \
-    ForbiddenException, ConanConnectionError, RequestErrorException
+from conan.internal.errors import ConanConnectionError, RequestErrorException, AuthenticationException, \
+    ForbiddenException, NotFoundException
+from conan.errors import ConanException
 from conans.util.files import human_size, check_with_algorithm_sum
 
 

--- a/conans/client/graph/build_mode.py
+++ b/conans/client/graph/build_mode.py
@@ -1,4 +1,4 @@
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.recipe_ref import ref_matches
 
 

--- a/conans/client/graph/compatibility.py
+++ b/conans/client/graph/compatibility.py
@@ -4,7 +4,8 @@ from collections import OrderedDict
 from conan.internal.cache.home_paths import HomePaths
 from conans.client.graph.compute_pid import run_validate_package_id
 from conans.client.loader import load_python_file
-from conans.errors import conanfile_exception_formatter, ConanException, scoped_traceback
+from conan.internal.errors import conanfile_exception_formatter, scoped_traceback
+from conan.errors import ConanException
 
 # TODO: Define other compatibility besides applications
 _default_compat = """\

--- a/conans/client/graph/compute_pid.py
+++ b/conans/client/graph/compute_pid.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 
-from conans.errors import conanfile_exception_formatter, ConanInvalidConfiguration, \
-    conanfile_remove_attr, ConanException
+from conan.internal.errors import conanfile_remove_attr, conanfile_exception_formatter
+from conan.errors import ConanException, ConanInvalidConfiguration
 from conans.model.info import ConanInfo, RequirementsInfo, RequirementInfo, PythonRequiresInfo
 from conans.client.conanfile.implementations import auto_header_only_package_id
 

--- a/conans/client/graph/graph_binaries.py
+++ b/conans/client/graph/graph_binaries.py
@@ -13,8 +13,9 @@ from conans.client.graph.graph import (BINARY_BUILD, BINARY_CACHE, BINARY_DOWNLO
                                        BINARY_INVALID, BINARY_EDITABLE_BUILD, RECIPE_PLATFORM,
                                        BINARY_PLATFORM)
 from conans.client.graph.proxy import should_update_reference
-from conans.errors import NotFoundException, \
-    PackageNotFoundException, conanfile_exception_formatter, ConanConnectionError, ConanException
+from conan.internal.errors import conanfile_exception_formatter, ConanConnectionError, NotFoundException, \
+    PackageNotFoundException
+from conan.errors import ConanException
 from conans.model.info import RequirementInfo, RequirementsInfo
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference

--- a/conans/client/graph/graph_builder.py
+++ b/conans/client/graph/graph_builder.py
@@ -11,7 +11,7 @@ from conans.client.graph.graph_error import GraphLoopError, GraphConflictError, 
     GraphRuntimeError, GraphError
 from conans.client.graph.profile_node_definer import initialize_conanfile_profile
 from conans.client.graph.provides import check_graph_provides
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.conan_file import ConanFile
 from conans.model.options import Options, _PackageOptions
 from conans.model.pkg_type import PackageType

--- a/conans/client/graph/graph_error.py
+++ b/conans/client/graph/graph_error.py
@@ -1,4 +1,4 @@
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 class GraphError(ConanException):

--- a/conans/client/graph/install_graph.py
+++ b/conans/client/graph/install_graph.py
@@ -5,7 +5,7 @@ import textwrap
 from conan.api.output import ConanOutput
 from conans.client.graph.graph import RECIPE_CONSUMER, RECIPE_VIRTUAL, BINARY_SKIP, \
     BINARY_MISSING, BINARY_INVALID, Overrides, BINARY_BUILD, BINARY_EDITABLE_BUILD, BINARY_PLATFORM
-from conans.errors import ConanInvalidConfiguration, ConanException
+from conan.errors import ConanException, ConanInvalidConfiguration
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
 from conans.util.files import load

--- a/conans/client/graph/profile_node_definer.py
+++ b/conans/client/graph/profile_node_definer.py
@@ -1,5 +1,5 @@
 from conans.client.graph.graph import CONTEXT_BUILD
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.recipe_ref import ref_matches
 
 

--- a/conans/client/graph/proxy.py
+++ b/conans/client/graph/proxy.py
@@ -3,7 +3,8 @@ from conan.internal.cache.conan_reference_layout import BasicLayout
 from conans.client.graph.graph import (RECIPE_DOWNLOADED, RECIPE_INCACHE, RECIPE_NEWER,
                                        RECIPE_NOT_IN_REMOTE, RECIPE_UPDATED, RECIPE_EDITABLE,
                                        RECIPE_INCACHE_DATE_UPDATED, RECIPE_UPDATEABLE)
-from conans.errors import ConanException, NotFoundException
+from conan.internal.errors import NotFoundException
+from conan.errors import ConanException
 
 
 class ConanProxy:

--- a/conans/client/graph/python_requires.py
+++ b/conans/client/graph/python_requires.py
@@ -1,6 +1,6 @@
 import os
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.recipe_ref import RecipeReference
 from conans.model.requires import Requirement
 

--- a/conans/client/graph/range_resolver.py
+++ b/conans/client/graph/range_resolver.py
@@ -1,5 +1,5 @@
 from conans.client.graph.proxy import should_update_reference
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.recipe_ref import RecipeReference
 from conans.model.version_range import VersionRange
 

--- a/conans/client/hook_manager.py
+++ b/conans/client/hook_manager.py
@@ -1,7 +1,7 @@
 import os
 
 from conans.client.loader import load_python_file
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 valid_hook_methods = ["pre_export", "post_export",
                       "pre_source", "post_source",

--- a/conans/client/installer.py
+++ b/conans/client/installer.py
@@ -10,7 +10,8 @@ from conans.client.graph.graph import BINARY_BUILD, BINARY_CACHE, BINARY_DOWNLOA
     BINARY_UPDATE, BINARY_EDITABLE_BUILD, BINARY_SKIP
 from conans.client.graph.install_graph import InstallGraph
 from conans.client.source import retrieve_exports_sources, config_source
-from conans.errors import (ConanException, conanfile_exception_formatter, conanfile_remove_attr)
+from conan.internal.errors import conanfile_remove_attr, conanfile_exception_formatter
+from conan.errors import ConanException
 from conans.model.build_info import CppInfo, MockInfoProperty
 from conans.model.package_ref import PkgReference
 from conan.internal.paths import CONANINFO

--- a/conans/client/loader.py
+++ b/conans/client/loader.py
@@ -16,7 +16,8 @@ from conan.tools.cmake import cmake_layout
 from conan.tools.google import bazel_layout
 from conan.tools.microsoft import vs_layout
 from conans.client.loader_txt import ConanFileTextLoader
-from conans.errors import ConanException, NotFoundException, conanfile_exception_formatter
+from conan.internal.errors import conanfile_exception_formatter, NotFoundException
+from conan.errors import ConanException
 from conans.model.conan_file import ConanFile
 from conans.model.options import Options
 from conans.model.recipe_ref import RecipeReference

--- a/conans/client/loader_txt.py
+++ b/conans/client/loader_txt.py
@@ -1,4 +1,4 @@
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.util.config_parser import ConfigParser
 
 

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -10,8 +10,8 @@ from conan.api.model import Remote
 from conan.api.output import ConanOutput
 from conan.internal.cache.conan_reference_layout import METADATA
 from conans.client.pkg_sign import PkgSignaturesPlugin
-from conans.errors import ConanConnectionError, ConanException, NotFoundException, \
-    PackageNotFoundException
+from conan.internal.errors import ConanConnectionError, NotFoundException, PackageNotFoundException
+from conan.errors import ConanException
 from conans.model.info import load_binary_info
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference

--- a/conans/client/rest/auth_manager.py
+++ b/conans/client/rest/auth_manager.py
@@ -14,7 +14,8 @@ Flow:
 from conan.api.output import ConanOutput
 from conans.client.rest.remote_credentials import RemoteCredentials
 from conans.client.rest.rest_client import RestApiClient
-from conans.errors import AuthenticationException, ConanException, ForbiddenException
+from conan.internal.errors import AuthenticationException, ForbiddenException
+from conan.errors import ConanException
 
 LOGIN_RETRIES = 3
 

--- a/conans/client/rest/conan_requester.py
+++ b/conans/client/rest/conan_requester.py
@@ -13,7 +13,8 @@ from conan.internal.cache.home_paths import HomePaths
 
 from conans import __version__ as client_version
 from conans.client.loader import load_python_file
-from conans.errors import ConanException, scoped_traceback
+from conan.internal.errors import scoped_traceback
+from conan.errors import ConanException
 
 # Capture SSL warnings as pointed out here:
 # https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning

--- a/conans/client/rest/file_uploader.py
+++ b/conans/client/rest/file_uploader.py
@@ -3,8 +3,9 @@ import time
 
 from conan.api.output import ConanOutput, TimedOutput
 from conans.client.rest import response_to_str
-from conans.errors import AuthenticationException, ConanException, \
-    NotFoundException, ForbiddenException, RequestErrorException, InternalErrorException
+from conan.internal.errors import InternalErrorException, RequestErrorException, AuthenticationException, \
+    ForbiddenException, NotFoundException
+from conan.errors import ConanException
 from conans.util.files import sha1sum
 
 

--- a/conans/client/rest/remote_credentials.py
+++ b/conans/client/rest/remote_credentials.py
@@ -9,7 +9,8 @@ from conan.internal.cache.home_paths import HomePaths
 from conans.client.loader import load_python_file
 from conan.api.output import ConanOutput
 from conans.client.userio import UserInput
-from conans.errors import ConanException, scoped_traceback
+from conan.internal.errors import scoped_traceback
+from conan.errors import ConanException
 from conans.util.files import load
 
 

--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -1,6 +1,6 @@
 from conans import CHECKSUM_DEPLOY, REVISIONS
 from conans.client.rest.rest_client_v2 import RestV2Methods
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 class RestApiClient:

--- a/conans/client/rest/rest_client_v2.py
+++ b/conans/client/rest/rest_client_v2.py
@@ -13,8 +13,9 @@ from conans.client.downloaders.caching_file_downloader import ConanInternalCache
 from conans.client.rest import response_to_str
 from conans.client.rest.client_routes import ClientV2Router
 from conans.client.rest.file_uploader import FileUploader
-from conans.errors import ConanException, NotFoundException, PackageNotFoundException, \
-    RecipeNotFoundException, AuthenticationException, ForbiddenException, EXCEPTION_CODE_MAPPING
+from conan.internal.errors import AuthenticationException, ForbiddenException, NotFoundException, \
+    RecipeNotFoundException, PackageNotFoundException, EXCEPTION_CODE_MAPPING
+from conan.errors import ConanException
 from conans.model.package_ref import PkgReference
 from conan.internal.paths import EXPORT_SOURCES_TGZ_NAME
 from conans.model.recipe_ref import RecipeReference

--- a/conans/client/rest_client_local_recipe_index.py
+++ b/conans/client/rest_client_local_recipe_index.py
@@ -11,8 +11,9 @@ from conan.api.output import ConanOutput
 from conan.internal.cache.home_paths import HomePaths
 from conan.internal.api.export import cmd_export
 from conans.client.loader import ConanFileLoader
-from conans.errors import ConanException, PackageNotFoundException, RecipeNotFoundException, \
-    ConanReferenceDoesNotExistInDB, NotFoundException
+from conan.internal.errors import ConanReferenceDoesNotExistInDB, NotFoundException, RecipeNotFoundException, \
+    PackageNotFoundException
+from conan.errors import ConanException
 from conans.model.conf import ConfDefinition
 from conans.model.recipe_ref import RecipeReference
 from conans.util.files import load, save, rmdir, copytree_compat

--- a/conans/client/source.py
+++ b/conans/client/source.py
@@ -2,8 +2,8 @@ import os
 
 from conan.api.output import ConanOutput
 from conan.tools.env import VirtualBuildEnv
-from conans.errors import ConanException, conanfile_exception_formatter, NotFoundException, \
-    conanfile_remove_attr
+from conan.internal.errors import conanfile_remove_attr, conanfile_exception_formatter, NotFoundException
+from conan.errors import ConanException
 from conans.util.files import (is_dirty, mkdir, rmdir, set_dirty_context_manager,
                                merge_directories, clean_dirty, chdir)
 

--- a/conans/client/subsystems.py
+++ b/conans/client/subsystems.py
@@ -24,7 +24,7 @@ import platform
 import re
 
 from conan.tools.build import cmd_args_to_string
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 WINDOWS = "windows"
 MSYS2 = 'msys2'

--- a/conans/client/userio.py
+++ b/conans/client/userio.py
@@ -2,7 +2,7 @@ import getpass
 import os
 import sys
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 def is_terminal(stream):

--- a/conans/migrations.py
+++ b/conans/migrations.py
@@ -3,7 +3,7 @@ import os
 from conan import conan_version
 from conan.api.output import ConanOutput
 from conans.client.loader import load_python_file
-from conans.errors import ConanException, ConanMigrationError
+from conan.errors import ConanException, ConanMigrationError
 from conans.model.version import Version
 from conans.util.files import load, save
 

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -4,7 +4,7 @@ import os
 from collections import OrderedDict, defaultdict
 
 from conan.api.output import ConanOutput
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.util.files import load, save
 
 _DIRS_VAR_NAMES = ["_includedirs", "_srcdirs", "_libdirs", "_resdirs", "_bindirs", "_builddirs",

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from conan.api.output import ConanOutput, Color
 from conans.client.subsystems import command_env_wrapper
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.build_info import MockInfoProperty
 from conans.model.conf import Conf
 from conans.model.dependencies import ConanFileDependencies

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -6,7 +6,7 @@ import fnmatch
 
 from collections import OrderedDict
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.recipe_ref import ref_matches
 
 BUILT_IN_CONFS = {

--- a/conans/model/dependencies.py
+++ b/conans/model/dependencies.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 
 from conans.client.graph.graph import RECIPE_PLATFORM
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.recipe_ref import RecipeReference
 from conans.model.conanfile_interface import ConanFileInterface
 

--- a/conans/model/graph_lock.py
+++ b/conans/model/graph_lock.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 
 from conan.api.output import ConanOutput
 from conans.client.graph.graph import RECIPE_VIRTUAL, RECIPE_CONSUMER, CONTEXT_BUILD, Overrides
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.recipe_ref import RecipeReference
 from conans.model.version_range import VersionRange
 from conans.util.files import load, save

--- a/conans/model/info.py
+++ b/conans/model/info.py
@@ -1,6 +1,6 @@
 import hashlib
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.dependencies import UserRequirementsDict
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference, Version

--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -1,4 +1,4 @@
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.recipe_ref import ref_matches
 
 _falsey_options = ["false", "none", "0", "off", ""]

--- a/conans/model/package_ref.py
+++ b/conans/model/package_ref.py
@@ -1,4 +1,4 @@
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.recipe_ref import RecipeReference
 from conans.util.dates import timestamp_to_str
 

--- a/conans/model/pkg_type.py
+++ b/conans/model/pkg_type.py
@@ -1,6 +1,6 @@
 from enum import Enum
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 class PackageType(Enum):

--- a/conans/model/recipe_ref.py
+++ b/conans/model/recipe_ref.py
@@ -3,7 +3,7 @@ import fnmatch
 import re
 from functools import total_ordering
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.version import Version
 from conans.util.dates import timestamp_to_str
 
@@ -120,7 +120,7 @@ class RecipeReference:
                 user = channel = None
             return RecipeReference(name, version, user, channel, revision, timestamp)
         except Exception:
-            from conans.errors import ConanException
+            from conan.errors import ConanException
             raise ConanException(
                 f"{rref} is not a valid recipe reference, provide a reference"
                 f" in the form name/version[@user/channel]")

--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.pkg_type import PackageType
 from conans.model.recipe_ref import RecipeReference
 from conans.model.version_range import VersionRange

--- a/conans/model/settings.py
+++ b/conans/model/settings.py
@@ -1,7 +1,7 @@
 import yaml
 
 from conan.internal.internal_tools import is_universal_arch
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 def bad_value_msg(name, value, value_range):

--- a/conans/model/version.py
+++ b/conans/model/version.py
@@ -1,6 +1,6 @@
 from functools import total_ordering
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 @total_ordering

--- a/conans/model/version_range.py
+++ b/conans/model/version_range.py
@@ -1,7 +1,7 @@
 from functools import total_ordering
 from typing import Optional
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.recipe_ref import Version
 from conans import __version__ as client_version
 

--- a/conans/server/conf/__init__.py
+++ b/conans/server/conf/__init__.py
@@ -8,7 +8,7 @@ import string
 from datetime import timedelta
 from configparser import ConfigParser, NoSectionError
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.server.conf.default_server_conf import default_server_conf
 from conans.server.store.disk_adapter import ServerDiskAdapter
 from conans.server.store.server_store import ServerStore

--- a/conans/server/rest/api_v2.py
+++ b/conans/server/rest/api_v2.py
@@ -1,6 +1,6 @@
 from bottle import Bottle
 
-from conans.errors import EXCEPTION_CODE_MAPPING
+from conan.internal.errors import EXCEPTION_CODE_MAPPING
 from conans.server.rest.bottle_plugins.http_basic_authentication import HttpBasicAuthentication
 from conans.server.rest.bottle_plugins.jwt_authentication import JWTAuthentication
 from conans.server.rest.bottle_plugins.return_handler import ReturnHandlerPlugin

--- a/conans/server/rest/bottle_plugins/return_handler.py
+++ b/conans/server/rest/bottle_plugins/return_handler.py
@@ -1,6 +1,6 @@
 from bottle import HTTPResponse
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 class ReturnHandlerPlugin(object):

--- a/conans/server/rest/controller/v2/conan.py
+++ b/conans/server/rest/controller/v2/conan.py
@@ -1,6 +1,6 @@
 from bottle import request
 
-from conans.errors import NotFoundException
+from conan.internal.errors import NotFoundException
 from conans.model.recipe_ref import RecipeReference
 from conans.server.rest.bottle_routes import BottleRoutes
 from conans.server.rest.controller.v2 import get_package_ref

--- a/conans/server/rest/controller/v2/users.py
+++ b/conans/server/rest/controller/v2/users.py
@@ -1,6 +1,6 @@
 from bottle import response
 
-from conans.errors import AuthenticationException
+from conan.internal.errors import AuthenticationException
 
 from conans.server.rest.bottle_routes import BottleRoutes
 from conans.server.service.user_service import UserService

--- a/conans/server/service/authorize.py
+++ b/conans/server/service/authorize.py
@@ -11,8 +11,7 @@ Replace this module with other that keeps the interface or super class.
 
 from abc import ABCMeta, abstractmethod
 
-from conans.errors import AuthenticationException, ForbiddenException, InternalErrorException
-
+from conan.internal.errors import InternalErrorException, AuthenticationException, ForbiddenException
 
 #  ############################################
 #  ############ ABSTRACT CLASSES ##############

--- a/conans/server/service/user_service.py
+++ b/conans/server/service/user_service.py
@@ -1,4 +1,4 @@
-from conans.errors import AuthenticationException
+from conan.internal.errors import AuthenticationException
 
 
 class UserService(object):

--- a/conans/server/service/v2/search.py
+++ b/conans/server/service/v2/search.py
@@ -3,7 +3,7 @@ import os
 import re
 from fnmatch import translate
 
-from conans.errors import ForbiddenException, RecipeNotFoundException
+from conan.internal.errors import ForbiddenException, RecipeNotFoundException
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
 from conan.internal.paths import CONANINFO

--- a/conans/server/service/v2/service_v2.py
+++ b/conans/server/service/v2/service_v2.py
@@ -3,7 +3,7 @@ import os
 
 from bottle import FileUpload, static_file
 
-from conans.errors import RecipeNotFoundException, PackageNotFoundException, NotFoundException
+from conan.internal.errors import NotFoundException, RecipeNotFoundException, PackageNotFoundException
 from conan.internal.paths import CONAN_MANIFEST
 from conans.model.package_ref import PkgReference
 from conans.server.service.mime import get_mime_type

--- a/conans/server/store/disk_adapter.py
+++ b/conans/server/store/disk_adapter.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 
 import fasteners
 
-from conans.errors import NotFoundException
+from conan.internal.errors import NotFoundException
 from conans.util.files import md5sum, rmdir
 from conans.server.utils.files import path_exists, relative_dirs
 

--- a/conans/server/store/server_store.py
+++ b/conans/server/store/server_store.py
@@ -1,7 +1,8 @@
 import os
 from os.path import join, normpath, relpath
 
-from conans.errors import ConanException, PackageNotFoundException, RecipeNotFoundException
+from conan.internal.errors import RecipeNotFoundException, PackageNotFoundException
+from conan.errors import ConanException
 from conan.internal.paths import CONAN_MANIFEST
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference

--- a/conans/util/config_parser.py
+++ b/conans/util/config_parser.py
@@ -1,6 +1,6 @@
 import re
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 class ConfigParser(object):

--- a/conans/util/dates.py
+++ b/conans/util/dates.py
@@ -4,7 +4,7 @@ import time
 
 from dateutil import parser
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 def from_timestamp_to_iso8601(timestamp):

--- a/conans/util/files.py
+++ b/conans/util/files.py
@@ -11,8 +11,7 @@ import time
 
 from contextlib import contextmanager
 
-
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 _DIRTY_FOLDER = ".dirty"
 

--- a/conans/util/runners.py
+++ b/conans/util/runners.py
@@ -5,7 +5,7 @@ import tempfile
 from contextlib import contextmanager
 from io import StringIO
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.util.files import load
 
 

--- a/test/functional/revisions_test.py
+++ b/test/functional/revisions_test.py
@@ -7,7 +7,7 @@ import pytest
 from mock import patch
 
 from conan.test.utils.env import environment_update
-from conans.errors import RecipeNotFoundException
+from conan.internal.errors import RecipeNotFoundException
 from conans.model.recipe_ref import RecipeReference
 from conans.server.revision_list import RevisionList
 from conan.test.utils.tools import TestServer, TurboTestClient, GenConanfile, TestClient

--- a/test/functional/util/tools_test.py
+++ b/test/functional/util/tools_test.py
@@ -6,7 +6,7 @@ from shutil import which
 import pytest
 
 from conan.internal.api.detect.detect_vs import vswhere
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conan.test.utils.env import environment_update
 
 

--- a/test/integration/cache/backup_sources_test.py
+++ b/test/integration/cache/backup_sources_test.py
@@ -6,7 +6,8 @@ from unittest import mock
 import pytest
 from bottle import static_file, HTTPError, request
 
-from conans.errors import NotFoundException, ConanException
+from conan.internal.errors import NotFoundException
+from conan.errors import ConanException
 from conan.test.utils.file_server import TestFileServer
 from conan.test.utils.test_files import temp_folder
 from conan.test.utils.tools import TestClient, StoppableThreadBottle

--- a/test/integration/command/remove_test.py
+++ b/test/integration/command/remove_test.py
@@ -5,7 +5,7 @@ import unittest
 import pytest
 
 from conan.api.conan_api import ConanAPI
-from conans.errors import NotFoundException
+from conan.internal.errors import NotFoundException
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
 from conan.test.utils.tools import NO_SETTINGS_PACKAGE_ID, TestClient, TestServer, GenConanfile

--- a/test/integration/command/upload/upload_test.py
+++ b/test/integration/command/upload/upload_test.py
@@ -10,7 +10,7 @@ import requests
 from mock import patch
 from requests import Response
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
 from conan.internal.paths import EXPORT_SOURCES_TGZ_NAME, PACKAGE_TGZ_NAME

--- a/test/integration/command_v2/list_test.py
+++ b/test/integration/command_v2/list_test.py
@@ -8,7 +8,8 @@ from unittest.mock import patch, Mock
 
 import pytest
 
-from conans.errors import ConanException, ConanConnectionError
+from conan.internal.errors import ConanConnectionError
+from conan.errors import ConanException
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient, TestServer, NO_SETTINGS_PACKAGE_ID
 from conan.test.utils.env import environment_update

--- a/test/integration/command_v2/search_test.py
+++ b/test/integration/command_v2/search_test.py
@@ -4,7 +4,8 @@ from unittest.mock import patch, Mock
 
 import pytest
 
-from conans.errors import ConanConnectionError, ConanException
+from conan.internal.errors import ConanConnectionError
+from conan.errors import ConanException
 from conans.model.recipe_ref import RecipeReference
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient, TestServer

--- a/test/integration/configuration/required_version_test.py
+++ b/test/integration/configuration/required_version_test.py
@@ -3,7 +3,7 @@ import unittest
 import mock
 
 from conans import __version__
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conan.test.utils.test_files import temp_folder
 from conan.test.utils.tools import TestClient
 from conans.util.files import save

--- a/test/integration/graph/core/graph_manager_test.py
+++ b/test/integration/graph/core/graph_manager_test.py
@@ -2,7 +2,7 @@ import pytest
 from parameterized import parameterized
 
 from conans.client.graph.graph_error import GraphMissingError, GraphLoopError, GraphConflictError
-from conans.errors import ConanException
+from conan.errors import ConanException
 from test.integration.graph.core.graph_manager_base import GraphManagerTest
 from conan.test.utils.tools import GenConanfile
 

--- a/test/integration/graph/test_validate_build.py
+++ b/test/integration/graph/test_validate_build.py
@@ -10,7 +10,7 @@ def test_basic_validate_build_test():
     t = TestClient()
     conanfile = textwrap.dedent("""
     from conan import ConanFile
-    from conans.errors import ConanInvalidConfiguration
+    from conan.errors import ConanInvalidConfiguration
 
     class myConan(ConanFile):
         name = "foo"
@@ -57,7 +57,7 @@ def test_with_options_validate_build_test():
     t = TestClient(light=True)
     conanfile = textwrap.dedent("""
     from conan import ConanFile
-    from conans.errors import ConanInvalidConfiguration
+    from conan.errors import ConanInvalidConfiguration
 
     class myConan(ConanFile):
         name = "foo"

--- a/test/integration/remote/auth_test.py
+++ b/test/integration/remote/auth_test.py
@@ -6,7 +6,7 @@ import unittest
 from requests.models import Response
 
 from conan.internal.api.remotes.localdb import LocalDB
-from conans.errors import AuthenticationException
+from conan.internal.errors import AuthenticationException
 from conans.model.recipe_ref import RecipeReference
 from conan.internal.paths import CONANFILE
 from conan.test.assets.genconanfile import GenConanfile

--- a/test/integration/remote/retry_test.py
+++ b/test/integration/remote/retry_test.py
@@ -5,7 +5,7 @@ from collections import namedtuple, Counter
 from requests.exceptions import HTTPError
 
 from conans.client.rest.file_uploader import FileUploader
-from conans.errors import AuthenticationException, ForbiddenException
+from conan.internal.errors import AuthenticationException, ForbiddenException
 from conan.test.utils.mocks import RedirectedTestOutput
 from conan.test.utils.test_files import temp_folder
 from conan.test.utils.tools import redirect_output

--- a/test/integration/tools/system/package_manager_test.py
+++ b/test/integration/tools/system/package_manager_test.py
@@ -7,7 +7,7 @@ from unittest.mock import PropertyMock
 
 from conan.tools.system.package_manager import Apt, Apk, Dnf, Yum, Brew, Pkg, PkgUtil, Chocolatey, \
     Zypper, PacMan, _SystemPackageManagerTool
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.settings import Settings
 from conan.test.utils.mocks import ConanFileMock, MockSettings
 

--- a/test/unittests/cli/common_test.py
+++ b/test/unittests/cli/common_test.py
@@ -5,7 +5,7 @@ import pytest
 
 from conan.api.conan_api import ConanAPI
 from conan.internal.cache.home_paths import HomePaths
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conan.test.utils.test_files import temp_folder
 from conans.util.files import save
 

--- a/test/unittests/client/conanfile_loader_test.py
+++ b/test/unittests/client/conanfile_loader_test.py
@@ -7,7 +7,7 @@ import pytest
 from parameterized import parameterized
 
 from conans.client.loader import ConanFileLoader, ConanFileTextLoader, load_python_file
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conan.test.utils.test_files import temp_folder
 from conans.util.files import save, chdir
 

--- a/test/unittests/client/graph/build_mode_test.py
+++ b/test/unittests/client/graph/build_mode_test.py
@@ -1,7 +1,7 @@
 import pytest
 
 from conans.client.graph.build_mode import BuildMode
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.recipe_ref import RecipeReference
 from conan.test.utils.mocks import ConanFileMock, RedirectedTestOutput
 from conan.test.utils.tools import redirect_output

--- a/test/unittests/client/migrations/test_migrator.py
+++ b/test/unittests/client/migrations/test_migrator.py
@@ -3,7 +3,7 @@ import platform
 
 import pytest
 
-from conans.errors import ConanMigrationError
+from conan.errors import ConanMigrationError
 from conans.migrations import Migrator
 from conan.test.utils.test_files import temp_folder
 

--- a/test/unittests/client/profile_loader/compiler_cppstd_test.py
+++ b/test/unittests/client/profile_loader/compiler_cppstd_test.py
@@ -9,7 +9,7 @@ from conan.internal.cache.cache import PkgCache
 from conan.internal.cache.home_paths import HomePaths
 from conan.internal.api.profile.profile_loader import ProfileLoader
 from conan.internal.default_settings import default_settings_yml
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.conf import ConfDefinition
 from conans.model.settings import Settings
 from conan.test.utils.test_files import temp_folder

--- a/test/unittests/client/profile_loader/profile_loader_test.py
+++ b/test/unittests/client/profile_loader/profile_loader_test.py
@@ -4,7 +4,7 @@ import textwrap
 import pytest
 
 from conan.internal.api.profile.profile_loader import _ProfileParser, ProfileLoader
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.recipe_ref import RecipeReference
 from conan.test.utils.mocks import ConanFileMock, MockSettings
 from conan.test.utils.test_files import temp_folder

--- a/test/unittests/client/rest/downloader_test.py
+++ b/test/unittests/client/rest/downloader_test.py
@@ -6,7 +6,7 @@ import unittest
 import pytest
 
 from conans.client.downloaders.file_downloader import FileDownloader
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 class MockResponse(object):

--- a/test/unittests/client/rest/uploader_test.py
+++ b/test/unittests/client/rest/uploader_test.py
@@ -3,7 +3,7 @@ import unittest
 from collections import namedtuple
 
 from conans.client.rest.file_uploader import FileUploader
-from conans.errors import AuthenticationException, ForbiddenException, InternalErrorException
+from conan.internal.errors import InternalErrorException, AuthenticationException, ForbiddenException
 from conans.util.files import save
 
 

--- a/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -5,7 +5,7 @@ import pytest
 
 from conan.tools.build import load_toolchain_args
 from conan.tools.gnu import AutotoolsToolchain
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.conf import Conf
 from conan.test.utils.mocks import ConanFileMock, MockSettings, MockOptions
 from conan.test.utils.test_files import temp_folder

--- a/test/unittests/client/tools/cppstd_required_test.py
+++ b/test/unittests/client/tools/cppstd_required_test.py
@@ -4,7 +4,7 @@ from parameterized import parameterized
 
 from conan.tools.build import check_max_cppstd, check_min_cppstd, valid_max_cppstd, valid_min_cppstd
 from conan.test.utils.mocks import MockSettings, ConanFileMock
-from conans.errors import ConanInvalidConfiguration, ConanException
+from conan.errors import ConanException, ConanInvalidConfiguration
 
 
 def _create_conanfile(compiler, version, os, cppstd, libcxx=None):

--- a/test/unittests/model/options_test.py
+++ b/test/unittests/model/options_test.py
@@ -2,7 +2,7 @@ import textwrap
 
 import pytest
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.options import Options
 from conans.model.recipe_ref import RecipeReference
 

--- a/test/unittests/model/settings_test.py
+++ b/test/unittests/model/settings_test.py
@@ -4,7 +4,7 @@ import unittest
 import pytest
 
 from conan.internal.default_settings import default_settings_yml
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.settings import Settings, bad_value_msg, undefined_field
 
 

--- a/test/unittests/model/test_conf.py
+++ b/test/unittests/model/test_conf.py
@@ -2,7 +2,7 @@ import textwrap
 
 import pytest
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.conf import ConfDefinition
 
 

--- a/test/unittests/model/test_recipe_reference.py
+++ b/test/unittests/model/test_recipe_reference.py
@@ -1,6 +1,6 @@
 import pytest
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.recipe_ref import RecipeReference
 
 

--- a/test/unittests/model/version/test_version_range.py
+++ b/test/unittests/model/version/test_version_range.py
@@ -2,7 +2,7 @@ import textwrap
 
 import pytest
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.version import Version
 from conans.model.version_range import VersionRange
 from conan.test.utils.tools import TestClient

--- a/test/unittests/server/conan_server_config_parser_test.py
+++ b/test/unittests/server/conan_server_config_parser_test.py
@@ -2,7 +2,7 @@
 import os
 import unittest
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.server.conf import ConanServerConfigParser
 from conan.test.utils.test_files import temp_folder
 from conans.util.files import mkdir, save

--- a/test/unittests/server/conf_test.py
+++ b/test/unittests/server/conf_test.py
@@ -2,7 +2,7 @@ import os
 import unittest
 from datetime import timedelta
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.server.conf import ConanServerConfigParser
 from conan.test.utils.test_files import temp_folder
 from conans.util.config_parser import ConfigParser

--- a/test/unittests/server/service/authorizer_test.py
+++ b/test/unittests/server/service/authorizer_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from conans.errors import AuthenticationException, ForbiddenException, InternalErrorException
+from conan.internal.errors import InternalErrorException, AuthenticationException, ForbiddenException
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference
 from conans.server.service.authorize import BasicAuthorizer

--- a/test/unittests/server/service/service_test.py
+++ b/test/unittests/server/service/service_test.py
@@ -2,7 +2,7 @@ import copy
 import os
 import unittest
 
-from conans.errors import NotFoundException
+from conan.internal.errors import NotFoundException
 from conans.model.manifest import FileTreeManifest
 from conans.model.package_ref import PkgReference
 from conans.model.recipe_ref import RecipeReference

--- a/test/unittests/source/merge_directories_test.py
+++ b/test/unittests/source/merge_directories_test.py
@@ -5,7 +5,7 @@ from os.path import join
 
 import pytest
 
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conan.test.utils.test_files import temp_folder
 from conans.util.files import mkdir, save, merge_directories, load
 

--- a/test/unittests/tools/android/test_android_tools.py
+++ b/test/unittests/tools/android/test_android_tools.py
@@ -1,5 +1,5 @@
 from conan.test.utils.mocks import ConanFileMock, MockSettings
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conan.tools.android import android_abi
 
 from pytest import raises

--- a/test/unittests/tools/apple/test_apple_tools.py
+++ b/test/unittests/tools/apple/test_apple_tools.py
@@ -3,7 +3,7 @@ import pytest
 import textwrap
 
 from conan.internal.internal_tools import is_universal_arch
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conan.test.utils.mocks import ConanFileMock, MockSettings, MockOptions
 from conan.test.utils.test_files import temp_folder
 from conan.tools.apple import is_apple_os, to_apple_arch, fix_apple_shared_install_name, XCRun

--- a/test/unittests/tools/build/test_cppstd.py
+++ b/test/unittests/tools/build/test_cppstd.py
@@ -2,7 +2,7 @@ import pytest
 
 from conan.internal.api.detect.detect_api import detect_cppstd
 from conan.tools.build import supported_cppstd, check_min_cppstd, valid_min_cppstd
-from conans.errors import ConanException, ConanInvalidConfiguration
+from conan.errors import ConanException, ConanInvalidConfiguration
 from conans.model.version import Version
 from conan.test.utils.mocks import MockSettings, ConanFileMock
 

--- a/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -7,7 +7,7 @@ from conan import ConanFile
 from conan.internal.default_settings import default_settings_yml
 from conan.tools.cmake import CMakeToolchain
 from conan.tools.cmake.toolchain.blocks import Block
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.conf import Conf
 from conans.model.options import Options
 from conans.model.settings import Settings

--- a/test/unittests/tools/files/test_downloads.py
+++ b/test/unittests/tools/files/test_downloads.py
@@ -4,7 +4,8 @@ import shutil
 import pytest
 
 from conan.tools.files import ftp_download, download, get
-from conans.errors import ConanException, AuthenticationException
+from conan.internal.errors import AuthenticationException
+from conan.errors import ConanException
 from conan.test.utils.file_server import TestFileServer
 from conan.test.utils.mocks import ConanFileMock, RedirectedTestOutput
 from conan.test.utils.test_files import temp_folder

--- a/test/unittests/tools/files/test_patches.py
+++ b/test/unittests/tools/files/test_patches.py
@@ -4,7 +4,7 @@ import patch_ng
 import pytest
 
 from conan.tools.files import patch, apply_conandata_patches
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conan.test.utils.mocks import ConanFileMock, RedirectedTestOutput
 from conan.test.utils.tools import redirect_output
 

--- a/test/unittests/tools/files/test_toolchain.py
+++ b/test/unittests/tools/files/test_toolchain.py
@@ -5,7 +5,7 @@ import pytest
 
 from conan.tools.build import load_toolchain_args, save_toolchain_args, CONAN_TOOLCHAIN_ARGS_FILE, \
     CONAN_TOOLCHAIN_ARGS_SECTION
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conan.test.utils.test_files import temp_folder
 from conans.util.files import save, load
 

--- a/test/unittests/tools/gnu/autotoolschain_test.py
+++ b/test/unittests/tools/gnu/autotoolschain_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from conan.tools.build import cmd_args_to_string
 from conan.tools.gnu import AutotoolsToolchain
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.conf import Conf
 from conan.test.utils.mocks import ConanFileMock, MockSettings
 

--- a/test/unittests/tools/gnu/test_gnutoolchain.py
+++ b/test/unittests/tools/gnu/test_gnutoolchain.py
@@ -4,7 +4,7 @@ import pytest
 
 from conan.tools.build import cmd_args_to_string
 from conan.tools.gnu import GnuToolchain
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.conf import Conf
 from conan.test.utils.mocks import ConanFileMock, MockSettings
 

--- a/test/unittests/tools/gnu/test_triplets.py
+++ b/test/unittests/tools/gnu/test_triplets.py
@@ -1,7 +1,7 @@
 import pytest
 
 from conan.tools.gnu.get_gnu_triplet import _get_gnu_triplet, _get_gnu_os, _get_gnu_arch
-from conans.errors import ConanException
+from conan.errors import ConanException
 
 
 @pytest.mark.parametrize("os_, arch, compiler, expected", [

--- a/test/unittests/tools/intel/test_intel_cc.py
+++ b/test/unittests/tools/intel/test_intel_cc.py
@@ -6,7 +6,7 @@ from mock import patch
 
 from conan.tools.build.flags import architecture_flag, cppstd_flag
 from conan.tools.intel import IntelCC
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.conf import ConfDefinition
 from conan.test.utils.mocks import ConanFileMock, MockSettings
 

--- a/test/unittests/tools/microsoft/test_check_min_vs.py
+++ b/test/unittests/tools/microsoft/test_check_min_vs.py
@@ -1,7 +1,7 @@
 import pytest
 
 from conan.tools.microsoft import check_min_vs
-from conans.errors import ConanInvalidConfiguration
+from conan.errors import ConanInvalidConfiguration
 from conan.test.utils.mocks import ConanFileMock, MockSettings
 
 

--- a/test/unittests/util/file_hashes_test.py
+++ b/test/unittests/util/file_hashes_test.py
@@ -2,7 +2,7 @@ import os
 import unittest
 
 from conan.tools.files import check_md5, check_sha1, check_sha256
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conan.test.utils.mocks import ConanFileMock
 from conan.test.utils.test_files import temp_folder
 from conans.util.files import save

--- a/test/unittests/util/files/strip_root_extract_test.py
+++ b/test/unittests/util/files/strip_root_extract_test.py
@@ -4,7 +4,7 @@ import unittest
 import zipfile
 
 from conan.tools.files.files import untargz, unzip
-from conans.errors import ConanException
+from conan.errors import ConanException
 from conans.model.manifest import gather_files
 from conan.test.utils.mocks import ConanFileMock
 from conan.test.utils.mocks import RedirectedTestOutput


### PR DESCRIPTION
Changelog: Fix: Moved exceptions from the legacy ``from conans.error`` to documented ``from conan.error``.
Docs: https://github.com/conan-io/docs/pull/3864

Pure refactor moved:
- public exceptions from ``conans.errors->conan.errors``
- private exceptions from ``conans.errors -> conan.internal.errors``