### PR TITLE
POC for tool_requires that make direct dependees inherit generators

### DIFF
--- a/conan/internal/api/install/generators.py
+++ b/conan/internal/api/install/generators.py
@@ -97,6 +97,7 @@ def write_generators(conanfile, app, envs_generation=None):
                 generator_class = global_generator or _get_generator_class(generator_name)
             else:
                 generator_class = generator_name
+                generator_name = generator_class.__name__
             if generator_class:
                 try:
                     generator = generator_class(conanfile)
@@ -157,11 +158,14 @@ def _receive_conf(conanfile):
 
 def _receive_generators(conanfile):
     """  Collect generators_info from the immediate build_requires"""
-    for build_require in conanfile.dependencies.direct_build.values():
-        if build_require.generator_info:
-            if not isinstance(build_require.generator_info, list):
-                raise ConanException(f"{build_require} 'generator_info' must be a list")
-            conanfile.generators = build_require.generator_info + conanfile.generators
+    for build_req in conanfile.dependencies.direct_build.values():
+        if build_req.generator_info:
+            if not isinstance(build_req.generator_info, list):
+                raise ConanException(f"{build_req} 'generator_info' must be a list")
+            names = [c.__name__ if not isinstance(c, str) else c for c in build_req.generator_info]
+            conanfile.output.warning(f"Tool-require {build_req} adding generators: {names}",
+                                     warn_tag="experimental")
+            conanfile.generators = build_req.generator_info + conanfile.generators
 
 
 def _generate_aggregated_env(conanfile):

--- a/conan/internal/api/install/generators.py
+++ b/conan/internal/api/install/generators.py
@@ -156,8 +156,7 @@ def _receive_generators(conanfile):
     """  Collect generators_info from the immediate build_requires"""
     for build_require in conanfile.dependencies.direct_build.values():
         if build_require.generator_info:
-            # In case generators has been defined as a tuple
-            conanfile.generators = list(build_require.generator_info) + list(conanfile.generators)
+            conanfile.generators = build_require.generator_info + conanfile.generators
 
 
 def _generate_aggregated_env(conanfile):

--- a/conan/internal/api/install/generators.py
+++ b/conan/internal/api/install/generators.py
@@ -73,6 +73,7 @@ def load_cache_generators(path):
 def write_generators(conanfile, app, envs_generation=None):
     new_gen_folder = conanfile.generators_folder
     _receive_conf(conanfile)
+    _receive_generators(conanfile)
 
     hook_manager = app.hook_manager
     # TODO: Optimize this, so the global generators are not loaded every call to write_generators
@@ -149,6 +150,14 @@ def _receive_conf(conanfile):
     for build_require in conanfile.dependencies.direct_build.values():
         if build_require.conf_info:
             conanfile.conf.compose_conf(build_require.conf_info)
+
+
+def _receive_generators(conanfile):
+    """  Collect generators_info from the immediate build_requires"""
+    for build_require in conanfile.dependencies.direct_build.values():
+        if build_require.generator_info:
+            # In case generators has been defined as a tuple
+            conanfile.generators = list(conanfile.generators) + list(build_require.generator_info)
 
 
 def _generate_aggregated_env(conanfile):

--- a/conan/internal/api/install/generators.py
+++ b/conan/internal/api/install/generators.py
@@ -160,7 +160,7 @@ def _receive_generators(conanfile):
     for build_require in conanfile.dependencies.direct_build.values():
         if build_require.generator_info:
             if not isinstance(build_require.generator_info, list):
-                raise ConanException(f"{conanfile} 'generator_info' must be a list")
+                raise ConanException(f"{build_require} 'generator_info' must be a list")
             conanfile.generators = build_require.generator_info + conanfile.generators
 
 

--- a/conan/internal/api/install/generators.py
+++ b/conan/internal/api/install/generators.py
@@ -92,8 +92,11 @@ def write_generators(conanfile, app, envs_generation=None):
     conanfile.generators = []
     try:
         for generator_name in old_generators:
-            global_generator = global_generators.get(generator_name)
-            generator_class = global_generator or _get_generator_class(generator_name)
+            if isinstance(generator_name, str):
+                global_generator = global_generators.get(generator_name)
+                generator_class = global_generator or _get_generator_class(generator_name)
+            else:
+                generator_class = generator_name
             if generator_class:
                 try:
                     generator = generator_class(conanfile)

--- a/conan/internal/api/install/generators.py
+++ b/conan/internal/api/install/generators.py
@@ -159,6 +159,8 @@ def _receive_generators(conanfile):
     """  Collect generators_info from the immediate build_requires"""
     for build_require in conanfile.dependencies.direct_build.values():
         if build_require.generator_info:
+            if not isinstance(build_require.generator_info, list):
+                raise ConanException(f"{conanfile} 'generator_info' must be a list")
             conanfile.generators = build_require.generator_info + conanfile.generators
 
 

--- a/conan/internal/api/install/generators.py
+++ b/conan/internal/api/install/generators.py
@@ -157,7 +157,7 @@ def _receive_generators(conanfile):
     for build_require in conanfile.dependencies.direct_build.values():
         if build_require.generator_info:
             # In case generators has been defined as a tuple
-            conanfile.generators = list(conanfile.generators) + list(build_require.generator_info)
+            conanfile.generators = list(build_require.generator_info) + list(conanfile.generators)
 
 
 def _generate_aggregated_env(conanfile):

--- a/conan/tools/env/__init__.py
+++ b/conan/tools/env/__init__.py
@@ -1,3 +1,3 @@
-from conan.tools.env.environment import Environment
+from conan.tools.env.environment import Environment, create_env_script, register_env_script
 from conan.tools.env.virtualbuildenv import VirtualBuildEnv
 from conan.tools.env.virtualrunenv import VirtualRunEnv

--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -646,9 +646,15 @@ class ProfileEnvironment:
         return result
 
 
-def create_env_script(conanfile, content, filename, scope):
+def create_env_script(conanfile, content, filename, scope="build"):
     """
-    Create a file with any content which will be registered as a new script for the defined "group".
+    Create a file with any content which will be registered as a new script for the defined "scope".
+
+    Args:
+        conanfile: The Conanfile instance.
+        content (str): The content of the script to write into the file.
+        filename (str): The name of the file to be created in the generators folder.
+        scope (str): The scope or environment group for which the script will be registered.
     """
     path = os.path.join(conanfile.generators_folder, filename)
     save(path, content)
@@ -657,11 +663,16 @@ def create_env_script(conanfile, content, filename, scope):
         register_env_script(conanfile, path, scope)
 
 
-def register_env_script(conanfile, env_script_path, scope):
+def register_env_script(conanfile, env_script_path, scope="build"):
     """
-    Add the "env_script_path" to the current list of registered scripts for defined "group"
+    Add the "env_script_path" to the current list of registered scripts for defined "scope"
     These will be mapped to files:
     - conan{group}.bat|sh = calls env_script_path1,... env_script_pathN
+
+    Args:
+        conanfile: The Conanfile instance.
+        env_script_path (str): The full path of the script to register.
+        scope (str): The scope ('build' or 'host') for which the script will be registered.
     """
     existing = conanfile.env_scripts.setdefault(scope, [])
     if env_script_path not in existing:

--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -74,6 +74,7 @@ class ConanFile:
     buildenv_info = None
     runenv_info = None
     conf_info = None
+    generator_info = None
 
     def __init__(self, display_name=""):
         self.display_name = display_name

--- a/conans/model/conanfile_interface.py
+++ b/conans/model/conanfile_interface.py
@@ -89,6 +89,10 @@ class ConanFileInterface:
         return self._conanfile.conf_info
 
     @property
+    def generator_info(self):
+        return self._conanfile.generator_info
+
+    @property
     def dependencies(self):
         return self._conanfile.dependencies
 

--- a/test/integration/generators/test_generators_from_br.py
+++ b/test/integration/generators/test_generators_from_br.py
@@ -1,4 +1,3 @@
-import re
 import textwrap
 
 from conan.test.assets.genconanfile import GenConanfile
@@ -36,13 +35,16 @@ def test_inject_vars():
     import os
     tc = TestClient(light=True)
     tc.save({
-    "tool/envars_generator.sh": textwrap.dedent("""
+    "tool/envars_generator1.sh": textwrap.dedent("""
     export VAR1="value1"
     export PATH="$PATH:/additional/path"
     """),
+    "tool/envars_generator2.sh": textwrap.dedent("""
+    export VAR2="value2"
+    """),
     "tool/conanfile.py": textwrap.dedent("""
     from conan import ConanFile
-    from conan.tools.env import create_env_script
+    from conan.tools.env import create_env_script, register_env_script
     import os
 
     class GeneratorSet:
@@ -53,6 +55,7 @@ def test_inject_vars():
             content = 'call envars_generator.sh'
             name = f"conantest.sh"
             create_env_script(self.conanfile, content, name)
+            register_env_script(self.conanfile, "tool/envars_generator2.sh")
 
     class ToolConan(ConanFile):
         name = "tool"
@@ -64,11 +67,8 @@ def test_inject_vars():
              "conanfile.py": GenConanfile("app", "1.0").with_tool_requires("tool/0.1")})
 
     tc.run("create tool")
-    tc.run(f"create . ")
+    tc.run(f"install . ")
 
-    regex = r'Build folder (.+)'
-    out = tc.out
-    build_folder = re.findall(regex, out)[0]
-    file_path = os.path.join(build_folder, "conanbuild.sh")
-    with open(file_path, 'r') as file:
-         assert "conantest.sh" in file.read()
+    content = tc.load("conanbuild.sh")
+    assert "conantest.sh" in content
+    assert "envars_generator2.sh" in content

--- a/test/integration/generators/test_generators_from_br.py
+++ b/test/integration/generators/test_generators_from_br.py
@@ -1,3 +1,4 @@
+import re
 import textwrap
 
 from conan.test.assets.genconanfile import GenConanfile
@@ -29,3 +30,45 @@ def test_inject_generators_conf():
     tc.run("create .")
     assert "app/1.0: CMakeToolchain generated: conan_toolchain.cmake" in tc.out
     assert "app/1.0: MyGenerator generated" in tc.out
+
+
+def test_inject_vars():
+    import os
+    tc = TestClient(light=True)
+    tc.save({
+    "tool/envars_generator.sh": textwrap.dedent("""
+    export VAR1="value1"
+    export PATH="$PATH:/additional/path"
+    """),
+    "tool/conanfile.py": textwrap.dedent("""
+    from conan import ConanFile
+    from conan.tools.env import create_env_script
+    import os
+
+    class GeneratorSet:
+        def __init__(self, conanfile):
+            self.conanfile = conanfile
+
+        def generate(self):
+            content = 'call envars_generator.sh'
+            name = f"conantest.sh"
+            create_env_script(self.conanfile, content, name)
+
+    class ToolConan(ConanFile):
+        name = "tool"
+        version = "0.1"
+
+        def package_info(self):
+            self.generator_info = [GeneratorSet]
+    """),
+             "conanfile.py": GenConanfile("app", "1.0").with_tool_requires("tool/0.1")})
+
+    tc.run("create tool")
+    tc.run(f"create . ")
+
+    regex = r'Build folder (.+)'
+    out = tc.out
+    build_folder = re.findall(regex, out)[0]
+    file_path = os.path.join(build_folder, "conanbuild.sh")
+    with open(file_path, 'r') as file:
+         assert "conantest.sh" in file.read()

--- a/test/integration/generators/test_generators_from_br.py
+++ b/test/integration/generators/test_generators_from_br.py
@@ -1,73 +1,86 @@
 import textwrap
 
-from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
 
 
 def test_inject_generators_conf():
     tc = TestClient(light=True)
     tc.save({"tool/conanfile.py": textwrap.dedent("""
-    from conan import ConanFile
+        from conan import ConanFile
 
-    class MyGenerator:
-        def __init__(self, conanfile):
-            self.conanfile = conanfile
+        class MyGenerator:
+            def __init__(self, conanfile):
+                self.conanfile = conanfile
 
-        def generate(self):
-            self.conanfile.output.info("MyGenerator generated")
+            def generate(self):
+                self.conanfile.output.info("MyGenerator generated")
 
-    class ToolConan(ConanFile):
-        name = "tool"
-        version = "0.1"
+        class ToolConan(ConanFile):
+            name = "tool"
+            version = "0.1"
 
-        def package_info(self):
-            self.generator_info = ["CMakeToolchain", MyGenerator]
-    """),
-             "conanfile.py": GenConanfile("app", "1.0").with_tool_requires("tool/0.1")})
+            def package_info(self):
+                self.generator_info = ["CMakeToolchain", MyGenerator]
+        """)})
 
     tc.run("create tool")
-    tc.run("create .")
-    assert "app/1.0: CMakeToolchain generated: conan_toolchain.cmake" in tc.out
-    assert "app/1.0: MyGenerator generated" in tc.out
+    tc.run("install --tool-requires=tool/0.1")
+    assert "CMakeToolchain generated: conan_toolchain.cmake" in tc.out
+    assert "MyGenerator generated" in tc.out
+
+
+def test_inject_generators_error():
+    c = TestClient(light=True)
+    c.save({"conanfile.py": textwrap.dedent("""
+        from conan import ConanFile
+
+        class ToolConan(ConanFile):
+            name = "tool"
+            version = "0.1"
+
+            def package_info(self):
+                self.generator_info = "CMakeToolchain"
+        """)})
+    c.run("create .")
+    c.run("install --tool-requires=tool/0.1", assert_error=True)
+    assert "ERROR: tool/0.1 'generator_info' must be a list" in c.out
 
 
 def test_inject_vars():
-    import os
     tc = TestClient(light=True)
     tc.save({
-    "tool/envars_generator1.sh": textwrap.dedent("""
-    export VAR1="value1"
-    export PATH="$PATH:/additional/path"
-    """),
-    "tool/envars_generator2.sh": textwrap.dedent("""
-    export VAR2="value2"
-    """),
-    "tool/conanfile.py": textwrap.dedent("""
-    from conan import ConanFile
-    from conan.tools.env import create_env_script, register_env_script
-    import os
+        "tool/envars_generator1.sh": textwrap.dedent("""
+        export VAR1="value1"
+        export PATH="$PATH:/additional/path"
+        """),
+        "tool/envars_generator2.sh": textwrap.dedent("""
+        export VAR2="value2"
+        """),
+        "tool/conanfile.py": textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.env import create_env_script, register_env_script
+        import os
 
-    class GeneratorSet:
-        def __init__(self, conanfile):
-            self.conanfile = conanfile
+        class GeneratorSet:
+            def __init__(self, conanfile):
+                self.conanfile = conanfile
 
-        def generate(self):
-            content = 'call envars_generator.sh'
-            name = f"conantest.sh"
-            create_env_script(self.conanfile, content, name)
-            register_env_script(self.conanfile, "tool/envars_generator2.sh")
+            def generate(self):
+                content = 'call envars_generator.sh'
+                name = f"conantest.sh"
+                create_env_script(self.conanfile, content, name)
+                register_env_script(self.conanfile, "tool/envars_generator2.sh")
 
-    class ToolConan(ConanFile):
-        name = "tool"
-        version = "0.1"
+        class ToolConan(ConanFile):
+            name = "tool"
+            version = "0.1"
 
-        def package_info(self):
-            self.generator_info = [GeneratorSet]
-    """),
-             "conanfile.py": GenConanfile("app", "1.0").with_tool_requires("tool/0.1")})
+            def package_info(self):
+                self.generator_info = [GeneratorSet]
+        """)})
 
     tc.run("create tool")
-    tc.run(f"install . ")
+    tc.run(f"install --tool-requires=tool/0.1")
 
     content = tc.load("conanbuild.sh")
     assert "conantest.sh" in content

--- a/test/integration/generators/test_generators_from_br.py
+++ b/test/integration/generators/test_generators_from_br.py
@@ -1,0 +1,22 @@
+import textwrap
+
+from conan.test.assets.genconanfile import GenConanfile
+from conan.test.utils.tools import TestClient
+
+
+def test_inject_generators_conf():
+    tc = TestClient(light=True)
+    tc.save({"tool/conanfile.py": textwrap.dedent("""
+    from conan import ConanFile
+    class ToolConan(ConanFile):
+        name = "tool"
+        version = "0.1"
+
+        def package_info(self):
+            self.generator_info = ["CMakeToolchain"]
+    """),
+             "conanfile.py": GenConanfile("app", "1.0").with_tool_requires("tool/0.1")})
+
+    tc.run("create tool")
+    tc.run("create .")
+    assert "app/1.0: CMakeToolchain generated: conan_toolchain.cmake" in tc.out

--- a/test/integration/generators/test_generators_from_br.py
+++ b/test/integration/generators/test_generators_from_br.py
@@ -25,6 +25,10 @@ def test_inject_generators_conf():
 
     tc.run("create tool")
     tc.run("install --tool-requires=tool/0.1")
+    assert "WARN: experimental: Tool-require tool/0.1 adding generators: " \
+           "['CMakeToolchain', 'MyGenerator']" in tc.out
+    assert "Generator 'CMakeToolchain' calling 'generate()'" in tc.out
+    assert "Generator 'MyGenerator' calling 'generate()'" in tc.out
     assert "CMakeToolchain generated: conan_toolchain.cmake" in tc.out
     assert "MyGenerator generated" in tc.out
 

--- a/test/integration/generators/test_generators_from_br.py
+++ b/test/integration/generators/test_generators_from_br.py
@@ -8,15 +8,24 @@ def test_inject_generators_conf():
     tc = TestClient(light=True)
     tc.save({"tool/conanfile.py": textwrap.dedent("""
     from conan import ConanFile
+
+    class MyGenerator:
+        def __init__(self, conanfile):
+            self.conanfile = conanfile
+
+        def generate(self):
+            self.conanfile.output.info("MyGenerator generated")
+
     class ToolConan(ConanFile):
         name = "tool"
         version = "0.1"
 
         def package_info(self):
-            self.generator_info = ["CMakeToolchain"]
+            self.generator_info = ["CMakeToolchain", MyGenerator]
     """),
              "conanfile.py": GenConanfile("app", "1.0").with_tool_requires("tool/0.1")})
 
     tc.run("create tool")
     tc.run("create .")
     assert "app/1.0: CMakeToolchain generated: conan_toolchain.cmake" in tc.out
+    assert "app/1.0: MyGenerator generated" in tc.out


### PR DESCRIPTION
Changelog: Feature: Add `self.generators_info` for `tool_requires` to propagate generators to their direct dependencies.
Docs: https://github.com/conan-io/docs/pull/3880

To share as idea for the team


Close https://github.com/conan-io/conan/issues/17113