### PR TITLE
fix server auth based on username

### DIFF
--- a/conans/client/downloaders/file_downloader.py
+++ b/conans/client/downloaders/file_downloader.py
@@ -84,7 +84,7 @@ class FileDownloader:
             if response.status_code == 404:
                 raise NotFoundException("Not found: %s" % url)
             elif response.status_code == 403:
-                if auth is None or (hasattr(auth, "token") and auth.token is None):
+                if auth is None or (hasattr(auth, "bearer") and auth.bearer is None):
                     # TODO: This is a bit weird, why this conversion? Need to investigate
                     raise AuthenticationException(response_to_str(response))
                 raise ForbiddenException(response_to_str(response))

--- a/conans/client/rest/auth_manager.py
+++ b/conans/client/rest/auth_manager.py
@@ -7,8 +7,7 @@ methods if receives AuthenticationException from RestApiClient.
 Flow:
     Directly invoke a REST method in RestApiClient, example: get_conan.
     if receives AuthenticationException (not open method) will ask user for login and password
-    and will invoke RestApiClient.get_token() (with LOGIN_RETRIES retries) and retry to call
-    get_conan with the new token.
+    (with LOGIN_RETRIES retries) and retry to call with the new token.
 """
 
 from conan.api.output import ConanOutput

--- a/conans/client/rest/file_uploader.py
+++ b/conans/client/rest/file_uploader.py
@@ -26,7 +26,7 @@ class FileUploader(object):
             raise AuthenticationException(response_to_str(response))
 
         if response.status_code == 403:
-            if auth is None or auth.token is None:
+            if auth is None or auth.bearer is None:
                 raise AuthenticationException(response_to_str(response))
             raise ForbiddenException(response_to_str(response))
 

--- a/conans/server/service/authorize.py
+++ b/conans/server/service/authorize.py
@@ -127,9 +127,6 @@ class BasicAuthorizer(Authorizer):
         username: User that request to read the conans
         ref: RecipeReference
         """
-        if ref.user == username:
-            return
-
         self._check_any_rule_ok(username, self.read_permissions, ref)
 
     def check_write_conan(self, username, ref):
@@ -137,9 +134,6 @@ class BasicAuthorizer(Authorizer):
         username: User that request to write the conans
         ref: RecipeReference
         """
-        if ref.user == username:
-            return True
-
         self._check_any_rule_ok(username, self.write_permissions, ref)
 
     def check_delete_conan(self, username, ref):

--- a/test/integration/remote/rest_api_test.py
+++ b/test/integration/remote/rest_api_test.py
@@ -32,7 +32,11 @@ class RestApiTest(unittest.TestCase):
     def setUpClass(cls):
         if not cls.server:
             with environment_update({"CONAN_SERVER_PORT": str(get_free_port())}):
-                cls.server = TestServerLauncher(server_capabilities=['ImCool', 'TooCool'])
+                read_perms = [("*/*@*/*", "private_user")]
+                write_perms = [("*/*@*/*", "private_user")]
+                cls.server = TestServerLauncher(server_capabilities=['ImCool', 'TooCool'],
+                                                read_permissions=read_perms,
+                                                write_permissions=write_perms)
                 cls.server.start()
 
                 filename = os.path.join(temp_folder(), "conan.conf")

--- a/test/integration/remote/retry_test.py
+++ b/test/integration/remote/retry_test.py
@@ -73,7 +73,7 @@ class RetryDownloadTests(unittest.TestCase):
             uploader = FileUploader(requester=_RequesterMock(403, "content"),
                                     verify=False, config=_ConfigMock())
             with self.assertRaisesRegex(ForbiddenException, "content"):
-                auth = namedtuple("auth", "token")
+                auth = namedtuple("auth", "bearer")
                 uploader.upload(url="fake", abs_path=self.filename, retry=2, auth=auth("token"))
             output_lines = output.getvalue().splitlines()
             counter = Counter(output_lines)
@@ -86,7 +86,7 @@ class RetryDownloadTests(unittest.TestCase):
             uploader = FileUploader(requester=_RequesterMock(403, "content"),
                                     verify=False, config=_ConfigMock())
             with self.assertRaisesRegex(AuthenticationException, "content"):
-                auth = namedtuple("auth", "token")
+                auth = namedtuple("auth", "bearer")
                 uploader.upload(url="fake", abs_path=self.filename, retry=2, auth=auth(None))
             output_lines = output.getvalue().splitlines()
             counter = Counter(output_lines)

--- a/test/unittests/client/rest/uploader_test.py
+++ b/test/unittests/client/rest/uploader_test.py
@@ -37,7 +37,7 @@ class UploaderUnitTest(unittest.TestCase):
             uploader.upload("fake_url", self.f)
 
     def test_403_raises_unauthoirzed_exception_if_no_token(self):
-        auth = namedtuple("auth", "token")(None)
+        auth = namedtuple("auth", "bearer")(None)
         uploader = FileUploader(MockRequester(403), verify=False, config=_ConfigMock())
         with self.assertRaisesRegex(AuthenticationException, "tururu"):
             uploader.upload("fake_url", self.f, auth=auth)
@@ -48,7 +48,7 @@ class UploaderUnitTest(unittest.TestCase):
             uploader.upload("fake_url", self.f)
 
     def test_403_raises_forbidden_exception_if_token(self):
-        auth = namedtuple("auth", "token")("SOMETOKEN")
+        auth = namedtuple("auth", "bearer")("SOMETOKEN")
         uploader = FileUploader(MockRequester(403), verify=False, config=_ConfigMock())
         with self.assertRaisesRegex(ForbiddenException, "tururu"):
             uploader.upload("fake_url", self.f, auth=auth)

--- a/test/unittests/server/service/authorizer_test.py
+++ b/test/unittests/server/service/authorizer_test.py
@@ -86,7 +86,7 @@ class AuthorizerTest(unittest.TestCase):
         # Only lasote can read it but other conans can be readed
         read_perms = [(str(self.openssl_ref), "lasote"), ("*/*@*/*", "*")]
         # Only pepe (and lasote because its owner) can write it and no more users can write
-        write_perms = [(str(self.openssl_ref), "pepe")]
+        write_perms = [(str(self.openssl_ref), "pepe, lasote")]
 
         authorizer = BasicAuthorizer(read_perms, write_perms)
 
@@ -185,12 +185,11 @@ class AuthorizerTest(unittest.TestCase):
         # Simple user list
         read_perms = [("openssl/*@lasote/testing", "user1,user2,user3")]
         authorizer = BasicAuthorizer(read_perms, [])
-        for u in ['user1','user2','user3']:
+        for u in ['user1', 'user2', 'user3']:
             authorizer.check_read_conan(u, self.openssl_ref)
 
         # Spaces bewteen user names should be ignored
         read_perms = [("openssl/*@lasote/testing", "user1 , user2,\tuser3")]
         authorizer = BasicAuthorizer(read_perms, [])
-        for u in ['user1','user2','user3']:
+        for u in ['user1', 'user2', 'user3']:
             authorizer.check_read_conan(u, self.openssl_ref)
-

--- a/test/unittests/server/service/service_test.py
+++ b/test/unittests/server/service/service_test.py
@@ -39,7 +39,7 @@ class ConanServiceTest(unittest.TestCase):
         self.tmp_dir = temp_folder()
 
         read_perms = [("*/*@*/*", "*")]
-        write_perms = []
+        write_perms = [("*/*@*/*", "*")]
         authorizer = BasicAuthorizer(read_perms, write_perms)
 
         self.fake_url = "http://url"


### PR DESCRIPTION
Changelog: Bugfix: Drop the username permission validation bypass in ``conan_server``, it could be a potential security issue.
Docs: Omit

Close https://github.com/conan-io/conan/issues/11185