### PR TITLE
fix: quote template CMake variables

### DIFF
--- a/conan/internal/api/profile/profile_loader.py
+++ b/conan/internal/api/profile/profile_loader.py
@@ -107,7 +107,7 @@ def _check_correct_cstd(settings):
             mver = {"17": "192",
                     "11": "192"}.get(cstd)
         if mver and version < mver:
-            _error(compiler, cppstd, mver, version)
+            _error(compiler, cstd, mver, version)
 """
 
 

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -274,11 +274,11 @@ class CppStdBlock(Block):
         # Define the C++ and C standards from 'compiler.cppstd' and 'compiler.cstd'
 
         function(conan_modify_std_watch variable access value current_list_file stack)
-            set(conan_watched_std_variable {{ cppstd }})
+            set(conan_watched_std_variable "{{ cppstd }}")
             if (${variable} STREQUAL "CMAKE_C_STANDARD")
-                set(conan_watched_std_variable {{ cstd }})
+                set(conan_watched_std_variable "{{ cstd }}")
             endif()
-            if (${access} STREQUAL "MODIFIED_ACCESS" AND NOT ${value} STREQUAL ${conan_watched_std_variable})
+            if ("${access}" STREQUAL "MODIFIED_ACCESS" AND NOT "${value}" STREQUAL "${conan_watched_std_variable}")
                 message(STATUS "Warning: Standard ${variable} value defined in conan_toolchain.cmake to ${conan_watched_std_variable} has been modified to ${value} by ${current_list_file}")
             endif()
             unset(conan_watched_std_variable)

--- a/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -2112,3 +2112,42 @@ def test_cmake_toolchain_crossbuild_set_cmake_compiler():
     c.run('build . --profile:host=android')
     assert 'VERSION ".0" format invalid.' not in c.out
     assert 'sdk: 1.0.0' in c.out
+
+
+@pytest.mark.tool("cmake")
+def test_cmake_toolchain_language_c():
+    client = TestClient()
+
+    conanfile = textwrap.dedent(r"""
+        from conan import ConanFile
+        from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+
+        class Pkg(ConanFile):
+            settings = "os", "compiler", "arch", "build_type"
+            generators = "CMakeToolchain"
+            languages = "C"
+
+            def layout(self):
+                cmake_layout(self)
+
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+                cmake.build()
+        """)
+
+    cmakelists = textwrap.dedent("""
+    cmake_minimum_required(VERSION 3.15)
+    project(pkg C)
+    """)
+
+    client.save(
+        {
+            "conanfile.py": conanfile,
+            "CMakeLists.txt": cmakelists,
+        },
+        clean_first=True,
+    )
+
+    client.run("install . -s compiler.cstd=11")
+    client.run("build . -s compiler.cstd=11")

--- a/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -2137,9 +2137,9 @@ def test_cmake_toolchain_language_c():
         """)
 
     cmakelists = textwrap.dedent("""
-    cmake_minimum_required(VERSION 3.15)
-    project(pkg C)
-    """)
+        cmake_minimum_required(VERSION 3.15)
+        project(pkg C)
+        """)
 
     client.save(
         {
@@ -2149,5 +2149,11 @@ def test_cmake_toolchain_language_c():
         clean_first=True,
     )
 
-    client.run("install . -s compiler.cstd=11")
-    client.run("build . -s compiler.cstd=11")
+    if platform.system() == "Windows":
+        # compiler.version=191 is already the default now
+        client.run("build . -s compiler.cstd=11 -s compiler.version=191", assert_error=True)
+        assert "The provided compiler.cstd=11 requires at least msvc>=192 but version 191 provided" \
+               in client.out
+    else:
+        client.run("build . -s compiler.cppstd=11")
+        # It doesn't fail


### PR DESCRIPTION
Changelog: Bugfix: Fix cppstd/cstd `variable_watch` when they are not defined.
Changelog: Bugfix: Fix cstd error reporting when a recipe does not support the required version.
Docs: Omit

This fix addresses an issue where "cppstd" is undefined for pure C recipes. Consequently, "set" sometimes leaves the
"conan_watched_std_variable" unset, leading to an error in the subsequent string comparison:

```
CMake Error at .../conan_toolchain.cmake:64 (if):
  if given arguments:

    "READ_ACCESS" "STREQUAL" "MODIFIED_ACCESS" "AND" "NOT" "11" "STREQUAL"

  Unknown arguments specified
```

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
