### PR TITLE
Better error for empty package scope

### DIFF
--- a/conans/model/options.py
+++ b/conans/model/options.py
@@ -234,6 +234,9 @@ class Options:
                     tokens = k.split(":", 1)
                     if len(tokens) == 2:
                         package, option = tokens
+                        if not package:
+                            raise ConanException("Invalid empty package name in options. "
+                                                 f"Use a pattern like `mypkg/*:{option}`")
                         if "/" not in package and "*" not in package and "&" not in package:
                             msg = "The usage of package names `{}` in options is " \
                                   "deprecated, use a pattern like `{}/*:{}` " \

--- a/test/functional/toolchains/env/test_complete.py
+++ b/test/functional/toolchains/env/test_complete.py
@@ -116,6 +116,9 @@ def test_complete():
     assert "The usage of package names `myopenssl:shared` in options is deprecated, " \
            "use a pattern like `myopenssl/*:shared` instead" in client.out
 
+    client.run("create . --name=mycmake --version=1.0 -o=:shared=True", assert_error=True)
+    assert "Invalid empty package" in client.out
+
     # Fix the default options and repeat the create
     fixed_cf = mycmake_conanfile.replace('default_options = {"myopenssl:shared": True}',
                                          'default_options = {"myopenssl*:shared": True}')

--- a/test/integration/command/test_profile.py
+++ b/test/integration/command/test_profile.py
@@ -129,6 +129,8 @@ def test_shorthand_syntax():
                                          'compiler.version': '11',
                                          'os': 'Linux'},
                             'tool_requires': {}}}
+    tc.run("profile show -o:shared=True", assert_error=True)
+    assert 'Invalid empty package name in options. Use a pattern like `mypkg/*:shared`' in tc.out
 
 
 def test_profile_show_json():


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

it used to recommend using `-o=/*:option` syntax if package it was empty