### PR TITLE
Report remote while requesting login

### DIFF
--- a/conans/client/userio.py
+++ b/conans/client/userio.py
@@ -75,7 +75,8 @@ class UserInput(object):
             self._out.write("Remote '%s' username: " % remote_name)
             username = self.get_username()
 
-        self._out.write('Please enter a password for "%s" account: ' % username)
+        self._out.write("Please enter a password for user '%s' on remote '%s': "
+                        % (username, remote_name))
         try:
             pwd = self.get_password()
         except ConanException:

--- a/test/integration/command/user_test.py
+++ b/test/integration/command/user_test.py
@@ -154,7 +154,7 @@ class ConanLib(ConanFile):
         client.save_home({"global.conf": conan_conf})
         client.run('remote login default admin -p', assert_error=True)
         self.assertIn('ERROR: Conan interactive mode disabled', client.out)
-        self.assertNotIn("Please enter a password for \"admin\" account:", client.out)
+        self.assertNotIn("Please enter a password for user 'admin'", client.out)
         client.run("remote list-users")
         self.assertIn("default:\n  No user", client.out)
 

--- a/test/integration/remote/auth_test.py
+++ b/test/integration/remote/auth_test.py
@@ -56,9 +56,9 @@ class AuthorizeTest(unittest.TestCase):
         ref = copy.copy(self.ref)
         ref.revision = rev
         self.assertTrue(os.path.exists(self.test_server.server_store.export(ref)))
-        self.assertIn('Please enter a password for "bad"', self.conan.out)
-        self.assertIn('Please enter a password for "bad2"', self.conan.out)
-        self.assertIn('Please enter a password for "nacho@gmail.com"', self.conan.out)
+        self.assertIn("Please enter a password for user 'bad'", self.conan.out)
+        self.assertIn("Please enter a password for user 'bad2'", self.conan.out)
+        self.assertIn("Please enter a password for user 'nacho@gmail.com'", self.conan.out)
 
     def test_auth_with_env(self):
 
@@ -128,7 +128,8 @@ class AuthorizeTest(unittest.TestCase):
         ref = copy.copy(self.ref)
         ref.revision = rev
         self.assertTrue(os.path.exists(self.test_server.server_store.export(ref)))
-        self.assertIn('Please enter a password for "some_random.special!characters"', client.out)
+        self.assertIn("Please enter a password for user 'some_random.special!characters' on remote 'default'",
+                      client.out)
 
     def test_authorize_disabled_remote(self):
         tc = TestClient(servers=self.servers)


### PR DESCRIPTION
Changelog: Fix: Add remote name to login prompt.
Docs: Omit
In setups with multiple remotes configured the prompt to enter a password might appear multiple times. After the first input users could deduce that the given password is wrong and in worst case start trying other ones, even if it was correct. Naming the remote name in the prompt as well will avoid such kind of confusion.
