### PR TITLE
Fix `cmake_target_aliases` set from CMakeDeps

### DIFF
--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -136,7 +136,9 @@ class CMakeDeps(object):
         """
         Using this method you can overwrite the :ref:`property<CMakeDeps Properties>` values set by
         the Conan recipes from the consumer. This can be done for `cmake_file_name`, `cmake_target_name`,
-        `cmake_find_mode`, `cmake_module_file_name` and `cmake_module_target_name` properties.
+        `cmake_find_mode`, `cmake_module_file_name`, `cmake_module_target_name`, `cmake_additional_variables_prefixes`,
+        `cmake_config_version_compat`, `system_package_version`, `cmake_set_interface_link_directories`,
+        `cmake_build_modules`, `nosoname`, and `cmake_target_aliases`.
 
         :param dep: Name of the dependency to set the :ref:`property<CMakeDeps Properties>`. For
          components use the syntax: ``dep_name::component_name``.

--- a/conan/tools/cmake/cmakedeps/templates/targets.py
+++ b/conan/tools/cmake/cmakedeps/templates/targets.py
@@ -25,8 +25,9 @@ class TargetsTemplate(CMakeDepsFileTemplate):
         target_pattern = "" if not self.generating_module else "module-"
         target_pattern += "{}-Target-*.cmake".format(self.file_name)
 
-        cmake_target_aliases = self.conanfile.cpp_info.\
-            get_property("cmake_target_aliases", check_type=list) or dict()
+        cmake_target_aliases = self.cmakedeps.get_property("cmake_target_aliases",
+                                                           self.conanfile,
+                                                           check_type=list) or dict()
 
         target = self.root_target_name
         cmake_target_aliases = {alias: target for alias in cmake_target_aliases}
@@ -34,10 +35,10 @@ class TargetsTemplate(CMakeDepsFileTemplate):
         cmake_component_target_aliases = dict()
         for comp_name in self.conanfile.cpp_info.components:
             if comp_name is not None:
-                aliases = \
-                    self.conanfile.cpp_info.components[comp_name].\
-                    get_property("cmake_target_aliases", check_type=list) or dict()
-
+                aliases = self.cmakedeps.get_property("cmake_target_aliases",
+                                                      self.conanfile,
+                                                      comp_name=comp_name,
+                                                      check_type=list) or dict()
                 target = self.get_component_alias(self.conanfile, comp_name)
                 cmake_component_target_aliases[comp_name] = {alias: target for alias in aliases}
 

--- a/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -843,3 +843,42 @@ def test_cmakedeps_set_get_property_checktype():
     c.run("create dep")
     c.run("create app", assert_error=True)
     assert 'The expected type for foo is "list", but "int" was found' in c.out
+
+
+def test_alias_cmakedeps_set_property():
+    tc = TestClient()
+    tc.save({"dep/conanfile.py": textwrap.dedent("""
+
+        from conan import ConanFile
+        class Dep(ConanFile):
+            name = "dep"
+            version = "1.0"
+            settings = "os", "compiler", "build_type", "arch"
+            def package_info(self):
+                self.cpp_info.components["mycomp"].set_property("cmake_target_name", "dep::mycomponent")
+        """),
+             "conanfile.py": textwrap.dedent("""
+             from conan import ConanFile
+             from conan.tools.cmake import CMakeDeps, CMake
+             class Pkg(ConanFile):
+                name = "pkg"
+                version = "1.0"
+                settings = "os", "compiler", "build_type", "arch"
+
+                requires = "dep/1.0"
+
+                def generate(self):
+                    deps = CMakeDeps(self)
+                    deps.set_property("dep", "cmake_target_aliases", ["alias", "dep::other_name"])
+                    deps.set_property("dep::mycomp", "cmake_target_aliases", ["component_alias", "dep::my_aliased_component"])
+                    deps.generate()
+             """)})
+    tc.run("create dep")
+    tc.run("install .")
+    targetsData = tc.load("depTargets.cmake")
+    assert "add_library(dep::dep" in targetsData
+    assert "add_library(alias" in targetsData
+    assert "add_library(dep::other_name" in targetsData
+
+    assert "add_library(component_alias" in targetsData
+    assert "add_library(dep::my_aliased_component" in targetsData


### PR DESCRIPTION
Changelog: Fix: Allow `cmake_target_aliases` to be set in CMakeDeps.
Docs: https://github.com/conan-io/docs/pull/3875
