### PR TITLE
Test to show that a static-library recipe won't change its pkg_type when header_only option is used

### DIFF
--- a/conans/model/pkg_type.py
+++ b/conans/model/pkg_type.py
@@ -58,6 +58,11 @@ class PackageType(Enum):
                 if conanfile_type is PackageType.UNKNOWN:
                     raise ConanException(f"{conanfile}: Package type is 'library',"
                                          " but no 'shared' option declared")
+            elif any(option in conanfile.options for option in ["shared", "header_only"]):
+                conanfile.output.warning(f"{conanfile}: package_type '{conanfile_type}' is defined, "
+                                         "but 'shared' and/or 'header_only' options are present. "
+                                         "The package_type will have precedence over the options "
+                                         "regardless of their value.")
             conanfile.package_type = conanfile_type
         else:  # automatic default detection with option shared/header-only
             conanfile.package_type = deduce_from_options()

--- a/test/integration/graph/core/test_auto_package_type.py
+++ b/test/integration/graph/core/test_auto_package_type.py
@@ -1,3 +1,5 @@
+import textwrap
+
 import pytest
 
 from conan.test.utils.tools import TestClient
@@ -43,3 +45,19 @@ def test_auto_package_type(conanfile):
     assert "package_type: header-library" in c.out
     c.run("graph info . --filter package_type -o header_only=True -o shared=False")
     assert "package_type: header-library" in c.out
+
+def test_package_type_and_header_library():
+    """ Show that forcing a package_type and header_only=True does not change the package_type"""
+    tc = TestClient(light=True)
+    tc.save({"conanfile.py": textwrap.dedent("""
+    from conan import ConanFile
+
+    class Pkg(ConanFile):
+        package_type = "static-library"
+        options = {"header_only": [True, False]}
+
+    """)})
+    tc.run("graph info . --filter package_type -o &:header_only=False")
+    assert "package_type: static-library" in tc.out
+    tc.run("graph info . --filter package_type -o &:header_only=True")
+    assert "package_type: static-library" in tc.out

--- a/test/integration/graph/core/test_auto_package_type.py
+++ b/test/integration/graph/core/test_auto_package_type.py
@@ -38,6 +38,7 @@ def test_auto_package_type(conanfile):
     c.run("graph info . --filter package_type")
     assert "package_type: static-library" in c.out
     c.run("graph info . --filter package_type -o shared=True")
+    assert "The package_type will have precedence over the options" not in c.out
     assert "package_type: shared-library" in c.out
     c.run("graph info . --filter package_type -o shared=True -o header_only=False")
     assert "package_type: shared-library" in c.out
@@ -59,5 +60,7 @@ def test_package_type_and_header_library():
     """)})
     tc.run("graph info . --filter package_type -o &:header_only=False")
     assert "package_type: static-library" in tc.out
+    assert "The package_type will have precedence over the options" in tc.out
     tc.run("graph info . --filter package_type -o &:header_only=True")
     assert "package_type: static-library" in tc.out
+    assert "The package_type will have precedence over the options" in tc.out


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

For https://github.com/conan-io/conan-center-index/pull/25741/, which tries just this pattern.
Maybe we could issue a warning at some point here, but for now this test validates the current behaviour