### PR TITLE
Add tools.build:asmflags configuration setting for cmake toolchain

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -233,11 +233,12 @@ class SkipRPath(Block):
 
 class ArchitectureBlock(Block):
     template = textwrap.dedent("""\
-        # Define C++ flags, C flags and linker flags from 'settings.arch'
+        # Define C++ flags, C flags, ASM flags and linker flags from 'settings.arch'
 
         message(STATUS "Conan toolchain: Defining architecture flag: {{ arch_flag }}")
         string(APPEND CONAN_CXX_FLAGS " {{ arch_flag }}")
         string(APPEND CONAN_C_FLAGS " {{ arch_flag }}")
+        string(APPEND CONAN_ASM_FLAGS " {{ arch_flag }}")
         string(APPEND CONAN_SHARED_LINKER_FLAGS " {{ arch_flag }}")
         string(APPEND CONAN_EXE_LINKER_FLAGS " {{ arch_flag }}")
         """)
@@ -343,6 +344,7 @@ class ParallelBlock(Block):
 
         string(APPEND CONAN_CXX_FLAGS " /MP{{ parallel }}")
         string(APPEND CONAN_C_FLAGS " /MP{{ parallel }}")
+        string(APPEND CONAN_ASM_FLAGS " /MP{{ parallel }}")
         """)
 
     def context(self):
@@ -729,6 +731,9 @@ class ExtraFlagsBlock(Block):
         {% if cflags %}
         string(APPEND CONAN_C_FLAGS{{suffix}} "{% for cflag in cflags %} {{ cflag }}{% endfor %}")
         {% endif %}
+        {% if asmflags %}
+        string(APPEND CONAN_ASM_FLAGS{{suffix}} "{% for asmflag in asmflags %} {{ asmflag }}{% endfor %}")
+        {% endif %}
         {% if sharedlinkflags %}
         string(APPEND CONAN_SHARED_LINKER_FLAGS{{suffix}} "{% for sharedlinkflag in sharedlinkflags %} {{ sharedlinkflag }}{% endfor %}")
         {% endif %}
@@ -783,6 +788,7 @@ class ExtraFlagsBlock(Block):
         # Now, it's time to get all the flags defined by the user
         cxxflags = self._toolchain.extra_cxxflags + self._conanfile.conf.get("tools.build:cxxflags", default=[], check_type=list)
         cflags = self._toolchain.extra_cflags + self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
+        asmflags = self._toolchain.extra_asmflags + self._conanfile.conf.get("tools.build:asmflags", default=[], check_type=list)
         sharedlinkflags = self._toolchain.extra_sharedlinkflags + self._conanfile.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)
         exelinkflags = self._toolchain.extra_exelinkflags + self._conanfile.conf.get("tools.build:exelinkflags", default=[], check_type=list)
         defines = self._conanfile.conf.get("tools.build:defines", default=[], check_type=list)
@@ -805,6 +811,7 @@ class ExtraFlagsBlock(Block):
             "suffix": suffix,
             "cxxflags": cxxflags,
             "cflags": cflags,
+            "asmflags": asmflags,
             "sharedlinkflags": sharedlinkflags,
             "exelinkflags": exelinkflags,
             "defines": [define.replace('"', '\\"') for define in defines]
@@ -823,6 +830,9 @@ class CMakeFlagsInitBlock(Block):
             if(DEFINED CONAN_C_FLAGS_${config})
               string(APPEND CMAKE_C_FLAGS_${config}_INIT " ${CONAN_C_FLAGS_${config}}")
             endif()
+            if(DEFINED CONAN_ASM_FLAGS_${config})
+              string(APPEND CMAKE_ASM_FLAGS_${config}_INIT " ${CONAN_ASM_FLAGS_${config}}")
+            endif()
             if(DEFINED CONAN_SHARED_LINKER_FLAGS_${config})
               string(APPEND CMAKE_SHARED_LINKER_FLAGS_${config}_INIT " ${CONAN_SHARED_LINKER_FLAGS_${config}}")
             endif()
@@ -836,6 +846,9 @@ class CMakeFlagsInitBlock(Block):
         endif()
         if(DEFINED CONAN_C_FLAGS)
           string(APPEND CMAKE_C_FLAGS_INIT " ${CONAN_C_FLAGS}")
+        endif()
+        if(DEFINED CONAN_ASM_FLAGS)
+          string(APPEND CMAKE_ASM_FLAGS_INIT " ${CONAN_ASM_FLAGS}")
         endif()
         if(DEFINED CONAN_SHARED_LINKER_FLAGS)
           string(APPEND CMAKE_SHARED_LINKER_FLAGS_INIT " ${CONAN_SHARED_LINKER_FLAGS}")

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -91,6 +91,7 @@ class CMakeToolchain:
 
         self.extra_cxxflags = []
         self.extra_cflags = []
+        self.extra_asmflags = []
         self.extra_sharedlinkflags = []
         self.extra_exelinkflags = []
 

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -124,7 +124,7 @@ BUILT_IN_CONFS = {
     "tools.build:compiler_executables": "Defines a Python dict-like with the compilers path to be used. Allowed keys {'c', 'cpp', 'cuda', 'objc', 'objcxx', 'rc', 'fortran', 'asm', 'hip', 'ispc'}",
     "tools.build:cxxflags": "List of extra CXX flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:cflags": "List of extra C flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
-    "tools.build:asmflags": "List of extra assembly flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
+    "tools.build:asmflags": "(Experimental) List of extra assembly flags used by the CMakeToolchain generator",
     "tools.build:defines": "List of extra definition flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:sharedlinkflags": "List of extra flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:exelinkflags": "List of extra flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",

--- a/conans/model/conf.py
+++ b/conans/model/conf.py
@@ -124,6 +124,7 @@ BUILT_IN_CONFS = {
     "tools.build:compiler_executables": "Defines a Python dict-like with the compilers path to be used. Allowed keys {'c', 'cpp', 'cuda', 'objc', 'objcxx', 'rc', 'fortran', 'asm', 'hip', 'ispc'}",
     "tools.build:cxxflags": "List of extra CXX flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:cflags": "List of extra C flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
+    "tools.build:asmflags": "List of extra assembly flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:defines": "List of extra definition flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:sharedlinkflags": "List of extra flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:exelinkflags": "List of extra flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",

--- a/test/integration/configuration/conf/test_conf.py
+++ b/test/integration/configuration/conf/test_conf.py
@@ -170,7 +170,7 @@ def test_composition_conan_conf_different_data_types_by_cli_arg(client):
     """
     Testing if you want to introduce a list/dict via cli
 
-    >> conan install . -c "tools.build.flags:ccflags+=['-Werror']"
+    >> conan install . -c "tools.build:cflags+=['-Werror']"
     >> conan install . -c "tools.microsoft.msbuildtoolchain:compile_options={'ExceptionHandling': 'Async'}"
 
     """

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -498,6 +498,7 @@ def test_extra_flags_via_conf():
         [conf]
         tools.build:cxxflags=["--flag1", "--flag2"]
         tools.build:cflags+=["--flag3", "--flag4"]
+        tools.build:asmflags+=["--flag3", "--flag4"]
         tools.build:sharedlinkflags=+["--flag5", "--flag6"]
         tools.build:exelinkflags=["--flag7", "--flag8"]
         tools.build:defines=["D1", "D2"]
@@ -513,6 +514,7 @@ def test_extra_flags_via_conf():
     toolchain = client.load("conan_toolchain.cmake")
     assert 'string(APPEND CONAN_CXX_FLAGS " --flag1 --flag2")' in toolchain
     assert 'string(APPEND CONAN_C_FLAGS " --flag3 --flag4")' in toolchain
+    assert 'string(APPEND CONAN_ASM_FLAGS " --flag3 --flag4")' in toolchain
     assert 'string(APPEND CONAN_SHARED_LINKER_FLAGS " --flag5 --flag6")' in toolchain
     assert 'string(APPEND CONAN_EXE_LINKER_FLAGS " --flag7 --flag8")' in toolchain
     assert 'add_compile_definitions( "D1" "D2")' in toolchain
@@ -1327,6 +1329,7 @@ def test_extra_flags():
                 tc = CMakeToolchain(self)
                 tc.extra_cxxflags = ["extra_cxxflags"]
                 tc.extra_cflags = ["extra_cflags"]
+                tc.extra_asmflags = ["extra_asmflags"]
                 tc.extra_sharedlinkflags = ["extra_sharedlinkflags"]
                 tc.extra_exelinkflags = ["extra_exelinkflags"]
                 tc.generate()
@@ -1336,6 +1339,7 @@ def test_extra_flags():
         [conf]
         tools.build:cxxflags+=['cxxflags']
         tools.build:cflags+=['cflags']
+        tools.build:asmflags+=['asmflags']
         tools.build:sharedlinkflags+=['sharedlinkflags']
         tools.build:exelinkflags+=['exelinkflags']
         """)
@@ -1345,6 +1349,7 @@ def test_extra_flags():
 
     assert 'string(APPEND CONAN_CXX_FLAGS " extra_cxxflags cxxflags")' in toolchain
     assert 'string(APPEND CONAN_C_FLAGS " extra_cflags cflags")' in toolchain
+    assert 'string(APPEND CONAN_ASM_FLAGS " extra_asmflags asmflags")' in toolchain
     assert 'string(APPEND CONAN_SHARED_LINKER_FLAGS " extra_sharedlinkflags sharedlinkflags")' in toolchain
     assert 'string(APPEND CONAN_EXE_LINKER_FLAGS " extra_exelinkflags exelinkflags")' in toolchain
 


### PR DESCRIPTION
Changelog: Feature

The CMake toolchain supports the `tools.build:cflags` and `tools.build:cxxflags` configuration settings, which then populate the `CMAKE_C_FLAGS_INIT` and the `CMAKE_CXX_FLAGS_INIT` CMake variables respectively. There doesn't seem to exist an equivalent for the `CMAKE_ASM_FLAGS_INIT` CMake variable in conan, right now.
This PR adds the new `tools.build:asmflags` configuration setting, to address this.

In this PR I only included the necessary changes for the CMake toolchain, but I could also add support for this setting in some of the other toolchain generators, if there's interest.

Docs: https://github.com/conan-io/docs/pull/3881

- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
