### PR TITLE
fix cppstd checks for c++26 in newer compiler versions

### DIFF
--- a/conan/tools/build/cppstd.py
+++ b/conan/tools/build/cppstd.py
@@ -164,8 +164,14 @@ def _apple_clang_supported_cppstd(version):
         return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"]
     if version < "13.0":
         return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17", "20", "gnu20"]
+    # https://github.com/conan-io/conan/pull/17092 doesn't show c++23 full support until 16
+    # but it was this before Conan 2.9, so keeping it to not break
+    if version < "16.0":
+        return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17", "20", "gnu20",
+                "23", "gnu23"]
 
-    return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17", "20", "gnu20", "23", "gnu23"]
+    return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17", "20", "gnu20", "23", "gnu23",
+            "26", "gnu26"]
 
 
 def _gcc_supported_cppstd(version):
@@ -184,8 +190,12 @@ def _gcc_supported_cppstd(version):
         return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"]
     if version < "11":
         return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17", "20", "gnu20"]
+    if version < "14.0":
+        return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17", "20", "gnu20",
+                "23", "gnu23"]
 
-    return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17", "20", "gnu20", "23", "gnu23"]
+    return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17", "20", "gnu20", "23", "gnu23",
+            "26", "gnu26"]
 
 
 def _msvc_supported_cppstd(version):
@@ -222,8 +232,11 @@ def _clang_supported_cppstd(version):
         return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"]
     if version < "12":
         return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17", "20", "gnu20"]
-
-    return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17", "20", "gnu20", "23", "gnu23"]
+    if version < "17.0":
+        return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17", "20", "gnu20",
+                "23", "gnu23"]
+    return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17", "20", "gnu20", "23", "gnu23",
+            "26", "gnu26"]
 
 
 def _mcst_lcc_supported_cppstd(version):

--- a/conan/tools/build/cppstd.py
+++ b/conan/tools/build/cppstd.py
@@ -190,6 +190,7 @@ def _gcc_supported_cppstd(version):
         return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"]
     if version < "11":
         return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17", "20", "gnu20"]
+    # https://github.com/conan-io/conan/pull/17092
     if version < "14.0":
         return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17", "20", "gnu20",
                 "23", "gnu23"]
@@ -232,6 +233,7 @@ def _clang_supported_cppstd(version):
         return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"]
     if version < "12":
         return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17", "20", "gnu20"]
+    # https://github.com/conan-io/conan/pull/17092
     if version < "17.0":
         return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17", "20", "gnu20",
                 "23", "gnu23"]

--- a/conans/__init__.py
+++ b/conans/__init__.py
@@ -1,4 +1,4 @@
 CHECKSUM_DEPLOY = "checksum_deploy"  # Only when v2
 REVISIONS = "revisions"  # Only when enabled in config, not by default look at server_launcher.py
 
-__version__ = '2.9.0'
+__version__ = '2.9.1'

--- a/test/integration/configuration/test_profile_plugin.py
+++ b/test/integration/configuration/test_profile_plugin.py
@@ -28,9 +28,14 @@ class TestErrorsProfilePlugin:
         assert "ERROR: The 'profile.py' plugin file doesn't exist" in c.out
 
     def test_regresion_29(self):
+        # https://github.com/conan-io/conan/issues/17247
         c = TestClient()
         c.save({"conanfile.txt": ""})
         c.run("install . -s compiler=clang -s compiler.version=19 -s compiler.cppstd=26")
+        # doesn't fail anymore
+        c.run("install . -s compiler=apple-clang -s compiler.version=16 -s compiler.cppstd=26")
+        # doesn't fail anymore
+        c.run("install . -s compiler=gcc -s compiler.version=14 -s compiler.cppstd=26")
         # doesn't fail anymore
 
 

--- a/test/integration/configuration/test_profile_plugin.py
+++ b/test/integration/configuration/test_profile_plugin.py
@@ -27,6 +27,12 @@ class TestErrorsProfilePlugin:
         c.run("profile show", assert_error=True)
         assert "ERROR: The 'profile.py' plugin file doesn't exist" in c.out
 
+    def test_regresion_29(self):
+        c = TestClient()
+        c.save({"conanfile.txt": ""})
+        c.run("install . -s compiler=clang -s compiler.version=19 -s compiler.cppstd=26")
+        # doesn't fail anymore
+
 
 def test_android_ndk_version():
     c = TestClient()


### PR DESCRIPTION
Changelog: Bugfix: Fixed false positives of ``profile.py`` plugin checks over c++26 for latest compiler versions
Docs: Omit

Close https://github.com/conan-io/conan/issues/17247
