### PR TITLE
[Environment] Fixed if scope=None

### DIFF
--- a/conans/client/subsystems.py
+++ b/conans/client/subsystems.py
@@ -128,7 +128,7 @@ def deduce_subsystem(conanfile, scope):
     - Aggregation of envfiles: to map each aggregated path to the subsystem
     - unix_path: util for recipes
     """
-    scope = "build" if scope is None else scope  # let's assume build context is scope=None
+    scope = "build" if scope is None else scope  # let's assume build context if scope=None
     if scope.startswith("build"):
         the_os = conanfile.settings_build.get_safe("os")
         if the_os is None:

--- a/conans/client/subsystems.py
+++ b/conans/client/subsystems.py
@@ -128,7 +128,7 @@ def deduce_subsystem(conanfile, scope):
     - Aggregation of envfiles: to map each aggregated path to the subsystem
     - unix_path: util for recipes
     """
-    scope = scope or "build"  # let's assume build context is scope=None
+    scope = "build" if scope is None else scope  # let's assume build context is scope=None
     if scope.startswith("build"):
         the_os = conanfile.settings_build.get_safe("os")
         if the_os is None:

--- a/conans/client/subsystems.py
+++ b/conans/client/subsystems.py
@@ -128,6 +128,7 @@ def deduce_subsystem(conanfile, scope):
     - Aggregation of envfiles: to map each aggregated path to the subsystem
     - unix_path: util for recipes
     """
+    scope = scope or "build"  # let's assume build context is scope=None
     if scope.startswith("build"):
         the_os = conanfile.settings_build.get_safe("os")
         if the_os is None:

--- a/test/integration/toolchains/env/test_environment.py
+++ b/test/integration/toolchains/env/test_environment.py
@@ -1,0 +1,56 @@
+import platform
+import textwrap
+
+from conan.test.utils.tools import TestClient
+
+
+def test_env_and_scope_none():
+    """
+    Check scope=None does not append foo=var to conan{build|run}.{bat|sh|ps1}
+    """
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.env import Environment
+        class Pkg(ConanFile):
+            name = "pkg"
+            version = "0.1"
+            settings = "os", "compiler", "build_type", "arch"
+            def generate(self):
+                env1 = Environment()
+                env1.define("foo", "var")
+                # Will not append "my_env_file" to "conanbuild.bat|sh|ps1"
+                envvars = env1.vars(self, scope=None)
+                envvars.save_script("my_env_file")
+            """)
+    client.save({"conanfile.py": conanfile})
+    client.run("install .")
+    ext = ".bat" if platform.system() == "Windows" else ".sh"
+    assert "my_env_file" not in client.load(f"conanbuild{ext}")
+    assert "my_env_file" not in client.load(f"conanrun{ext}")
+
+
+# TODO: Change this test when we refactor EnvVars. The UX leaves much to be desired
+def test_envvars_and_scope_none_apply():
+    """
+    Applying env context if scope=None
+
+    Issue: https://github.com/conan-io/conan/issues/17249
+    """
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.env import Environment
+        class Pkg(ConanFile):
+            name = "pkg"
+            version = "0.1"
+            settings = "os", "compiler", "build_type", "arch"
+            def generate(self):
+                env1 = Environment()
+                env1.define("foo", "var")
+                with env1.vars(self, scope=None).apply():
+                    import os
+                    assert os.environ["foo"] == "var"
+            """)
+    client.save({"conanfile.py": conanfile})
+    client.run("install .")

--- a/test/integration/toolchains/env/test_environment.py
+++ b/test/integration/toolchains/env/test_environment.py
@@ -4,9 +4,12 @@ import textwrap
 from conan.test.utils.tools import TestClient
 
 
+# TODO: Change this test when we refactor EnvVars. The UX leaves much to be desired
 def test_env_and_scope_none():
     """
     Check scope=None does not append foo=var to conan{build|run}.{bat|sh|ps1}
+
+    Issue: https://github.com/conan-io/conan/issues/17249
     """
     client = TestClient()
     conanfile = textwrap.dedent("""
@@ -22,6 +25,10 @@ def test_env_and_scope_none():
                 # Will not append "my_env_file" to "conanbuild.bat|sh|ps1"
                 envvars = env1.vars(self, scope=None)
                 envvars.save_script("my_env_file")
+                # Let's check the apply() function
+                with env1.vars(self, scope=None).apply():
+                    import os
+                    assert os.environ["foo"] == "var"
             """)
     client.save({"conanfile.py": conanfile})
     client.run("install .")
@@ -29,28 +36,3 @@ def test_env_and_scope_none():
     assert "my_env_file" not in client.load(f"conanbuild{ext}")
     assert "my_env_file" not in client.load(f"conanrun{ext}")
 
-
-# TODO: Change this test when we refactor EnvVars. The UX leaves much to be desired
-def test_envvars_and_scope_none_apply():
-    """
-    Applying env context if scope=None
-
-    Issue: https://github.com/conan-io/conan/issues/17249
-    """
-    client = TestClient()
-    conanfile = textwrap.dedent("""
-        from conan import ConanFile
-        from conan.tools.env import Environment
-        class Pkg(ConanFile):
-            name = "pkg"
-            version = "0.1"
-            settings = "os", "compiler", "build_type", "arch"
-            def generate(self):
-                env1 = Environment()
-                env1.define("foo", "var")
-                with env1.vars(self, scope=None).apply():
-                    import os
-                    assert os.environ["foo"] == "var"
-            """)
-    client.save({"conanfile.py": conanfile})
-    client.run("install .")


### PR DESCRIPTION
Changelog: Bugfix: Fix `deduce_subsystem` when `scope=None` assuming the scope is `build`.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/17249


Pending an improvement in UX.