### PR TITLE
Bugfix: Fix ROSEnv quotes for CMAKE_TOOLCHAIN_FILE var

### DIFF
--- a/conan/tools/ros/rosenv.py
+++ b/conan/tools/ros/rosenv.py
@@ -28,7 +28,7 @@ class ROSEnv:
         """
         cmake_toolchain_path = os.path.join(self._conanfile.generators_folder,
                                             "conan_toolchain.cmake")
-        self.variables["CMAKE_TOOLCHAIN_FILE"] = f"\"{cmake_toolchain_path}\""
+        self.variables["CMAKE_TOOLCHAIN_FILE"] = cmake_toolchain_path
         build_type = self._conanfile.settings.get_safe("build_type")
         if build_type:
             self.variables["CMAKE_BUILD_TYPE"] = build_type

--- a/test/integration/tools/ros/test_rosenv.py
+++ b/test/integration/tools/ros/test_rosenv.py
@@ -34,9 +34,9 @@ def test_rosenv():
     assert os.path.exists(conanrosenvbuild_path)
     toolchain_path = os.path.join(client.current_folder, "install", "conan", "conan_toolchain.cmake")
     content = client.load(conanrosenvbuild_path)
-    assert f"CMAKE_TOOLCHAIN_FILE=\"{toolchain_path}\"" in content
-    assert "CMAKE_BUILD_TYPE=\"Release\"" in content
-    client.run_command(f". \"{conanrosenv_path}\" && env")
+    assert f'CMAKE_TOOLCHAIN_FILE="{toolchain_path}"' in content
+    assert 'CMAKE_BUILD_TYPE="Release"' in content
+    client.run_command(f'. "{conanrosenv_path}" && env')
     assert f"CMAKE_TOOLCHAIN_FILE={toolchain_path}" in client.out
     assert "CMAKE_BUILD_TYPE=Release" in client.out
 

--- a/test/integration/tools/ros/test_rosenv.py
+++ b/test/integration/tools/ros/test_rosenv.py
@@ -34,7 +34,7 @@ def test_rosenv():
     assert os.path.exists(conanrosenvbuild_path)
     client.run_command(f". \"{conanrosenv_path}\" && env")
     toolchain_path = os.path.join(client.current_folder, "install", "conan", "conan_toolchain.cmake")
-    assert f"CMAKE_TOOLCHAIN_FILE=\"{toolchain_path}\"" in client.out
+    assert f"CMAKE_TOOLCHAIN_FILE={toolchain_path}" in client.out
     assert "CMAKE_BUILD_TYPE=Release" in client.out
 
 

--- a/test/integration/tools/ros/test_rosenv.py
+++ b/test/integration/tools/ros/test_rosenv.py
@@ -32,8 +32,11 @@ def test_rosenv():
     assert os.path.exists(conanrosenv_path)
     conanrosenvbuild_path = os.path.join(install_folder, "conanrosenv-build.sh")
     assert os.path.exists(conanrosenvbuild_path)
-    client.run_command(f". \"{conanrosenv_path}\" && env")
     toolchain_path = os.path.join(client.current_folder, "install", "conan", "conan_toolchain.cmake")
+    content = client.load(conanrosenvbuild_path)
+    assert f"CMAKE_TOOLCHAIN_FILE=\"{toolchain_path}\"" in content
+    assert "CMAKE_BUILD_TYPE=\"Release\"" in content
+    client.run_command(f". \"{conanrosenv_path}\" && env")
     assert f"CMAKE_TOOLCHAIN_FILE={toolchain_path}" in client.out
     assert "CMAKE_BUILD_TYPE=Release" in client.out
 


### PR DESCRIPTION
Changelog: Bugfix: Fix ROSEnv quotes for CMAKE_TOOLCHAIN_FILE variable.
Docs: omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
