### PR TITLE
Use center2.conan.io as new default remote and warn about having the old one.

### DIFF
--- a/conan/api/subapi/remotes.py
+++ b/conan/api/subapi/remotes.py
@@ -254,7 +254,7 @@ class RemotesAPI:
 
 def _load(remotes_file):
     if not os.path.exists(remotes_file):
-        remote = Remote(CONAN_CENTER_REMOTE_NAME, "https://center.conan.io", True, False)
+        remote = Remote(CONAN_CENTER_REMOTE_NAME, "https://center2.conan.io", True, False)
         _save(remotes_file, [remote])
         return [remote]
 
@@ -313,7 +313,7 @@ def _validate_url(url):
         if url.startswith("https://conan.io/center"):
             raise ConanException("Wrong ConanCenter remote URL. You are adding the web "
                                  "https://conan.io/center the correct remote API is "
-                                 "https://center.conan.io")
+                                 "https://center2.conan.io")
         address = urlparse(url)
         if not all([address.scheme, address.netloc]):
             out.warning(f"The URL '{url}' is invalid. It must contain scheme and hostname.")

--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -245,6 +245,20 @@ def _warn_python_version():
         ConanOutput().warning("*" * 80, warn_tag="deprecated")
 
 
+def _warn_frozen_center(conan_api):
+    remotes = conan_api.remotes.list()
+    for r in remotes:
+        if r.url == "https://center.conan.io":
+            ConanOutput().warning(
+                "The remote 'https://center.conan.io' is now frozen and has been replaced by 'https://center2.conan.io'. \n"
+                "Starting from Conan 2.9.2, the default remote is 'center2.conan.io'. \n"
+                "It is recommended to update to the new remote using the following command:\n"
+                f"'conan remote update {r.name} --url=\"https://center2.conan.io\"'",
+                warn_tag="deprecated"
+            )
+            break
+
+
 def main(args):
     """ main entry point of the conan application, using a Command to
     parse parameters
@@ -291,6 +305,7 @@ def main(args):
     try:
         cli.run(args)
         _warn_python_version()
+        _warn_frozen_center(conan_api)
     except BaseException as e:
         error = cli.exception_exit_error(e)
     sys.exit(error)

--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -190,6 +190,7 @@ class Cli:
 
         try:
             command.run(self._conan_api, args[0][1:])
+            _warn_frozen_center(self._conan_api)
         except Exception as e:
             # must be a local-import to get updated value
             if ConanOutput.level_allowed(LEVEL_TRACE):
@@ -305,7 +306,6 @@ def main(args):
     try:
         cli.run(args)
         _warn_python_version()
-        _warn_frozen_center(conan_api)
     except BaseException as e:
         error = cli.exception_exit_error(e)
     sys.exit(error)

--- a/test/integration/command/remote_test.py
+++ b/test/integration/command/remote_test.py
@@ -344,6 +344,29 @@ def test_add_wrong_conancenter():
     assert "the correct remote API is https://center2.conan.io" in c.out
 
 
+def test_using_frozen_center():
+    """ If the legacy center.conan.io is in the remote list warn about it.
+    """
+    c = TestClient(light=True)
+    c.run("remote add whatever https://center.conan.io")
+    assert "The remote 'https://center.conan.io' is now frozen and has been replaced by 'https://center2.conan.io'." in c.out
+    assert 'conan remote update whatever --url="https://center2.conan.io"' in c.out
+
+    c.run("remote list")
+    assert "The remote 'https://center.conan.io' is now frozen and has been replaced by 'https://center2.conan.io'." in c.out
+
+    c.run("remote remove whatever")
+
+    c.run("remote add conancenter https://center2.conan.io")
+    assert "The remote 'https://center.conan.io' is now frozen and has been replaced by 'https://center2.conan.io'." not in c.out
+
+    c.run("remote list")
+    assert "The remote 'https://center.conan.io' is now frozen and has been replaced by 'https://center2.conan.io'." not in c.out
+
+    c.run("remote update conancenter --url=https://center.conan.io")
+    assert "The remote 'https://center.conan.io' is now frozen and has been replaced by 'https://center2.conan.io'." in c.out
+
+
 def test_wrong_remotes_json_file():
     c = TestClient(light=True)
     c.save_home({"remotes.json": ""})

--- a/test/integration/command/remote_test.py
+++ b/test/integration/command/remote_test.py
@@ -337,11 +337,11 @@ def test_add_wrong_conancenter():
     c = TestClient(light=True)
     c.run("remote add whatever https://conan.io/center", assert_error=True)
     assert "Wrong ConanCenter remote URL. You are adding the web https://conan.io/center" in c.out
-    assert "the correct remote API is https://center.conan.io" in c.out
-    c.run("remote add conancenter https://center.conan.io")
+    assert "the correct remote API is https://center2.conan.io" in c.out
+    c.run("remote add conancenter https://center2.conan.io")
     c.run("remote update conancenter --url=https://conan.io/center", assert_error=True)
     assert "Wrong ConanCenter remote URL. You are adding the web https://conan.io/center" in c.out
-    assert "the correct remote API is https://center.conan.io" in c.out
+    assert "the correct remote API is https://center2.conan.io" in c.out
 
 
 def test_wrong_remotes_json_file():


### PR DESCRIPTION
Changelog: Feature: Use center2.conan.io as new default remote and warn about having the old one.
Docs: https://github.com/conan-io/docs/pull/3893
