### PR TITLE
fix CMake max_cpu_count

### DIFF
--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -20,7 +20,7 @@ def _cmake_cmd_line_args(conanfile, generator):
 
     maxcpucount = conanfile.conf.get("tools.microsoft.msbuild:max_cpu_count", check_type=int)
     if maxcpucount and "Visual Studio" in generator:
-        args.append("/m:{}".format(njobs))
+        args.append("/m:{}".format(maxcpucount))
 
     # Arguments for verbosity
     if "Visual Studio" in generator:

--- a/test/unittests/tools/cmake/test_cmake_cmd_line_args.py
+++ b/test/unittests/tools/cmake/test_cmake_cmd_line_args.py
@@ -12,6 +12,7 @@ def conanfile():
     c = ConfDefinition()
     c.loads(textwrap.dedent("""\
         tools.build:jobs=10
+        tools.microsoft.msbuild:max_cpu_count=23
     """))
 
     conanfile = ConanFileMock()
@@ -39,7 +40,7 @@ def test_ninja(conanfile):
 
 def test_visual_studio(conanfile):
     args = _cmake_cmd_line_args(conanfile, 'Visual Studio 16 2019')
-    assert [] == args
+    assert ["/m:23"] == args
 
     args = _cmake_cmd_line_args(conanfile, 'Ninja')
     assert args == ['-j10']


### PR DESCRIPTION
Changelog: Bugfix: Solve bug in ``CMake`` not using the correct value from ``tools.microsoft.msbuild:max_cpu_count``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/17290