### PR TITLE
Raise ConanException if source patch does not exist in export_conandata_patches

### DIFF
--- a/conan/tools/files/patches.py
+++ b/conan/tools/files/patches.py
@@ -142,5 +142,7 @@ def export_conandata_patches(conanfile):
         if patch_file:
             src = os.path.join(conanfile.recipe_folder, patch_file)
             dst = os.path.join(conanfile.export_sources_folder, patch_file)
+            if not os.path.exists(src):
+                raise ConanException(f"Patch file does not exist: '{src}'")
             mkdir(os.path.dirname(dst))
             shutil.copy2(src, dst)

--- a/test/functional/tools/test_files.py
+++ b/test/functional/tools/test_files.py
@@ -407,7 +407,7 @@ def test_export_conandata_patches(mock_patch_ng):
     # No patch found
     client.save({"conandata.yml": conandata_yml})
     client.run("create .", assert_error=True)
-    assert "No such file or directory" in client.out
+    assert "Patch file does not exist: '" in client.out
 
     client.save({"patches/mypatch.patch": "mypatch!!!"})
     client.run("create .")


### PR DESCRIPTION
Changelog: Fix: Raise ConanException if source patch does not exist in `export_conandata_patches`. 
Docs: Omit

Trying to fix tests that fail in Python 3.13: https://github.com/conan-io/conan/pull/17205

I found that now the error thrown by shutil.copy2 [has changed in Windows](https://github.com/python/cpython/commit/cda1bd3c9d3b2cecdeeba0c498cd2df83fbdb535). So if the source patch does not exist now the error is different.

It was like this:

```
FileNotFoundError: [Errno 2] No such file or directory: '/private/var/folders/hr/t3_1lzj9145g383b4zyj67d40000gn/T/tmpjqj9cq99conans/path with spaces/patches/mypatch.patch'
```

now it's like this:

```
FileNotFoundError: [WinError 3] The system cannot find the path specified
```


So I think it would be better to throw that error ourselves si that we always output a meaningful message:

```
ConanException: Patch file does not exist: '/private/var/folders/hr/t3_1lzj9145g383b4zyj67d40000gn/T/tmpuewtmlhpconans/path with spaces/patches/mypatch.patch'
```

