### PR TITLE
[cpp_info][BazelDeps] Improve auto deduce locations

### DIFF
--- a/conan/internal/api/new/bazel_7_lib.py
+++ b/conan/internal/api/new/bazel_7_lib.py
@@ -49,7 +49,10 @@ class {{package_name}}Recipe(ConanFile):
         copy(self, "*.so", build, dest_lib, keep_path=False)
         copy(self, "*.dll", build, dest_bin, keep_path=False)
         copy(self, "*.dylib", build, dest_lib, keep_path=False)
-        copy(self, "*.a", build, dest_lib, keep_path=False)
+        if self.settings.os == "Linux" and self.options.get_safe("fPIC"):
+            copy(self, "*.pic.a", build, dest_lib, keep_path=False)
+        else:
+            copy(self, "*.a", build, dest_lib, keep_path=False)
         copy(self, "*.lib", build, dest_lib, keep_path=False)
         copy(self, "{{name}}.h", os.path.join(self.source_folder, "main"),
              os.path.join(self.package_folder, "include"), keep_path=False)

--- a/conan/internal/api/new/bazel_lib.py
+++ b/conan/internal/api/new/bazel_lib.py
@@ -53,7 +53,10 @@ class {{package_name}}Recipe(ConanFile):
         copy(self, "*.so", build, dest_lib, keep_path=False)
         copy(self, "*.dll", build, dest_bin, keep_path=False)
         copy(self, "*.dylib", build, dest_lib, keep_path=False)
-        copy(self, "*.a", build, dest_lib, keep_path=False)
+        if self.settings.os == "Linux" and self.options.get_safe("fPIC"):
+            copy(self, "*.pic.a", build, dest_lib, keep_path=False)
+        else:
+            copy(self, "*.a", build, dest_lib, keep_path=False)
         copy(self, "*.lib", build, dest_lib, keep_path=False)
         copy(self, "{{name}}.h", os.path.join(self.source_folder, "main"),
              os.path.join(self.package_folder, "include"), keep_path=False)

--- a/conan/test/utils/mocks.py
+++ b/conan/test/utils/mocks.py
@@ -2,8 +2,8 @@ from collections import defaultdict
 from io import StringIO
 
 from conan import ConanFile
-from conan.internal.conan_app import ConanFileHelpers
 from conan.errors import ConanException
+from conan.internal.conan_app import ConanFileHelpers
 from conans.model.conf import Conf
 from conans.model.layout import Folders, Infos
 from conans.model.options import Options

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -1,7 +1,7 @@
 import os
 import re
 import textwrap
-from collections import namedtuple
+from collections import namedtuple, defaultdict
 
 from jinja2 import Template, StrictUndefined
 
@@ -70,100 +70,6 @@ def _get_requirements(conanfile, build_context_activated):
         if require.build and dep.ref.name not in build_context_activated:
             continue
         yield require, dep
-
-
-def _get_libs(dep, cpp_info=None) -> list:
-    """
-    Get the static/shared library paths
-
-    :param dep: normally a <ConanFileInterface obj>
-    :param cpp_info: <CppInfo obj> of the component.
-    :return: list of tuples per static/shared library ->
-             [(name, is_shared, lib_path, import_lib_path)]
-             Note: ``library_path`` could be both static and shared ones in case of UNIX systems.
-                    Windows would have:
-                        * shared: library_path as DLL, and import_library_path as LIB
-                        * static: library_path as LIB, and import_library_path as None
-    """
-    def _is_shared():
-        """
-        Checking traits and shared option
-        """
-        default_value = dep.options.get_safe("shared") if dep.options else False
-        return {"shared-library": True,
-                "static-library": False}.get(str(dep.package_type), default_value)
-
-    def _save_lib_path(file_name, file_path):
-        """Add each lib with its full library path"""
-        name, ext = file_name.split('.', maxsplit=1)  # ext could be .if.lib
-        formatted_path = file_path.replace("\\", "/")
-        lib_name = None
-        # Users may not name their libraries in a conventional way. For example, directly
-        # use the basename of the lib file as lib name, e.g., cpp_info.libs = ["liblib1.a"]
-        # Issue related: https://github.com/conan-io/conan/issues/11331
-        if file_name in libs:  # let's ensure that it has any extension
-            lib_name = file_name
-        elif name in libs:
-            lib_name = name
-        elif name.startswith("lib"):
-            short_name = name[3:]  # libpkg -> pkg
-            if short_name in libs:
-                lib_name = short_name
-        # FIXME: CPS will be in charge of defining correctly this part. At the moment, we can
-        #        only guess the name of the DLL binary as it does not follow any Conan pattern.
-        if ext == "dll" or ext.endswith(".dll"):
-            if lib_name:
-                shared_windows_libs[lib_name] = formatted_path
-            elif total_libs_number == 1 and libs[0] not in shared_windows_libs:
-                shared_windows_libs[libs[0]] = formatted_path
-            else:  # let's cross the fingers... This is the last chance.
-                for lib in libs:
-                    if lib in name and lib not in shared_windows_libs:
-                        shared_windows_libs[lib] = formatted_path
-                        break
-        elif lib_name is not None:
-            lib_paths[lib_name] = formatted_path
-
-    cpp_info = cpp_info or dep.cpp_info
-    libs = cpp_info.libs[:]  # copying the values
-    if not libs:  # no libraries declared
-        return []
-    is_shared = _is_shared()
-    libdirs = cpp_info.libdirs
-    bindirs = cpp_info.bindirs if is_shared else []  # just want to get shared libraries
-    if hasattr(cpp_info, "aggregated_components"):
-        # Global cpp_info
-        total_libs_number = len(cpp_info.aggregated_components().libs)
-    else:
-        total_libs_number = len(libs)
-    lib_paths = {}
-    shared_windows_libs = {}
-    for libdir in set(libdirs + bindirs):
-        if not os.path.exists(libdir):
-            continue
-        files = os.listdir(libdir)
-        for f in files:
-            full_path = os.path.join(libdir, f)
-            if not os.path.isfile(full_path):  # Make sure that directories are excluded
-                continue
-            _, ext = os.path.splitext(f)
-            if is_shared and ext in (".so", ".dylib", ".lib", ".dll"):
-                _save_lib_path(f, full_path)
-            elif not is_shared and ext in (".a", ".lib"):
-                _save_lib_path(f, full_path)
-
-    libraries = []
-    for name, lib_path in lib_paths.items():
-        import_lib_path = None
-        if is_shared and os.path.splitext(lib_path)[1] == ".lib":
-            if name not in shared_windows_libs:
-                raise ConanException(f"Windows needs a .lib for link-time and .dll for runtime."
-                                     f" Only found {lib_path}")
-            import_lib_path = lib_path  # .lib
-            lib_path = shared_windows_libs.pop(name)  # .dll
-        libraries.append((name, is_shared, lib_path, import_lib_path))
-    # TODO: Would we want to manage the cases where DLLs are provided by the system?
-    return libraries
 
 
 def _get_headers(cpp_info, package_folder_path):
@@ -490,8 +396,51 @@ class _BazelBUILDGenerator:
         """
         return self._root_package_info.repository_name
 
+    def deduce_libs_info(self):
+        def is_shared(deduced_info):
+            if deduced_info.link_location:  # import library
+                return True
+            elif deduced_info.location:
+                _, ext = os.path.splitext(deduced_info.location)
+                if ext in (".so", ".dylib", ".dll"):  # adding dll just in case
+                    return True
+            return False
+
+        full_libs_info = defaultdict(list)
+        cpp_info = self._dep.cpp_info
+        result = cpp_info.deduce_full_cpp_info(self._dep)
+        package_folder_path = self.package_folder
+        # Root
+        if len(cpp_info.libs) > 1:
+            for lib_name in cpp_info.libs:
+                virtual_component = result.components.pop(f"_{lib_name}")  # removing it!
+                full_libs_info["root"].append(
+                    _LibInfo(lib_name, is_shared(virtual_component),
+                         _relativize_path(virtual_component.location, package_folder_path),
+                         _relativize_path(virtual_component.link_location, package_folder_path))
+                )
+        elif cpp_info.libs:
+            full_libs_info["root"].append(
+                _LibInfo(cpp_info.libs[0], is_shared(result),
+                         _relativize_path(result.location, package_folder_path),
+                         _relativize_path(result.link_location, package_folder_path))
+            )
+        # components
+        for cmp_name, cmp_cpp_info in result.components.items():
+            if len(cmp_cpp_info.libs) > 1:
+                raise ConanException(f"BazelDeps only allows 1 lib per component:\n"
+                                     f"{self._dep}: {cmp_cpp_info.libs}")
+            elif cmp_cpp_info.libs:
+                # Bazel needs to relativize each path
+                full_libs_info[_get_component_name(self._dep, cmp_name)].append(
+                    _LibInfo(cmp_cpp_info.libs[0], is_shared(cmp_cpp_info),
+                             _relativize_path(cmp_cpp_info.location, package_folder_path),
+                             _relativize_path(cmp_cpp_info.link_location, package_folder_path))
+                )
+        return full_libs_info
+
     def _get_context(self):
-        def fill_info(info):
+        def fill_info(info, libs_info):
             ret = {
                 "name": info.name,  # package name and components name
                 "libs": {},
@@ -511,17 +460,8 @@ class _BazelBUILDGenerator:
                 defines = _get_defines(cpp_info)
                 os_build = self._dep.settings_build.get_safe("os")
                 linkopts = _get_linkopts(cpp_info, os_build)
-                libs = _get_libs(self._dep, cpp_info)
-                libs_info = []
                 bindirs = [_relativize_path(bindir, package_folder_path)
                            for bindir in cpp_info.bindirs]
-                for (lib, is_shared, lib_path, import_lib_path) in libs:
-                    # Bazel needs to relativize each path
-                    libs_info.append(
-                        _LibInfo(lib, is_shared,
-                                 _relativize_path(lib_path, package_folder_path),
-                                 _relativize_path(import_lib_path, package_folder_path))
-                    )
                 ret.update({
                     "libs": libs_info,
                     "bindirs": bindirs,
@@ -535,12 +475,14 @@ class _BazelBUILDGenerator:
 
         package_folder_path = self.package_folder
         context = dict()
-        context["root"] = fill_info(self._root_package_info)
+        deduced_libs_info = self.deduce_libs_info()
+        context["root"] = fill_info(self._root_package_info, deduced_libs_info.get("root", []))
         context["components"] = []
         for component in self._components_info:
-            component_context = fill_info(component)
+            component_context = fill_info(component, deduced_libs_info.get(component.name, []))
             context["components"].append(component_context)
             context["root"]["component_names"].append(component_context["name"])
+
         return context
 
     def generate(self):

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -427,6 +427,8 @@ class _BazelBUILDGenerator:
             )
         # components
         for cmp_name, cmp_cpp_info in result.components.items():
+            if cmp_name == "_common":  # FIXME: placeholder?
+                continue
             if len(cmp_cpp_info.libs) > 1:
                 raise ConanException(f"BazelDeps only allows 1 lib per component:\n"
                                      f"{self._dep}: {cmp_cpp_info.libs}")

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -12,7 +12,6 @@ from conans.model.pkg_type import PackageType
 from conans.util.files import save
 
 _BazelTargetInfo = namedtuple("DepInfo", ['repository_name', 'name', 'ref_name', 'requires', 'cpp_info'])
-_LibInfo = namedtuple("LibInfo", ['name', 'is_shared', 'lib_path', 'import_lib_path'])
 
 
 def _get_name_with_namespace(namespace, name):
@@ -249,12 +248,19 @@ class _BazelDependenciesBZLGenerator:
         save("BUILD.bazel", "# This is an empty BUILD file.")
 
 
+class _LibInfo:
+    def __init__(self, lib_name, cpp_info_, package_folder_path):
+        self.name = lib_name
+        self.is_shared = cpp_info_.type == PackageType.SHARED
+        self.lib_path = _relativize_path(cpp_info_.location, package_folder_path)
+        self.import_lib_path = _relativize_path(cpp_info_.link_location, package_folder_path)
+
+
 class _BazelBUILDGenerator:
     """
     This class creates the BUILD.bazel for each dependency where it's declared all the
     necessary information to load the libraries
     """
-
     # If both files exist, BUILD.bazel takes precedence over BUILD
     # https://bazel.build/concepts/build-files
     filename = "BUILD.bazel"
@@ -398,10 +404,6 @@ class _BazelBUILDGenerator:
         return self._root_package_info.repository_name
 
     def get_full_libs_info(self):
-
-        def is_shared(cpp_info_):
-            return cpp_info_.type == PackageType.SHARED
-
         full_libs_info = defaultdict(list)
         cpp_info = self._dep.cpp_info
         deduced_cpp_info = cpp_info.deduce_full_cpp_info(self._dep)
@@ -411,15 +413,11 @@ class _BazelBUILDGenerator:
             for lib_name in cpp_info.libs:
                 virtual_component = deduced_cpp_info.components.pop(f"_{lib_name}")  # removing it!
                 full_libs_info["root"].append(
-                    _LibInfo(lib_name, is_shared(virtual_component),
-                         _relativize_path(virtual_component.location, package_folder_path),
-                         _relativize_path(virtual_component.link_location, package_folder_path))
+                    _LibInfo(lib_name, virtual_component, package_folder_path)
                 )
         elif cpp_info.libs:
             full_libs_info["root"].append(
-                _LibInfo(cpp_info.libs[0], is_shared(deduced_cpp_info),
-                         _relativize_path(deduced_cpp_info.location, package_folder_path),
-                         _relativize_path(deduced_cpp_info.link_location, package_folder_path))
+                _LibInfo(cpp_info.libs[0], deduced_cpp_info, package_folder_path)
             )
         # components
         for cmp_name, cmp_cpp_info in deduced_cpp_info.components.items():
@@ -431,9 +429,7 @@ class _BazelBUILDGenerator:
             elif cmp_cpp_info.libs:
                 # Bazel needs to relativize each path
                 full_libs_info[_get_component_name(self._dep, cmp_name)].append(
-                    _LibInfo(cmp_cpp_info.libs[0], is_shared(cmp_cpp_info),
-                             _relativize_path(cmp_cpp_info.location, package_folder_path),
-                             _relativize_path(cmp_cpp_info.link_location, package_folder_path))
+                    _LibInfo(cmp_cpp_info.libs[0], cmp_cpp_info, package_folder_path)
                 )
         return full_libs_info
 

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -8,6 +8,7 @@ from jinja2 import Template, StrictUndefined
 from conan.errors import ConanException
 from conan.internal import check_duplicated_generator
 from conans.model.dependencies import get_transitive_requires
+from conans.model.pkg_type import PackageType
 from conans.util.files import save
 
 _BazelTargetInfo = namedtuple("DepInfo", ['repository_name', 'name', 'ref_name', 'requires', 'cpp_info'])
@@ -396,24 +397,19 @@ class _BazelBUILDGenerator:
         """
         return self._root_package_info.repository_name
 
-    def deduce_libs_info(self):
-        def is_shared(deduced_info):
-            if deduced_info.link_location:  # import library
-                return True
-            elif deduced_info.location:
-                _, ext = os.path.splitext(deduced_info.location)
-                if ext in (".so", ".dylib", ".dll"):  # adding dll just in case
-                    return True
-            return False
+    def get_full_libs_info(self):
+
+        def is_shared(cpp_info_):
+            return cpp_info_.type == PackageType.SHARED
 
         full_libs_info = defaultdict(list)
         cpp_info = self._dep.cpp_info
-        result = cpp_info.deduce_full_cpp_info(self._dep)
+        deduced_cpp_info = cpp_info.deduce_full_cpp_info(self._dep)
         package_folder_path = self.package_folder
         # Root
         if len(cpp_info.libs) > 1:
             for lib_name in cpp_info.libs:
-                virtual_component = result.components.pop(f"_{lib_name}")  # removing it!
+                virtual_component = deduced_cpp_info.components.pop(f"_{lib_name}")  # removing it!
                 full_libs_info["root"].append(
                     _LibInfo(lib_name, is_shared(virtual_component),
                          _relativize_path(virtual_component.location, package_folder_path),
@@ -421,12 +417,12 @@ class _BazelBUILDGenerator:
                 )
         elif cpp_info.libs:
             full_libs_info["root"].append(
-                _LibInfo(cpp_info.libs[0], is_shared(result),
-                         _relativize_path(result.location, package_folder_path),
-                         _relativize_path(result.link_location, package_folder_path))
+                _LibInfo(cpp_info.libs[0], is_shared(deduced_cpp_info),
+                         _relativize_path(deduced_cpp_info.location, package_folder_path),
+                         _relativize_path(deduced_cpp_info.link_location, package_folder_path))
             )
         # components
-        for cmp_name, cmp_cpp_info in result.components.items():
+        for cmp_name, cmp_cpp_info in deduced_cpp_info.components.items():
             if cmp_name == "_common":  # FIXME: placeholder?
                 continue
             if len(cmp_cpp_info.libs) > 1:
@@ -477,11 +473,11 @@ class _BazelBUILDGenerator:
 
         package_folder_path = self.package_folder
         context = dict()
-        deduced_libs_info = self.deduce_libs_info()
-        context["root"] = fill_info(self._root_package_info, deduced_libs_info.get("root", []))
+        full_libs_info = self.get_full_libs_info()
+        context["root"] = fill_info(self._root_package_info, full_libs_info.get("root", []))
         context["components"] = []
         for component in self._components_info:
-            component_context = fill_info(component, deduced_libs_info.get(component.name, []))
+            component_context = fill_info(component, full_libs_info.get(component.name, []))
             context["components"].append(component_context)
             context["root"]["component_names"].append(component_context["name"])
 

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -484,48 +484,6 @@ class _Component:
 
     def _auto_deduce_locations(self, conanfile):
 
-        def _get_real_path(file_path):
-            # File name could be a symlink, e.g., mylib.1.0.0.so -> mylib.so
-            if os.path.islink(file_path):
-                # Important! os.path.realpath returns the final path of the symlink even if it points
-                # to another symlink, i.e., libmylib.dylib -> libmylib.1.dylib -> libmylib.1.0.0.dylib
-                # then os.path.realpath("libmylib.1.0.0.dylib") == "libmylib.dylib"
-                # Note: os.readlink() returns the path which the symbolic link points to.
-                file_path = os.path.realpath(file_path)
-            return file_path.replace("\\", "/")
-
-        # def _save_lib_path(file_name, file_path):
-        #     """Add each lib with its full library path"""
-        #     name, ext, formatted_path = _get_real_path(file_name, file_path)
-        #     lib_name = None
-        #     # Users may not name their libraries in a conventional way. For example, directly
-        #     # use the basename of the lib file as lib name, e.g., cpp_info.libs = ["liblib1.a"]
-        #     # Issue related: https://github.com/conan-io/conan/issues/11331
-        #     if file_name in libs:  # let's ensure that it has any extension
-        #         lib_name = file_name
-        #     elif name in libs:
-        #         lib_name = name
-        #     elif name.startswith("lib"):
-        #         short_name = name[3:]  # libpkg -> pkg
-        #         if short_name in libs:
-        #             lib_name = short_name
-        #     # DLL check
-        #     if not lib_name and ext == "dll" or ext.endswith(".dll"):
-        #         if len(libs) == 1:  # first DLL should be the good one
-        #             lib_name = libs[0]
-        #         else:  # let's cross the fingers... This is the last chance.
-        #             for lib in libs:
-        #                 if lib in name and lib not in lib_paths:
-        #                     lib_name = lib
-        #                     break
-        #     if lib_name is not None:
-        #         # Let's save the lib
-        #         lib_paths[lib_name] = formatted_path
-        #         # Removing it from the global list to simplify the rest of the lib matches
-        #         libs.remove(lib_name)
-        #         return True
-        #     return False
-
         def _find_matching(dirs, pattern):
             lib_found = ""
             for d in dirs:

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -779,8 +779,7 @@ class CppInfo:
             common.libs = []
             common.type = str(PackageType.HEADER)  # the type of components is a string!
             common.requires = list(result.components.keys()) + (self.requires or [])
-
-            # result.components["_common"] = common
+            result.components["_common"] = common
         else:
             result._package = self._package.clone()
             result.default_components = self.default_components

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -552,11 +552,15 @@ class _Component:
         out = ConanOutput(scope=str(conanfile))
         if static_location:
             if shared_location:
-                raise ConanException(f"{conanfile}: obtained for library '{libname}' both static "
-                                     f"and shared libraries at the same time:\n"
-                                     f"- STATIC: {static_location}\n"
-                                     f"- SHARED: {shared_location}")
-            if dll_location:
+                out.warning(f"Lib {libname} has both static {static_location} and "
+                            f"shared {shared_location} in the same package")
+                if pkg_type is PackageType.STATIC:
+                    self._location = static_location
+                    self._type = PackageType.STATIC
+                else:
+                    self._location = shared_location
+                    self._type = PackageType.SHARED
+            elif dll_location:
                 self._location = dll_location
                 self._link_location = static_location
                 self._type = PackageType.SHARED

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -489,7 +489,7 @@ class _Component:
             for d in dirs:
                 if lib_found:
                     break
-                # If pattern is a exact match
+                # If pattern is an exact match
                 if isinstance(pattern, str):
                     matches = glob.glob(f"{d}/{pattern}")
                     if matches:
@@ -510,17 +510,15 @@ class _Component:
                             # Note: os.readlink() returns the path which the symbolic link points to.
                             real_path = os.path.realpath(full_path)
                             if pattern.match(os.path.basename(real_path)):
-                                lib_found = real_path.replace("\\", "/")
+                                lib_found = real_path
                         else:
-                            lib_found = full_path.replace("\\", "/")
+                            lib_found = full_path
                         break
-            return lib_found
+            return lib_found.replace("\\", "/")
 
         pkg_type = conanfile.package_type
-        # Recipe didn't specify things, need to auto deduce
         libdirs = self.libdirs
         bindirs = self.bindirs
-
         libname = self.libs[0]
         static_location = None
         shared_location = None
@@ -771,6 +769,7 @@ class CppInfo:
                 c.type = self.type  # This should be a string
                 c.includedirs = self.includedirs
                 c.libdirs = self.libdirs
+                c.bindirs = self.bindirs
                 c.libs = [lib]
                 result.components[f"_{lib}"] = c
 

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -533,7 +533,9 @@ class _Component:
                     break
                 # If pattern is a exact match
                 if isinstance(pattern, str):
-                    matches.update(glob.glob(f"{d}/{pattern}"))
+                    matches = glob.glob(f"{d}/{pattern}")
+                    if matches:
+                        lib_found = matches[0]
                     continue
                 # Otherwise, it's a regex
                 files = os.listdir(d)
@@ -578,18 +580,14 @@ class _Component:
             regex_static = re.compile(rf"(?:lib)?{libname}(?:[._-].+)?\.(?:a|lib)")
             regex_shared = re.compile(rf"(?:lib)?{libname}(?:[._-].+)?\.(?:so|dylib)")
             regex_dll = re.compile(rf"(?:.+)?{libname}(?:[._-].+)?\.dll")
-            # global libname search
-            # static_patterns = [f"{libname}.lib", f"{libname}.a",  # exact match
-            #                    f"lib{libname}.lib", f"lib{libname}.a"]  # exact match
-            # shared_patterns = [f"{libname}.so", f"{libname}.dylib",  # exact match
-            #                    f"lib{libname}.so", f"lib{libname}.dylib"]  # exact match
-            # # This could not follow any pattern, e.g., zdll.lib and zlib1.dll
-            # dll_patterns = [f"*{libname}*.dll" "*.dll"]
+            regex_any_dll = re.compile(rf".+(?:[._-].+)?\.dll")
             static_location = _find_matching(libdirs, regex_static)
             if not static_location:
                 shared_location = _find_matching(libdirs, regex_shared)
             if static_location and static_location.endswith(".lib"):
                 dll_location = _find_matching(bindirs, regex_dll)
+                if not dll_location:  # any existing DLL is going to be found
+                    dll_location = _find_matching(bindirs, regex_any_dll)
 
         out = ConanOutput(scope=str(conanfile))
         if static_location:

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -482,17 +482,17 @@ class _Component:
     def parsed_requires(self):
         return [r.split("::", 1) if "::" in r else (None, r) for r in self.requires]
 
-    def _auto_deduce_locations(self, conanfile, first_match=True):
+    def _auto_deduce_locations(self, conanfile, component_name):
 
-        def _lib_match_by_glob(dir_, filename, first_match=True):
+        def _lib_match_by_glob(dir_, filename):
             # Run a glob.glob function to find the file given by the filename
             matches = glob.glob(f"{dir_}/{filename}")
             if matches:
-                return matches[0] if first_match else matches
+                return matches
 
 
-        def _lib_match_by_regex(dir_, pattern, first_match=True):
-            ret = []
+        def _lib_match_by_regex(dir_, pattern):
+            ret = set()
             # pattern is a regex compiled pattern, so let's iterate each file to find the library
             files = os.listdir(dir_)
             for file_name in files:
@@ -506,29 +506,27 @@ class _Component:
                         # Note: os.readlink() returns the path which the symbolic link points to.
                         real_path = os.path.realpath(full_path)
                         if pattern.match(os.path.basename(real_path)):
-                            ret.append(real_path)
+                            ret.add(real_path)
                     else:
-                        ret.append(full_path)
-                    if first_match:
-                        return ret[0]
-            return ret
+                        ret.add(full_path)
+            return list(ret)
 
 
-        def _find_matching(dirs, pattern, first_match=True):
+        def _find_matching(dirs, pattern):
             for d in dirs:
                 if not os.path.exists(d):
                     continue
                 # If pattern is an exact match
                 if isinstance(pattern, str):
                     # pattern == filename
-                    lib_found = _lib_match_by_glob(d, pattern, first_match=first_match)
+                    lib_found = _lib_match_by_glob(d, pattern)
                 else:
-                    lib_found = _lib_match_by_regex(d, pattern, first_match=first_match)
+                    lib_found = _lib_match_by_regex(d, pattern)
                 if lib_found:
-                    if first_match:
-                        return lib_found.replace("\\", "/")
-                    else:
-                        return [m.replace("\\", "/") for m in lib_found]
+                    if len(lib_found) > 1:
+                        raise ConanException(f"There were several matches for Lib {libname}: "
+                                             f"{lib_found}")
+                    return lib_found[0].replace("\\", "/")
 
 
         pkg_type = conanfile.package_type
@@ -550,19 +548,11 @@ class _Component:
         else:
             regex_static = re.compile(rf"(?:lib)?{libname}(?:[._-].+)?\.(?:a|lib)")
             regex_shared = re.compile(rf"(?:lib)?{libname}(?:[._-].+)?\.(?:so|dylib)")
-            regex_dll = re.compile(rf"(?:.+)?{libname}(?:[._-].+)?\.dll")
-            regex_any_dll = re.compile(rf".+(?:[._-].+)?\.dll")
+            regex_dll = re.compile(rf"(?:.+)?({libname}|{component_name})(?:.+)?\.dll")
             static_location = _find_matching(libdirs, regex_static)
             shared_location = _find_matching(libdirs, regex_shared)
             if static_location or not shared_location:
                 dll_location = _find_matching(bindirs, regex_dll)
-                if not dll_location:  # any existing DLL is going to be found
-                    dll_location = _find_matching(bindirs, regex_any_dll, first_match=False)
-                    if dll_location:
-                        if len(dll_location) > 1:
-                            raise ConanException(f"There were found more than 1 DLL for Lib {libname}: "
-                                                 f"{dll_location}")
-                        dll_location = dll_location[0]
 
         out = ConanOutput(scope=str(conanfile))
         if static_location:
@@ -597,7 +587,7 @@ class _Component:
         if self._type != pkg_type:
             out.warning(f"Lib {libname} deduced as '{self._type}, but 'package_type={pkg_type}'")
 
-    def deduce_locations(self, conanfile):
+    def deduce_locations(self, conanfile, component_name=""):
         if self._exe:   # exe is a new field, it should have the correct location
             return
         if self._location or self._link_location:
@@ -614,7 +604,7 @@ class _Component:
                 f"More than 1 library defined in cpp_info.libs, cannot deduce CPS ({num_libs} libraries found)")
         else:
             # If no location is defined, it's time to guess the location
-            self._auto_deduce_locations(conanfile)
+            self._auto_deduce_locations(conanfile, component_name=component_name)
 
 
 class CppInfo:
@@ -811,8 +801,8 @@ class CppInfo:
             result.default_components = self.default_components
             result.components = {k: v.clone() for k, v in self.components.items()}
 
-        result._package.deduce_locations(conanfile)
-        for comp in result.components.values():
-            comp.deduce_locations(conanfile)
+        result._package.deduce_locations(conanfile, component_name=conanfile.ref.name)
+        for comp_name, comp in result.components.items():
+            comp.deduce_locations(conanfile, component_name=comp_name)
 
         return result

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -524,11 +524,11 @@ class _Component:
                     lib_found = _lib_match_by_regex(d, pattern)
                 if lib_found:
                     if len(lib_found) > 1:
-                        raise ConanException(f"There were several matches for Lib {libname}: "
-                                             f"{lib_found}")
+                        lib_found.sort()
+                        out.warning(f"There were several matches for Lib {libname}: {lib_found}")
                     return lib_found[0].replace("\\", "/")
 
-
+        out = ConanOutput(scope=str(conanfile))
         pkg_type = conanfile.package_type
         libdirs = self.libdirs
         bindirs = self.bindirs
@@ -554,7 +554,6 @@ class _Component:
             if static_location or not shared_location:
                 dll_location = _find_matching(bindirs, regex_dll)
 
-        out = ConanOutput(scope=str(conanfile))
         if static_location:
             if shared_location:
                 out.warning(f"Lib {libname} has both static {static_location} and "

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -2,6 +2,7 @@ import copy
 import glob
 import json
 import os
+import re
 from collections import OrderedDict, defaultdict
 
 from conan.api.output import ConanOutput
@@ -481,57 +482,118 @@ class _Component:
     def parsed_requires(self):
         return [r.split("::", 1) if "::" in r else (None, r) for r in self.requires]
 
-    def deduce_locations(self, conanfile):
-        pkg_type = conanfile.package_type
-        if self._exe:   # exe is a new field, it should have the correct location
-            return
-        if self._location or self._link_location:
-            if self._type is None or self._type is PackageType.HEADER:
-                raise ConanException("Incorrect cpp_info defining location without type or header")
-            return
-        if self._type not in [None, PackageType.SHARED, PackageType.STATIC, PackageType.APP]:
-            return
+    def _auto_deduce_locations(self, conanfile):
 
-        if len(self.libs) == 0:
-            return
+        def _get_real_path(file_path):
+            # File name could be a symlink, e.g., mylib.1.0.0.so -> mylib.so
+            if os.path.islink(file_path):
+                # Important! os.path.realpath returns the final path of the symlink even if it points
+                # to another symlink, i.e., libmylib.dylib -> libmylib.1.dylib -> libmylib.1.0.0.dylib
+                # then os.path.realpath("libmylib.1.0.0.dylib") == "libmylib.dylib"
+                # Note: os.readlink() returns the path which the symbolic link points to.
+                file_path = os.path.realpath(file_path)
+            return file_path.replace("\\", "/")
 
-        if len(self.libs) != 1:
-            raise ConanException("More than 1 library defined in cpp_info.libs, cannot deduce CPS")
+        # def _save_lib_path(file_name, file_path):
+        #     """Add each lib with its full library path"""
+        #     name, ext, formatted_path = _get_real_path(file_name, file_path)
+        #     lib_name = None
+        #     # Users may not name their libraries in a conventional way. For example, directly
+        #     # use the basename of the lib file as lib name, e.g., cpp_info.libs = ["liblib1.a"]
+        #     # Issue related: https://github.com/conan-io/conan/issues/11331
+        #     if file_name in libs:  # let's ensure that it has any extension
+        #         lib_name = file_name
+        #     elif name in libs:
+        #         lib_name = name
+        #     elif name.startswith("lib"):
+        #         short_name = name[3:]  # libpkg -> pkg
+        #         if short_name in libs:
+        #             lib_name = short_name
+        #     # DLL check
+        #     if not lib_name and ext == "dll" or ext.endswith(".dll"):
+        #         if len(libs) == 1:  # first DLL should be the good one
+        #             lib_name = libs[0]
+        #         else:  # let's cross the fingers... This is the last chance.
+        #             for lib in libs:
+        #                 if lib in name and lib not in lib_paths:
+        #                     lib_name = lib
+        #                     break
+        #     if lib_name is not None:
+        #         # Let's save the lib
+        #         lib_paths[lib_name] = formatted_path
+        #         # Removing it from the global list to simplify the rest of the lib matches
+        #         libs.remove(lib_name)
+        #         return True
+        #     return False
 
-        # Recipe didn't specify things, need to auto deduce
-        libdirs = [x.replace("\\", "/") for x in self.libdirs]
-        bindirs = [x.replace("\\", "/") for x in self.bindirs]
-
-        # TODO: Do a better handling of pre-defined type
-        libname = self.libs[0]
-        static_patterns = [f"{libname}.lib", f"{libname}.a", f"lib{libname}.a"]
-        shared_patterns = [f"lib{libname}.so", f"lib{libname}.so.*", f"lib{libname}.dylib",
-                           f"lib{libname}.*dylib"]
-        dll_patterns = [f"{libname}.dll"]
-
-        def _find_matching(patterns, dirs):
-            matches = set()
-            for pattern in patterns:
-                for d in dirs:
+        def _find_matching(dirs, pattern):
+            lib_found = ""
+            for d in dirs:
+                if lib_found:
+                    break
+                # If pattern is a exact match
+                if isinstance(pattern, str):
                     matches.update(glob.glob(f"{d}/{pattern}"))
-            if len(matches) == 1:
-                return next(iter(matches))
+                    continue
+                # Otherwise, it's a regex
+                files = os.listdir(d)
+                for file_name in files:
+                    full_path = os.path.join(d, file_name)
+                    if not os.path.isfile(full_path):  # Make sure that directories are excluded
+                        continue
+                    elif pattern.match(file_name):
+                        # File name could be a symlink, e.g., mylib.1.0.0.so -> mylib.so
+                        if os.path.islink(full_path):
+                            # Important! os.path.realpath returns the final path of the symlink even if it points
+                            # to another symlink, i.e., libmylib.dylib -> libmylib.1.dylib -> libmylib.1.0.0.dylib
+                            # then os.path.realpath("libmylib.1.0.0.dylib") == "libmylib.dylib"
+                            # Note: os.readlink() returns the path which the symbolic link points to.
+                            real_path = os.path.realpath(full_path)
+                            if pattern.match(os.path.basename(real_path)):
+                                lib_found = real_path.replace("\\", "/")
+                        else:
+                            lib_found = full_path.replace("\\", "/")
+                        break
+            return lib_found
 
-        static_location = _find_matching(static_patterns, libdirs)
-        shared_location = _find_matching(shared_patterns, libdirs)
-        dll_location = _find_matching(dll_patterns, bindirs)
+        pkg_type = conanfile.package_type
+        # Recipe didn't specify things, need to auto deduce
+        libdirs = self.libdirs
+        bindirs = self.bindirs
+
+        libname = self.libs[0]
+        static_location = None
+        shared_location = None
+        dll_location = None
+        # libname is exactly the pattern, e.g., ["mylib.a"] instead of ["mylib"]
+        _, ext = os.path.splitext(libname)
+        if ext in (".lib", ".a", ".dll", ".so", ".dylib"):
+            if ext in (".lib", ".a"):
+                static_location = _find_matching(libdirs, libname)
+            elif ext in (".so", ".dylib"):
+                shared_location = _find_matching(libdirs, libname)
+            elif ext == ".dll":
+                dll_location = _find_matching(bindirs, libname)
+        else:
+            regex_static = re.compile(rf"(?:lib)?{libname}(?:[._-].+)?\.(?:a|lib)")
+            regex_shared = re.compile(rf"(?:lib)?{libname}(?:[._-].+)?\.(?:so|dylib)")
+            regex_dll = re.compile(rf"(?:.+)?{libname}(?:[._-].+)?\.dll")
+            # global libname search
+            # static_patterns = [f"{libname}.lib", f"{libname}.a",  # exact match
+            #                    f"lib{libname}.lib", f"lib{libname}.a"]  # exact match
+            # shared_patterns = [f"{libname}.so", f"{libname}.dylib",  # exact match
+            #                    f"lib{libname}.so", f"lib{libname}.dylib"]  # exact match
+            # # This could not follow any pattern, e.g., zdll.lib and zlib1.dll
+            # dll_patterns = [f"*{libname}*.dll" "*.dll"]
+            static_location = _find_matching(libdirs, regex_static)
+            if not static_location:
+                shared_location = _find_matching(libdirs, regex_shared)
+            if static_location and static_location.endswith(".lib"):
+                dll_location = _find_matching(bindirs, regex_dll)
+
         out = ConanOutput(scope=str(conanfile))
         if static_location:
-            if shared_location:
-                out.warning(f"Lib {libname} has both static {static_location} and "
-                            f"shared {shared_location} in the same package")
-                if pkg_type is PackageType.STATIC:
-                    self._location = static_location
-                    self._type = PackageType.STATIC
-                else:
-                    self._location = shared_location
-                    self._type = PackageType.SHARED
-            elif dll_location:
+            if dll_location:
                 self._location = dll_location
                 self._link_location = static_location
                 self._type = PackageType.SHARED
@@ -552,6 +614,25 @@ class _Component:
                                  f"should have been deduced correctly.")
         if self._type != pkg_type:
             out.warning(f"Lib {libname} deduced as '{self._type}, but 'package_type={pkg_type}'")
+
+    def deduce_locations(self, conanfile):
+        if self._exe:   # exe is a new field, it should have the correct location
+            return
+        if self._location or self._link_location:
+            if self._type is None or self._type is PackageType.HEADER:
+                raise ConanException("Incorrect cpp_info defining location without type or header")
+            return
+        if self._type not in [None, PackageType.SHARED, PackageType.STATIC, PackageType.APP]:
+            return
+
+        if len(self.libs) == 0:
+            return
+
+        if len(self.libs) != 1:
+            raise ConanException("More than 1 library defined in cpp_info.libs, cannot deduce CPS")
+
+        # If no location is defined, it's time to guess the location
+        self._auto_deduce_locations(conanfile)
 
 
 class CppInfo:

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -484,39 +484,41 @@ class _Component:
 
     def _auto_deduce_locations(self, conanfile):
 
+        def _lib_match_by_glob(dir_, pattern):
+            # Run a glob.glob function to find the file given by the pattern
+            matches = glob.glob(f"{dir_}/{pattern}")
+            if matches:
+                return matches[0]
+
+        def _lib_match_by_regex(dir_, pattern):
+            # pattern is a regex compiled pattern, so let's iterate each file to find the library
+            files = os.listdir(dir_)
+            for file_name in files:
+                full_path = os.path.join(dir_, file_name)
+                if os.path.isfile(full_path) and pattern.match(file_name):
+                    # File name could be a symlink, e.g., mylib.1.0.0.so -> mylib.so
+                    if os.path.islink(full_path):
+                        # Important! os.path.realpath returns the final path of the symlink even if it points
+                        # to another symlink, i.e., libmylib.dylib -> libmylib.1.dylib -> libmylib.1.0.0.dylib
+                        # then os.path.realpath("libmylib.1.0.0.dylib") == "libmylib.dylib"
+                        # Note: os.readlink() returns the path which the symbolic link points to.
+                        real_path = os.path.realpath(full_path)
+                        if pattern.match(os.path.basename(real_path)):
+                            return real_path
+                    else:
+                        return full_path
+
         def _find_matching(dirs, pattern):
-            lib_found = ""
             for d in dirs:
-                if lib_found:
-                    break
                 if not os.path.exists(d):
                     continue
                 # If pattern is an exact match
                 if isinstance(pattern, str):
-                    matches = glob.glob(f"{d}/{pattern}")
-                    if matches:
-                        lib_found = matches[0]
-                    continue
-                # Otherwise, it's a regex
-                files = os.listdir(d)
-                for file_name in files:
-                    full_path = os.path.join(d, file_name)
-                    if not os.path.isfile(full_path):  # Make sure that directories are excluded
-                        continue
-                    elif pattern.match(file_name):
-                        # File name could be a symlink, e.g., mylib.1.0.0.so -> mylib.so
-                        if os.path.islink(full_path):
-                            # Important! os.path.realpath returns the final path of the symlink even if it points
-                            # to another symlink, i.e., libmylib.dylib -> libmylib.1.dylib -> libmylib.1.0.0.dylib
-                            # then os.path.realpath("libmylib.1.0.0.dylib") == "libmylib.dylib"
-                            # Note: os.readlink() returns the path which the symbolic link points to.
-                            real_path = os.path.realpath(full_path)
-                            if pattern.match(os.path.basename(real_path)):
-                                lib_found = real_path
-                        else:
-                            lib_found = full_path
-                        break
-            return lib_found.replace("\\", "/")
+                    lib_found = _lib_match_by_glob(d, pattern)
+                else:
+                    lib_found = _lib_match_by_regex(d, pattern)
+                if lib_found is not None:
+                    return lib_found.replace("\\", "/")
 
         pkg_type = conanfile.package_type
         libdirs = self.libdirs
@@ -580,15 +582,15 @@ class _Component:
             return
         if self._type not in [None, PackageType.SHARED, PackageType.STATIC, PackageType.APP]:
             return
-
-        if len(self.libs) == 0:
+        num_libs = len(self.libs)
+        if num_libs == 0:
             return
-
-        if len(self.libs) != 1:
-            raise ConanException("More than 1 library defined in cpp_info.libs, cannot deduce CPS")
-
-        # If no location is defined, it's time to guess the location
-        self._auto_deduce_locations(conanfile)
+        elif num_libs > 1:
+            raise ConanException(
+                f"More than 1 library defined in cpp_info.libs, cannot deduce CPS ({num_libs} libraries found)")
+        else:
+            # If no location is defined, it's time to guess the location
+            self._auto_deduce_locations(conanfile)
 
 
 class CppInfo:

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -484,9 +484,9 @@ class _Component:
 
     def _auto_deduce_locations(self, conanfile):
 
-        def _lib_match_by_glob(dir_, pattern):
-            # Run a glob.glob function to find the file given by the pattern
-            matches = glob.glob(f"{dir_}/{pattern}")
+        def _lib_match_by_glob(dir_, filename):
+            # Run a glob.glob function to find the file given by the filename
+            matches = glob.glob(f"{dir_}/{filename}")
             if matches:
                 return matches[0]
 
@@ -514,6 +514,7 @@ class _Component:
                     continue
                 # If pattern is an exact match
                 if isinstance(pattern, str):
+                    # pattern == filename
                     lib_found = _lib_match_by_glob(d, pattern)
                 else:
                     lib_found = _lib_match_by_regex(d, pattern)
@@ -542,8 +543,7 @@ class _Component:
             regex_dll = re.compile(rf"(?:.+)?{libname}(?:[._-].+)?\.dll")
             regex_any_dll = re.compile(rf".+(?:[._-].+)?\.dll")
             static_location = _find_matching(libdirs, regex_static)
-            if not static_location:
-                shared_location = _find_matching(libdirs, regex_shared)
+            shared_location = _find_matching(libdirs, regex_shared)
             if static_location and static_location.endswith(".lib"):
                 dll_location = _find_matching(bindirs, regex_dll)
                 if not dll_location:  # any existing DLL is going to be found
@@ -551,6 +551,11 @@ class _Component:
 
         out = ConanOutput(scope=str(conanfile))
         if static_location:
+            if shared_location:
+                raise ConanException(f"{conanfile}: obtained for library '{libname}' both static "
+                                     f"and shared libraries at the same time:\n"
+                                     f"- STATIC: {static_location}\n"
+                                     f"- SHARED: {shared_location}")
             if dll_location:
                 self._location = dll_location
                 self._link_location = static_location

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -489,6 +489,8 @@ class _Component:
             for d in dirs:
                 if lib_found:
                     break
+                if not os.path.exists(d):
+                    continue
                 # If pattern is an exact match
                 if isinstance(pattern, str):
                     matches = glob.glob(f"{d}/{pattern}")
@@ -778,7 +780,7 @@ class CppInfo:
             common.type = str(PackageType.HEADER)  # the type of components is a string!
             common.requires = list(result.components.keys()) + (self.requires or [])
 
-            result.components["_common"] = common
+            # result.components["_common"] = common
         else:
             result._package = self._package.clone()
             result.default_components = self.default_components

--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -482,15 +482,17 @@ class _Component:
     def parsed_requires(self):
         return [r.split("::", 1) if "::" in r else (None, r) for r in self.requires]
 
-    def _auto_deduce_locations(self, conanfile):
+    def _auto_deduce_locations(self, conanfile, first_match=True):
 
-        def _lib_match_by_glob(dir_, filename):
+        def _lib_match_by_glob(dir_, filename, first_match=True):
             # Run a glob.glob function to find the file given by the filename
             matches = glob.glob(f"{dir_}/{filename}")
             if matches:
-                return matches[0]
+                return matches[0] if first_match else matches
 
-        def _lib_match_by_regex(dir_, pattern):
+
+        def _lib_match_by_regex(dir_, pattern, first_match=True):
+            ret = []
             # pattern is a regex compiled pattern, so let's iterate each file to find the library
             files = os.listdir(dir_)
             for file_name in files:
@@ -504,22 +506,30 @@ class _Component:
                         # Note: os.readlink() returns the path which the symbolic link points to.
                         real_path = os.path.realpath(full_path)
                         if pattern.match(os.path.basename(real_path)):
-                            return real_path
+                            ret.append(real_path)
                     else:
-                        return full_path
+                        ret.append(full_path)
+                    if first_match:
+                        return ret[0]
+            return ret
 
-        def _find_matching(dirs, pattern):
+
+        def _find_matching(dirs, pattern, first_match=True):
             for d in dirs:
                 if not os.path.exists(d):
                     continue
                 # If pattern is an exact match
                 if isinstance(pattern, str):
                     # pattern == filename
-                    lib_found = _lib_match_by_glob(d, pattern)
+                    lib_found = _lib_match_by_glob(d, pattern, first_match=first_match)
                 else:
-                    lib_found = _lib_match_by_regex(d, pattern)
-                if lib_found is not None:
-                    return lib_found.replace("\\", "/")
+                    lib_found = _lib_match_by_regex(d, pattern, first_match=first_match)
+                if lib_found:
+                    if first_match:
+                        return lib_found.replace("\\", "/")
+                    else:
+                        return [m.replace("\\", "/") for m in lib_found]
+
 
         pkg_type = conanfile.package_type
         libdirs = self.libdirs
@@ -544,10 +554,15 @@ class _Component:
             regex_any_dll = re.compile(rf".+(?:[._-].+)?\.dll")
             static_location = _find_matching(libdirs, regex_static)
             shared_location = _find_matching(libdirs, regex_shared)
-            if static_location and static_location.endswith(".lib"):
+            if static_location or not shared_location:
                 dll_location = _find_matching(bindirs, regex_dll)
                 if not dll_location:  # any existing DLL is going to be found
-                    dll_location = _find_matching(bindirs, regex_any_dll)
+                    dll_location = _find_matching(bindirs, regex_any_dll, first_match=False)
+                    if dll_location:
+                        if len(dll_location) > 1:
+                            raise ConanException(f"There were found more than 1 DLL for Lib {libname}: "
+                                                 f"{dll_location}")
+                        dll_location = dll_location[0]
 
         out = ConanOutput(scope=str(conanfile))
         if static_location:

--- a/test/integration/toolchains/google/test_bazeldeps.py
+++ b/test/integration/toolchains/google/test_bazeldeps.py
@@ -1137,7 +1137,7 @@ def test_shared_windows_find_libraries():
 
     cc_import(
         name = "libssl_precompiled",
-        shared_library = "bin/libcrypto-3-x64.dll",
+        shared_library = "bin/libssl-3-x64.dll",
         interface_library = "lib/libssl.lib",
     )
     """)

--- a/test/integration/toolchains/google/test_bazeldeps.py
+++ b/test/integration/toolchains/google/test_bazeldeps.py
@@ -679,8 +679,14 @@ def test_tool_requires():
     client = TestClient()
     conanfile = textwrap.dedent("""
         from conan import ConanFile
+        from conan.tools.files import save
 
         class PkgBazelConan(ConanFile):
+
+            def package(self):
+                import os
+                libdirs = os.path.join(self.package_folder, "lib")
+                save(self, os.path.join(libdirs, "libtool.lib"), "")
 
             def package_info(self):
                 self.cpp_info.libs = ["libtool"]
@@ -690,8 +696,15 @@ def test_tool_requires():
 
     conanfile = textwrap.dedent("""
         from conan import ConanFile
+        from conan.tools.files import save
 
         class PkgBazelConan(ConanFile):
+
+            def package(self):
+                import os
+                libdirs = os.path.join(self.package_folder, "lib")
+                save(self, os.path.join(libdirs, "other_cmp1.lib"), "")
+                save(self, os.path.join(libdirs, "other_cmp2.lib"), "")
 
             def package_info(self):
                 self.cpp_info.set_property("bazel_target_name", "libother")
@@ -726,6 +739,20 @@ def test_tool_requires():
     client.run("install . -pr:h default -pr:b default")
     assert 'name = "tool"' in client.load("build-tool/BUILD.bazel")
     assert textwrap.dedent("""\
+    # Components precompiled libs
+    cc_import(
+        name = "other_cmp1_precompiled",
+        static_library = "lib/other_cmp1.lib",
+    )
+
+    cc_import(
+        name = "other_cmp2_precompiled",
+        static_library = "lib/other_cmp2.lib",
+    )
+
+
+    # Root package precompiled libs
+
     # Components libraries declaration
     cc_library(
         name = "component1",
@@ -736,6 +763,10 @@ def test_tool_requires():
             "include",
         ],
         visibility = ["//visibility:public"],
+        deps = [
+            # do not sort
+            ":other_cmp1_precompiled",
+        ],
     )
 
     cc_library(
@@ -747,6 +778,10 @@ def test_tool_requires():
             "include",
         ],
         visibility = ["//visibility:public"],
+        deps = [
+            # do not sort
+            ":other_cmp2_precompiled",
+        ],
     )
 
     cc_library(
@@ -800,9 +835,14 @@ def test_tool_requires_not_created_if_no_activated():
     client = TestClient()
     conanfile = textwrap.dedent("""
         from conan import ConanFile
+        from conan.tools.files import save
 
         class PkgBazelConan(ConanFile):
 
+            def package(self):
+                import os
+                libdirs = os.path.join(self.package_folder, "lib")
+                save(self, os.path.join(libdirs, "libtool.lib"), "")
             def package_info(self):
                 self.cpp_info.libs = ["libtool"]
         """)
@@ -833,9 +873,14 @@ def test_tool_requires_raise_exception_if_exist_both_require_and_build_one():
     client = TestClient()
     conanfile = textwrap.dedent("""
         from conan import ConanFile
+        from conan.tools.files import save
 
         class PkgBazelConan(ConanFile):
 
+            def package(self):
+                import os
+                libdirs = os.path.join(self.package_folder, "lib")
+                save(self, os.path.join(libdirs, "libtool.lib"), "")
             def package_info(self):
                 self.cpp_info.libs = ["libtool"]
         """)

--- a/test/unittests/model/build_info/test_deduce_locations.py
+++ b/test/unittests/model/build_info/test_deduce_locations.py
@@ -195,3 +195,20 @@ def test_error_if_shared_and_static_found(static):
     ext = "a" if static else "so"
     assert result.location == f"{folder}/libdir/libmylib.{ext}"
     assert result.type == (PackageType.STATIC if static else PackageType.SHARED)
+
+
+def test_error_windows_if_more_than_one_dll():
+    folder = temp_folder()
+    save(os.path.join(folder, "libdir", "mylib.a"), "")
+    save(os.path.join(folder, "bindir", "libx.dll"), "")
+    save(os.path.join(folder, "bindir", "liby.dll"), "")
+
+    cppinfo = CppInfo()
+    cppinfo.libdirs = ["libdir"]
+    cppinfo.bindirs = ["bindir"]
+    cppinfo.libs = ["mylib"]
+    cppinfo.set_relative_base_folder(folder)
+
+    with pytest.raises(ConanException) as e:
+        cppinfo.deduce_full_cpp_info(ConanFileMock())
+    assert "There were found more than 1 DLL for Lib mylib:" in str(e.value)

--- a/test/unittests/model/build_info/test_deduce_locations.py
+++ b/test/unittests/model/build_info/test_deduce_locations.py
@@ -19,7 +19,7 @@ from conans.util.files import save
     ("mylibwin2.if.lib", ["mylibwin2.if.lib"]),
     ("mylibwin2.if.lib", ["mylibwin2"])
 ])
-def test_simple_deduce_locations(lib_name, libs):
+def test_simple_deduce_locations_static(lib_name, libs):
     folder = temp_folder()
     location = os.path.join(folder, "libdir", lib_name)
     save(location, "")
@@ -54,6 +54,33 @@ def test_deduce_shared_link_locations():
     assert result.type == "shared-library"
 
 
+@pytest.mark.parametrize("lib_name, libs", [
+    ("liblog4cxx.so.15.2.0", ["log4cxx"]),
+    ("libapr-1.0.dylib", ["apr-1"]),
+    ("libapr-1.so.0.7.4", ["apr-1"])
+])
+def test_complex_deduce_locations_shared(lib_name, libs):
+    """
+    Tests real examples of shared library names in Linux/MacOS,
+    e.g., log4cxx, apr-1, etc.
+
+    Related issue: https://github.com/conan-io/conan/issues/16990
+    """
+    folder = temp_folder()
+    location = os.path.join(folder, "libdir", lib_name)
+    save(location, "")
+
+    cppinfo = CppInfo()
+    cppinfo.libdirs = ["libdir"]
+    cppinfo.libs = libs
+    cppinfo.set_relative_base_folder(folder)
+
+    result = cppinfo.deduce_full_cpp_info(ConanFileMock())
+    assert result.location == location.replace("\\", "/")
+    assert result.link_location is None
+    assert result.type == "shared-library"
+
+
 @pytest.mark.parametrize("lib_name, dll_name, libs", [
     ("libcurl_imp.lib", "libcurl.dll", ["libcurl_imp"]),
     ("libcrypto.lib", "libcrypto-3-x64.dll", ["libcrypto"]),
@@ -61,6 +88,10 @@ def test_deduce_shared_link_locations():
     ("zdll.lib", "zlib1.dll", ["zdll"])
 ])
 def test_windows_shared_link_locations(lib_name, dll_name, libs):
+    """
+    Tests real examples of shared library names in Windows,
+    e.g., openssl, zlib, libcurlb, etc.
+    """
     folder = temp_folder()
     imp_location = os.path.join(folder, "libdir", lib_name)
     save(imp_location, "")
@@ -80,17 +111,27 @@ def test_windows_shared_link_locations(lib_name, dll_name, libs):
 
 
 @pytest.mark.parametrize("lib_info", [
-    {"charset": ("charset.lib", "charset-1.dll"),
-     "iconv": ("iconv.lib", "iconv-2.dll")}
+    {"charset": ["charset.lib", "charset-1.dll"],
+     "iconv": ["iconv.lib", "iconv-2.dll"]},
+    {"charset": ["libcharset.so.1.0.0"],
+     "iconv": ["libiconv.so.2.6.1"]},
 ])
 def test_windows_several_shared_link_locations(lib_info):
+    """
+    Tests a real model as LIBICONV with several libs defined in the root component
+    """
     folder = temp_folder()
     locations = {}
+    is_windows = False
     for lib_name, lib_files in lib_info.items():
         imp_location = os.path.join(folder, "libdir", lib_files[0])
         save(imp_location, "")
-        location = os.path.join(folder, "bindir", lib_files[1])
-        save(location, "")
+        if len(lib_files) > 1:
+            is_windows = True
+            location = os.path.join(folder, "bindir", lib_files[1])
+            save(location, "")
+        else:
+            location = imp_location  # Linux
         locations[lib_name] = (location, imp_location)
 
     cppinfo = CppInfo()
@@ -102,12 +143,17 @@ def test_windows_several_shared_link_locations(lib_info):
     result = cppinfo.deduce_full_cpp_info(ConanFileMock())
     for lib_name in lib_info:
         assert result.components[f"_{lib_name}"].location == locations[lib_name][0].replace("\\", "/")
-        assert result.components[f"_{lib_name}"].link_location == locations[lib_name][1].replace("\\", "/")
+        if is_windows:
+            assert result.components[f"_{lib_name}"].link_location == locations[lib_name][1].replace("\\", "/")
         assert result.components[f"_{lib_name}"].type == "shared-library"
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="Can't apply symlink on Windows")
 def test_shared_link_locations_symlinks():
+    """
+    Tests auto deduce location is able to find the real path of
+    any symlink created in the libs folder
+    """
     folder = temp_folder()
     # forcing a folder that it's not going to be analysed by the deduce_location() function
     real_location = os.path.join(folder, "other", "mylib.so")

--- a/test/unittests/model/build_info/test_deduce_locations.py
+++ b/test/unittests/model/build_info/test_deduce_locations.py
@@ -1,82 +1,12 @@
 import os
-from unittest.mock import MagicMock
 
 import pytest
 
 from conan.test.utils.mocks import ConanFileMock
 from conan.test.utils.test_files import temp_folder
 from conan.tools.files import save
-from conan.tools.google.bazeldeps import _get_libs
 from conans.model.build_info import CppInfo
 from conans.util.files import save
-
-
-# @pytest.fixture(scope="module")
-# def cpp_info():
-#     folder = temp_folder(path_with_spaces=False)
-#     bindirs = os.path.join(folder, "bin")
-#     libdirs = os.path.join(folder, "lib")
-#     save(ConanFileMock(), os.path.join(bindirs, "mylibwin.dll"), "")
-#     save(ConanFileMock(), os.path.join(bindirs, "mylibwin2.dll"), "")
-#     save(ConanFileMock(), os.path.join(bindirs, "myliblin.so"), "")
-#     save(ConanFileMock(), os.path.join(bindirs, "mylibmac.dylib"), "")
-#     save(ConanFileMock(), os.path.join(bindirs, "protoc"), "")  # binary
-#     save(ConanFileMock(), os.path.join(libdirs, "myliblin.a"), "")
-#     save(ConanFileMock(), os.path.join(libdirs, "mylibmac.a"), "")
-#     save(ConanFileMock(), os.path.join(libdirs, "mylibwin.lib"), "")
-#     save(ConanFileMock(), os.path.join(libdirs, "mylibwin2.if.lib"), "")
-#     save(ConanFileMock(), os.path.join(libdirs, "libmylib.so"), "")
-#     save(ConanFileMock(), os.path.join(libdirs, "subfolder", "libmylib.a"), "")  # recursive
-#     cpp_info_mock = MagicMock(_base_folder=None, libdirs=[], bindirs=[], libs=[],
-#                               aggregated_components=MagicMock())
-#     cpp_info_mock._base_folder = folder.replace("\\", "/")
-#     cpp_info_mock.libdirs = [libdirs]
-#     cpp_info_mock.bindirs = [bindirs]
-#     cpp_info_mock.aggregated_components.return_value = cpp_info_mock
-#     return cpp_info_mock
-#
-#
-# @pytest.mark.parametrize("libs, is_shared, expected", [
-#     # expected == (lib_name, is_shared, library_path, interface_library_path)
-#     (["mylibwin"], False, [('mylibwin', False, '{base_folder}/lib/mylibwin.lib', None)]),
-#     # Win + shared
-#     (["mylibwin"], True, [('mylibwin', True, '{base_folder}/bin/mylibwin.dll', '{base_folder}/lib/mylibwin.lib')]),
-#     # Win + shared (interface with another ext)
-#     (["mylibwin2"], True, [('mylibwin2', True, '{base_folder}/bin/mylibwin2.dll', '{base_folder}/lib/mylibwin2.if.lib')]),
-#     # Mac + shared
-#     (["mylibmac"], True, [('mylibmac', True, '{base_folder}/bin/mylibmac.dylib', None)]),
-#     # Mac + static
-#     (["mylibmac"], False, [('mylibmac', False, '{base_folder}/lib/mylibmac.a', None)]),
-#     # mylib + shared (saved as libmylib.so) -> removing the leading "lib" if it matches
-#     (["mylib"], True, [('mylib', True, '{base_folder}/lib/libmylib.so', None)]),
-#     # mylib + static (saved in a subfolder subfolder/libmylib.a) -> non-recursive at this moment
-#     (["mylib"], False, []),
-#     # no lib matching
-#     (["noexist"], False, []),
-#     # no lib matching + Win + static
-#     (["noexist", "mylibwin"], False, [('mylibwin', False, '{base_folder}/lib/mylibwin.lib', None)]),
-#     # protobuf (Issue related https://github.com/conan-io/conan/issues/15390)
-#     (["protoc"], True, []),
-#     # non-conventional library name (Issue related https://github.com/conan-io/conan/pull/11343)
-#     (["libmylib.so"], True, [('libmylib.so', True, '{base_folder}/lib/libmylib.so', None)]),
-# ])
-# def test_bazeldeps_get_libs(cpp_info, libs, is_shared, expected):
-#     cpp_info.libs = libs
-#     ret = []
-#     for (lib, is_shared, lib_path, interface_lib_path) in expected:
-#         if lib_path:
-#             lib_path = lib_path.format(base_folder=cpp_info._base_folder)
-#         if interface_lib_path:
-#             interface_lib_path = interface_lib_path.format(base_folder=cpp_info._base_folder)
-#         ret.append((lib, is_shared, lib_path, interface_lib_path))
-#     dep = MagicMock()
-#     dep.options.get_safe.return_value = is_shared
-#     dep.ref.name = "my_pkg"
-#     found_libs = _get_libs(dep, cpp_info)
-#     found_libs.sort()
-#     ret.sort()
-#     assert found_libs == ret
-
 
 
 @pytest.mark.parametrize("lib_name, libs", [
@@ -174,3 +104,7 @@ def test_windows_several_shared_link_locations(lib_info):
         assert result.components[f"_{lib_name}"].location == locations[lib_name][0].replace("\\", "/")
         assert result.components[f"_{lib_name}"].link_location == locations[lib_name][1].replace("\\", "/")
     assert result.type == "shared-library"
+
+
+def test_shared_link_locations_symlinks():
+    pass

--- a/test/unittests/model/build_info/test_deduce_locations.py
+++ b/test/unittests/model/build_info/test_deduce_locations.py
@@ -109,9 +109,11 @@ def test_windows_several_shared_link_locations(lib_info):
 @pytest.mark.skipif(platform.system() == "Windows", reason="Can't apply symlink on Windows")
 def test_shared_link_locations_symlinks():
     folder = temp_folder()
-    real_location = os.path.join(folder, "libdir", "mylib.so")
+    # forcing a folder that it's not going to be analysed by the deduce_location() function
+    real_location = os.path.join(folder, "other", "mylib.so")
     save(real_location, "")
     # Symlinks
+    os.makedirs(os.path.join(folder, "libdir"))
     sym_1 = os.path.join(folder, "libdir", "mylib.1.0.0.so")
     sym_2 = os.path.join(folder, "libdir", "mylib.2.0.0.so")
     os.symlink(real_location, sym_1)

--- a/test/unittests/model/build_info/test_deduce_locations.py
+++ b/test/unittests/model/build_info/test_deduce_locations.py
@@ -1,4 +1,5 @@
 import os
+import platform
 
 import pytest
 
@@ -57,8 +58,7 @@ def test_deduce_shared_link_locations():
     ("libcurl_imp.lib", "libcurl.dll", ["libcurl_imp"]),
     ("libcrypto.lib", "libcrypto-3-x64.dll", ["libcrypto"]),
     ("libssl.lib", "libssl-3-x64.dll", ["libssl"]),
-    ("zdll.lib", "zlib1.dll", ["zdll"]),
-    (["iconv.lib", "charset.lib"], ["charset-1.dll", "iconv-2.dll"], ["charset", "iconv"]),
+    ("zdll.lib", "zlib1.dll", ["zdll"])
 ])
 def test_windows_shared_link_locations(lib_name, dll_name, libs):
     folder = temp_folder()
@@ -103,8 +103,25 @@ def test_windows_several_shared_link_locations(lib_info):
     for lib_name in lib_info:
         assert result.components[f"_{lib_name}"].location == locations[lib_name][0].replace("\\", "/")
         assert result.components[f"_{lib_name}"].link_location == locations[lib_name][1].replace("\\", "/")
-    assert result.type == "shared-library"
+        assert result.components[f"_{lib_name}"].type == "shared-library"
 
 
+@pytest.mark.skipif(platform.system() == "Windows", reason="Can't apply symlink on Windows")
 def test_shared_link_locations_symlinks():
-    pass
+    folder = temp_folder()
+    real_location = os.path.join(folder, "libdir", "mylib.so")
+    save(real_location, "")
+    # Symlinks
+    sym_1 = os.path.join(folder, "libdir", "mylib.1.0.0.so")
+    sym_2 = os.path.join(folder, "libdir", "mylib.2.0.0.so")
+    os.symlink(real_location, sym_1)
+    os.symlink(sym_1, sym_2)
+
+    cppinfo = CppInfo()
+    cppinfo.libdirs = ["libdir"]
+    cppinfo.libs = ["mylib"]
+    cppinfo.set_relative_base_folder(folder)
+
+    result = cppinfo.deduce_full_cpp_info(ConanFileMock())
+    assert result.location == real_location
+    assert result.type == "shared-library"

--- a/test/unittests/model/build_info/test_deduce_locations.py
+++ b/test/unittests/model/build_info/test_deduce_locations.py
@@ -217,7 +217,7 @@ def test_warning_windows_if_more_than_one_dll(conanfile):
     cppinfo.bindirs = ["bindir"]
     cppinfo.libs = ["mylib"]
     cppinfo.set_relative_base_folder(folder)
-
+    folder = folder.replace("\\", "/")
     result = cppinfo.deduce_full_cpp_info(conanfile)
     assert result.location == f"{folder}/bindir/libx.dll"
     assert result.type == "shared-library"

--- a/test/unittests/model/build_info/test_deduce_locations.py
+++ b/test/unittests/model/build_info/test_deduce_locations.py
@@ -8,6 +8,7 @@ from conan.test.utils.mocks import ConanFileMock
 from conan.test.utils.test_files import temp_folder
 from conan.tools.files import save
 from conans.model.build_info import CppInfo
+from conans.model.pkg_type import PackageType
 from conans.util.files import save
 
 
@@ -176,7 +177,8 @@ def test_shared_link_locations_symlinks():
     assert result.type == "shared-library"
 
 
-def test_error_if_shared_and_static_found():
+@pytest.mark.parametrize("static", [True, False])
+def test_error_if_shared_and_static_found(static):
     folder = temp_folder()
     save(os.path.join(folder, "libdir", "libmylib.a"), "")
     save(os.path.join(folder, "libdir", "libmylib.so"), "")
@@ -186,8 +188,10 @@ def test_error_if_shared_and_static_found():
     cppinfo.libs = ["mylib"]
     cppinfo.set_relative_base_folder(folder)
     folder = folder.replace("\\", "/")
-    with pytest.raises(ConanException) as e:
-        cppinfo.deduce_full_cpp_info(ConanFileMock())
-    assert (f"obtained for library 'mylib' both static and shared libraries at the same time:\n"
-            f"- STATIC: {folder}/libdir/libmylib.a\n"
-            f"- SHARED: {folder}/libdir/libmylib.so") in str(e.value)
+    conanfile = ConanFileMock()
+    if static:
+        conanfile.package_type = PackageType.STATIC
+    result = cppinfo.deduce_full_cpp_info(conanfile)
+    ext = "a" if static else "so"
+    assert result.location == f"{folder}/libdir/libmylib.{ext}"
+    assert result.type == (PackageType.STATIC if static else PackageType.SHARED)

--- a/test/unittests/model/build_info/test_deduce_locations.py
+++ b/test/unittests/model/build_info/test_deduce_locations.py
@@ -206,7 +206,7 @@ def test_error_if_shared_and_static_found(static, conanfile):
     assert result.type == (PackageType.STATIC if static else PackageType.SHARED)
 
 
-def test_error_windows_if_more_than_one_dll(conanfile):
+def test_warning_windows_if_more_than_one_dll(conanfile):
     folder = temp_folder()
     save(os.path.join(folder, "libdir", "mylib.a"), "")
     save(os.path.join(folder, "bindir", "libx.dll"), "")
@@ -218,6 +218,6 @@ def test_error_windows_if_more_than_one_dll(conanfile):
     cppinfo.libs = ["mylib"]
     cppinfo.set_relative_base_folder(folder)
 
-    with pytest.raises(ConanException) as e:
-        cppinfo.deduce_full_cpp_info(conanfile)
-    assert "There were several matches for Lib mylib:" in str(e.value)
+    result = cppinfo.deduce_full_cpp_info(conanfile)
+    assert result.location == f"{folder}/bindir/libx.dll"
+    assert result.type == "shared-library"

--- a/test/unittests/model/build_info/test_deduce_locations.py
+++ b/test/unittests/model/build_info/test_deduce_locations.py
@@ -1,5 +1,6 @@
 import os
 import platform
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -9,7 +10,15 @@ from conan.test.utils.test_files import temp_folder
 from conan.tools.files import save
 from conans.model.build_info import CppInfo
 from conans.model.pkg_type import PackageType
+from conans.model.recipe_ref import RecipeReference
 from conans.util.files import save
+
+
+@pytest.fixture
+def conanfile():
+    c = ConanFileMock()
+    c._conan_node = MagicMock(ref=RecipeReference(""))
+    return c
 
 
 @pytest.mark.parametrize("lib_name, libs", [
@@ -21,7 +30,7 @@ from conans.util.files import save
     ("mylibwin2.if.lib", ["mylibwin2.if.lib"]),
     ("mylibwin2.if.lib", ["mylibwin2"])
 ])
-def test_simple_deduce_locations_static(lib_name, libs):
+def test_simple_deduce_locations_static(lib_name, libs, conanfile):
     folder = temp_folder()
     location = os.path.join(folder, "libdir", lib_name)
     save(location, "")
@@ -31,13 +40,13 @@ def test_simple_deduce_locations_static(lib_name, libs):
     cppinfo.libs = libs
     cppinfo.set_relative_base_folder(folder)
 
-    result = cppinfo.deduce_full_cpp_info(ConanFileMock())
+    result = cppinfo.deduce_full_cpp_info(conanfile)
     assert result.location == location.replace("\\", "/")
     assert result.link_location is None
     assert result.type == "static-library"
 
 
-def test_deduce_shared_link_locations():
+def test_deduce_shared_link_locations(conanfile):
     folder = temp_folder()
     imp_location = os.path.join(folder, "libdir", "mylib.lib")
     save(imp_location, "")
@@ -50,7 +59,7 @@ def test_deduce_shared_link_locations():
     cppinfo.libs = ["mylib"]
     cppinfo.set_relative_base_folder(folder)
 
-    result = cppinfo.deduce_full_cpp_info(ConanFileMock())
+    result = cppinfo.deduce_full_cpp_info(conanfile)
     assert result.location == location.replace("\\", "/")
     assert result.link_location == imp_location.replace("\\", "/")
     assert result.type == "shared-library"
@@ -61,7 +70,7 @@ def test_deduce_shared_link_locations():
     ("libapr-1.0.dylib", ["apr-1"]),
     ("libapr-1.so.0.7.4", ["apr-1"])
 ])
-def test_complex_deduce_locations_shared(lib_name, libs):
+def test_complex_deduce_locations_shared(lib_name, libs, conanfile):
     """
     Tests real examples of shared library names in Linux/MacOS,
     e.g., log4cxx, apr-1, etc.
@@ -77,19 +86,19 @@ def test_complex_deduce_locations_shared(lib_name, libs):
     cppinfo.libs = libs
     cppinfo.set_relative_base_folder(folder)
 
-    result = cppinfo.deduce_full_cpp_info(ConanFileMock())
+    result = cppinfo.deduce_full_cpp_info(conanfile)
     assert result.location == location.replace("\\", "/")
     assert result.link_location is None
     assert result.type == "shared-library"
 
 
-@pytest.mark.parametrize("lib_name, dll_name, libs", [
-    ("libcurl_imp.lib", "libcurl.dll", ["libcurl_imp"]),
-    ("libcrypto.lib", "libcrypto-3-x64.dll", ["libcrypto"]),
-    ("libssl.lib", "libssl-3-x64.dll", ["libssl"]),
-    ("zdll.lib", "zlib1.dll", ["zdll"])
+@pytest.mark.parametrize("lib_name, dll_name, libs, pkg_name", [
+    ("libcurl_imp.lib", "libcurl.dll", ["libcurl_imp"], "libcurl"),
+    ("libcrypto.lib", "libcrypto-3-x64.dll", ["libcrypto"], "crypto"),
+    ("libssl.lib", "libssl-3-x64.dll", ["libssl"], "ssl"),
+    ("zdll.lib", "zlib1.dll", ["zdll"], "zlib")
 ])
-def test_windows_shared_link_locations(lib_name, dll_name, libs):
+def test_windows_shared_link_locations(lib_name, dll_name, libs, pkg_name, conanfile):
     """
     Tests real examples of shared library names in Windows,
     e.g., openssl, zlib, libcurlb, etc.
@@ -106,7 +115,8 @@ def test_windows_shared_link_locations(lib_name, dll_name, libs):
     cppinfo.libs = libs
     cppinfo.set_relative_base_folder(folder)
 
-    result = cppinfo.deduce_full_cpp_info(ConanFileMock())
+    conanfile._conan_node.ref = RecipeReference(name=pkg_name)
+    result = cppinfo.deduce_full_cpp_info(conanfile)
     assert result.location == location.replace("\\", "/")
     assert result.link_location == imp_location.replace("\\", "/")
     assert result.type == "shared-library"
@@ -118,7 +128,7 @@ def test_windows_shared_link_locations(lib_name, dll_name, libs):
     {"charset": ["libcharset.so.1.0.0"],
      "iconv": ["libiconv.so.2.6.1"]},
 ])
-def test_windows_several_shared_link_locations(lib_info):
+def test_windows_several_shared_link_locations(lib_info, conanfile):
     """
     Tests a real model as LIBICONV with several libs defined in the root component
     """
@@ -142,7 +152,7 @@ def test_windows_several_shared_link_locations(lib_info):
     cppinfo.libs = list(lib_info.keys())
     cppinfo.set_relative_base_folder(folder)
 
-    result = cppinfo.deduce_full_cpp_info(ConanFileMock())
+    result = cppinfo.deduce_full_cpp_info(conanfile)
     for lib_name in lib_info:
         assert result.components[f"_{lib_name}"].location == locations[lib_name][0].replace("\\", "/")
         if is_windows:
@@ -151,7 +161,7 @@ def test_windows_several_shared_link_locations(lib_info):
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="Can't apply symlink on Windows")
-def test_shared_link_locations_symlinks():
+def test_shared_link_locations_symlinks(conanfile):
     """
     Tests auto deduce location is able to find the real path of
     any symlink created in the libs folder
@@ -172,13 +182,13 @@ def test_shared_link_locations_symlinks():
     cppinfo.libs = ["mylib"]
     cppinfo.set_relative_base_folder(folder)
 
-    result = cppinfo.deduce_full_cpp_info(ConanFileMock())
+    result = cppinfo.deduce_full_cpp_info(conanfile)
     assert result.location == real_location
     assert result.type == "shared-library"
 
 
 @pytest.mark.parametrize("static", [True, False])
-def test_error_if_shared_and_static_found(static):
+def test_error_if_shared_and_static_found(static, conanfile):
     folder = temp_folder()
     save(os.path.join(folder, "libdir", "libmylib.a"), "")
     save(os.path.join(folder, "libdir", "libmylib.so"), "")
@@ -188,7 +198,6 @@ def test_error_if_shared_and_static_found(static):
     cppinfo.libs = ["mylib"]
     cppinfo.set_relative_base_folder(folder)
     folder = folder.replace("\\", "/")
-    conanfile = ConanFileMock()
     if static:
         conanfile.package_type = PackageType.STATIC
     result = cppinfo.deduce_full_cpp_info(conanfile)
@@ -197,7 +206,7 @@ def test_error_if_shared_and_static_found(static):
     assert result.type == (PackageType.STATIC if static else PackageType.SHARED)
 
 
-def test_error_windows_if_more_than_one_dll():
+def test_error_windows_if_more_than_one_dll(conanfile):
     folder = temp_folder()
     save(os.path.join(folder, "libdir", "mylib.a"), "")
     save(os.path.join(folder, "bindir", "libx.dll"), "")
@@ -210,5 +219,5 @@ def test_error_windows_if_more_than_one_dll():
     cppinfo.set_relative_base_folder(folder)
 
     with pytest.raises(ConanException) as e:
-        cppinfo.deduce_full_cpp_info(ConanFileMock())
-    assert "There were found more than 1 DLL for Lib mylib:" in str(e.value)
+        cppinfo.deduce_full_cpp_info(conanfile)
+    assert "There were several matches for Lib mylib:" in str(e.value)

--- a/test/unittests/model/build_info/test_deduce_locations.py
+++ b/test/unittests/model/build_info/test_deduce_locations.py
@@ -1,9 +1,82 @@
 import os
+from unittest.mock import MagicMock
+
+import pytest
 
 from conan.test.utils.mocks import ConanFileMock
 from conan.test.utils.test_files import temp_folder
+from conan.tools.files import save
+from conan.tools.google.bazeldeps import _get_libs
 from conans.model.build_info import CppInfo
 from conans.util.files import save
+
+
+# @pytest.fixture(scope="module")
+# def cpp_info():
+#     folder = temp_folder(path_with_spaces=False)
+#     bindirs = os.path.join(folder, "bin")
+#     libdirs = os.path.join(folder, "lib")
+#     save(ConanFileMock(), os.path.join(bindirs, "mylibwin.dll"), "")
+#     save(ConanFileMock(), os.path.join(bindirs, "mylibwin2.dll"), "")
+#     save(ConanFileMock(), os.path.join(bindirs, "myliblin.so"), "")
+#     save(ConanFileMock(), os.path.join(bindirs, "mylibmac.dylib"), "")
+#     save(ConanFileMock(), os.path.join(bindirs, "protoc"), "")  # binary
+#     save(ConanFileMock(), os.path.join(libdirs, "myliblin.a"), "")
+#     save(ConanFileMock(), os.path.join(libdirs, "mylibmac.a"), "")
+#     save(ConanFileMock(), os.path.join(libdirs, "mylibwin.lib"), "")
+#     save(ConanFileMock(), os.path.join(libdirs, "mylibwin2.if.lib"), "")
+#     save(ConanFileMock(), os.path.join(libdirs, "libmylib.so"), "")
+#     save(ConanFileMock(), os.path.join(libdirs, "subfolder", "libmylib.a"), "")  # recursive
+#     cpp_info_mock = MagicMock(_base_folder=None, libdirs=[], bindirs=[], libs=[],
+#                               aggregated_components=MagicMock())
+#     cpp_info_mock._base_folder = folder.replace("\\", "/")
+#     cpp_info_mock.libdirs = [libdirs]
+#     cpp_info_mock.bindirs = [bindirs]
+#     cpp_info_mock.aggregated_components.return_value = cpp_info_mock
+#     return cpp_info_mock
+#
+#
+# @pytest.mark.parametrize("libs, is_shared, expected", [
+#     # expected == (lib_name, is_shared, library_path, interface_library_path)
+#     (["mylibwin"], False, [('mylibwin', False, '{base_folder}/lib/mylibwin.lib', None)]),
+#     # Win + shared
+#     (["mylibwin"], True, [('mylibwin', True, '{base_folder}/bin/mylibwin.dll', '{base_folder}/lib/mylibwin.lib')]),
+#     # Win + shared (interface with another ext)
+#     (["mylibwin2"], True, [('mylibwin2', True, '{base_folder}/bin/mylibwin2.dll', '{base_folder}/lib/mylibwin2.if.lib')]),
+#     # Mac + shared
+#     (["mylibmac"], True, [('mylibmac', True, '{base_folder}/bin/mylibmac.dylib', None)]),
+#     # Mac + static
+#     (["mylibmac"], False, [('mylibmac', False, '{base_folder}/lib/mylibmac.a', None)]),
+#     # mylib + shared (saved as libmylib.so) -> removing the leading "lib" if it matches
+#     (["mylib"], True, [('mylib', True, '{base_folder}/lib/libmylib.so', None)]),
+#     # mylib + static (saved in a subfolder subfolder/libmylib.a) -> non-recursive at this moment
+#     (["mylib"], False, []),
+#     # no lib matching
+#     (["noexist"], False, []),
+#     # no lib matching + Win + static
+#     (["noexist", "mylibwin"], False, [('mylibwin', False, '{base_folder}/lib/mylibwin.lib', None)]),
+#     # protobuf (Issue related https://github.com/conan-io/conan/issues/15390)
+#     (["protoc"], True, []),
+#     # non-conventional library name (Issue related https://github.com/conan-io/conan/pull/11343)
+#     (["libmylib.so"], True, [('libmylib.so', True, '{base_folder}/lib/libmylib.so', None)]),
+# ])
+# def test_bazeldeps_get_libs(cpp_info, libs, is_shared, expected):
+#     cpp_info.libs = libs
+#     ret = []
+#     for (lib, is_shared, lib_path, interface_lib_path) in expected:
+#         if lib_path:
+#             lib_path = lib_path.format(base_folder=cpp_info._base_folder)
+#         if interface_lib_path:
+#             interface_lib_path = interface_lib_path.format(base_folder=cpp_info._base_folder)
+#         ret.append((lib, is_shared, lib_path, interface_lib_path))
+#     dep = MagicMock()
+#     dep.options.get_safe.return_value = is_shared
+#     dep.ref.name = "my_pkg"
+#     found_libs = _get_libs(dep, cpp_info)
+#     found_libs.sort()
+#     ret.sort()
+#     assert found_libs == ret
+#
 
 
 def test_deduce_locations():

--- a/test/unittests/model/build_info/test_deduce_locations.py
+++ b/test/unittests/model/build_info/test_deduce_locations.py
@@ -3,6 +3,7 @@ import platform
 
 import pytest
 
+from conan.errors import ConanException
 from conan.test.utils.mocks import ConanFileMock
 from conan.test.utils.test_files import temp_folder
 from conan.tools.files import save
@@ -173,3 +174,20 @@ def test_shared_link_locations_symlinks():
     result = cppinfo.deduce_full_cpp_info(ConanFileMock())
     assert result.location == real_location
     assert result.type == "shared-library"
+
+
+def test_error_if_shared_and_static_found():
+    folder = temp_folder()
+    save(os.path.join(folder, "libdir", "libmylib.a"), "")
+    save(os.path.join(folder, "libdir", "libmylib.so"), "")
+
+    cppinfo = CppInfo()
+    cppinfo.libdirs = ["libdir"]
+    cppinfo.libs = ["mylib"]
+    cppinfo.set_relative_base_folder(folder)
+    folder = folder.replace("\\", "/")
+    with pytest.raises(ConanException) as e:
+        cppinfo.deduce_full_cpp_info(ConanFileMock())
+    assert (f"obtained for library 'mylib' both static and shared libraries at the same time:\n"
+            f"- STATIC: {folder}/libdir/libmylib.a\n"
+            f"- SHARED: {folder}/libdir/libmylib.so") in str(e.value)

--- a/test/unittests/model/build_info/test_deduce_locations.py
+++ b/test/unittests/model/build_info/test_deduce_locations.py
@@ -76,17 +76,26 @@ from conans.util.files import save
 #     found_libs.sort()
 #     ret.sort()
 #     assert found_libs == ret
-#
 
 
-def test_deduce_locations():
+
+@pytest.mark.parametrize("lib_name, libs", [
+    ("myliblin.a", ["myliblin"]),
+    ("libmyliblin.a", ["myliblin"]),
+    ("mylibmac.a", ["mylibmac"]),
+    ("mylibwin.lib", ["mylibwin"]),
+    ("libmylibwin.lib", ["libmylibwin"]),
+    ("mylibwin2.if.lib", ["mylibwin2.if.lib"]),
+    ("mylibwin2.if.lib", ["mylibwin2"])
+])
+def test_simple_deduce_locations(lib_name, libs):
     folder = temp_folder()
-    location = os.path.join(folder, "libdir", "mylib.lib")
+    location = os.path.join(folder, "libdir", lib_name)
     save(location, "")
 
     cppinfo = CppInfo()
     cppinfo.libdirs = ["libdir"]
-    cppinfo.libs = ["mylib"]
+    cppinfo.libs = libs
     cppinfo.set_relative_base_folder(folder)
 
     result = cppinfo.deduce_full_cpp_info(ConanFileMock())
@@ -111,4 +120,57 @@ def test_deduce_shared_link_locations():
     result = cppinfo.deduce_full_cpp_info(ConanFileMock())
     assert result.location == location.replace("\\", "/")
     assert result.link_location == imp_location.replace("\\", "/")
+    assert result.type == "shared-library"
+
+
+@pytest.mark.parametrize("lib_name, dll_name, libs", [
+    ("libcurl_imp.lib", "libcurl.dll", ["libcurl_imp"]),
+    ("libcrypto.lib", "libcrypto-3-x64.dll", ["libcrypto"]),
+    ("libssl.lib", "libssl-3-x64.dll", ["libssl"]),
+    ("zdll.lib", "zlib1.dll", ["zdll"]),
+    (["iconv.lib", "charset.lib"], ["charset-1.dll", "iconv-2.dll"], ["charset", "iconv"]),
+])
+def test_windows_shared_link_locations(lib_name, dll_name, libs):
+    folder = temp_folder()
+    imp_location = os.path.join(folder, "libdir", lib_name)
+    save(imp_location, "")
+    location = os.path.join(folder, "bindir", dll_name)
+    save(location, "")
+
+    cppinfo = CppInfo()
+    cppinfo.libdirs = ["libdir"]
+    cppinfo.bindirs = ["bindir"]
+    cppinfo.libs = libs
+    cppinfo.set_relative_base_folder(folder)
+
+    result = cppinfo.deduce_full_cpp_info(ConanFileMock())
+    assert result.location == location.replace("\\", "/")
+    assert result.link_location == imp_location.replace("\\", "/")
+    assert result.type == "shared-library"
+
+
+@pytest.mark.parametrize("lib_info", [
+    {"charset": ("charset.lib", "charset-1.dll"),
+     "iconv": ("iconv.lib", "iconv-2.dll")}
+])
+def test_windows_several_shared_link_locations(lib_info):
+    folder = temp_folder()
+    locations = {}
+    for lib_name, lib_files in lib_info.items():
+        imp_location = os.path.join(folder, "libdir", lib_files[0])
+        save(imp_location, "")
+        location = os.path.join(folder, "bindir", lib_files[1])
+        save(location, "")
+        locations[lib_name] = (location, imp_location)
+
+    cppinfo = CppInfo()
+    cppinfo.libdirs = ["libdir"]
+    cppinfo.bindirs = ["bindir"]
+    cppinfo.libs = list(lib_info.keys())
+    cppinfo.set_relative_base_folder(folder)
+
+    result = cppinfo.deduce_full_cpp_info(ConanFileMock())
+    for lib_name in lib_info:
+        assert result.components[f"_{lib_name}"].location == locations[lib_name][0].replace("\\", "/")
+        assert result.components[f"_{lib_name}"].link_location == locations[lib_name][1].replace("\\", "/")
     assert result.type == "shared-library"

--- a/test/unittests/tools/google/test_bazel.py
+++ b/test/unittests/tools/google/test_bazel.py
@@ -8,7 +8,7 @@ from conan.test.utils.mocks import ConanFileMock
 from conan.test.utils.test_files import temp_folder
 from conan.tools.files import save
 from conan.tools.google import Bazel
-from conan.tools.google.bazeldeps import _relativize_path, _get_libs
+from conan.tools.google.bazeldeps import _relativize_path
 
 
 @pytest.fixture(scope="module")
@@ -77,45 +77,3 @@ def test_bazel_command_with_config_values():
 ])
 def test_bazeldeps_relativize_path(path, pattern, expected):
     assert _relativize_path(path, pattern) == expected
-
-
-@pytest.mark.parametrize("libs, is_shared, expected", [
-    # expected == (lib_name, is_shared, library_path, interface_library_path)
-    (["mylibwin"], False, [('mylibwin', False, '{base_folder}/lib/mylibwin.lib', None)]),
-    # Win + shared
-    (["mylibwin"], True, [('mylibwin', True, '{base_folder}/bin/mylibwin.dll', '{base_folder}/lib/mylibwin.lib')]),
-    # Win + shared (interface with another ext)
-    (["mylibwin2"], True, [('mylibwin2', True, '{base_folder}/bin/mylibwin2.dll', '{base_folder}/lib/mylibwin2.if.lib')]),
-    # Mac + shared
-    (["mylibmac"], True, [('mylibmac', True, '{base_folder}/bin/mylibmac.dylib', None)]),
-    # Mac + static
-    (["mylibmac"], False, [('mylibmac', False, '{base_folder}/lib/mylibmac.a', None)]),
-    # mylib + shared (saved as libmylib.so) -> removing the leading "lib" if it matches
-    (["mylib"], True, [('mylib', True, '{base_folder}/lib/libmylib.so', None)]),
-    # mylib + static (saved in a subfolder subfolder/libmylib.a) -> non-recursive at this moment
-    (["mylib"], False, []),
-    # no lib matching
-    (["noexist"], False, []),
-    # no lib matching + Win + static
-    (["noexist", "mylibwin"], False, [('mylibwin', False, '{base_folder}/lib/mylibwin.lib', None)]),
-    # protobuf (Issue related https://github.com/conan-io/conan/issues/15390)
-    (["protoc"], True, []),
-    # non-conventional library name (Issue related https://github.com/conan-io/conan/pull/11343)
-    (["libmylib.so"], True, [('libmylib.so', True, '{base_folder}/lib/libmylib.so', None)]),
-])
-def test_bazeldeps_get_libs(cpp_info, libs, is_shared, expected):
-    cpp_info.libs = libs
-    ret = []
-    for (lib, is_shared, lib_path, interface_lib_path) in expected:
-        if lib_path:
-            lib_path = lib_path.format(base_folder=cpp_info._base_folder)
-        if interface_lib_path:
-            interface_lib_path = interface_lib_path.format(base_folder=cpp_info._base_folder)
-        ret.append((lib, is_shared, lib_path, interface_lib_path))
-    dep = MagicMock()
-    dep.options.get_safe.return_value = is_shared
-    dep.ref.name = "my_pkg"
-    found_libs = _get_libs(dep, cpp_info)
-    found_libs.sort()
-    ret.sort()
-    assert found_libs == ret


### PR DESCRIPTION
Changelog: Feature: Improved auto deduce location function.
Changelog: Feature: BazelDeps using the new `deduce_location` mechanism to find the libraries.
Changelog: Bugfix: BazelDeps failed to find OpenSSL shared libraries.
Docs: omit
Close: https://github.com/conan-io/conan/issues/16990
Close: https://github.com/conan-io/conan/issues/16926