### PR TITLE
use * as default for conan list when no args

### DIFF
--- a/conan/cli/commands/list.py
+++ b/conan/cli/commands/list.py
@@ -233,7 +233,7 @@ def list(conan_api: ConanAPI, parser, *args):
     args = parser.parse_args(*args)
 
     if args.pattern is None and args.graph is None:
-        raise ConanException("Missing pattern or graph json file")
+        args.pattern = "*"  # All packages
     if args.graph:  # a few arguments are not compatible with this
         if args.pattern:
             raise ConanException("Cannot define both the pattern and the graph json file")

--- a/test/integration/command_v2/list_test.py
+++ b/test/integration/command_v2/list_test.py
@@ -18,20 +18,22 @@ from conans.util.files import load, save
 
 class TestParamErrors:
 
-    def test_query_param_is_required(self):
+    def test_default_pattern(self):
         c = TestClient()
-        c.run("list", assert_error=True)
-        assert "ERROR: Missing pattern or graph json file" in c.out
+        c.run("list")
+        assert "Found 0 pkg/version" in c.out
 
-        c.run("list -c", assert_error=True)
-        assert "ERROR: Missing pattern or graph json file" in c.out
+        c.run("list -c")
+        assert "Found 0 pkg/version" in c.out
 
         c.run('list -r="*"', assert_error=True)
-        assert "ERROR: Missing pattern or graph json file" in c.out
+        assert "ERROR: Remotes for pattern '*' can't be found" in c.out
 
         c.run("list --remote remote1 --cache", assert_error=True)
-        assert "ERROR: Missing pattern or graph json file" in c.out
+        assert "ERROR: Remote 'remote1' can't be found or is disabled" in c.out
 
+    def test_query_param(self):
+        c = TestClient()
         c.run("list * --graph=myjson", assert_error=True)
         assert "ERROR: Cannot define both the pattern and the graph json file" in c.out
 


### PR DESCRIPTION
Changelog: Feature: define ``*`` as default argument if no args specified for ``conan list``.
Docs: https://github.com/conan-io/docs/pull/3927

Close https://github.com/conan-io/conan/issues/17299