### PR TITLE
maxcpucount=0 will use all cpus

### DIFF
--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -19,8 +19,8 @@ def _cmake_cmd_line_args(conanfile, generator):
         args.append("-j{}".format(njobs))
 
     maxcpucount = conanfile.conf.get("tools.microsoft.msbuild:max_cpu_count", check_type=int)
-    if maxcpucount and "Visual Studio" in generator:
-        args.append("/m:{}".format(maxcpucount))
+    if maxcpucount is not None and "Visual Studio" in generator:
+        args.append(f"/m:{maxcpucount}" if maxcpucount > 0 else "/m")
 
     # Arguments for verbosity
     if "Visual Studio" in generator:

--- a/conan/tools/microsoft/msbuild.py
+++ b/conan/tools/microsoft/msbuild.py
@@ -64,8 +64,8 @@ class MSBuild(object):
 
         maxcpucount = self._conanfile.conf.get("tools.microsoft.msbuild:max_cpu_count",
                                                check_type=int)
-        if maxcpucount:
-            cmd += " /m:{}".format(maxcpucount)
+        if maxcpucount is not None:
+            cmd += f" /m:{maxcpucount}" if maxcpucount > 0 else " /m"
 
         if targets:
             if not isinstance(targets, list):

--- a/test/unittests/tools/cmake/test_cmake_cmd_line_args.py
+++ b/test/unittests/tools/cmake/test_cmake_cmd_line_args.py
@@ -44,3 +44,13 @@ def test_visual_studio(conanfile):
 
     args = _cmake_cmd_line_args(conanfile, 'Ninja')
     assert args == ['-j10']
+
+
+def test_maxcpucount_zero():
+    c = ConfDefinition()
+    c.loads("tools.microsoft.msbuild:max_cpu_count=0")
+
+    conanfile = ConanFileMock()
+    conanfile.conf = c.get_conanfile_conf(None)
+    args = _cmake_cmd_line_args(conanfile, 'Visual Studio 16 2019')
+    assert ["/m"] == args

--- a/test/unittests/tools/microsoft/test_msbuild.py
+++ b/test/unittests/tools/microsoft/test_msbuild.py
@@ -1,5 +1,4 @@
 import os
-import textwrap
 
 import pytest
 
@@ -31,14 +30,9 @@ def test_msbuild_targets():
 
 def test_msbuild_cpu_count():
     c = ConfDefinition()
-    c.loads(textwrap.dedent("""\
-        tools.microsoft.msbuild:max_cpu_count=23
-    """))
+    c.loads("tools.microsoft.msbuild:max_cpu_count=23")
 
     settings = MockSettings({"build_type": "Release",
-                             "compiler": "gcc",
-                             "compiler.version": "7",
-                             "os": "Linux",
                              "arch": "x86_64"})
     conanfile = ConanFileMock()
     conanfile.settings = settings
@@ -46,8 +40,12 @@ def test_msbuild_cpu_count():
 
     msbuild = MSBuild(conanfile)
     cmd = msbuild.command('project.sln')
+    assert 'msbuild "project.sln" /p:Configuration="Release" /p:Platform=x64 /m:23' == cmd
 
-    assert '/m:23' in cmd
+    c.loads("tools.microsoft.msbuild:max_cpu_count=0")
+    conanfile.conf = c.get_conanfile_conf(None)
+    cmd = msbuild.command('project.sln')
+    assert 'msbuild "project.sln" /p:Configuration="Release" /p:Platform=x64 /m' == cmd
 
 
 def test_msbuild_toolset():
@@ -81,10 +79,10 @@ def test_msbuild_toolset_for_intel_cc(mode, expected_toolset):
     conanfile = ConanFile()
     conanfile.settings = "os", "compiler", "build_type", "arch"
     conanfile.settings = Settings({"build_type": ["Release"],
-                         "compiler": {"intel-cc": {"version": ["2021.3"], "mode": [mode]},
-                                      "msvc": {"version": ["193"], "cppstd": ["20"]}},
-                         "os": ["Windows"],
-                         "arch": ["x86_64"]})
+                                   "compiler": {"intel-cc": {"version": ["2021.3"], "mode": [mode]},
+                                                "msvc": {"version": ["193"], "cppstd": ["20"]}},
+                                   "os": ["Windows"],
+                                   "arch": ["x86_64"]})
     conanfile.settings.build_type = "Release"
     conanfile.settings.compiler = "intel-cc"
     conanfile.settings.compiler.version = "2021.3"


### PR DESCRIPTION
Changelog: Feature: Allow ``tools.microsoft.msbuild:max_cpu_count=0`` to use ``/m`` to use all available cores.
Docs: https://github.com/conan-io/docs/pull/3926

Close https://github.com/conan-io/conan/issues/17290
