### PR TITLE
Disable auto-generation of virtual envs only when `generate()` is called

### DIFF
--- a/conan/tools/env/virtualbuildenv.py
+++ b/conan/tools/env/virtualbuildenv.py
@@ -11,8 +11,6 @@ class VirtualBuildEnv:
     def __init__(self, conanfile, auto_generate=False):
         self._buildenv = None
         self._conanfile = conanfile
-        if not auto_generate:
-            self._conanfile.virtualbuildenv = False
         self.basename = "conanbuildenv"
         self.configuration = None
         self.arch = None
@@ -90,3 +88,5 @@ class VirtualBuildEnv:
         check_duplicated_generator(self, self._conanfile)
         build_env = self.environment()
         build_env.vars(self._conanfile, scope=scope).save_script(self._filename)
+        if not auto_generate and scope == "build":
+            self._conanfile.virtualbuildenv = False

--- a/conan/tools/env/virtualbuildenv.py
+++ b/conan/tools/env/virtualbuildenv.py
@@ -11,6 +11,7 @@ class VirtualBuildEnv:
     def __init__(self, conanfile, auto_generate=False):
         self._buildenv = None
         self._conanfile = conanfile
+        self._auto_generate = auto_generate
         self.basename = "conanbuildenv"
         self.configuration = None
         self.arch = None
@@ -88,5 +89,5 @@ class VirtualBuildEnv:
         check_duplicated_generator(self, self._conanfile)
         build_env = self.environment()
         build_env.vars(self._conanfile, scope=scope).save_script(self._filename)
-        if not auto_generate and scope == "build":
+        if not self._auto_generate and scope == "build":
             self._conanfile.virtualbuildenv = False

--- a/conan/tools/env/virtualrunenv.py
+++ b/conan/tools/env/virtualrunenv.py
@@ -36,6 +36,7 @@ class VirtualRunEnv:
         """
         self._runenv = None
         self._conanfile = conanfile
+        self._auto_generate = auto_generate
         self.basename = "conanrunenv"
         self.configuration = conanfile.settings.get_safe("build_type")
         if self.configuration:
@@ -96,5 +97,5 @@ class VirtualRunEnv:
         check_duplicated_generator(self, self._conanfile)
         run_env = self.environment()
         run_env.vars(self._conanfile, scope=scope).save_script(self._filename)
-        if not auto_generate and scope == "run":
+        if not self._auto_generate and scope == "run":
             self._conanfile.virtualbuildenv = False

--- a/conan/tools/env/virtualrunenv.py
+++ b/conan/tools/env/virtualrunenv.py
@@ -36,8 +36,6 @@ class VirtualRunEnv:
         """
         self._runenv = None
         self._conanfile = conanfile
-        if not auto_generate:
-            self._conanfile.virtualrunenv = False
         self.basename = "conanrunenv"
         self.configuration = conanfile.settings.get_safe("build_type")
         if self.configuration:
@@ -98,3 +96,5 @@ class VirtualRunEnv:
         check_duplicated_generator(self, self._conanfile)
         run_env = self.environment()
         run_env.vars(self._conanfile, scope=scope).save_script(self._filename)
+        if not auto_generate and scope == "run":
+            self._conanfile.virtualbuildenv = False

--- a/conan/tools/env/virtualrunenv.py
+++ b/conan/tools/env/virtualrunenv.py
@@ -98,4 +98,4 @@ class VirtualRunEnv:
         run_env = self.environment()
         run_env.vars(self._conanfile, scope=scope).save_script(self._filename)
         if not self._auto_generate and scope == "run":
-            self._conanfile.virtualbuildenv = False
+            self._conanfile.virtualrunenv = False


### PR DESCRIPTION
Changelog: (Fix): Skip auto-generation on virtual envs only after they have been generated instead of just instantiated
Docs: https://github.com/conan-io/docs/pull/XXXX

I was experimenting with removing an explicit call to `VirtualBuildEnv(self).generate()` in the Boost recipe on CCI and was surprised to discover that the auto-generation of VirtualBuildEnv was not being activated for the recipe, causing build errors.

VirtualBuildEnv and VirtualRunEnv currently disable the auto-generation as soon as a corresponding object has been instantiated, regardless of whether `.generate()` has been called on it and whether it uses the default build/run scope. This causes the auto-generation to be skipped in the Boost recipe and several others where only the info from `VirtualBuildEnv().vars()` is used to fill in details about the compiler path and similar (https://github.com/conan-io/conan-center-index/blob/master/recipes/boost/all/conanfile.py#L1481).

Many recipes also call `VirtualRunEnv(self).generate(scope="build")` for shared libraries to be found during the build process, which would also disable the auto-generation.

The current behavior seems unexpected and counter-intuitive to me. I would expect the auto-generation to be only disabled when `self.virtualbuildenv`/`self.virtualrunenv` is set to False or when the virtual env has been generated using the default scope.

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
