### PR TITLE
fix new CMakeDeps in-package casing

### DIFF
--- a/conan/tools/cmake/cmakedeps2/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps2/cmakedeps.py
@@ -191,9 +191,10 @@ class _PathGenerator:
                     build_dir = dep.package_folder
                 pkg_folder = build_dir.replace("\\", "/") if build_dir else None
                 if pkg_folder:
-                    config_file = ConfigTemplate2(self._cmakedeps, dep).filename
-                    if os.path.isfile(os.path.join(pkg_folder, config_file)):
-                        pkg_paths[pkg_name] = pkg_folder
+                    f = self._cmakedeps.get_cmake_filename(dep)
+                    for filename in (f"{f}-config.cmake", f"{f}Config.cmake"):
+                        if os.path.isfile(os.path.join(pkg_folder, filename)):
+                            pkg_paths[pkg_name] = pkg_folder
                 continue
 
             # If CMakeDeps generated, the folder is this one

--- a/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_new_paths.py
+++ b/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_new_paths.py
@@ -47,10 +47,12 @@ def test_cmake_generated(client):
 
 
 @pytest.mark.tool("cmake")
-def test_cmake_in_package(client):
+@pytest.mark.parametrize("lowercase", [False, True])
+def test_cmake_in_package(client, lowercase):
     c = client
     # same, but in-package
-    dep = textwrap.dedent("""
+    f = "dep-config" if lowercase else "depConfig"
+    dep = textwrap.dedent(f"""
         import os
         from conan import ConanFile
         from conan.tools.files import save
@@ -60,7 +62,7 @@ def test_cmake_in_package(client):
 
             def package(self):
                 content = 'message(STATUS "Hello from dep dep-Config.cmake!!!!!")'
-                save(self, os.path.join(self.package_folder, "cmake", "dep-config.cmake"), content)
+                save(self, os.path.join(self.package_folder, "cmake", "{f}.cmake"), content)
             def package_info(self):
                 self.cpp_info.set_property("cmake_find_mode", "none")
                 self.cpp_info.builddirs = ["cmake"]


### PR DESCRIPTION
Changelog: Fix: New ``CMakeDeps`` generator allow ``fooConfig.cmake`` for in-package files besides ``foo-config.cmake``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/17321