### PR TITLE
Fix `conan graph info ... -f=html` in Safari

### DIFF
--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -24,7 +24,7 @@ graph_info_html = r"""
         </style>
 
         <div style="display: grid; grid-template-columns: 75% 25%; grid-template-rows: 30px auto; height: 100vh;">
-            <div id="mylegend" style="background-color: lightgrey; grid-column-end: span 2;"></div>
+            <div id="mylegend" style="background-color: lightgrey; grid-column-end: span 2;height: 100%"></div>
             <div id="mynetwork"></div>
             <div style="background-color: lightgrey;min-height:100%;height:0;overflow-y: auto;">
                 <div>


### PR DESCRIPTION
Changelog: Bugfix: Fix `conan graph info ... -f=html` in Safari.
Docs: Omit

Closes https://github.com/conan-io/conan/issues/17323

One of those fixes that seem simple but finding it took longer that expected

Took the chance to also check that the build order html correctly renders in Safari too.
Now both files are confirmed to work properly in Chrome, Firefox and Safari

Safari after the fix:

![image](https://github.com/user-attachments/assets/dadd093e-a375-485b-9c7d-7896ce6f07b2)
