### PR TITLE
Comply with PEP 625 for Conan Server distribution

### DIFF
--- a/setup_server.py
+++ b/setup_server.py
@@ -52,7 +52,7 @@ dev_requirements = get_requires("conans/requirements_dev.txt")
 
 
 setup(
-    name='conan-server',
+    name='conan_server',
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

In the future, PyPI will require all newly uploaded source distribution filenames to comply with [PEP 625](https://peps.python.org/pep-0625/).

These changes ensure that the Conan Server distribution complies with [PEP 625](https://peps.python.org/pep-0625/) by renaming `conan-server` to `conan_server`. This update does not affect how users install Conan Server; they can continue using either `pip install conan-server` or `pip install conan_server`.
