### PR TITLE
Add `--output` option to `conan new` command

### DIFF
--- a/conan/api/subapi/new.py
+++ b/conan/api/subapi/new.py
@@ -93,9 +93,11 @@ class NewAPI:
     @staticmethod
     def render(template_files, definitions):
         result = {}
-        name = definitions.get("name", "Pkg")
+        name = definitions.get("name", "pkg")
         if isinstance(name, list):
             raise ConanException(f"name argument can't be multiple: {name}")
+        if name != name.lower():
+            raise ConanException(f"name argument must be lowercase: {name}")
         definitions["conan_version"] = __version__
 
         def ensure_list(key):

--- a/conan/cli/commands/new.py
+++ b/conan/cli/commands/new.py
@@ -24,6 +24,8 @@ def new(conan_api, parser, *args):
     parser.add_argument("-d", "--define", action="append",
                         help="Define a template argument as key=value, e.g., -d name=mypkg")
     parser.add_argument("-f", "--force", action='store_true', help="Overwrite file if it already exists")
+    parser.add_argument("-of", "--output-folder", help="Output folder for the generated files",
+                        default=os.getcwd())
 
     args = parser.parse_args(*args)
     # Manually parsing the remainder
@@ -59,10 +61,10 @@ def new(conan_api, parser, *args):
 
     # Saving the resulting files
     output = ConanOutput()
-    cwd = os.getcwd()
+    output_folder = args.output_folder
     # Making sure they don't overwrite existing files
     for f, v in sorted(template_files.items()):
-        path = os.path.join(cwd, f)
+        path = os.path.join(output_folder, f)
         if os.path.exists(path) and not args.force:
             raise ConanException(f"File '{f}' already exists, and --force not defined, aborting")
         save(path, v)
@@ -70,7 +72,7 @@ def new(conan_api, parser, *args):
 
     # copy non-templates
     for f, v in sorted(non_template_files.items()):
-        path = os.path.join(cwd, f)
+        path = os.path.join(output_folder, f)
         if os.path.exists(path) and not args.force:
             raise ConanException(f"File '{f}' already exists, and --force not defined, aborting")
         shutil.copy2(v, path)

--- a/conan/cli/commands/new.py
+++ b/conan/cli/commands/new.py
@@ -24,7 +24,7 @@ def new(conan_api, parser, *args):
     parser.add_argument("-d", "--define", action="append",
                         help="Define a template argument as key=value, e.g., -d name=mypkg")
     parser.add_argument("-f", "--force", action='store_true', help="Overwrite file if it already exists")
-    parser.add_argument("-of", "--output-folder", help="Output folder for the generated files",
+    parser.add_argument("-o", "--output", help="Output folder for the generated files",
                         default=os.getcwd())
 
     args = parser.parse_args(*args)
@@ -61,7 +61,7 @@ def new(conan_api, parser, *args):
 
     # Saving the resulting files
     output = ConanOutput()
-    output_folder = args.output_folder
+    output_folder = args.output
     # Making sure they don't overwrite existing files
     for f, v in sorted(template_files.items()):
         path = os.path.join(output_folder, f)


### PR DESCRIPTION
Changelog: Feature: Add `--output` option to `conan new` command.
Docs: Omit

We found that it was usueful when creating a mock multiproject

Only thing is that we recently removed the conan new command tests, and there's no good place to add one now :(.

I can confirm that it works locally for me though