### PR TITLE
Fix an error that occurred when using `conan.tools.scm.Git.fetch_commit()` in a subfolder

### DIFF
--- a/conan/tools/scm/git.py
+++ b/conan/tools/scm/git.py
@@ -231,6 +231,7 @@ class Git:
         """
         if os.path.exists(url):
             url = url.replace("\\", "/")  # Windows local directory
+        mkdir(self.folder)
         self._conanfile.output.info("Shallow fetch of git repo")
         self.run('init')
         self.run(f'remote add origin "{url}"', hidden_output=url if hide_url else None)

--- a/test/functional/tools/scm/test_git.py
+++ b/test/functional/tools/scm/test_git.py
@@ -504,6 +504,45 @@ class TestGitShallowClone:
         c.run("source .")
         assert f'conanfile.py (pkg/0.1): RUN: git remote add origin "{url}"' in c.out
 
+    def test_clone_to_subfolder(self):
+        conanfile = textwrap.dedent("""
+            import os
+            from conan import ConanFile
+            from conan.tools.scm import Git
+            from conan.tools.files import load
+
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "0.1"
+
+                def layout(self):
+                    self.folders.source = "source"
+
+                def source(self):
+                    git = Git(self, folder="folder")
+                    git.fetch_commit(url="{url}", commit="{commit}")
+                    self.output.info("MYCMAKE: {{}}".format(load(self, "folder/CMakeLists.txt")))
+                    self.output.info("MYFILE: {{}}".format(load(self, "folder/src/myfile.h")))
+            """)
+        folder = os.path.join(temp_folder(), "myrepo")
+        url, commit = create_local_git_repo(files={"src/myfile.h": "myheader!",
+                                                   "CMakeLists.txt": "mycmake"}, folder=folder)
+        # This second commit will NOT be used, as I will use the above commit in the conanfile
+        save_files(path=folder, files={"src/myfile.h": "my2header2!"})
+        git_add_changes_commit(folder=folder)
+
+        c = TestClient()
+        c.save({"conanfile.py": conanfile.format(url=url, commit=commit)})
+        c.run("create . -v")
+        assert "pkg/0.1: MYCMAKE: mycmake" in c.out
+        assert "pkg/0.1: MYFILE: myheader!" in c.out
+
+        # It also works in local flow
+        c.run("source .")
+        assert "conanfile.py (pkg/0.1): MYCMAKE: mycmake" in c.out
+        assert "conanfile.py (pkg/0.1): MYFILE: myheader!" in c.out
+        assert c.load("source/folder/CMakeLists.txt") == "mycmake"
+        assert c.load("source/folder/src/myfile.h") == "myheader!"
 
 class TestGitCloneWithArgs:
     """ Git cloning passing additional arguments

--- a/test/functional/tools/scm/test_git.py
+++ b/test/functional/tools/scm/test_git.py
@@ -504,6 +504,7 @@ class TestGitShallowClone:
         c.run("source .")
         assert f'conanfile.py (pkg/0.1): RUN: git remote add origin "{url}"' in c.out
 
+    @pytest.mark.skipif(platform.system() == "Linux", reason="Git version in Linux not support it")
     def test_clone_to_subfolder(self):
         conanfile = textwrap.dedent("""
             import os


### PR DESCRIPTION
Changelog: Fix: Fixed an error that occurred when using `conan.tools.scm.Git.fetch_commit()` in a subfolder.
Docs: Omit

Fixes #17295  