### PR TITLE
pure refactor of ConanApp

### DIFF
--- a/conan/api/subapi/install.py
+++ b/conan/api/subapi/install.py
@@ -1,10 +1,12 @@
 import os
 
 from conan.internal.api.install.generators import write_generators
+from conan.internal.cache.home_paths import HomePaths
 from conan.internal.conan_app import ConanApp
 from conan.internal.deploy import do_deploys
 
 from conans.client.graph.install_graph import InstallGraph
+from conans.client.hook_manager import HookManager
 from conans.client.installer import BinaryInstaller
 from conan.errors import ConanInvalidConfiguration
 
@@ -87,5 +89,6 @@ class InstallAPI:
             if gen not in final_generators:
                 final_generators.append(gen)
         conanfile.generators = final_generators
-        app = ConanApp(self.conan_api)
-        write_generators(conanfile, app, envs_generation=envs_generation)
+        hook_manager = HookManager(HomePaths(self.conan_api.home_folder).hooks_path)
+        write_generators(conanfile, hook_manager, self.conan_api.home_folder,
+                         envs_generation=envs_generation)

--- a/conan/api/subapi/local.py
+++ b/conan/api/subapi/local.py
@@ -1,6 +1,7 @@
 import os
 
 from conan.cli import make_abs_path
+from conan.internal.cache.home_paths import HomePaths
 from conan.internal.conan_app import ConanApp
 from conan.internal.api.local.editable import EditablePackages
 from conan.internal.methods import run_build_method, run_source_method
@@ -8,6 +9,7 @@ from conans.client.graph.graph import CONTEXT_HOST
 from conans.client.graph.profile_node_definer import initialize_conanfile_profile
 from conan.internal.errors import conanfile_exception_formatter
 from conan.errors import ConanException
+from conans.client.hook_manager import HookManager
 from conans.model.recipe_ref import RecipeReference
 from conans.util.files import chdir
 
@@ -97,16 +99,16 @@ class LocalAPI:
         conanfile.folders.set_base_build(None)
         conanfile.folders.set_base_package(None)
 
-        app = ConanApp(self._conan_api)
-        run_source_method(conanfile, app.hook_manager)
+        hook_manager = HookManager(HomePaths(self._conan_api.home_folder).hooks_path)
+        run_source_method(conanfile, hook_manager)
 
     def build(self, conanfile):
         """ calls the 'build()' method of the current (user folder) conanfile.py
         """
-        app = ConanApp(self._conan_api)
+        hook_manager = HookManager(HomePaths(self._conan_api.home_folder).hooks_path)
         conanfile.folders.set_base_package(conanfile.folders.base_build)
         conanfile.folders.set_base_pkg_metadata(os.path.join(conanfile.build_folder, "metadata"))
-        run_build_method(conanfile, app.hook_manager)
+        run_build_method(conanfile, hook_manager)
 
     @staticmethod
     def test(conanfile):

--- a/conan/cli/command.py
+++ b/conan/cli/command.py
@@ -117,6 +117,7 @@ class ConanArgumentParser(argparse.ArgumentParser):
         ConanOutput.define_log_level(args.v)
         if getattr(args, "lockfile_packages", None):
             ConanOutput().error("The --lockfile-packages arg is private and shouldn't be used")
+        global_conf = self._conan_api.config.global_conf
         if args.core_conf:
             from conans.model.conf import ConfDefinition
             confs = ConfDefinition()
@@ -125,7 +126,14 @@ class ConanArgumentParser(argparse.ArgumentParser):
                     raise ConanException(f"Only core. values are allowed in --core-conf. Got {c}")
             confs.loads("\n".join(args.core_conf))
             confs.validate()
-            self._conan_api.config.global_conf.update_conf_definition(confs)
+            global_conf.update_conf_definition(confs)
+
+        # TODO: This might be even better moved to the ConanAPI so users without doing custom
+        #  commands can benefit from it
+        ConanOutput.set_warnings_as_errors(global_conf.get("core:warnings_as_errors",
+                                                           default=[], check_type=list))
+        ConanOutput.define_silence_warnings(global_conf.get("core:skip_warnings",
+                                                            default=[], check_type=list))
         return args
 
 

--- a/conan/internal/api/export.py
+++ b/conan/internal/api/export.py
@@ -12,13 +12,13 @@ from conan.internal.paths import DATA_YML
 from conans.util.files import is_dirty, rmdir, set_dirty, mkdir, clean_dirty, chdir
 
 
-def cmd_export(app, global_conf, conanfile_path, name, version, user, channel, graph_lock=None,
-               remotes=None):
+def cmd_export(app, hook_manager, global_conf, conanfile_path, name, version, user, channel,
+               graph_lock=None, remotes=None):
     """ Export the recipe
     param conanfile_path: the original source directory of the user containing a
                        conanfile.py
     """
-    loader, cache, hook_manager = app.loader, app.cache, app.hook_manager
+    loader, cache = app.loader, app.cache
     conanfile = loader.load_export(conanfile_path, name, version, user, channel, graph_lock,
                                    remotes=remotes)
 

--- a/conan/internal/api/install/generators.py
+++ b/conan/internal/api/install/generators.py
@@ -72,14 +72,13 @@ def load_cache_generators(path):
     return result
 
 
-def write_generators(conanfile, app, envs_generation=None):
+def write_generators(conanfile, hook_manager, home_folder, envs_generation=None):
     new_gen_folder = conanfile.generators_folder
     _receive_conf(conanfile)
     _receive_generators(conanfile)
 
-    hook_manager = app.hook_manager
     # TODO: Optimize this, so the global generators are not loaded every call to write_generators
-    global_generators = load_cache_generators(HomePaths(app.cache_folder).custom_generators_path)
+    global_generators = load_cache_generators(HomePaths(home_folder).custom_generators_path)
     hook_manager.execute("pre_generate", conanfile=conanfile)
 
     if conanfile.generators:

--- a/conan/internal/cache/integrity_check.py
+++ b/conan/internal/cache/integrity_check.py
@@ -17,8 +17,8 @@ class IntegrityChecker:
         This is to be done over the package contents, not the compressed conan_package.tgz
         artifacts
     """
-    def __init__(self, app):
-        self._app = app
+    def __init__(self, cache):
+        self._cache = cache
 
     def check(self, upload_data):
         corrupted = False
@@ -30,7 +30,7 @@ class IntegrityChecker:
             raise ConanException("There are corrupted artifacts, check the error logs")
 
     def _recipe_corrupted(self, ref: RecipeReference):
-        layout = self._app.cache.recipe_layout(ref)
+        layout = self._cache.recipe_layout(ref)
         output = ConanOutput()
         read_manifest, expected_manifest = layout.recipe_manifests()
         # Filter exports_sources from read manifest if there are no exports_sources locally
@@ -50,7 +50,7 @@ class IntegrityChecker:
         output.info(f"{ref}: Integrity checked: ok")
 
     def _package_corrupted(self, ref: PkgReference):
-        layout = self._app.cache.pkg_layout(ref)
+        layout = self._cache.pkg_layout(ref)
         output = ConanOutput()
         read_manifest, expected_manifest = layout.package_manifests()
 

--- a/conan/internal/conan_app.py
+++ b/conan/internal/conan_app.py
@@ -1,6 +1,5 @@
 import os
 
-from conan.api.output import ConanOutput
 from conan.internal.cache.cache import PkgCache
 from conan.internal.cache.home_paths import HomePaths
 from conans.client.graph.proxy import ConanProxy
@@ -41,12 +40,10 @@ class ConanApp:
     def __init__(self, conan_api):
         global_conf = conan_api.config.global_conf
         cache_folder = conan_api.home_folder
-        self._configure(global_conf)
         self.cache_folder = cache_folder
         self.cache = PkgCache(self.cache_folder, global_conf)
 
         home_paths = HomePaths(self.cache_folder)
-        self.hook_manager = HookManager(home_paths.hooks_path)
 
         # Wraps an http_requester to inject proxies, certs, etc
         self.requester = ConanRequester(global_conf, cache_folder)
@@ -65,10 +62,3 @@ class ConanApp:
         conanfile_helpers = ConanFileHelpers(self.requester, cmd_wrap, global_conf, self.cache,
                                              self.cache_folder)
         self.loader = ConanFileLoader(self.pyreq_loader, conanfile_helpers)
-
-    @staticmethod
-    def _configure(global_conf):
-        ConanOutput.set_warnings_as_errors(global_conf.get("core:warnings_as_errors",
-                                                           default=[], check_type=list))
-        ConanOutput.define_silence_warnings(global_conf.get("core:skip_warnings",
-                                                            default=[], check_type=list))

--- a/conans/client/rest_client_local_recipe_index.py
+++ b/conans/client/rest_client_local_recipe_index.py
@@ -10,6 +10,7 @@ from conan.api.model import LOCAL_RECIPES_INDEX
 from conan.api.output import ConanOutput
 from conan.internal.cache.home_paths import HomePaths
 from conan.internal.api.export import cmd_export
+from conans.client.hook_manager import HookManager
 from conans.client.loader import ConanFileLoader
 from conan.internal.errors import ConanReferenceDoesNotExistInDB, NotFoundException, RecipeNotFoundException, \
     PackageNotFoundException
@@ -68,6 +69,7 @@ class RestApiClientLocalRecipesIndex:
         from conan.api.conan_api import ConanAPI
         conan_api = ConanAPI(local_recipes_index_path)
         self._app = ConanApp(conan_api)
+        self._hook_manager = HookManager(HomePaths(conan_api.home_folder).hooks_path)
         self._layout = _LocalRecipesIndexLayout(repo_folder)
 
     def call_method(self, method_name, *args, **kwargs):
@@ -150,8 +152,8 @@ class RestApiClientLocalRecipesIndex:
         sys.stderr = StringIO()
         try:
             global_conf = ConfDefinition()
-            new_ref, _ = cmd_export(self._app, global_conf, conanfile_path, ref.name,
-                                    str(ref.version), None, None, remotes=[self._remote])
+            new_ref, _ = cmd_export(self._app, self._hook_manager, global_conf, conanfile_path,
+                                    ref.name, str(ref.version), None, None, remotes=[self._remote])
         except Exception as e:
             raise ConanException(f"Error while exporting recipe from remote: {self._remote.name}\n"
                                  f"{str(e)}")


### PR DESCRIPTION
Changelog: Omit
Docs: Omit


Pure internal refactor:

- To reduce the usage of ``ConanApp``, which is excessive in many situations
- To remove ConanOutput initialization logic from ``ConanApp``
- Decoupled ``HookManager`` from ``ConanApp``. It might end in its own API initialization, to load only once hooks, but that would be in a separate PR