### PR TITLE
Fix Conan auth for certain Artifactory configurations: #17365

### DIFF
--- a/conan/api/subapi/remotes.py
+++ b/conan/api/subapi/remotes.py
@@ -247,7 +247,7 @@ class RemotesAPI:
                 user = os.getenv(var_name, None) or os.getenv("CONAN_LOGIN_USERNAME", None)
             if not user:
                 return
-        app.remote_manager.check_credentials(remote)
+        app.remote_manager.check_credentials(remote, True)
         user, token, _ = app.localdb.get_login(remote.url)
         return user
 

--- a/conan/api/subapi/remotes.py
+++ b/conan/api/subapi/remotes.py
@@ -237,7 +237,7 @@ class RemotesAPI:
             username = None
         localdb.store(username, token=None, refresh_token=None, remote_url=remote.url)
 
-    def user_auth(self, remote: Remote, with_user=False):
+    def user_auth(self, remote: Remote, with_user=False, force=False):
         # TODO: Review
         app = ConanApp(self.conan_api)
         if with_user:
@@ -247,7 +247,7 @@ class RemotesAPI:
                 user = os.getenv(var_name, None) or os.getenv("CONAN_LOGIN_USERNAME", None)
             if not user:
                 return
-        app.remote_manager.check_credentials(remote, True)
+        app.remote_manager.check_credentials(remote, force)
         user, token, _ = app.localdb.get_login(remote.url)
         return user
 

--- a/conan/cli/commands/remote.py
+++ b/conan/cli/commands/remote.py
@@ -278,7 +278,11 @@ def print_auth_json(results):
 @conan_subcommand(formatters={"text": print_auth, "json": print_auth_json})
 def remote_auth(conan_api, parser, subparser, *args):
     """
-    Authenticate in the defined remotes
+    Authenticate in the defined remotes. Use CONAN_LOGIN* and CONAN_PASSWORD* variables if available.
+    Ask for username and password interactively in case (re-)authentication is required and there are
+    no CONAN_LOGIN* and CONAN_PASSWORD* variables available which could be used.
+    Usually you'd use this method over conan remote login for scripting which needs to run in CI
+    and locally.
     """
     subparser.add_argument("remote", help="Pattern or name of the remote/s to authenticate against."
                                           " The pattern uses 'fnmatch' style wildcards.")

--- a/conan/cli/commands/remote.py
+++ b/conan/cli/commands/remote.py
@@ -289,6 +289,12 @@ def remote_auth(conan_api, parser, subparser, *args):
     subparser.add_argument("--with-user", action="store_true",
                            help="Only try to auth in those remotes that already "
                                 "have a username or a CONAN_LOGIN_ env-var defined")
+    subparser.add_argument("--force", action="store_true",
+                           help="Force authentication for anonymous-enabled repositories. "
+                                "Can be used for force authentication in case your Artifactory "
+                                "instance has anonymous access enabled and Conan would not ask "
+                                "for username and password even for non-anonymous repositories "
+                                "if not yet authenticated.")
     args = parser.parse_args(*args)
     remotes = conan_api.remotes.list(pattern=args.remote)
     if not remotes:
@@ -297,7 +303,7 @@ def remote_auth(conan_api, parser, subparser, *args):
     results = {}
     for r in remotes:
         try:
-            results[r.name] = {"user": conan_api.remotes.user_auth(r, args.with_user)}
+            results[r.name] = {"user": conan_api.remotes.user_auth(r, args.with_user, args.force)}
         except Exception as e:
             results[r.name] = {"error": str(e)}
     return results

--- a/conans/client/remote_manager.py
+++ b/conans/client/remote_manager.py
@@ -32,8 +32,8 @@ class RemoteManager:
         if remote.remote_type == LOCAL_RECIPES_INDEX:
             return RestApiClientLocalRecipesIndex(remote, self._home_folder)
 
-    def check_credentials(self, remote):
-        self._call_remote(remote, "check_credentials")
+    def check_credentials(self, remote, force_auth=False):
+        self._call_remote(remote, "check_credentials", force_auth)
 
     def upload_recipe(self, ref, files_to_upload, remote):
         assert isinstance(ref, RecipeReference)

--- a/conans/client/rest/rest_client.py
+++ b/conans/client/rest/rest_client.py
@@ -62,8 +62,8 @@ class RestApiClient:
         token = api_v2.authenticate(user, password)
         return token
 
-    def check_credentials(self):
-        return self._get_api().check_credentials()
+    def check_credentials(self, force_auth=False):
+        return self._get_api().check_credentials(force_auth)
 
     def search(self, pattern=None, ignorecase=True):
         return self._get_api().search(pattern, ignorecase)

--- a/conans/client/rest/rest_client_v2.py
+++ b/conans/client/rest/rest_client_v2.py
@@ -95,12 +95,16 @@ class RestV2Methods:
         self._check_error_response(ret)
         return ret.content.decode()
 
-    def check_credentials(self):
+    def check_credentials(self, force_auth=False):
         """If token is not valid will raise AuthenticationException.
         User will be asked for new user/pass"""
         url = self.router.common_check_credentials()
+        auth = self.auth
+        if force_auth and auth.bearer is None:
+            auth = JWTAuth("unset")
+
         # logger.debug("REST: Check credentials: %s" % url)
-        ret = self.requester.get(url, auth=self.auth, headers=self.custom_headers,
+        ret = self.requester.get(url, auth=auth, headers=self.custom_headers,
                                  verify=self.verify_ssl)
         if ret.status_code != 200:
             ret.charset = "utf-8"  # To be able to access ret.text (ret.content are bytes)

--- a/conans/client/rest_client_local_recipe_index.py
+++ b/conans/client/rest_client_local_recipe_index.py
@@ -102,7 +102,7 @@ class RestApiClientLocalRecipesIndex:
         raise ConanException(f"Remote local-recipes-index '{self._remote.name}' doesn't support "
                              "authentication")
 
-    def check_credentials(self):
+    def check_credentials(self, force_auth=False):
         raise ConanException(f"Remote local-recipes-index '{self._remote.name}' doesn't support upload")
 
     def search(self, pattern=None):

--- a/test/integration/command/user_test.py
+++ b/test/integration/command/user_test.py
@@ -5,6 +5,8 @@ import unittest
 from collections import OrderedDict
 from datetime import timedelta
 
+from mock import patch
+
 from conan.internal.api.remotes.localdb import LocalDB
 from conan.test.utils.tools import TestClient, TestServer
 from conan.test.utils.env import environment_update
@@ -362,6 +364,28 @@ class TestRemoteAuth:
         c.run("remote auth * --format=json")
         result = json.loads(c.stdout)
         assert result == {'default': {'user': 'lasote'}, 'other_server': {'user': 'lasote'}}
+
+    def test_remote_auth_force(self):
+        servers = OrderedDict()
+        servers["default"] = TestServer(users={"lasote": "mypass", "danimtb": "passpass"})
+        servers["other_server"] = TestServer(users={"lasote": "mypass"})
+        c = TestClient(servers=servers, inputs=["lasote", "mypass", "danimtb", "passpass",
+                                                "lasote", "mypass"])
+
+        with patch("conans.client.rest.rest_client_v2.RestV2Methods.check_credentials") as check_credentials_mock:
+            c.run("remote auth --force *")
+            check_credentials_mock.assert_called_with(True)
+
+    def test_remote_auth_force_false(self):
+        servers = OrderedDict()
+        servers["default"] = TestServer(users={"lasote": "mypass", "danimtb": "passpass"})
+        servers["other_server"] = TestServer(users={"lasote": "mypass"})
+        c = TestClient(servers=servers, inputs=["lasote", "mypass", "danimtb", "passpass",
+                                                "lasote", "mypass"])
+
+        with patch("conans.client.rest.rest_client_v2.RestV2Methods.check_credentials") as check_credentials_mock:
+            c.run("remote auth *")
+            check_credentials_mock.assert_called_with(False)
 
     def test_remote_auth_with_user(self):
         servers = OrderedDict()

--- a/test/unittests/client/rest/rest_client_v2/rest_client_v2_test.py
+++ b/test/unittests/client/rest/rest_client_v2/rest_client_v2_test.py
@@ -1,0 +1,30 @@
+from conans.client.rest.rest_client_v2 import RestV2Methods
+from mock import ANY, MagicMock, patch
+
+
+@patch("conans.client.rest.conan_requester.ConanRequester")
+def test_check_credentials_set_token_to_unset_with_force_auth_true_and_token_none(
+    conanRequesterMock,
+):
+    return_status = MagicMock()
+    return_status.status_code = 200
+    conanRequesterMock.get = MagicMock(return_value=return_status)
+
+    rest_v2_methods = RestV2Methods("foo", None, conanRequesterMock, None, True)
+    rest_v2_methods.check_credentials(True)
+
+    assert conanRequesterMock.get.call_args[1]["auth"].bearer == "Bearer unset"
+
+
+@patch("conans.client.rest.conan_requester.ConanRequester")
+def test_check_credentials_keep_token_none_with_force_auth_false_and_token_none(
+    conanRequesterMock,
+):
+    return_status = MagicMock()
+    return_status.status_code = 200
+    conanRequesterMock.get = MagicMock(return_value=return_status)
+
+    rest_v2_methods = RestV2Methods("foo", None, conanRequesterMock, None, True)
+    rest_v2_methods.check_credentials(False)
+
+    assert conanRequesterMock.get.call_args[1]["auth"].bearer is None


### PR DESCRIPTION
Changelog: Feature: Add `--force` option to `conan remote auth` to force authentication even for remotes that have anonymous access enabled.
Docs: https://github.com/conan-io/docs/pull/3924

- [x] Issue: #17365.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
