### PR TITLE
[CMakeToolchain] fix adding tools.android:ndk_path with spaces in path

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -375,7 +375,7 @@ class AndroidSystemBlock(Block):
         {% if android_use_legacy_toolchain_file %}
         set(ANDROID_USE_LEGACY_TOOLCHAIN_FILE {{ android_use_legacy_toolchain_file }})
         {% endif %}
-        include({{ android_ndk_path }}/build/cmake/android.toolchain.cmake)
+        include("{{ android_ndk_path }}/build/cmake/android.toolchain.cmake")
         """)
 
     def context(self):

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -831,7 +831,7 @@ def test_android_c_library():
     conan_toolchain = client.load(os.path.join(client.current_folder, "conan_toolchain.cmake"))
     assert "set(ANDROID_PLATFORM android-23)" in conan_toolchain
     assert "set(ANDROID_ABI x86_64)" in conan_toolchain
-    assert "include("/foo/build/cmake/android.toolchain.cmake")" in conan_toolchain
+    assert 'include("/foo/build/cmake/android.toolchain.cmake")' in conan_toolchain
     client.run("create . --name=foo --version=1.0 " + settings)
 
 

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -831,7 +831,7 @@ def test_android_c_library():
     conan_toolchain = client.load(os.path.join(client.current_folder, "conan_toolchain.cmake"))
     assert "set(ANDROID_PLATFORM android-23)" in conan_toolchain
     assert "set(ANDROID_ABI x86_64)" in conan_toolchain
-    assert "include(/foo/build/cmake/android.toolchain.cmake)" in conan_toolchain
+    assert "include("/foo/build/cmake/android.toolchain.cmake")" in conan_toolchain
     client.run("create . --name=foo --version=1.0 " + settings)
 
 


### PR DESCRIPTION
Changelog: Bugfix: Fix adding `tools.android:ndk_path` with spaces in path.
Docs: Omit

Closes: https://github.com/conan-io/conan/issues/17378

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
