### PR TITLE
fixing clang-cl flags

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -243,7 +243,7 @@ class ArchitectureBlock(Block):
         """)
 
     def context(self):
-        arch_flag = architecture_flag(self._conanfile.settings)
+        arch_flag = architecture_flag(self._conanfile)
         if not arch_flag:
             return
         return {"arch_flag": arch_flag}

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -46,12 +46,12 @@ class AutotoolsToolchain:
             self.ndebug = "NDEBUG"
 
         # TODO: This is also covering compilers like Visual Studio, necessary to test it (&remove?)
-        self.build_type_flags = build_type_flags(self._conanfile.settings)
+        self.build_type_flags = build_type_flags(self._conanfile)
         self.build_type_link_flags = build_type_link_flags(self._conanfile.settings)
 
         self.cppstd = cppstd_flag(self._conanfile)
         self.cstd = cstd_flag(self._conanfile)
-        self.arch_flag = architecture_flag(self._conanfile.settings)
+        self.arch_flag = architecture_flag(self._conanfile)
         self.libcxx, self.gcc_cxx11_abi = libcxx_flags(self._conanfile)
         self.fpic = self._conanfile.options.get_safe("fPIC")
         self.msvc_runtime_flag = self._get_msvc_runtime_flag()

--- a/conan/tools/gnu/gnutoolchain.py
+++ b/conan/tools/gnu/gnutoolchain.py
@@ -53,11 +53,11 @@ class GnuToolchain:
             self.ndebug = "NDEBUG"
 
         # TODO: This is also covering compilers like Visual Studio, necessary to test it (&remove?)
-        self.build_type_flags = build_type_flags(self._conanfile.settings)
+        self.build_type_flags = build_type_flags(self._conanfile)
         self.build_type_link_flags = build_type_link_flags(self._conanfile.settings)
 
         self.cppstd = cppstd_flag(self._conanfile)
-        self.arch_flag = architecture_flag(self._conanfile.settings)
+        self.arch_flag = architecture_flag(self._conanfile)
         self.libcxx, self.gcc_cxx11_abi = libcxx_flags(self._conanfile)
         self.fpic = self._conanfile.options.get_safe("fPIC")
         self.msvc_runtime_flag = self._get_msvc_runtime_flag()

--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -43,7 +43,7 @@ class NMakeToolchain(object):
 
     @property
     def _cl(self):
-        bt_flags = build_type_flags(self._conanfile.settings)
+        bt_flags = build_type_flags(self._conanfile)
         bt_flags = bt_flags if bt_flags else []
 
         rt_flags = msvc_runtime_flag(self._conanfile)

--- a/test/unittests/tools/intel/test_intel_cc.py
+++ b/test/unittests/tools/intel/test_intel_cc.py
@@ -25,7 +25,9 @@ def test_architecture_flag_if_intel_cc(os_, arch, expected):
         "arch": arch,
         "os": os_
     })
-    flag = architecture_flag(settings)
+    conanfile = ConanFileMock()
+    conanfile.settings = settings
+    flag = architecture_flag(conanfile)
     assert flag == expected
 
 


### PR DESCRIPTION
Changelog: Bugfix: Add correct flags when ``compiler=clang`` and ``compiler_executables={"c": "clang-cl"}`` to not inject incorrect flags when cross-building from Linux to Windows.
Docs: Omit

Close https://github.com/conan-io/conan/issues/17039