### PR TITLE
Warn on empty version ranges

### DIFF
--- a/conan/cli/printers/graph.py
+++ b/conan/cli/printers/graph.py
@@ -68,6 +68,10 @@ def print_graph_basic(graph):
                        "it might be removed in 3.0.")
         output.warning("Consider using version-ranges instead.")
     _format_resolved("Resolved version ranges", graph.resolved_ranges)
+    for req in graph.resolved_ranges:
+        if str(req.version) == "[]":
+            output.warning("Empty version range usage is discouraged. Use [*] instead", warn_tag="deprecated")
+            break
 
     overrides = graph.overrides()
     if overrides:

--- a/conans/model/version_range.py
+++ b/conans/model/version_range.py
@@ -148,9 +148,6 @@ class _ConditionSet:
 class VersionRange:
     def __init__(self, expression):
         self._expression = expression
-        if not expression:
-            from conan.api.output import ConanOutput
-            ConanOutput().warning("Empty version range usage is discouraged. Use [*] instead", warn_tag="deprecated")
         tokens = expression.split(",")
         prereleases = False
         for t in tokens[1:]:

--- a/conans/model/version_range.py
+++ b/conans/model/version_range.py
@@ -148,6 +148,9 @@ class _ConditionSet:
 class VersionRange:
     def __init__(self, expression):
         self._expression = expression
+        if not expression:
+            from conan.api.output import ConanOutput
+            ConanOutput().warning("Empty version range usage is discouraged", warn_tag="deprecated")
         tokens = expression.split(",")
         prereleases = False
         for t in tokens[1:]:

--- a/conans/model/version_range.py
+++ b/conans/model/version_range.py
@@ -150,7 +150,7 @@ class VersionRange:
         self._expression = expression
         if not expression:
             from conan.api.output import ConanOutput
-            ConanOutput().warning("Empty version range usage is discouraged", warn_tag="deprecated")
+            ConanOutput().warning("Empty version range usage is discouraged. Use [*] instead", warn_tag="deprecated")
         tokens = expression.split(",")
         prereleases = False
         for t in tokens[1:]:

--- a/test/integration/graph/core/test_version_ranges.py
+++ b/test/integration/graph/core/test_version_ranges.py
@@ -437,3 +437,13 @@ def test_bad_options_syntax(version_range, should_warn):
         assert "its presence unconditionally enables prereleases" in tc.out
     else:
         assert "its presence unconditionally enables prereleases" not in tc.out
+
+
+def test_empty_version_ranger():
+    tc = TestClient(light=True)
+    tc.save({"lib/conanfile.py": GenConanfile("lib", "1.0"),
+             "app/conanfile.py": GenConanfile("app", "1.0").with_requires("lib/[]")})
+    tc.run("export lib")
+    tc.run("graph info app")
+    assert "lib/[]: lib/1.0" in tc.out
+    assert "Empty version range usage is discouraged" in tc.out

--- a/test/unittests/model/version/test_version_range.py
+++ b/test/unittests/model/version/test_version_range.py
@@ -112,6 +112,10 @@ def test_range(version_range, conditions, versions_in, versions_out):
     ['>1 <=2.0', False, ["1.1", "1.9", "2.0"], ["0.9", "1.0-pre.1", "1.0", "1.1-pre.1", "2.0-pre"]],
     # This should be old and new behaviors remain the same
     ['>1 <=2.0', True, ["1.1-pre.1", "1.1", "1.9", "2.0", "2.0-pre"], ["0.9", "1.0", "1.0-pre.1"]],
+
+    # Codified quirks
+    ['', False, ["1.0", "2.0"], ["1.0-pre.1", "2.0-pre.1"]],
+    ['', True, ["1.0", "2.0", "1.0-pre.1", "2.0-pre.1"], []],
 ])
 def test_range_prereleases_conf(version_range, resolve_prereleases, versions_in, versions_out):
     r = VersionRange(version_range)


### PR DESCRIPTION
Changelog: Fix: Add warning for empty version ranges.
Docs: Omit

For https://github.com/conan-io/conan/issues/17403
