### PR TITLE
Add get_safe None comparison tests

### DIFF
--- a/test/integration/options/options_test.py
+++ b/test/integration/options/options_test.py
@@ -773,3 +773,17 @@ class TestConflictOptionsWarnings:
             """)
         assert expected in c.out
         assert "WARN: risk: There are options conflicts in the dependency graph" in c.out
+
+
+def test_get_safe_none_option_checks():
+    tc = TestClient(light=True)
+    tc.save({"conanfile.py": GenConanfile("foo", "1.0")
+            .with_package("self.output.info(f'get_safe is None: {self.options.get_safe('myoption') is None}')",
+                          "self.output.info(f'get_safe is not None: {self.options.get_safe('myoption') is not None}')",
+                          "self.output.info(f'get_safe == None: {self.options.get_safe('myoption') == None}')",
+                          "self.output.info(f'get_safe != None: {self.options.get_safe('myoption') != None}')" )})
+    tc.run("create .")
+    assert "get_safe is None: True" in tc.out
+    assert "get_safe is not None: False" in tc.out
+    assert "get_safe == None: True" in tc.out
+    assert "get_safe != None: False" in tc.out

--- a/test/integration/options/options_test.py
+++ b/test/integration/options/options_test.py
@@ -778,10 +778,10 @@ class TestConflictOptionsWarnings:
 def test_get_safe_none_option_checks():
     tc = TestClient(light=True)
     tc.save({"conanfile.py": GenConanfile("foo", "1.0")
-            .with_package("self.output.info(f'get_safe is None: {self.options.get_safe('myoption') is None}')",
-                          "self.output.info(f'get_safe is not None: {self.options.get_safe('myoption') is not None}')",
-                          "self.output.info(f'get_safe == None: {self.options.get_safe('myoption') == None}')",
-                          "self.output.info(f'get_safe != None: {self.options.get_safe('myoption') != None}')" )})
+            .with_package("self.output.info(f'get_safe is None: {self.options.get_safe(\"myoption\") is None}')",
+                          "self.output.info(f'get_safe is not None: {self.options.get_safe(\"myoption\") is not None}')",
+                          "self.output.info(f'get_safe == None: {self.options.get_safe(\"myoption\") == None}')",
+                          "self.output.info(f'get_safe != None: {self.options.get_safe(\"myoption\") != None}')" )})
     tc.run("create .")
     assert "get_safe is None: True" in tc.out
     assert "get_safe is not None: False" in tc.out


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

There were no explicit tests for how the get_safe function behaves for `None` comparisions

Came about as part of the review of https://github.com/conan-io/conan-center-index/pull/25687 