### PR TITLE
Remove timeouts from db connection

### DIFF
--- a/conan/internal/cache/db/table.py
+++ b/conan/internal/cache/db/table.py
@@ -23,13 +23,12 @@ class BaseDbTable:
 
     @contextmanager
     def db_connection(self):
-        assert self._lock.acquire(timeout=10), "Conan failed to acquire database lock"
-        connection = sqlite3.connect(self.filename, isolation_level=None, timeout=10)
-        try:
-            yield connection
-        finally:
-            connection.close()
-            self._lock.release()
+        with self._lock:
+            connection = sqlite3.connect(self.filename, isolation_level=None)
+            try:
+                yield connection
+            finally:
+                connection.close()
 
     def create_table(self):
         def field(name, typename, nullable=False, check_constraints: Optional[List] = None,


### PR DESCRIPTION
Changelog: Fix: Remove DB connection timeouts

As observed in https://github.com/conan-io/conan/issues/13924#issuecomment-2494111079 and also by me, `Conan failed to acquire database lock` may be triggered on machines with lots of cores and high load - in CI, in other words. All cases I observed were because of high load. I don't think it is meaningful to fail because of this, as it's treated as a flap, build gets restarted which does not help with cpu load. I don't know any other possible reasons for this timeout to trigger, so in my opinion it should not exist at all.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
