### PR TITLE
jinja profiles folder added to search path

### DIFF
--- a/conan/internal/api/profile/profile_loader.py
+++ b/conan/internal/api/profile/profile_loader.py
@@ -123,12 +123,9 @@ class ProfileLoader:
                    "conan_version": conan_version,
                    "detect_api": detect_api}
 
-        # If the profile is in the home profiles folder, use the profiles folder as search
-        # path too, to allow loading "common" profiles in common folders, not only children
-        loader_paths = base_path
-        if os.path.commonpath([profiles_folder]) == os.path.commonpath([profiles_folder,
-                                                                        profile_path]):
-            loader_paths = [base_path, profiles_folder]
+        # Always include the root Conan home "profiles" folder as secondary route for loading
+        # imports and includes from jinja2 templates.
+        loader_paths = [base_path, profiles_folder]
         rtemplate = Environment(loader=FileSystemLoader(loader_paths)).from_string(text)
 
         try:

--- a/conan/internal/api/profile/profile_loader.py
+++ b/conan/internal/api/profile/profile_loader.py
@@ -123,7 +123,13 @@ class ProfileLoader:
                    "conan_version": conan_version,
                    "detect_api": detect_api}
 
-        rtemplate = Environment(loader=FileSystemLoader(base_path)).from_string(text)
+        # If the profile is in the home profiles folder, use the profiles folder as search
+        # path too, to allow loading "common" profiles in common folders, not only children
+        loader_paths = base_path
+        if os.path.commonpath([profiles_folder]) == os.path.commonpath([profiles_folder,
+                                                                        profile_path]):
+            loader_paths = [base_path, profiles_folder]
+        rtemplate = Environment(loader=FileSystemLoader(loader_paths)).from_string(text)
 
         try:
             text = rtemplate.render(context)

--- a/test/integration/configuration/test_profile_jinja.py
+++ b/test/integration/configuration/test_profile_jinja.py
@@ -55,6 +55,24 @@ def test_profile_template_import():
     assert "os=FreeBSD" in client.out
 
 
+def test_profile_template_import_sibling():
+    # https://github.com/conan-io/conan/issues/17431
+    client = TestClient()
+    tpl1 = textwrap.dedent(r"""
+        {% import "sub2/profile_vars" as vars %}
+        [settings]
+        os = {{ vars.a }}
+        """)
+    tpl2 = textwrap.dedent("""
+        {% set a = "FreeBSD" %}
+        """)
+    client.save_home({"profiles/sub1/profile1": tpl1,
+                      "profiles/sub2/profile_vars": tpl2})
+    client.save({"conanfile.py": GenConanfile()})
+    client.run("install . -pr=sub1/profile1")
+    assert "os=FreeBSD" in client.out
+
+
 def test_profile_template_include():
     client = TestClient()
     tpl1 = textwrap.dedent("""
@@ -69,6 +87,24 @@ def test_profile_template_include():
                  "profile1": tpl1,
                  "profile_vars": tpl2})
     client.run("install . -pr=profile1")
+    assert "os=FreeBSD" in client.out
+
+
+def test_profile_template_include_sibling():
+    # https://github.com/conan-io/conan/issues/17431
+    client = TestClient()
+    tpl1 = textwrap.dedent(r"""
+        {% include "sub2/profile_vars" %}
+        """)
+    tpl2 = textwrap.dedent("""
+        {% set a = "FreeBSD" %}
+        [settings]
+        os = {{ a }}
+        """)
+    client.save_home({"profiles/sub1/profile1": tpl1,
+                      "profiles/sub2/profile_vars": tpl2})
+    client.save({"conanfile.py": GenConanfile()})
+    client.run("install . -pr=sub1/profile1")
     assert "os=FreeBSD" in client.out
 
 

--- a/test/integration/configuration/test_profile_jinja.py
+++ b/test/integration/configuration/test_profile_jinja.py
@@ -108,6 +108,24 @@ def test_profile_template_include_sibling():
     assert "os=FreeBSD" in client.out
 
 
+def test_profile_template_include_from_cache():
+    # https://github.com/conan-io/conan/issues/17431
+    client = TestClient()
+    tpl1 = textwrap.dedent(r"""
+        {% include "sub2/profile_vars" %}
+        """)
+    tpl2 = textwrap.dedent("""
+        {% set a = "FreeBSD" %}
+        [settings]
+        os = {{ a }}
+        """)
+    client.save_home({"profiles/sub2/profile_vars": tpl2})
+    client.save({"conanfile.py": GenConanfile(),
+                 "sub1/profile1": tpl1})
+    client.run("install . -pr=sub1/profile1")
+    assert "os=FreeBSD" in client.out
+
+
 def test_profile_template_profile_dir():
     client = TestClient()
     tpl1 = textwrap.dedent("""


### PR DESCRIPTION
Changelog: Feature: Adding the Conan cache "profiles" folder to the jinja2 search path, so profiles can be included/imported from jinja syntax even for parent and sibling folders.
Docs: https://github.com/conan-io/docs/pull/3950

Close https://github.com/conan-io/conan/issues/17431

I think this shouldn't have a high risk, because it is adding a new search path to the ``FileSystemLoader``. That means that Conan will keep looking for the paths for imported/included in exactly the same way, and only after exhausting the search, will start searching in the added path. So the jinja rendered shouldn't change the found files, and only add new files that were not found before (failing with an error, so it cannot break)

I have only added the ``profiles-folder`` in the cache, I don't think for a local folder not in the cache, a clear "base" path doesn't exist, so not possible to define that base search path.