### PR TITLE
Only warn on frozen conan v1 remote if enabled

### DIFF
--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -249,7 +249,7 @@ def _warn_python_version():
 def _warn_frozen_center(conan_api):
     remotes = conan_api.remotes.list()
     for r in remotes:
-        if r.url == "https://center.conan.io":
+        if r.url == "https://center.conan.io" and not r.disabled:
             ConanOutput().warning(
                 "The remote 'https://center.conan.io' is now frozen and has been replaced by 'https://center2.conan.io'. \n"
                 "Starting from Conan 2.9.2, the default remote is 'center2.conan.io'. \n"

--- a/test/integration/command/remote_test.py
+++ b/test/integration/command/remote_test.py
@@ -366,6 +366,9 @@ def test_using_frozen_center():
     c.run("remote update conancenter --url=https://center.conan.io")
     assert "The remote 'https://center.conan.io' is now frozen and has been replaced by 'https://center2.conan.io'." in c.out
 
+    c.run("remote disable conancenter")
+    assert "The remote 'https://center.conan.io' is now frozen and has been replaced by 'https://center2.conan.io'." not in c.out
+
 
 def test_wrong_remotes_json_file():
     c = TestClient(light=True)


### PR DESCRIPTION
Changelog: Feature: Only warn on frozen conan v1 remote if enabled.
Docs: Omit

cc/ @jcar87 


