### PR TITLE
refactor test usage of ConanAPI

### DIFF
--- a/conan/test/utils/tools.py
+++ b/conan/test/utils/tools.py
@@ -24,6 +24,7 @@ from mock import Mock
 from requests.exceptions import HTTPError
 from webtest.app import TestApp
 
+from conan.api.subapi.config import ConfigAPI
 from conan.api.subapi.remotes import _save
 from conan.cli.exit_codes import SUCCESS, ERROR_GENERAL
 from conan.internal.cache.cache import PackageLayout, RecipeLayout, PkgCache
@@ -457,7 +458,7 @@ class TestClient:
         # create default profile
         if light:
             text = "[settings]\nos=Linux"  # Needed at least build-os
-            save(self.cache.settings_path, "os: [Linux, Windows]")
+            save(self.paths.settings_path, "os: [Linux, Windows]")
         else:
             text = default_profiles[platform.system()]
         save(os.path.join(self.cache_folder, "profiles", "default"), text)
@@ -476,15 +477,11 @@ class TestClient:
     @property
     def cache(self):
         # Returns a temporary cache object intended for inspecting it
-        api = ConanAPI(cache_folder=self.cache_folder)
-        global_conf = api.config.global_conf
+        return PkgCache(self.cache_folder, ConfigAPI.load_config(self.cache_folder))
 
-        class MyCache(PkgCache, HomePaths):  # Temporary class to avoid breaking all tests
-            def __init__(self, cache_folder):
-                PkgCache.__init__(self, cache_folder, global_conf)
-                HomePaths.__init__(self, cache_folder)
-
-        return MyCache(self.cache_folder)
+    @property
+    def paths(self):
+        return HomePaths(self.cache_folder)
 
     @property
     def base_folder(self):

--- a/test/functional/command/config_install_test.py
+++ b/test/functional/command/config_install_test.py
@@ -79,8 +79,8 @@ myfuncpy = """def mycooladd(a, b):
 class ConfigInstallTest(unittest.TestCase):
     def setUp(self):
         self.client = TestClient()
-        save(os.path.join(self.client.cache.profiles_path, "default"), "#default profile empty")
-        save(os.path.join(self.client.cache.profiles_path, "linux"), "#empty linux profile")
+        save(os.path.join(self.client.paths.profiles_path, "default"), "#default profile empty")
+        save(os.path.join(self.client.paths.profiles_path, "linux"), "#empty linux profile")
 
     @staticmethod
     def _create_profile_folder(folder=None):
@@ -134,7 +134,7 @@ class ConfigInstallTest(unittest.TestCase):
         return tgz_with_contents(files, tgz_path)
 
     def _check(self, params):
-        settings_path = self.client.cache.settings_path
+        settings_path = self.client.paths.settings_path
         self.assertEqual(load(settings_path).splitlines(), settings_yml.splitlines())
         api = self.client.api
         cache_remotes = api.remotes.list()
@@ -142,11 +142,11 @@ class ConfigInstallTest(unittest.TestCase):
             Remote("myrepo1", "https://myrepourl.net", False, False),
             Remote("my-repo-2", "https://myrepo2.com", True, False),
         ])
-        self.assertEqual(sorted(os.listdir(self.client.cache.profiles_path)),
+        self.assertEqual(sorted(os.listdir(self.client.paths.profiles_path)),
                          sorted(["default", "linux", "windows"]))
-        self.assertEqual(load(os.path.join(self.client.cache.profiles_path, "linux")).splitlines(),
+        self.assertEqual(load(os.path.join(self.client.paths.profiles_path, "linux")).splitlines(),
                          linux_profile.splitlines())
-        self.assertEqual(load(os.path.join(self.client.cache.profiles_path,
+        self.assertEqual(load(os.path.join(self.client.paths.profiles_path,
                                            "windows")).splitlines(),
                          win_profile.splitlines())
         self.assertEqual("#Custom pylint",
@@ -260,12 +260,12 @@ class ConfigInstallTest(unittest.TestCase):
         assert "repojson2: https://repojson2.com [Verify SSL: True, Enabled: True]" in self.client.out
 
     def test_without_profile_folder(self):
-        shutil.rmtree(self.client.cache.profiles_path)
+        shutil.rmtree(self.client.paths.profiles_path)
         zippath = self._create_zip()
         self.client.run('config install "%s"' % zippath)
-        self.assertEqual(sorted(os.listdir(self.client.cache.profiles_path)),
+        self.assertEqual(sorted(os.listdir(self.client.paths.profiles_path)),
                          sorted(["linux", "windows"]))
-        self.assertEqual(load(os.path.join(self.client.cache.profiles_path, "linux")).splitlines(),
+        self.assertEqual(load(os.path.join(self.client.paths.profiles_path, "linux")).splitlines(),
                          linux_profile.splitlines())
 
     def test_install_url(self):
@@ -496,7 +496,7 @@ class ConfigInstallTest(unittest.TestCase):
         self.client.run('config install "%s/.git" --args "-b other_branch"' % folder)
         check_path = os.path.join(folder, ".git")
         self._check("git, %s, True, -b other_branch" % check_path)
-        file_path = os.path.join(self.client.cache.hooks_path, "cust", "cust.py")
+        file_path = os.path.join(self.client.paths.hooks_path, "cust", "cust.py")
         assert load(file_path) == ""
 
         # Add changes to that branch and update
@@ -525,12 +525,12 @@ class ConfigInstallTest(unittest.TestCase):
         source_folder = self._create_profile_folder()
         self.client.run('config install "%s"' % source_folder)
         # make existing settings.yml read-only
-        make_file_read_only(self.client.cache.settings_path)
-        self.assertFalse(os.access(self.client.cache.settings_path, os.W_OK))
+        make_file_read_only(self.client.paths.settings_path)
+        self.assertFalse(os.access(self.client.paths.settings_path, os.W_OK))
 
         # config install should overwrite the existing read-only file
         self.client.run('config install "%s"' % source_folder)
-        self.assertTrue(os.access(self.client.cache.settings_path, os.W_OK))
+        self.assertTrue(os.access(self.client.paths.settings_path, os.W_OK))
 
     def test_dont_copy_file_permissions(self):
         source_folder = self._create_profile_folder()
@@ -538,7 +538,7 @@ class ConfigInstallTest(unittest.TestCase):
         make_file_read_only(os.path.join(source_folder, 'remotes.json'))
 
         self.client.run('config install "%s"' % source_folder)
-        self.assertTrue(os.access(self.client.cache.settings_path, os.W_OK))
+        self.assertTrue(os.access(self.client.paths.settings_path, os.W_OK))
 
 
 class ConfigInstallSchedTest(unittest.TestCase):
@@ -587,7 +587,7 @@ class ConfigInstallSchedTest(unittest.TestCase):
         assert ".gitlab-conan" in client.cache_folder
         assert os.path.basename(client.cache_folder) == DEFAULT_CONAN_HOME
         client.run('config install "%s/.git" --type git' % self.folder)
-        conf = load(client.cache.new_config_path)
+        conf = load(client.paths.new_config_path)
         dirs = os.listdir(client.cache_folder)
         assert ".git" not in dirs
 

--- a/test/functional/command/export_test.py
+++ b/test/functional/command/export_test.py
@@ -71,7 +71,7 @@ class TestRevisionModeSCM:
         t = TestClient()
         recipe_excluded = f'revision_mode_excluded = {recipe_excluded}' if recipe_excluded else ""
         conf_excluded = f'core.scm:excluded={conf_excluded}' if conf_excluded else ""
-        save(t.cache.global_conf_path, conf_excluded)
+        save(t.paths.global_conf_path, conf_excluded)
         conanfile = GenConanfile("pkg", "0.1").with_class_attribute('revision_mode = "scm"') \
                                               .with_class_attribute(recipe_excluded)
         commit = t.init_git_repo({'conanfile.py': str(conanfile),

--- a/test/functional/command/profile_test.py
+++ b/test/functional/command/profile_test.py
@@ -30,11 +30,11 @@ class TestProfile(unittest.TestCase):
         if platform.system() != "Windows":
             profiles.append("symlink_me" + os.path.sep + "profile7")
         for profile in profiles:
-            save(os.path.join(client.cache.profiles_path, profile), "")
+            save(os.path.join(client.paths.profiles_path, profile), "")
 
         if platform.system() != "Windows":
-            os.symlink(os.path.join(client.cache.profiles_path, 'symlink_me'),
-                       os.path.join(client.cache.profiles_path, 'link'))
+            os.symlink(os.path.join(client.paths.profiles_path, 'symlink_me'),
+                       os.path.join(client.paths.profiles_path, 'link'))
             # profile7 will be shown twice because it is symlinked.
             profiles.append("link" + os.path.sep + "profile7")
 
@@ -62,7 +62,7 @@ class TestProfile(unittest.TestCase):
             [conf]
             tools.build:jobs=20
             """)
-        save(os.path.join(client.cache.profiles_path, "profile1"), profile1)
+        save(os.path.join(client.paths.profiles_path, "profile1"), profile1)
 
         client.run("profile show -pr=profile1")
         self.assertIn("[settings]\nos=Windows", client.out)

--- a/test/functional/command/runner_test.py
+++ b/test/functional/command/runner_test.py
@@ -116,7 +116,7 @@ def test_create_docker_runner_cache_shared_profile_from_cache():
     remove=True
     """)
 
-    client.save({"default_host": profile_host, "default_build": profile_build}, path=client.cache.profiles_path)
+    client.save({"default_host": profile_host, "default_build": profile_build}, path=client.paths.profiles_path)
     client.run("new cmake_lib -d name=pkg -d version=0.2")
     client.run("create . -pr:h default_host -pr:b default_build")
 

--- a/test/functional/conftest.py
+++ b/test/functional/conftest.py
@@ -12,7 +12,7 @@ from conan.test.utils.tools import TestClient
 @pytest.fixture(scope="session")
 def _matrix_client():
     """
-    engine/1.0->matrix/1.0
+    matrix/1.0, just static, no test_package
     """
     c = TestClient()
     c.run("new cmake_lib -d name=matrix -d version=1.0")
@@ -20,11 +20,47 @@ def _matrix_client():
     return c
 
 
+@pytest.fixture(scope="session")
+def _matrix_client_shared(_matrix_client):
+    _matrix_client.run("create . -o *:shared=True -tf=")
+    return _matrix_client
+
+
+@pytest.fixture(scope="session")
+def _matrix_client_debug(_matrix_client):
+    _matrix_client.run("create . -s build_type=Debug -tf=")
+    return _matrix_client
+
+
 @pytest.fixture()
 def matrix_client(_matrix_client):
     c = TestClient()
     c.cache_folder = os.path.join(temp_folder(), ".conan2")
     shutil.copytree(_matrix_client.cache_folder, c.cache_folder)
+    return c
+
+
+@pytest.fixture()
+def matrix_client_shared(_matrix_client_shared):
+    c = TestClient()
+    c.cache_folder = os.path.join(temp_folder(), ".conan2")
+    shutil.copytree(_matrix_client_shared.cache_folder, c.cache_folder)
+    return c
+
+
+@pytest.fixture()
+def matrix_client_shared_debug(_matrix_client_shared, _matrix_client_debug):
+    c = TestClient()
+    c.cache_folder = os.path.join(temp_folder(), ".conan2")
+    shutil.copytree(_matrix_client_shared.cache_folder, c.cache_folder)
+    return c
+
+
+@pytest.fixture()
+def matrix_client_debug(_matrix_client_debug):
+    c = TestClient()
+    c.cache_folder = os.path.join(temp_folder(), ".conan2")
+    shutil.copytree(_matrix_client_debug.cache_folder, c.cache_folder)
     return c
 
 

--- a/test/functional/layout/test_build_system_layout_helpers.py
+++ b/test/functional/layout/test_build_system_layout_helpers.py
@@ -105,7 +105,7 @@ def test_error_no_msvc():
         """)
     client = TestClient()
     client.save({"conanfile.py": conanfile})
-    save(client.cache.settings_path, settings_yml)
+    save(client.paths.settings_path, settings_yml)
     client.run('install . -s os=Windows -s build_type=Release -s arch=x86_64 '
                '-s compiler=gcc -s compiler.version=8 '
                '-s:b os=Windows -s:b build_type=Release -s:b arch=x86_64 '

--- a/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_custom_configs.py
+++ b/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_custom_configs.py
@@ -145,10 +145,8 @@ class CustomSettingsTest(unittest.TestCase):
 
     def setUp(self):
         self.client = TestClient(path_with_spaces=False)
-        settings = default_settings_yml
-        settings = settings.replace("build_type: [null, Debug, Release, ",
-                                    "build_type: [null, Debug, MyRelease, ")
-        save(self.client.paths.settings_path, settings)
+        settings = "build_type: [MyRelease]"
+        save(self.client.paths.settings_path_user, settings)
         self.client.run("new cmake_lib -d name=hello -d version=0.1")
         cmake = self.client.load("CMakeLists.txt")
 

--- a/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_custom_configs.py
+++ b/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_custom_configs.py
@@ -148,7 +148,7 @@ class CustomSettingsTest(unittest.TestCase):
         settings = default_settings_yml
         settings = settings.replace("build_type: [null, Debug, Release, ",
                                     "build_type: [null, Debug, MyRelease, ")
-        save(self.client.cache.settings_path, settings)
+        save(self.client.paths.settings_path, settings)
         self.client.run("new cmake_lib -d name=hello -d version=0.1")
         cmake = self.client.load("CMakeLists.txt")
 

--- a/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_versions.py
+++ b/test/functional/toolchains/cmake/cmakedeps/test_cmakedeps_versions.py
@@ -3,14 +3,15 @@ import textwrap
 
 import pytest
 
+from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
 
 
 @pytest.fixture(scope="module")
 def hello_client():
     client = TestClient()
-    client.run("new cmake_lib -d name=hello -d version=1.1")
-    client.run("create . -tf=\"\"")
+    client.save({"conanfile.py": GenConanfile("hello", "1.1")})
+    client.run("create .")
     return client
 
 
@@ -38,7 +39,7 @@ def hello_client():
 def test_version(hello_client, name, version, params, cmake_fails, package_found):
     client = hello_client
     cmakelists = textwrap.dedent("""
-        cmake_minimum_required(VERSION 3.1)
+        cmake_minimum_required(VERSION 3.15)
         project(consumer NONE)
         find_package({name} {version} {params})
         message(STATUS "hello found: ${{{name}_FOUND}}")
@@ -59,7 +60,6 @@ def test_version(hello_client, name, version, params, cmake_fails, package_found
         """)
 
     client.save({"conanfile.py": conanfile, "CMakeLists.txt": cmakelists}, clean_first=True)
-    client.run("install .")
     exit_code = client.run("build .", assert_error=cmake_fails)
     if cmake_fails:
         assert exit_code != 0

--- a/test/functional/toolchains/cmake/test_cmake.py
+++ b/test/functional/toolchains/cmake/test_cmake.py
@@ -584,8 +584,8 @@ class TestCmakeTestMethod:
     """
     test the cmake.test() helper
     """
-    def test_test(self):
-
+    def test_test(self, matrix_client_shared):
+        c = matrix_client_shared
         conanfile = textwrap.dedent("""
             from conan import ConanFile
             from conan.tools.cmake import CMake
@@ -595,7 +595,7 @@ class TestCmakeTestMethod:
                 exports_sources = "CMakeLists.txt", "example.cpp"
 
                 def build_requirements(self):
-                    self.test_requires("test/0.1")
+                    self.test_requires("matrix/1.0")
 
                 def build(self):
                     cmake = CMake(self)
@@ -608,25 +608,22 @@ class TestCmakeTestMethod:
         cmakelist = textwrap.dedent("""
             cmake_minimum_required(VERSION 3.15)
             project(App CXX)
-            find_package(test CONFIG REQUIRED)
+            find_package(matrix CONFIG REQUIRED)
             add_executable(example example.cpp)
-            target_link_libraries(example test::test)
+            target_link_libraries(example matrix::matrix)
 
             enable_testing()
             add_test(NAME example
                       COMMAND example)
             """)
-        c = TestClient()
-        c.run("new cmake_lib -d name=test -d version=0.1")
-        c.run("create .  -tf=\"\" -o test*:shared=True")
 
         c.save({"conanfile.py": conanfile,
                 "CMakeLists.txt": cmakelist,
-                "example.cpp": gen_function_cpp(name="main", includes=["test"], calls=["test"])},
+                "example.cpp": gen_function_cpp(name="main", includes=["matrix"], calls=["matrix"])},
                clean_first=True)
 
         # The create flow must work
-        c.run("create . --name=pkg --version=0.1 -pr:b=default -o test*:shared=True")
+        c.run("create . --name=pkg --version=0.1 -pr:b=default -o matrix*:shared=True")
         assert str(c.out).count("1/1 Test #1: example ..........................   Passed") == 2
         assert "pkg/0.1: RUN: ctest --build-config Release --parallel"
 
@@ -712,4 +709,3 @@ class TestCMakeFindPackagePreferConfig:
 
         client.run("build . --profile=profile_false")
         assert "using FindComandante.cmake" in client.out
-

--- a/test/functional/toolchains/cmake/test_cmake.py
+++ b/test/functional/toolchains/cmake/test_cmake.py
@@ -213,7 +213,7 @@ class WinTest(Base):
                     "build_type": build_type,
                     }
         options = {"shared": shared}
-        save(self.client.cache.new_config_path, "tools.build:jobs=1")
+        save(self.client.paths.new_config_path, "tools.build:jobs=1")
         self._run_build(settings, options)
         self.assertIn('cmake -G "Visual Studio 15 2017" '
                       '-DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake"', self.client.out)
@@ -473,7 +473,7 @@ def test_msvc_vs_versiontoolset():
                 "build_type": "Release",
                 }
     client = TestClient()
-    save(client.cache.new_config_path, "tools.microsoft.msbuild:vs_version=15")
+    save(client.paths.new_config_path, "tools.microsoft.msbuild:vs_version=15")
     conanfile = textwrap.dedent("""
             from conan import ConanFile
             from conan.tools.cmake import CMake

--- a/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -50,7 +50,7 @@ def test_cmake_toolchain_user_toolchain():
     client = TestClient(path_with_spaces=False)
     conanfile = GenConanfile().with_settings("os", "compiler", "build_type", "arch").\
         with_generator("CMakeToolchain")
-    save(client.cache.new_config_path, "tools.cmake.cmaketoolchain:user_toolchain+=mytoolchain.cmake")
+    save(client.paths.new_config_path, "tools.cmake.cmaketoolchain:user_toolchain+=mytoolchain.cmake")
 
     client.save({"conanfile.py": conanfile})
     client.run("install .")
@@ -62,7 +62,7 @@ def test_cmake_toolchain_custom_toolchain():
     client = TestClient(path_with_spaces=False)
     conanfile = GenConanfile().with_settings("os", "compiler", "build_type", "arch").\
         with_generator("CMakeToolchain")
-    save(client.cache.new_config_path, "tools.cmake.cmaketoolchain:toolchain_file=mytoolchain.cmake")
+    save(client.paths.new_config_path, "tools.cmake.cmaketoolchain:toolchain_file=mytoolchain.cmake")
 
     client.save({"conanfile.py": conanfile})
     client.run("install .")
@@ -1509,8 +1509,8 @@ def test_inject_user_toolchain():
         include(default)
         [conf]
         tools.cmake.cmaketoolchain:user_toolchain+={{profile_dir}}/myvars.cmake""")
-    save(os.path.join(client.cache.profiles_path, "myprofile"), profile)
-    save(os.path.join(client.cache.profiles_path, "myvars.cmake"), 'set(MY_USER_VAR1 "MYVALUE1")')
+    save(os.path.join(client.paths.profiles_path, "myprofile"), profile)
+    save(os.path.join(client.paths.profiles_path, "myvars.cmake"), 'set(MY_USER_VAR1 "MYVALUE1")')
     client.save({"conanfile.py": conanfile,
                  "CMakeLists.txt": cmake})
     client.run("build . -pr=myprofile")
@@ -1519,7 +1519,7 @@ def test_inject_user_toolchain():
     # Now test with the global.conf
     global_conf = 'tools.cmake.cmaketoolchain:user_toolchain=' \
                   '["{{conan_home_folder}}/my.cmake"]'
-    save(client.cache.new_config_path, global_conf)
+    save(client.paths.new_config_path, global_conf)
     save(os.path.join(client.cache_folder, "my.cmake"), 'message(STATUS "IT WORKS!!!!")')
     client.run("build .")
     # The toolchain is found and can be used

--- a/test/functional/toolchains/cmake/test_v2_cmake_template.py
+++ b/test/functional/toolchains/cmake/test_v2_cmake_template.py
@@ -20,6 +20,7 @@ def test_cmake_lib_template():
 @pytest.mark.tool("cmake")
 def test_cmake_lib_template_create(matrix_client_shared_debug):
     client = matrix_client_shared_debug
+    client.run("new cmake_lib -d name=matrix -d version=1.0")
     # Create works
     client.run("create . --build=never")
     assert "matrix/1.0: Hello World Release!" in client.out

--- a/test/functional/toolchains/cmake/test_v2_cmake_template.py
+++ b/test/functional/toolchains/cmake/test_v2_cmake_template.py
@@ -16,16 +16,20 @@ def test_cmake_lib_template():
     package_folder = client.created_layout().package()
     assert os.path.exists(os.path.join(package_folder, "include", "hello.h"))
 
-    # Create works
-    client.run("create .")
-    assert "hello/0.1: Hello World Release!" in client.out
 
-    client.run("create . -s build_type=Debug")
-    assert "hello/0.1: Hello World Debug!" in client.out
+@pytest.mark.tool("cmake")
+def test_cmake_lib_template_create(matrix_client_shared_debug):
+    client = matrix_client_shared_debug
+    # Create works
+    client.run("create . --build=never")
+    assert "matrix/1.0: Hello World Release!" in client.out
+
+    client.run("create . -s build_type=Debug --build=never")
+    assert "matrix/1.0: Hello World Debug!" in client.out
 
     # Create + shared works
-    client.run("create . -o hello/*:shared=True")
-    assert "hello/0.1: Hello World Release!" in client.out
+    client.run("create . -o hello/*:shared=True --build=never")
+    assert "matrix/1.0: Hello World Release!" in client.out
 
 
 @pytest.mark.tool("cmake")

--- a/test/functional/toolchains/env/test_virtualenv_powershell.py
+++ b/test/functional/toolchains/env/test_virtualenv_powershell.py
@@ -30,7 +30,7 @@ def client():
     """
     client.save({"conanfile.py": conanfile})
     client.run("create .")
-    save(client.cache.new_config_path, "tools.env.virtualenv:powershell=powershell.exe\n")
+    save(client.paths.new_config_path, "tools.env.virtualenv:powershell=powershell.exe\n")
     return client
 
 

--- a/test/functional/toolchains/gnu/autotools/test_crossbuild_triplet.py
+++ b/test/functional/toolchains/gnu/autotools/test_crossbuild_triplet.py
@@ -42,7 +42,7 @@ def test_crossbuild_triplet_from_conf():
     """)
 
     client = TestClient(path_with_spaces=False)
-    client.save({client.cache.settings_path: settings_yml})
+    client.save({client.paths.settings_path: settings_yml})
     client.save({"host_profile": host_profile})
     client.save({"build_profile": build_profile})
 

--- a/test/functional/toolchains/gnu/autotools/test_win_bash.py
+++ b/test/functional/toolchains/gnu/autotools/test_win_bash.py
@@ -79,7 +79,7 @@ def test_add_msys2_path_automatically():
     except KeyError:
         pytest.skip("msys2 path not defined")
 
-    save(client.cache.new_config_path, textwrap.dedent("""
+    save(client.paths.new_config_path, textwrap.dedent("""
             tools.microsoft.bash:subsystem=msys2
             tools.microsoft.bash:path={}
             """.format(bash_path)))

--- a/test/functional/toolchains/gnu/test_pkgconfigdeps.py
+++ b/test/functional/toolchains/gnu/test_pkgconfigdeps.py
@@ -4,6 +4,7 @@ import textwrap
 
 import pytest
 
+from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
 
 
@@ -37,12 +38,10 @@ def test_pkgconfigdeps_with_test_requires():
     Related issue: https://github.com/conan-io/conan/issues/11376
     """
     client = TestClient()
-    with client.chdir("app"):
-        client.run("new cmake_lib -d name=app -d version=1.0")
-        client.run("create . -tf=\"\"")
-    with client.chdir("test"):
-        client.run("new cmake_lib -d name=test -d version=1.0")
-        client.run("create . -tf=\"\"")
+    client.save({"app/conanfile.py": GenConanfile("app", "1.0"),
+                 "test/conanfile.py": GenConanfile("test", "1.0")})
+    client.run("create app")
+    client.run("create test")
     # Create library having build and test requires
     conanfile = textwrap.dedent(r'''
         from conan import ConanFile

--- a/test/functional/tools/scm/test_git.py
+++ b/test/functional/tools/scm/test_git.py
@@ -135,7 +135,7 @@ class TestGitBasicCapture:
         assert "pkg/0.1: DIRTY: True" in c.out
 
         conf_excluded = f'core.scm:excluded+=["other.txt"]'
-        save(c.cache.global_conf_path, conf_excluded)
+        save(c.paths.global_conf_path, conf_excluded)
         c.run("export .")
         assert "pkg/0.1: DIRTY: False" in c.out
 

--- a/test/integration/cache/download_cache_test.py
+++ b/test/integration/cache/download_cache_test.py
@@ -138,7 +138,7 @@ class TestDownloadCache:
         assert "some content 3" in client.load("myfile3.txt")
 
         # disabling cache will make it fail
-        save(client.cache.new_config_path, "")
+        save(client.paths.new_config_path, "")
         client.run("source .", assert_error=True)
         assert "ERROR: conanfile.py: Error in source() method, line 10" in client.out
         assert "Not found" in client.out

--- a/test/integration/command/install/install_test.py
+++ b/test/integration/command/install/install_test.py
@@ -175,12 +175,12 @@ def test_install_with_profile(client):
         """)
 
     client.save({"conanfile.py": conanfile})
-    save(os.path.join(client.cache.profiles_path, "myprofile"), "[settings]\nos=Linux")
+    save(os.path.join(client.paths.profiles_path, "myprofile"), "[settings]\nos=Linux")
     client.run("install . -pr=myprofile --build='*'")
     assert "PKGOS=Linux" in client.out
     mkdir(os.path.join(client.current_folder, "myprofile"))
     client.run("install . -pr=myprofile")
-    save(os.path.join(client.cache.profiles_path, "myotherprofile"), "[settings]\nos=FreeBSD")
+    save(os.path.join(client.paths.profiles_path, "myotherprofile"), "[settings]\nos=FreeBSD")
     client.run("install . -pr=myotherprofile")
     assert "PKGOS=FreeBSD" in client.out
     client.save({"myotherprofile": "Some garbage without sense [garbage]"})

--- a/test/integration/command/remote_test.py
+++ b/test/integration/command/remote_test.py
@@ -200,7 +200,7 @@ class RemoteModificationTest(unittest.TestCase):
         client.run("remote add my-remote2 http://someurl2 --insecure")
         client.run("remote add my-remote3 http://someurl3")
 
-        registry = load(client.cache.remotes_path)
+        registry = load(client.paths.remotes_path)
         data = json.loads(registry)
         self.assertEqual(data["remotes"][0]["name"], "my-remote")
         self.assertEqual(data["remotes"][0]["url"], "http://someurl")
@@ -226,7 +226,7 @@ class RemoteModificationTest(unittest.TestCase):
         client.run("remote disable my-remote3")
         assert "my-remote3" in client.out
         assert "Enabled: False" in client.out
-        registry = load(client.cache.remotes_path)
+        registry = load(client.paths.remotes_path)
         data = json.loads(registry)
         self.assertEqual(data["remotes"][0]["name"], "my-remote0")
         self.assertEqual(data["remotes"][0]["url"], "http://someurl0")
@@ -242,7 +242,7 @@ class RemoteModificationTest(unittest.TestCase):
 
         client.run("remote disable * --format=json")
 
-        registry = load(client.cache.remotes_path)
+        registry = load(client.paths.remotes_path)
         data = json.loads(registry)
         for remote in data["remotes"]:
             self.assertEqual(remote["disabled"], True)
@@ -252,7 +252,7 @@ class RemoteModificationTest(unittest.TestCase):
             assert remote["enabled"] is False
 
         client.run("remote enable *")
-        registry = load(client.cache.remotes_path)
+        registry = load(client.paths.remotes_path)
         data = json.loads(registry)
         for remote in data["remotes"]:
             self.assertNotIn("disabled", remote)
@@ -292,7 +292,7 @@ class RemoteModificationTest(unittest.TestCase):
         client.run("remote add my-remote http://someurl some_invalid_option=foo", assert_error=True)
 
         self.assertIn("unrecognized arguments: some_invalid_option=foo", client.out)
-        data = json.loads(load(client.cache.remotes_path))
+        data = json.loads(load(client.paths.remotes_path))
         self.assertEqual(data["remotes"], [])
 
 

--- a/test/integration/command/source_test.py
+++ b/test/integration/command/source_test.py
@@ -246,7 +246,7 @@ class TestSourceWithoutDefaultProfile:
     def client(self):
         c = TestClient()
         # The ``source()`` should still receive necessary configuration
-        save(c.cache.new_config_path, "tools.files.download:retry=MYCACHE")
+        save(c.paths.new_config_path, "tools.files.download:retry=MYCACHE")
         # Make sure we don't have default profile
         os.remove(os.path.join(c.cache_folder, "profiles", "default"))
         return c

--- a/test/integration/command/test_profile.py
+++ b/test/integration/command/test_profile.py
@@ -22,10 +22,10 @@ def test_ignore_paths_when_listing_profiles():
     ignore_path = '.DS_Store'
 
     # just in case
-    os.makedirs(c.cache.profiles_path, exist_ok=True)
+    os.makedirs(c.paths.profiles_path, exist_ok=True)
     # This a "touch" equivalent
-    open(os.path.join(c.cache.profiles_path, '.DS_Store'), 'w').close()
-    os.utime(os.path.join(c.cache.profiles_path, ".DS_Store"))
+    open(os.path.join(c.paths.profiles_path, '.DS_Store'), 'w').close()
+    os.utime(os.path.join(c.paths.profiles_path, ".DS_Store"))
 
     c.run("profile list")
 

--- a/test/integration/command_v2/list_test.py
+++ b/test/integration/command_v2/list_test.py
@@ -13,7 +13,7 @@ from conan.errors import ConanException
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient, TestServer, NO_SETTINGS_PACKAGE_ID
 from conan.test.utils.env import environment_update
-from conans.util.files import load, save
+from conans.util.files import save
 
 
 class TestParamErrors:
@@ -620,14 +620,13 @@ def test_list_prefs_query_custom_settings():
     # https://github.com/conan-io/conan/issues/13071
     """
     c = TestClient(default_server_user=True)
-    settings = load(c.cache.settings_path)
-    settings += textwrap.dedent("""\
+    settings = textwrap.dedent("""\
         newsetting:
             value1:
             value2:
                 subsetting: [1, 2, 3]
         """)
-    save(c.cache.settings_path, settings)
+    save(c.paths.settings_path_user, settings)
     c.save({"conanfile.py": GenConanfile("pkg", "1.0").with_settings("newsetting")})
     c.run("create . -s newsetting=value1")
     c.run("create . -s newsetting=value2 -s newsetting.subsetting=1")

--- a/test/integration/command_v2/test_cache_clean.py
+++ b/test/integration/command_v2/test_cache_clean.py
@@ -121,7 +121,7 @@ def test_cache_multiple_builds_diff_prev_clean():
 def test_cache_clean_custom_storage():
     c = TestClient()
     t = temp_folder(path_with_spaces=False)
-    save(c.cache.global_conf_path, f"core.cache:storage_path={t}")
+    save(c.paths.global_conf_path, f"core.cache:storage_path={t}")
     c.save({"conanfile.py": GenConanfile("pkg", "0.1").with_cmake_build()})
     c.run("create .", assert_error=True)
     build_folder = re.search(r"pkg/0.1: Building your package in (\S+)", str(c.out)).group(1)

--- a/test/integration/conan_v2/test_legacy_cpp_info.py
+++ b/test/integration/conan_v2/test_legacy_cpp_info.py
@@ -36,7 +36,7 @@ def test_legacy_names_filenames():
     for name in ["cpp_info.names", "cpp_info.filenames", "env_info", "user_info", "cpp_info.build_modules"]:
         assert f"WARN: deprecated:     '{name}' used in: pkg/1.0" in c.out
 
-    save(c.cache.new_config_path, 'core:skip_warnings=["deprecated"]')
+    save(c.paths.new_config_path, 'core:skip_warnings=["deprecated"]')
     c.run("create .")
     for name in ["cpp_info.names", "cpp_info.filenames", "env_info", "user_info",
                  "cpp_info.build_modules"]:

--- a/test/integration/configuration/custom_setting_test_package_test.py
+++ b/test/integration/configuration/custom_setting_test_package_test.py
@@ -22,7 +22,7 @@ class TestConanLib(ConanFile):
         pass
 '''
         client = TestClient()
-        save(client.cache.settings_path_user, "product: [onion, potato]")
+        save(client.paths.settings_path_user, "product: [onion, potato]")
         client.save({"conanfile.py": conanfile,
                      "test_package/conanfile.py": test_conanfile})
         client.run("create . -s os=Windows -s product=onion -s build_type=Release")

--- a/test/integration/configuration/default_profile_test.py
+++ b/test/integration/configuration/default_profile_test.py
@@ -45,7 +45,7 @@ class MyConanfile(ConanFile):
         default_profile_path = os.path.join(tmp, "myprofile")
         save(default_profile_path, "[buildenv]\nValue1=A")
         client = TestClient()
-        save(client.cache.new_config_path, "core:default_profile={}".format(default_profile_path))
+        save(client.paths.new_config_path, "core:default_profile={}".format(default_profile_path))
 
         client.save({CONANFILE: br})
         client.run("export . --user=lasote --channel=stable")
@@ -53,8 +53,8 @@ class MyConanfile(ConanFile):
 
         # Now use a name, in the default profile folder
         os.unlink(default_profile_path)
-        save(os.path.join(client.cache.profiles_path, "other"), "[buildenv]\nValue1=A")
-        save(client.cache.new_config_path, "core:default_profile=other")
+        save(os.path.join(client.paths.profiles_path, "other"), "[buildenv]\nValue1=A")
+        save(client.paths.new_config_path, "core:default_profile=other")
         client.save({CONANFILE: br})
         client.run("export . --user=lasote --channel=stable")
         client.run('install --requires=mylib/0.1@lasote/stable --build="*"')
@@ -130,7 +130,7 @@ class MyConanfile(ConanFile):
         env_variable = "env_variable=relative_profile"
         rel_path = os.path.join('..', 'env_rel_profile')
         self.assertFalse(os.path.isabs(rel_path))
-        default_profile_path = os.path.join(client.cache.profiles_path, rel_path)
+        default_profile_path = os.path.join(client.paths.profiles_path, rel_path)
         save(default_profile_path, "[settings]\nos=Windows\n[buildenv]\n" + env_variable)
         with environment_update({'CONAN_DEFAULT_PROFILE': rel_path}):
             client.run("create . --name=name --version=version --user=user --channel=channel")
@@ -147,13 +147,13 @@ class MyConanfile(ConanFile):
 
 def test_conf_default_two_profiles():
     client = TestClient()
-    save(os.path.join(client.cache.profiles_path, "mydefault"), "[settings]\nos=FreeBSD")
-    save(os.path.join(client.cache.profiles_path, "mydefault_build"), "[settings]\nos=Android")
+    save(os.path.join(client.paths.profiles_path, "mydefault"), "[settings]\nos=FreeBSD")
+    save(os.path.join(client.paths.profiles_path, "mydefault_build"), "[settings]\nos=Android")
     global_conf = textwrap.dedent("""
         core:default_profile=mydefault
         core:default_build_profile=mydefault_build
         """)
-    save(client.cache.new_config_path, global_conf)
+    save(client.paths.new_config_path, global_conf)
     client.save({"conanfile.txt": ""})
     client.run("install .")
     assert "Profile host:" in client.out

--- a/test/integration/configuration/profile_test.py
+++ b/test/integration/configuration/profile_test.py
@@ -61,7 +61,7 @@ class ProfileTest(unittest.TestCase):
         profile = '''
         [settings
         '''
-        clang_profile_path = os.path.join(self.client.cache.profiles_path, "clang")
+        clang_profile_path = os.path.join(self.client.paths.profiles_path, "clang")
         save(clang_profile_path, profile)
         self.client.run("install --requires=hello0/0.1@lasote/stable --build missing -pr clang",
                         assert_error=True)
@@ -117,7 +117,7 @@ class ProfileTest(unittest.TestCase):
                                         ("compiler.runtime", "dynamic"),
                                         ("arch", "x86")])
 
-        create_profile(self.client.cache.profiles_path, "vs_12_86",
+        create_profile(self.client.paths.profiles_path, "vs_12_86",
                        settings=profile_settings, package_settings={})
 
         self.client.save({"conanfile.py": conanfile_scope_env})
@@ -142,7 +142,7 @@ class ProfileTest(unittest.TestCase):
         tmp_settings["compiler.libcxx"] = "libstdc++11"
         tmp_settings["compiler.version"] = "4.8"
         package_settings = {"hello0/*": tmp_settings}
-        create_profile(self.client.cache.profiles_path,
+        create_profile(self.client.paths.profiles_path,
                        "vs_12_86_hello0_gcc", settings=profile_settings,
                        package_settings=package_settings)
         # Try to override some settings in install command
@@ -153,13 +153,13 @@ class ProfileTest(unittest.TestCase):
 
         # If other package is specified compiler is not modified
         package_settings = {"NoExistsRecipe": tmp_settings}
-        create_profile(self.client.cache.profiles_path,
+        create_profile(self.client.paths.profiles_path,
                        "vs_12_86_hello0_gcc", settings=profile_settings,
                        package_settings=package_settings)
 
         # Mix command line package settings with profile
         package_settings = {"hello0/*": tmp_settings}
-        create_profile(self.client.cache.profiles_path, "vs_12_86_hello0_gcc",
+        create_profile(self.client.paths.profiles_path, "vs_12_86_hello0_gcc",
                        settings=profile_settings, package_settings=package_settings)
 
         # Try to override some settings in install command
@@ -197,7 +197,7 @@ class ProfileTest(unittest.TestCase):
         tmp_settings["compiler.libcxx"] = "libstdc++11"
         tmp_settings["compiler.version"] = "4.8"
         package_settings = {"*@lasote/*": tmp_settings}
-        _create_profile(self.client.cache.profiles_path,
+        _create_profile(self.client.paths.profiles_path,
                         "myprofile", settings=profile_settings,
                         package_settings=package_settings)
         # Try to override some settings in install command
@@ -207,7 +207,7 @@ class ProfileTest(unittest.TestCase):
         self.assertIn("(hello0/0.1@lasote/testing): 4.8", info)
 
         package_settings = {"*@other/*": tmp_settings}
-        _create_profile(self.client.cache.profiles_path,
+        _create_profile(self.client.paths.profiles_path,
                         "myprofile", settings=profile_settings,
                         package_settings=package_settings)
         # Try to override some settings in install command
@@ -243,7 +243,7 @@ class ProfileTest(unittest.TestCase):
         assert "mypkg/0.1: SETTINGS! os=Linux!!" in client.out
 
     def test_install_profile_options(self):
-        create_profile(self.client.cache.profiles_path, "vs_12_86",
+        create_profile(self.client.paths.profiles_path, "vs_12_86",
                        options={"hello0*:language": 1,
                                 "hello0*:static": False})
 
@@ -304,7 +304,7 @@ class DefaultNameConan(ConanFile):
         self.client.run("export . --user=lasote --channel=stable")
 
         # Create a profile that doesn't activate the require
-        create_profile(self.client.cache.profiles_path, "scopes_env",
+        create_profile(self.client.paths.profiles_path, "scopes_env",
                        settings={"os": "Linux"})
 
         # Install with the previous profile
@@ -313,7 +313,7 @@ class DefaultNameConan(ConanFile):
                 winrequire/0.1@lasote/stable''', self.client.out)
 
         # Create a profile that activate the require
-        create_profile(self.client.cache.profiles_path, "scopes_env",
+        create_profile(self.client.paths.profiles_path, "scopes_env",
                        settings={"os": "Windows"})
 
         # Install with the previous profile
@@ -414,7 +414,7 @@ def test_profile_from_cache_path():
         https://github.com/conan-io/conan/pull/8685
     """
     client = TestClient()
-    path = os.path.join(client.cache.profiles_path, "android", "profile1")
+    path = os.path.join(client.paths.profiles_path, "android", "profile1")
     save(path, "[settings]\nos=Android")
     client.save({"conanfile.txt": ""})
     client.run("install . -pr=android/profile1")

--- a/test/integration/configuration/proxies_conf_test.py
+++ b/test/integration/configuration/proxies_conf_test.py
@@ -22,7 +22,7 @@ class TestProxiesConfTest:
                 return resp
 
         client = TestClient(requester_class=MyHttpRequester)
-        save(client.cache.new_config_path, 'core.net.http:proxies = {"myproxykey": "myvalue"}')
+        save(client.paths.new_config_path, 'core.net.http:proxies = {"myproxykey": "myvalue"}')
         conanfile = textwrap.dedent("""
             from conan import ConanFile
             from conan.tools.files import download
@@ -50,7 +50,7 @@ class TestProxiesConfTest:
                 return resp
 
         client = TestClient(requester_class=MyHttpRequester)
-        save(client.cache.new_config_path,
+        save(client.paths.new_config_path,
              'core.net.http:no_proxy_match = ["MyExcludedUrl*", "*otherexcluded_one*"]\n'
              'core.net.http:proxies = {"http": "value"}')
         for url in ("**otherexcluded_one***", "MyUrl", "MyExcludedUrl***", "**MyExcludedUrl***"):
@@ -128,7 +128,7 @@ class TestProxiesConfTest:
                 return resp
 
         client = TestClient(requester_class=MyHttpRequester)
-        save(client.cache.new_config_path, 'core.net.http:clean_system_proxy = True')
+        save(client.paths.new_config_path, 'core.net.http:clean_system_proxy = True')
 
         with environment_update({"http_proxy": "my_system_proxy"}):
             client.save({"conanfile.py": conanfile})

--- a/test/integration/configuration/test_profile_jinja.py
+++ b/test/integration/configuration/test_profile_jinja.py
@@ -205,8 +205,8 @@ def test_profile_template_profile_name():
                  "profile_folder/foobar": tpl1,
                  "another_folder/foo.profile": tpl1,
                  "include_folder/include_default": tpl2,
-                 os.path.join(client.cache.profiles_path, "baz"): tpl1,
-                 os.path.join(client.cache.profiles_path, "default"): default})
+                 os.path.join(client.paths.profiles_path, "baz"): tpl1,
+                 os.path.join(client.paths.profiles_path, "default"): default})
 
     # show only file name as profile name
     client.run("install . -pr=profile_folder/foobar")

--- a/test/integration/configuration/test_profile_priority.py
+++ b/test/integration/configuration/test_profile_priority.py
@@ -12,7 +12,7 @@ def test_profile_local_folder_priority_cache():
     c.save({"profiles/default": f"include(otherprofile)",
             "profiles/otherprofile": "[settings]\nos=AIX",
             "conanfile.txt": ""})
-    save(os.path.join(c.cache.profiles_path, "otherprofile"), "[settings]\nos=FreeBSD")
+    save(os.path.join(c.paths.profiles_path, "otherprofile"), "[settings]\nos=FreeBSD")
 
     # Must use local path, otherwise look for it in the cache
     c.run("install . -pr=./profiles/default")
@@ -26,7 +26,7 @@ def test_profile_local_folder_priority_relative():
     c.save({"profiles/default": f"include(./otherprofile)",
             "profiles/otherprofile": "[settings]\nos=AIX",
             "conanfile.txt": ""})
-    save(os.path.join(c.cache.profiles_path, "otherprofile"), "[settings]\nos=FreeBSD")
+    save(os.path.join(c.paths.profiles_path, "otherprofile"), "[settings]\nos=FreeBSD")
 
     # Must use local path, otherwise look for it in the cache
     c.run("install . -pr=./profiles/default")
@@ -39,8 +39,8 @@ def test_profile_cache_folder_priority():
     c = TestClient()
     c.save({"otherprofile": "[settings]\nos=FreeBSD",
             "conanfile.txt": ""})
-    save(os.path.join(c.cache.profiles_path, "default"), "include(./otherprofile)")
-    save(os.path.join(c.cache.profiles_path, "otherprofile"), "[settings]\nos=AIX")
+    save(os.path.join(c.paths.profiles_path, "default"), "include(./otherprofile)")
+    save(os.path.join(c.paths.profiles_path, "otherprofile"), "[settings]\nos=AIX")
 
     c.run("install . -pr=default")
     assert "os=AIX" in c.out

--- a/test/integration/cross_building/test_package_test.py
+++ b/test/integration/cross_building/test_package_test.py
@@ -52,7 +52,7 @@ class TestPackageTestCase(unittest.TestCase):
 
     def test_command(self):
         t = TestClient()
-        save(t.cache.settings_path, self.settings_yml)
+        save(t.paths.settings_path, self.settings_yml)
         t.save({'br.py': self.conanfile_br,
                 'conanfile.py': self.conanfile,
                 'test_package/conanfile.py': self.conanfile_test,

--- a/test/integration/extensions/test_profile_plugin_runtime.py
+++ b/test/integration/extensions/test_profile_plugin_runtime.py
@@ -38,10 +38,10 @@ class HelloConan(ConanFile):
 
     def test_runtime_not_present_ok(self):
         self.client.run("install .")
-        default_settings = load(self.client.cache.settings_path)
+        default_settings = load(self.client.paths.settings_path)
         default_settings = default_settings.replace("runtime:", "# runtime:")
         default_settings = default_settings.replace("runtime_type:", "# runtime_type:")
-        save(self.client.cache.settings_path, default_settings)
+        save(self.client.paths.settings_path, default_settings)
         self.client.save_home({
             "profiles/default": "[settings]\nos=Windows\ncompiler=msvc\ncompiler.version=191"
         })

--- a/test/integration/generators/test_custom_global_generators.py
+++ b/test/integration/generators/test_custom_global_generators.py
@@ -16,7 +16,7 @@ def test_custom_global_generator():
                 pkg = self._conanfile.dependencies["pkg"].ref
                 self._conanfile.output.info(f"DEP: {pkg}!!")
         """)
-    save(os.path.join(c.cache.custom_generators_path, "mygen.py"), generator)
+    save(os.path.join(c.paths.custom_generators_path, "mygen.py"), generator)
     conanfile = textwrap.dedent("""
         [requires]
         pkg/0.1
@@ -72,8 +72,8 @@ def test_custom_global_generator_imports():
         def mygenerate(conanfile):
             conanfile.output.info("MYGENERATE WORKS!!")
         """)
-    save(os.path.join(c.cache.custom_generators_path, "mygen.py"), generator)
-    save(os.path.join(c.cache.custom_generators_path, "_myfunc.py"), myaux)
+    save(os.path.join(c.paths.custom_generators_path, "mygen.py"), generator)
+    save(os.path.join(c.paths.custom_generators_path, "_myfunc.py"), myaux)
 
     c.save({"conanfile.txt": ""})
     c.run("install . -g MyCustomGenerator")
@@ -94,7 +94,7 @@ def test_custom_global_generator_multiple():
                 def generate(self):
                     self._conanfile.output.info(f"MyGenerator{num}!!")
             """)
-        save(os.path.join(c.cache.custom_generators_path, f"mygen{num}.py"), generator)
+        save(os.path.join(c.paths.custom_generators_path, f"mygen{num}.py"), generator)
     conanfile = textwrap.dedent("""
         [requires]
         pkg/0.1

--- a/test/integration/graph/test_platform_requires.py
+++ b/test/integration/graph/test_platform_requires.py
@@ -225,7 +225,7 @@ class TestPackageID:
         or package_id
         """
         client = TestClient(light=True)
-        save(client.cache.new_config_path, f"core.package_id:default_unknown_mode={package_id_mode}")
+        save(client.paths.new_config_path, f"core.package_id:default_unknown_mode={package_id_mode}")
         client.save({"conanfile.py": GenConanfile("pkg", "1.0").with_requires("dep/1.0"),
                      "profile": "[platform_requires]\ndep/1.0"})
         client.run("create . -pr=profile")
@@ -236,7 +236,7 @@ class TestPackageID:
         Changing the platform_requires revision affects consumers if package_revision_mode=recipe_revision
         """
         client = TestClient(light=True)
-        save(client.cache.new_config_path, "core.package_id:default_unknown_mode=recipe_revision_mode")
+        save(client.paths.new_config_path, "core.package_id:default_unknown_mode=recipe_revision_mode")
         client.save({"conanfile.py": GenConanfile("pkg", "1.0").with_requires("dep/1.0"),
                      "profile": "[platform_requires]\ndep/1.0#r1",
                      "profile2": "[platform_requires]\ndep/1.0#r2"})
@@ -256,7 +256,7 @@ class TestPackageID:
         platform_requires do not have settings or package_id, so it is ignored
         """
         client = TestClient()
-        save(client.cache.new_config_path, "core.package_id:default_unknown_mode=full_package_mode")
+        save(client.paths.new_config_path, "core.package_id:default_unknown_mode=full_package_mode")
         client.save({"conanfile.py": GenConanfile("pkg", "1.0").with_requires("dep/1.0"),
                      "profile": "[platform_requires]\ndep/1.0"})
         client.run("create . -pr=profile -s os=Linux")

--- a/test/integration/graph/test_system_tools.py
+++ b/test/integration/graph/test_system_tools.py
@@ -225,7 +225,7 @@ class TestPackageID:
         or package_id
         """
         client = TestClient(light=True)
-        save(client.cache.new_config_path, f"core.package_id:default_build_mode={package_id_mode}")
+        save(client.paths.new_config_path, f"core.package_id:default_build_mode={package_id_mode}")
         client.save({"conanfile.py": GenConanfile("pkg", "1.0").with_tool_requires("dep/1.0"),
                      "profile": "[platform_tool_requires]\ndep/1.0"})
         client.run("create . -pr=profile")
@@ -236,7 +236,7 @@ class TestPackageID:
         Changing the system_tool_require revision affects consumers if package_revision_mode=recipe_revision
         """
         client = TestClient(light=True)
-        save(client.cache.new_config_path, "core.package_id:default_build_mode=recipe_revision_mode")
+        save(client.paths.new_config_path, "core.package_id:default_build_mode=recipe_revision_mode")
         client.save({"conanfile.py": GenConanfile("pkg", "1.0").with_tool_requires("dep/1.0"),
                      "profile": "[platform_tool_requires]\ndep/1.0#r1",
                      "profile2": "[platform_tool_requires]\ndep/1.0#r2"})

--- a/test/integration/hooks/hook_test.py
+++ b/test/integration/hooks/hook_test.py
@@ -71,7 +71,7 @@ class TestHooks:
 
     def test_complete_hook(self):
         c = TestClient()
-        hook_path = os.path.join(c.cache.hooks_path, "complete_hook", "hook_complete.py")
+        hook_path = os.path.join(c.paths.hooks_path, "complete_hook", "hook_complete.py")
         save(hook_path, complete_hook)
         c.save({"conanfile.py": GenConanfile("pkg", "0.1")})
 
@@ -127,9 +127,9 @@ class TestHooks:
                 my_printer(conanfile.output)
             """)
         c = TestClient()
-        hook_path = os.path.join(c.cache.hooks_path, "my_hook", "hook_my_hook.py")
-        init_path = os.path.join(c.cache.hooks_path, "my_hook", "custom_module", "__init__.py")
-        custom_path = os.path.join(c.cache.hooks_path, "my_hook", "custom_module", "custom.py")
+        hook_path = os.path.join(c.paths.hooks_path, "my_hook", "hook_my_hook.py")
+        init_path = os.path.join(c.paths.hooks_path, "my_hook", "custom_module", "__init__.py")
+        custom_path = os.path.join(c.paths.hooks_path, "my_hook", "custom_module", "custom.py")
         c.save({init_path: "",
                 custom_path: custom_module,
                 hook_path: my_hook,
@@ -147,7 +147,7 @@ class TestHooks:
             def pre_export(conanfile):
                 raise Exception("Boom")
             """)
-        hook_path = os.path.join(c.cache.hooks_path, "my_hook", "hook_my_hook.py")
+        hook_path = os.path.join(c.paths.hooks_path, "my_hook", "hook_my_hook.py")
         c.save({hook_path: my_hook,
                 "conanfile.py": GenConanfile("pkg", "1.0")})
 
@@ -162,7 +162,7 @@ class TestHooks:
            def post_build_fail(conanfile):
                conanfile.output.info("Hello")
            """)
-        hook_path = os.path.join(c.cache.hooks_path, "my_hook", "hook_my_hook.py")
+        hook_path = os.path.join(c.paths.hooks_path, "my_hook", "hook_my_hook.py")
         save(hook_path, my_hook)
         conanfile = textwrap.dedent("""
             from conan import ConanFile

--- a/test/integration/hooks/test_post_export.py
+++ b/test/integration/hooks/test_post_export.py
@@ -18,7 +18,7 @@ def test_called_before_digest():
         def post_export(conanfile):
             save(conanfile, os.path.join(conanfile.export_folder, "myfile.txt"), "content!!")
         """)
-    hook_path = os.path.join(t.cache.hooks_path, "complete_hook", "hook_complete.py")
+    hook_path = os.path.join(t.paths.hooks_path, "complete_hook", "hook_complete.py")
     save(hook_path, complete_hook)
     t.save({'conanfile.py': GenConanfile("pkg", "0.1")})
     t.run("export .")

--- a/test/integration/hooks/test_post_package.py
+++ b/test/integration/hooks/test_post_package.py
@@ -17,7 +17,7 @@ def test_post_package():
         def post_package(conanfile):
             save(conanfile, os.path.join(conanfile.package_folder, "myfile.txt"), "content!!")
         """)
-    hook_path = os.path.join(t.cache.hooks_path, "complete_hook", "hook_complete.py")
+    hook_path = os.path.join(t.paths.hooks_path, "complete_hook", "hook_complete.py")
     save(hook_path, complete_hook)
     t.save({'conanfile.py': GenConanfile("pkg", "0.1")})
     t.run("create .")

--- a/test/integration/metadata/test_metadata_commands.py
+++ b/test/integration/metadata/test_metadata_commands.py
@@ -151,7 +151,7 @@ class TestMetadataCommands:
         c2 = TestClient(servers=c.servers)
         tmp_folder = temp_folder()
         # MOST important part: activate cache
-        save(c2.cache.new_config_path, f"core.download:download_cache={tmp_folder}\n")
+        save(c2.paths.new_config_path, f"core.download:download_cache={tmp_folder}\n")
 
         # download package and metadata
         c2.run("download pkg/0.1 -r=default --metadata=*")

--- a/test/integration/metadata/test_metadata_logs.py
+++ b/test/integration/metadata/test_metadata_logs.py
@@ -140,7 +140,7 @@ class TestHooksMetadataLogs:
                 copy(conanfile, "*", src=os.path.join(conanfile.build_folder, "logs"),
                      dst=os.path.join(conanfile.package_metadata_folder, "logs"))
             """)
-        hook_path = os.path.join(c.cache.hooks_path, "my_hook", "hook_my_hook.py")
+        hook_path = os.path.join(c.paths.hooks_path, "my_hook", "hook_my_hook.py")
         save(hook_path, my_hook)
         conanfile = textwrap.dedent("""
             import os

--- a/test/integration/metadata/test_metadata_test_package.py
+++ b/test/integration/metadata/test_metadata_test_package.py
@@ -25,7 +25,7 @@ class TestMetadataTestPackage:
                copy(conanfile, "*", src=folder,
                     dst=os.path.join(conanfile.recipe_metadata_folder, "test_package"))
             """)
-        hook_path = os.path.join(c.cache.hooks_path, "my_hook", "hook_my_hook.py")
+        hook_path = os.path.join(c.paths.hooks_path, "my_hook", "hook_my_hook.py")
         save(hook_path, my_hook)
         c.save({"conanfile.py": GenConanfile("pkg", "0.1"),
                 "test_package/conanfile.py": GenConanfile().with_test("pass")})

--- a/test/integration/package_id/compatible_test.py
+++ b/test/integration/package_id/compatible_test.py
@@ -175,7 +175,7 @@ class CompatibleIDsTest(unittest.TestCase):
             compiler.version=4.9
             compiler.libcxx=libstdc++
             """)
-        save(client.cache.new_config_path,
+        save(client.paths.new_config_path,
              "core.package_id:default_unknown_mode=recipe_revision_mode")
         client.save({"conanfile.py": conanfile,
                      "myprofile": profile})

--- a/test/integration/package_id/full_revision_mode_test.py
+++ b/test/integration/package_id/full_revision_mode_test.py
@@ -14,7 +14,7 @@ class FullRevisionModeTest(unittest.TestCase):
         libb_ref = RecipeReference.loads("libb/0.1@user/testing")
 
         clienta = TestClient()
-        save(clienta.cache.new_config_path,
+        save(clienta.paths.new_config_path,
              "core.package_id:default_unknown_mode=recipe_revision_mode")
         conanfilea = dedent("""
             from conan import ConanFile

--- a/test/integration/package_id/package_id_test.py
+++ b/test/integration/package_id/package_id_test.py
@@ -180,7 +180,7 @@ def test_package_id_validate_settings():
 class TestBuildRequiresHeaderOnly:
     def test_header_only(self):
         c = TestClient(light=True)
-        save(c.cache.global_conf_path, "core.package_id:default_build_mode=minor_mode")
+        save(c.paths.global_conf_path, "core.package_id:default_build_mode=minor_mode")
         pkg = textwrap.dedent("""\
             from conan import ConanFile
             class Pkg(ConanFile):
@@ -201,7 +201,7 @@ class TestBuildRequiresHeaderOnly:
 
     def test_header_only_implements(self):
         c = TestClient(light=True)
-        save(c.cache.global_conf_path, "core.package_id:default_build_mode=minor_mode")
+        save(c.paths.global_conf_path, "core.package_id:default_build_mode=minor_mode")
         pkg = textwrap.dedent("""\
             from conan import ConanFile
             class Pkg(ConanFile):

--- a/test/integration/package_id/python_requires_package_id_test.py
+++ b/test/integration/package_id/python_requires_package_id_test.py
@@ -47,7 +47,7 @@ class PythonRequiresPackageIDTest(unittest.TestCase):
 
     def test_change_mode_conf(self):
         # change the policy in conan.conf
-        save(self.client2.cache.new_config_path, "core.package_id:default_python_mode=patch_mode")
+        save(self.client2.paths.new_config_path, "core.package_id:default_python_mode=patch_mode")
         self.client2.run("create . --name=pkg --version=0.1")
         self.assertIn("tool/1.1.1", self.client2.out)
         self.client2.assert_listed_binary({"pkg/0.1": (PKG_ID_1,
@@ -62,7 +62,7 @@ class PythonRequiresPackageIDTest(unittest.TestCase):
 
     def test_unrelated_conf(self):
         # change the policy in conan.conf
-        save(self.client2.cache.new_config_path,
+        save(self.client2.paths.new_config_path,
              "core.package_id:default_python_mode=unrelated_mode")
         self.client2.run("create . --name=pkg --version=0.1")
         self.assertIn("tool/1.1.1", self.client2.out)
@@ -104,7 +104,7 @@ class PythonRequiresForBuildRequiresPackageIDTest(unittest.TestCase):
 
     def test(self):
         client = TestClient()
-        save(client.cache.new_config_path, "core.package_id:default_python_mode=full_version_mode")
+        save(client.paths.new_config_path, "core.package_id:default_python_mode=full_version_mode")
         client.save({"conanfile.py": GenConanfile()})
         client.run("create . --name=tool --version=1.1.1")
 

--- a/test/integration/package_id/test_config_package_id.py
+++ b/test/integration/package_id/test_config_package_id.py
@@ -16,8 +16,8 @@ from conans.util.files import save
 def test_config_package_id(config_version, mode, result):
     c = TestClient()
     config_version = json.dumps({"config_version": [config_version]})
-    save(c.cache.config_version_path, config_version)
-    save(c.cache.global_conf_path, f"core.package_id:config_mode={mode}")
+    save(c.paths.config_version_path, config_version)
+    save(c.paths.global_conf_path, f"core.package_id:config_mode={mode}")
     c.save({"conanfile.py": GenConanfile("pkg", "0.1")})
     c.run("create .")
     c.run("list pkg/0.1:* --format=json")

--- a/test/integration/package_id/test_package_id_test_requires.py
+++ b/test/integration/package_id/test_package_id_test_requires.py
@@ -11,7 +11,7 @@ def test_package_id_not_affected_test_requires(build_mode):
     """
     c = TestClient()
     if build_mode is not None:
-        save(c.cache.new_config_path, "core.package_id:default_build_mode={build_mode}")
+        save(c.paths.new_config_path, "core.package_id:default_build_mode={build_mode}")
     c.save({"gtest/conanfile.py": GenConanfile("gtest", "1.0"),
             "engine/conanfile.py": GenConanfile("engine", "1.0").with_test_requires("gtest/1.0")})
     c.run("create gtest")

--- a/test/integration/package_id/test_validate.py
+++ b/test/integration/package_id/test_validate.py
@@ -340,7 +340,7 @@ class TestValidate(unittest.TestCase):
 
     def test_validate_package_id_mode(self):
         client = TestClient()
-        save(client.cache.new_config_path, "core.package_id:default_unknown_mode=full_package_mode")
+        save(client.paths.new_config_path, "core.package_id:default_unknown_mode=full_package_mode")
         conanfile = textwrap.dedent("""
           from conan import ConanFile
           from conan.errors import ConanInvalidConfiguration

--- a/test/integration/package_id/transitive_header_only_test.py
+++ b/test/integration/package_id/transitive_header_only_test.py
@@ -9,7 +9,7 @@ class TransitiveIdsTest(unittest.TestCase):
     def test_transitive_library(self):
         # https://github.com/conan-io/conan/issues/6450
         client = TestClient()
-        save(client.cache.new_config_path, "core.package_id:default_unknown_mode=full_version_mode")
+        save(client.paths.new_config_path, "core.package_id:default_unknown_mode=full_version_mode")
         client.save({"conanfile.py": GenConanfile()})
         client.run("create . --name=liba --version=1.0")
         client.run("create . --name=liba --version=1.1")
@@ -39,7 +39,7 @@ class TransitiveIdsTest(unittest.TestCase):
         # So LibC package ID doesn't change, even if LibA changes
         # But LibD package ID changes, even if its direct dependency LibC doesn't
         client = TestClient()
-        save(client.cache.new_config_path, "core.package_id:default_unknown_mode=full_version_mode")
+        save(client.paths.new_config_path, "core.package_id:default_unknown_mode=full_version_mode")
         # LibA
         client.save({"conanfile.py": GenConanfile()})
         client.run("create . --name=liba --version=1.0")
@@ -134,7 +134,7 @@ class TransitiveIdsTest(unittest.TestCase):
     def test_transitive_header_only(self):
         # https://github.com/conan-io/conan/issues/6450
         client = TestClient()
-        save(client.cache.new_config_path, "core.package_id:default_unknown_mode=full_version_mode")
+        save(client.paths.new_config_path, "core.package_id:default_unknown_mode=full_version_mode")
         client.save({"conanfile.py": GenConanfile()})
         client.run("create . --name=liba --version=1.0")
         client.run("create . --name=liba --version=2.0")

--- a/test/integration/test_migrations.py
+++ b/test/integration/test_migrations.py
@@ -94,7 +94,7 @@ def test_migration_profile_checker_plugin(plugin_path, string_replace, new_strin
 def test_migration_db_lru():
     t = TestClient()
     storage = temp_folder()
-    save(t.cache.global_conf_path, f"core.cache:storage_path={storage}")
+    save(t.paths.global_conf_path, f"core.cache:storage_path={storage}")
     t.save({"conanfile.py": GenConanfile("pkg", "0.1")})
     t.run("create .")
     # Any command generates the profile and compatibility plugin files

--- a/test/integration/toolchains/env/test_virtualenv_winbash.py
+++ b/test/integration/toolchains/env/test_virtualenv_winbash.py
@@ -31,7 +31,7 @@ def client():
     """
     client.save({"conanfile.py": conanfile})
     client.run("create . --name=foo --version=1.0")
-    save(client.cache.new_config_path, "tools.microsoft.bash:subsystem=cygwin")
+    save(client.paths.new_config_path, "tools.microsoft.bash:subsystem=cygwin")
     return client
 
 

--- a/test/integration/toolchains/gnu/test_autotoolstoolchain.py
+++ b/test/integration/toolchains/gnu/test_autotoolstoolchain.py
@@ -187,9 +187,7 @@ def test_set_prefix():
 
 def test_unknown_compiler():
     client = TestClient()
-    settings = load(client.cache.settings_path)
-    settings = settings.replace("gcc:", "xlc:\n    gcc:", 1)
-    save(client.cache.settings_path, settings)
+    save(client.paths.settings_path_user, "compiler:\n  xlc:\n")
     client.save({"conanfile.py": GenConanfile().with_settings("compiler", "build_type")
                                                .with_generator("AutotoolsToolchain")})
     # this used to crash, because of build_type_flags in AutotoolsToolchain returning empty string

--- a/test/integration/toolchains/gnu/test_gnutoolchain.py
+++ b/test/integration/toolchains/gnu/test_gnutoolchain.py
@@ -199,9 +199,7 @@ def test_set_prefix():
 
 def test_unknown_compiler():
     client = TestClient()
-    settings = load(client.cache.settings_path)
-    settings = settings.replace("gcc:", "xlc:\n    gcc:", 1)
-    save(client.cache.settings_path, settings)
+    save(client.paths.settings_path_user, "compiler:\n  xlc:\n")
     client.save({"conanfile.py": GenConanfile().with_settings("compiler", "build_type")
                 .with_generator("GnuToolchain")
                  })

--- a/test/integration/ui/exit_with_code_test.py
+++ b/test/integration/ui/exit_with_code_test.py
@@ -32,6 +32,6 @@ class HelloConan(ConanFile):
 
 def test_wrong_home_error():
     client = TestClient()
-    save(client.cache.new_config_path, "core.cache:storage_path=//")
+    save(client.paths.new_config_path, "core.cache:storage_path=//")
     client.run("list *")
     assert "Couldn't initialize storage in" in client.out

--- a/test/unittests/model/other_settings_test.py
+++ b/test/unittests/model/other_settings_test.py
@@ -24,7 +24,7 @@ class SettingsTest(unittest.TestCase):
         subsystem: [null, msys]
 """
         client = TestClient()
-        save(client.cache.settings_path, settings)
+        save(client.paths.settings_path, settings)
         client.save_home({"profiles/default": ""})
         conanfile = """from conan import ConanFile
 class Pkg(ConanFile):
@@ -134,11 +134,11 @@ class SayConan(ConanFile):
         assert "Possible values are ['Windows', 'WindowsStore', 'WindowsCE', 'Linux'" in client.out
 
         # Now add new settings to config and try again
-        config = load(client.cache.settings_path)
+        config = load(client.paths.settings_path)
         config = config.replace("Windows:",
                                 "Windows:\n    ChromeOS:\n")
 
-        save(client.cache.settings_path, config)
+        save(client.paths.settings_path, config)
         client.run("create . -s os=ChromeOS --build missing")
 
         # Settings is None


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Pure refactor, to keep decoupling ConanAPI usage in tests

I have also reused some fixtures in "functional" tests to save some time in CI
