### PR TITLE
fix missing is_test fix of 2.9.3

### DIFF
--- a/conan/__init__.py
+++ b/conan/__init__.py
@@ -1,5 +1,5 @@
 from conans.model.conan_file import ConanFile
 from conan.tools.scm import Version as _Version
 
-__version__ = '2.10.2'
+__version__ = '2.10.3'
 conan_version = _Version(__version__)

--- a/conans/model/requires.py
+++ b/conans/model/requires.py
@@ -255,6 +255,7 @@ class Requirement:
         self.transitive_libs = self.transitive_libs or other.transitive_libs
         if not other.test:
             self.test = False  # it it was previously a test, but also required by non-test
+        # necessary even if no propagation, order of requires matter
         self.is_test = self.is_test or other.is_test
         # package_id_mode is not being propagated downstream. So it is enough to check if the
         # current require already defined it or not
@@ -347,7 +348,6 @@ class Requirement:
 
         if self.test:
             downstream_require.test = True
-        downstream_require.is_test = require.is_test
 
         # If the current one is resolving conflicts, the downstream one will be too
         downstream_require.force = require.force


### PR DESCRIPTION
Changelog: Bugfix: Integrate Conan 2.9.3 missing fix https://github.com/conan-io/conan/pull/17338
Docs: Omit

@bmwrightson raised the issue in https://github.com/conan-io/conan/pull/17338#issuecomment-2549828139

This PR replaces https://github.com/conan-io/conan/pull/17495 because this needs to have permissions to write a package in Github so it can't be a fork.
