### PR TITLE
Don't use a reference for new component properties lists when merging

### DIFF
--- a/conans/model/build_info.py
+++ b/conans/model/build_info.py
@@ -451,7 +451,7 @@ class _Component:
                 if existing is not None and isinstance(existing, list) and not overwrite:
                     existing.extend(v)
                 else:
-                    current_values[k] = v
+                    current_values[k] = copy.copy(v)
 
     def set_relative_base_folder(self, folder):
         for varname in _DIRS_VAR_NAMES:

--- a/test/integration/test_components.py
+++ b/test/integration/test_components.py
@@ -149,3 +149,39 @@ def test_components_overrides():
     # This used to crash, because override was not correctly excluded
     c.run("create app")
     assert "app/0.1: Created package" in c.out
+
+def test_duplication_component_properties():
+    """ Regression for PR 17503 - component lists would be incorrectly aggregated """
+    tc = TestClient(light=True)
+    tc.save({"dep/conanfile.py": textwrap.dedent("""
+    from conan import ConanFile
+
+    class Dep(ConanFile):
+        name = "dep"
+        version = "0.1"
+
+        def package_info(self):
+            self.cpp_info.components["acomp"].set_property("prop_list", ["value1"])
+            self.cpp_info.components["bcomp"].set_property("prop_list", ["value2"])
+            self.cpp_info.components["ccomp"].set_property("prop_list", ["value3"])
+    """),
+             "conanfile.py": textwrap.dedent("""
+             from conan import ConanFile
+
+             class Pkg(ConanFile):
+                 name = "pkg"
+                 version = "0.1"
+                 requires = "dep/0.1"
+
+                 def generate(self):
+                    # Calling this would break property lists of the last lex sorted component
+                    aggregated_components = self.dependencies["dep"].cpp_info.aggregated_components()
+                    ccomp = self.dependencies["dep"].cpp_info.components["ccomp"]
+                    self.output.info("ccomp list: " + str(ccomp.get_property("prop_list")))
+
+             """)})
+    tc.run("create dep")
+    tc.run("create .")
+    # The bug would give ccomp the prop_list values of the other two components
+    assert "pkg/0.1: ccomp list: ['value3', 'value2', 'value1']" not in tc.out
+    assert "pkg/0.1: ccomp list: ['value3']" in tc.out


### PR DESCRIPTION
Changelog: Bugfix: Fix bogus duplication of component properties
Docs: Omit

Found as the root cause of https://github.com/conan-io/conan-center-index/issues/26213

This caused component properties to be broken when merging lists, as the first component would get the rest of the values that ended up being set

Closes https://github.com/conan-io/conan-center-index/issues/26213