### PR TITLE
Guard against unknown languages attribute values

### DIFF
--- a/conans/model/conan_file.py
+++ b/conans/model/conan_file.py
@@ -95,6 +95,8 @@ class ConanFile:
             self.generators = [self.generators]
         if isinstance(self.languages, str):
             self.languages = [self.languages]
+        if not all(lang == "C" or lang == "C++" for lang in self.languages):
+            raise ConanException("Only 'C' and 'C++' languages are allowed in 'languages' attribute")
         if isinstance(self.settings, str):
             self.settings = [self.settings]
         self.requires = Requirements(self.requires, self.build_requires, self.test_requires,

--- a/test/integration/conanfile/conanfile_errors_test.py
+++ b/test/integration/conanfile/conanfile_errors_test.py
@@ -240,3 +240,22 @@ def test_consumer_unexpected():
     tc.run("create cmake")
     tc.run("create . -b=missing -pr=profile")
     assert "cmake/1.0 -> True" not in tc.out
+
+
+@pytest.mark.parametrize("languages", [
+    "['C', 'CXX']",
+    "['CXX']",
+    "'CXX'",
+])
+def test_language_unexpected(languages):
+    tc = TestClient(light=True)
+    tc.save({"conanfile.py": GenConanfile().with_class_attribute(f"languages = {languages}")})
+    tc.run("inspect .", assert_error=True)
+    assert "Only 'C' and 'C++' languages are allowed in 'languages' attribute" in tc.out
+
+
+def test_empty_languages():
+    tc = TestClient(light=True)
+    tc.save({"conanfile.py": GenConanfile().with_class_attribute("languages = []")})
+    tc.run("inspect .")
+    assert "Only 'C' and 'C++' languages are allowed in 'languages' attribute" not in tc.out


### PR DESCRIPTION
Changelog: Fix: Error out when unknown language is used in languages attribute.
Docs: Omit

This ensures only known languages are used - Helpful when typing lowercase versions or variants of C++ by mistake. In case of C for example, this would lead to the cppstd setting unexpectedly affecting the pkgid, for which there was no warn before this

The only drawback for this is that it eliminates potential custom usages of the attribute in user customizations, but those can be solved by using any other user-specific attribute if needed