### PR TITLE
Change replace_in_file to return True on success

### DIFF
--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -451,6 +451,7 @@ def replace_in_file(conanfile, file_path, search, replace, strict=True, encoding
            string is not found, so nothing is actually replaced.
     :param encoding: (Optional, Defaulted to utf-8): Specifies the input and output files text
            encoding.
+    :return: ``True`` if the pattern was found, ``False`` otherwise if `strict` is ``False``.
     """
     output = conanfile.output
     content = load(conanfile, file_path, encoding=encoding)
@@ -463,6 +464,7 @@ def replace_in_file(conanfile, file_path, search, replace, strict=True, encoding
             return False
     content = content.replace(search, replace)
     save(conanfile, file_path, content, encoding=encoding)
+    return True
 
 
 def collect_libs(conanfile, folder=None):

--- a/test/unittests/tools/files/test_file_read_and_write.py
+++ b/test/unittests/tools/files/test_file_read_and_write.py
@@ -3,6 +3,9 @@
 
 import os
 
+import pytest
+
+from conan.errors import ConanException
 from conan.tools.files import replace_in_file, save, load
 from conan.test.utils.mocks import ConanFileMock
 from conan.test.utils.test_files import temp_folder
@@ -36,18 +39,18 @@ def test_replace_in_file():
 
     # By default utf-8 is used
     save(conanfile, file_path, "你很重，伙計")
-    replace_in_file(conanfile, file_path, "重", "0")
+    assert replace_in_file(conanfile, file_path, "重", "0")
     contents = load(conanfile, file_path)
     assert contents == "你很0，伙計"
 
     # Replacing with other encodings is also possible
     save(conanfile, file_path, "Ö¼", encoding="cp1252")
-    replace_in_file(conanfile, file_path, "¼", "0", encoding="cp1252")
+    assert replace_in_file(conanfile, file_path, "¼", "0", encoding="cp1252")
     contents = load(conanfile, file_path, encoding="cp1252")
     assert contents == "Ö0"
 
     save(conanfile, file_path, "Ö¼", encoding="ISO-8859-1")
-    replace_in_file(conanfile, file_path, "¼", "0", encoding="ISO-8859-1")
+    assert replace_in_file(conanfile, file_path, "¼", "0", encoding="ISO-8859-1")
     contents = load(conanfile, file_path, encoding="ISO-8859-1")
     assert contents == "Ö0"
 
@@ -57,3 +60,9 @@ def test_replace_in_file():
     replace_in_file(conanfile, file_path, "重", "0", encoding="utf-16")
     contents = load(conanfile, file_path, encoding="utf-16")
     assert contents == "你很0，伙計"
+
+    with pytest.raises(ConanException, match="didn't find pattern"):
+        replace_in_file(conanfile, file_path, "not existing", "0", encoding="utf-16")
+
+    assert not replace_in_file(conanfile, file_path, "not existing", "0",
+                               encoding="utf-16", strict=False)


### PR DESCRIPTION
- was inconsistent before: returned `False` if the pattern was not found (with strict off), otherwise `None`
- fixes #17530

Changelog: Fix: Fix inconsistency in ``replace_in_file``, that returned `False` if the pattern was not found (with strict off), otherwise `None`.
Docs: Omit

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
