### PR TITLE
GnuToolchain's make_args handle empty values correctly

### DIFF
--- a/conan/tools/gnu/gnutoolchain.py
+++ b/conan/tools/gnu/gnutoolchain.py
@@ -237,7 +237,7 @@ class GnuToolchain:
 
     @staticmethod
     def _dict_to_list(flags):
-        return [f"{k}={v}" if v else k for k, v in flags.items()]
+        return [f"{k}={v}" if v is not None else k for k, v in flags.items()]
 
     @property
     def cxxflags(self):

--- a/test/unittests/tools/gnu/test_gnutoolchain.py
+++ b/test/unittests/tools/gnu/test_gnutoolchain.py
@@ -192,5 +192,9 @@ def test_update_or_prune_any_args(cross_building_conanfile):
     assert "'--force" not in new_autoreconf_args
     # Add new value to make_args
     at.make_args.update({"--new-complex-flag": "new-value"})
+    at.make_args.update({"--new-empty-flag": ""})
+    at.make_args.update({"--new-no-value-flag": None})
     new_make_args = cmd_args_to_string(GnuToolchain._dict_to_list(at.make_args))
     assert "--new-complex-flag=new-value" in new_make_args
+    assert "--new-empty-flag=" in new_make_args
+    assert "--new-no-value-flag" in new_make_args and "--new-no-value-flag=" not in new_make_args


### PR DESCRIPTION
Changelog: Fix: GnuToolchain's make_args handle empty values correctly.
Docs: Omit

Close: https://github.com/conan-io/conan/issues/17171


