### PR TITLE
upgrade bottle version

### DIFF
--- a/conans/requirements_server.txt
+++ b/conans/requirements_server.txt
@@ -1,4 +1,4 @@
 # Server
-bottle>=0.12.8, < 0.13
+bottle>=0.12.8, < 0.14
 pluginbase>=0.5
 PyJWT>=2.4.0, <3.0.0


### PR DESCRIPTION
Changelog: Fix: Allow latest bottle 0.13 release for ``conan_server`` to work with Python 3.13.
Docs: Omit

Close https://github.com/conan-io/conan/issues/17533