### PR TITLE
update webtest testing version

### DIFF
--- a/conans/requirements_dev.txt
+++ b/conans/requirements_dev.txt
@@ -2,7 +2,7 @@ pytest>=7, <8.0.0
 pytest-xdist  # To launch in N cores with pytest -n
 parameterized>=0.6.3
 mock>=1.3.0, <1.4.0
-WebTest>=2.0.18, <2.1.0
+WebTest>=3.0.0, <4
 bottle
 PyJWT
 pluginbase


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Follow up from https://github.com/conan-io/conan/pull/17534, same reason, Python 3.13 deprecations of ``cgi``

