### PR TITLE
Improve typing information in remove sub API

### DIFF
--- a/conan/api/subapi/remove.py
+++ b/conan/api/subapi/remove.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from conan.api.model import Remote
 from conan.internal.conan_app import ConanBasicApp
 from conans.model.package_ref import PkgReference
@@ -9,7 +11,7 @@ class RemoveAPI:
     def __init__(self, conan_api):
         self.conan_api = conan_api
 
-    def recipe(self, ref: RecipeReference, remote: Remote=None):
+    def recipe(self, ref: RecipeReference, remote: Optional[Remote] = None):
         assert ref.revision, "Recipe revision cannot be None to remove a recipe"
         """Removes the recipe (or recipe revision if present) and all the packages (with all prev)"""
         app = ConanBasicApp(self.conan_api)
@@ -20,7 +22,7 @@ class RemoveAPI:
             recipe_layout = app.cache.recipe_layout(ref)
             app.cache.remove_recipe_layout(recipe_layout)
 
-    def all_recipe_packages(self, ref: RecipeReference, remote: Remote = None):
+    def all_recipe_packages(self, ref: RecipeReference, remote: Optional[Remote] = None):
         assert ref.revision, "Recipe revision cannot be None to remove a recipe"
         """Removes all the packages from the provided reference"""
         app = ConanBasicApp(self.conan_api)
@@ -38,7 +40,7 @@ class RemoveAPI:
             package_layout = app.cache.pkg_layout(pref)
             app.cache.remove_package_layout(package_layout)
 
-    def package(self, pref: PkgReference, remote: Remote):
+    def package(self, pref: PkgReference, remote: Optional[Remote]):
         assert pref.ref.revision, "Recipe revision cannot be None to remove a package"
         assert pref.revision, "Package revision cannot be None to remove a package"
 


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

As the API actually accepts the remote to be `None`, this should also be
reflected in the type information in order to support users.
