### PR TITLE
Updated to use maxsplit=1

### DIFF
--- a/conan/tools/scm/git.py
+++ b/conan/tools/scm/git.py
@@ -137,7 +137,7 @@ class Git:
             return bool(status)
         # Parse the status output, line by line, and match it with "_excluded"
         lines = [line.strip() for line in status.splitlines()]
-        lines = [line.split()[1] for line in lines if line]
+        lines = [line.split(maxsplit=1)[1] for line in lines if line]
         lines = [line for line in lines if not any(fnmatch.fnmatch(line, p) for p in self._excluded)]
         self._conanfile.output.debug(f"Filtered git status: {lines}")
         return bool(lines)

--- a/conan/tools/scm/git.py
+++ b/conan/tools/scm/git.py
@@ -137,7 +137,9 @@ class Git:
             return bool(status)
         # Parse the status output, line by line, and match it with "_excluded"
         lines = [line.strip() for line in status.splitlines()]
-        lines = [line.split(maxsplit=1)[1] for line in lines if line]
+        # line is of the form STATUS PATH, get the path by splitting
+        # (Taking into account that STATUS is one word, PATH might be many)
+        lines = [line.split(maxsplit=1)[1].strip('"') for line in lines if line]
         lines = [line for line in lines if not any(fnmatch.fnmatch(line, p) for p in self._excluded)]
         self._conanfile.output.debug(f"Filtered git status: {lines}")
         return bool(lines)

--- a/test/functional/tools/scm/test_git.py
+++ b/test/functional/tools/scm/test_git.py
@@ -26,7 +26,7 @@ class TestGitBasicCapture:
             version = "0.1"
 
             def export(self):
-                git = Git(self, self.recipe_folder, excluded=["myfile.txt", "mynew.txt"])
+                git = Git(self, self.recipe_folder, excluded=["myfile.txt", "mynew.txt", "file with spaces.txt"])
                 commit = git.get_commit()
                 repo_commit = git.get_commit(repository=True)
                 url = git.get_remote_url()
@@ -127,7 +127,8 @@ class TestGitBasicCapture:
         c.run("export . -vvv")
         assert "pkg/0.1: DIRTY: False" in c.out
         c.save({"myfile.txt": "changed",
-                "mynew.txt": "new"})
+                "mynew.txt": "new",
+                "file with spaces.txt": "hello"})
         c.run("export .")
         assert "pkg/0.1: DIRTY: False" in c.out
         c.save({"other.txt": "new"})


### PR DESCRIPTION
Changelog: Fix: Fix `Git` `is_dirty` detection of excluded files with paths.
Docs: Omit


I have a file that has a space in its name. In the conan export method I use it like this:
```
def export(self):
        git = Git(self, self.recipe_folder, excluded=["src/file Component Toolchain.prj"])
        git.coordinates_to_conandata()
```
 and this fails because of the split:
```
lines = [line.split()[1] for line in lines if line]
```

Closes https://github.com/conan-io/conan/issues/17570



- [X] Refer to the issue that supports this Pull Request. https://github.com/conan-io/conan/issues/17570
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
