### PR TITLE
Add core:legacy_update_mode config to opt-in for old Conan 1 update behavior

### DIFF
--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -19,6 +19,7 @@ BUILT_IN_CONFS = {
     "core:default_profile": "Defines the default host profile ('default' by default)",
     "core:default_build_profile": "Defines the default build profile ('default' by default)",
     "core:allow_uppercase_pkg_names": "Temporarily (will be removed in 2.X) allow uppercase names",
+    "core:legacy_update_mode": "Use the Conan 1 update mode, where recipe revisions are resolved in the order of the remotes",
     "core.version_ranges:resolve_prereleases": "Whether version ranges can resolve to pre-releases or not",
     "core.upload:retry": "Number of retries in case of failure when uploading to Conan server",
     "core.upload:retry_wait": "Seconds to wait between upload attempts to Conan server",

--- a/conans/client/graph/proxy.py
+++ b/conans/client/graph/proxy.py
@@ -14,6 +14,7 @@ class ConanProxy:
         self._cache = conan_app.cache
         self._remote_manager = conan_app.remote_manager
         self._resolved = {}  # Cache of the requested recipes to optimize calls
+        self._legacy_update = conan_app.global_conf.get("core:legacy_update_mode", False)
 
     def get_recipe(self, ref, remotes, update, check_update):
         """
@@ -108,7 +109,7 @@ class ConanProxy:
                     ref = self._remote_manager.get_latest_recipe_reference(reference, remote)
                 else:
                     ref = self._remote_manager.get_recipe_revision_reference(reference, remote)
-                if not should_update_reference(reference, update) and not check_update:
+                if self._legacy_update or (not should_update_reference(reference, update) and not check_update):
                     return remote, ref
                 results.append({'remote': remote, 'ref': ref})
             except NotFoundException:


### PR DESCRIPTION
Changelog: Feature: Make it possible to opt-in for old Conan 1 update behavior which stops at the first remote containing a matching rrev
Docs: TODO

Addresses problem described in #17548 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
