### PR TITLE
make saving remotes file transactional

### DIFF
--- a/conan/api/subapi/remotes.py
+++ b/conan/api/subapi/remotes.py
@@ -290,7 +290,9 @@ def _save(remotes_file, remotes):
         if r.remote_type:
             remote["remote_type"] = r.remote_type
         remote_list.append(remote)
-    save(remotes_file, json.dumps({"remotes": remote_list}, indent=True))
+    # This atomic replace avoids a corrupted remotes.json file if this is killed during the process
+    save(remotes_file + ".tmp", json.dumps({"remotes": remote_list}, indent=True))
+    os.replace(remotes_file + ".tmp", remotes_file)
 
 
 def _filter(remotes, pattern, only_enabled=True):


### PR DESCRIPTION
Changelog: Fix: Make ``remotes.json`` saving transactional to avoid corruption for hard killed processes.
Docs: Omit

For https://github.com/conan-io/conan/issues/17578#issuecomment-2596840636