### PR TITLE
Feature/custom user presets

### DIFF
--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -77,7 +77,7 @@ BUILT_IN_CONFS = {
     "tools.cmake.cmaketoolchain:presets_environment": "String to define wether to add or not the environment section to the CMake presets. Empty by default, will generate the environment section in CMakePresets. Can take values: 'disabled'.",
     "tools.cmake.cmaketoolchain:extra_variables": "Dictionary with variables to be injected in CMakeToolchain (potential override of CMakeToolchain defined variables)",
     "tools.cmake.cmaketoolchain:enabled_blocks": "Select the specific blocks to use in the conan_toolchain.cmake",
-    "tools.cmake.cmaketoolchain:user_presets": "Select a different name instead of CMakeUserPresets.json, empty to disable",
+    "tools.cmake.cmaketoolchain:user_presets": "(Experimental) Select a different name instead of CMakeUserPresets.json, empty to disable",
     "tools.cmake.cmake_layout:build_folder_vars": "Settings and Options that will produce a different build folder and different CMake presets names",
     "tools.cmake.cmake_layout:build_folder": "(Experimental) Allow configuring the base folder of the build for local builds",
     "tools.cmake.cmake_layout:test_folder": "(Experimental) Allow configuring the base folder of the build for test_package",

--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -77,6 +77,7 @@ BUILT_IN_CONFS = {
     "tools.cmake.cmaketoolchain:presets_environment": "String to define wether to add or not the environment section to the CMake presets. Empty by default, will generate the environment section in CMakePresets. Can take values: 'disabled'.",
     "tools.cmake.cmaketoolchain:extra_variables": "Dictionary with variables to be injected in CMakeToolchain (potential override of CMakeToolchain defined variables)",
     "tools.cmake.cmaketoolchain:enabled_blocks": "Select the specific blocks to use in the conan_toolchain.cmake",
+    "tools.cmake.cmaketoolchain:user_presets": "Select a different name instead of CMakeUserPresets.json, empty to disable",
     "tools.cmake.cmake_layout:build_folder_vars": "Settings and Options that will produce a different build folder and different CMake presets names",
     "tools.cmake.cmake_layout:build_folder": "(Experimental) Allow configuring the base folder of the build for local builds",
     "tools.cmake.cmake_layout:test_folder": "(Experimental) Allow configuring the base folder of the build for test_package",

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -261,6 +261,7 @@ class _IncludingPresets:
         if not (conanfile.source_folder and conanfile.source_folder != conanfile.generators_folder):
             return
 
+        is_default = user_presets_path == "CMakeUserPresets.json"
         user_presets_path = os.path.join(conanfile.source_folder, user_presets_path)
         if os.path.isdir(user_presets_path):  # Allows user to specify only the folder
             output_dir = user_presets_path
@@ -268,7 +269,7 @@ class _IncludingPresets:
         else:
             output_dir = os.path.dirname(user_presets_path)
 
-        if not os.path.exists(os.path.join(output_dir, "CMakeLists.txt")):
+        if is_default and not os.path.exists(os.path.join(output_dir, "CMakeLists.txt")):
             return
 
         # It uses schema version 4 unless it is forced to 2

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -210,8 +210,10 @@ class CMakeToolchain:
 
             cmake_executable = self._conanfile.conf.get("tools.cmake:cmake_program", None) or self._find_cmake_exe()
 
+        user_presets = self._conanfile.conf.get("tools.cmake.cmaketoolchain:user_presets",
+                                                default=self.user_presets_path)
         write_cmake_presets(self._conanfile, toolchain_file, self.generator, cache_variables,
-                            self.user_presets_path, self.presets_prefix, buildenv, runenv,
+                            user_presets, self.presets_prefix, buildenv, runenv,
                             cmake_executable, self.absolute_paths)
 
     def _get_generator(self, recipe_generator):

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -22,6 +22,7 @@ from conan.tools.microsoft import VCVars
 from conan.tools.microsoft.visual import vs_ide_version
 from conan.errors import ConanException
 from conan.internal.model.options import _PackageOption
+from conans.client.graph.graph import RECIPE_CONSUMER, RECIPE_EDITABLE
 from conans.util.files import save
 
 
@@ -210,8 +211,15 @@ class CMakeToolchain:
 
             cmake_executable = self._conanfile.conf.get("tools.cmake:cmake_program", None) or self._find_cmake_exe()
 
-        user_presets = self._conanfile.conf.get("tools.cmake.cmaketoolchain:user_presets",
-                                                default=self.user_presets_path)
+        user_presets = self.user_presets_path
+        try:  # TODO: Refactor this repeated pattern to deduce "is-consumer"
+            # The user conf user_presets ONLY applies to dev space, not in the cache
+            if self._conanfile._conan_node.recipe in (RECIPE_CONSUMER, RECIPE_EDITABLE):
+                user_presets = self._conanfile.conf.get("tools.cmake.cmaketoolchain:user_presets",
+                                                        default=self.user_presets_path)
+        except AttributeError:
+            pass
+
         write_cmake_presets(self._conanfile, toolchain_file, self.generator, cache_variables,
                             user_presets, self.presets_prefix, buildenv, runenv,
                             cmake_executable, self.absolute_paths)

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -1550,6 +1550,11 @@ def test_customize_cmakeuserpresets():
     c.run("install . -g CMakeToolchain -of=build -c tools.cmake.cmaketoolchain:user_presets=my.json")
     new = c.load("my.json")
     assert old == new
+    # also in subfolder
+    c.run("install . -g CMakeToolchain -of=build "
+          "-c tools.cmake.cmaketoolchain:user_presets=mysub/my.json")
+    assert os.path.exists(os.path.join(c.current_folder, "mysub", "my.json"))
+
     assert not os.path.exists(os.path.join(c.current_folder, "CMakeUserPresets.json"))
     c.run("install . -g CMakeToolchain -of=build -c tools.cmake.cmaketoolchain:user_presets=")
     assert not os.path.exists(os.path.join(c.current_folder, "CMakeUserPresets.json"))

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -383,6 +383,7 @@ def lib_dir_setup():
     client.save({"conanfile.py": conanfile})
     return client
 
+
 def test_runtime_lib_dirs_single_conf(lib_dir_setup):
     client = lib_dir_setup
     generator = ""
@@ -1537,6 +1538,23 @@ def test_toolchain_keep_absolute_paths():
     assert os.path.isabs(presets["configurePresets"][0]["toolchainFile"])
 
 
+def test_customize_cmakeuserpresets():
+    # https://github.com/conan-io/conan/issues/15639
+    c = TestClient()
+    c.save({"conanfile.py": GenConanfile(),
+            "CMakeLists.txt": ""})
+    c.run("install . -g CMakeToolchain -of=build")
+    old = c.load("CMakeUserPresets.json")
+    os.remove(os.path.join(c.current_folder, "CMakeUserPresets.json"))
+
+    c.run("install . -g CMakeToolchain -of=build -c tools.cmake.cmaketoolchain:user_presets=my.json")
+    new = c.load("my.json")
+    assert old == new
+    assert not os.path.exists(os.path.join(c.current_folder, "CMakeUserPresets.json"))
+    c.run("install . -g CMakeToolchain -of=build -c tools.cmake.cmaketoolchain:user_presets=")
+    assert not os.path.exists(os.path.join(c.current_folder, "CMakeUserPresets.json"))
+
+
 def test_output_dirs_gnudirs_local_default():
     # https://github.com/conan-io/conan/issues/14733
     c = TestClient()
@@ -1634,7 +1652,7 @@ def test_toolchain_extra_variables():
     # Test input from command line passing dict between doble quotes
     client.run(textwrap.dedent(r"""
         install . -c tools.cmake.cmaketoolchain:extra_variables="{'CMAKE_GENERATOR_INSTANCE': '${GENERATOR_INSTANCE}/buildTools/', 'FOO': 42.2, 'DICT': {'value': 1}, 'CACHE_VAR': {'value': 'hello world', 'cache': True, 'type': 'BOOL', 'docstring': 'test variable'}}"
-    """)
+        """)
     )
 
     toolchain = client.load("conan_toolchain.cmake")
@@ -1643,32 +1661,31 @@ def test_toolchain_extra_variables():
     assert 'set(DICT 1)' in toolchain
     assert 'set(CACHE_VAR "hello world" CACHE BOOL "test variable")' in toolchain
 
-
     client.run(textwrap.dedent("""
         install . -c tools.cmake.cmaketoolchain:extra_variables="{'myVar': {'value': 'hello world', 'cache': 'true'}}"
-    """) , assert_error=True)
+    """), assert_error=True)
     assert 'tools.cmake.cmaketoolchain:extra_variables "myVar" "cache" must be a boolean' in client.out
 
     # Test invalid force
     client.run(textwrap.dedent("""
         install . -c tools.cmake.cmaketoolchain:extra_variables="{'myVar': {'value': 'hello world', 'force': True}}"
-    """) , assert_error=True)
+    """), assert_error=True)
     assert 'tools.cmake.cmaketoolchain:extra_variables "myVar" "force" is only allowed for cache variables' in client.out
 
     client.run(textwrap.dedent("""
         install . -c tools.cmake.cmaketoolchain:extra_variables="{'myVar': {'value': 'hello world', 'cache': True, 'force': 'true'}}"
-    """) , assert_error=True)
+    """), assert_error=True)
     assert 'tools.cmake.cmaketoolchain:extra_variables "myVar" "force" must be a boolean' in client.out
 
     # Test invalid cache variable
     client.run(textwrap.dedent("""
         install . -c tools.cmake.cmaketoolchain:extra_variables="{'myVar': {'value': 'hello world', 'cache': True}}"
-    """) , assert_error=True)
+    """), assert_error=True)
     assert 'tools.cmake.cmaketoolchain:extra_variables "myVar" needs "type" defined for cache variable' in client.out
 
     client.run(textwrap.dedent("""
         install . -c tools.cmake.cmaketoolchain:extra_variables="{'myVar': {'value': 'hello world', 'cache': True, 'type': 'INVALID_TYPE'}}"
-    """) , assert_error=True)
+    """), assert_error=True)
     assert 'tools.cmake.cmaketoolchain:extra_variables "myVar" invalid type "INVALID_TYPE" for cache variable. Possible types: BOOL, FILEPATH, PATH, STRING, INTERNAL' in client.out
 
     client.run(textwrap.dedent("""


### PR DESCRIPTION
Changelog: Feature: Define new ``tools.cmake.cmaketoolchain:user_presets`` to customize the name of the generated ``CMakeUserPresets.json``, disabling its generation. Also can generate it in a subfolder.
Docs: https://github.com/conan-io/docs/pull/3967

Close https://github.com/conan-io/conan/issues/15639
