### PR TITLE
[MesonToolchain] New `arch_flag` attribute

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -9,7 +9,7 @@ from conan.internal.internal_tools import raise_on_universal_arch
 from conan.tools.apple.apple import is_apple_os, apple_min_version_flag, \
     resolve_apple_flags
 from conan.tools.build.cross_building import cross_building
-from conan.tools.build.flags import libcxx_flags
+from conan.tools.build.flags import libcxx_flags, architecture_flag
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.meson.helpers import *
 from conan.tools.microsoft import VCVars, msvc_runtime_flag
@@ -210,6 +210,8 @@ class MesonToolchain:
         #: List of extra preprocessor definitions. Added to ``c_args`` and ``cpp_args`` with the
         #: format ``-D[FLAG_N]``.
         self.extra_defines = []
+        #: Architecture flag deduced by Conan and added to ``c_args``, ``cpp_args``, ``c_link_args`` and ``cpp_link_args``
+        self.arch_flag = architecture_flag(self._conanfile)  # https://github.com/conan-io/conan/issues/17624
         #: Dict-like object that defines Meson ``properties`` with ``key=value`` format
         self.properties = {}
         #: Dict-like object that defines Meson ``project options`` with ``key=value`` format
@@ -429,9 +431,9 @@ class MesonToolchain:
         sys_root = [f"--sysroot={self._sys_root}"] if self._sys_root else [""]
         ld = sharedlinkflags + exelinkflags + linker_script_flags + sys_root + self.extra_ldflags
         return {
-            "cxxflags": cxxflags + sys_root + self.extra_cxxflags,
-            "cflags": cflags + sys_root + self.extra_cflags,
-            "ldflags": ld,
+            "cxxflags": [self.arch_flag] + cxxflags + sys_root + self.extra_cxxflags,
+            "cflags": [self.arch_flag] + cflags + sys_root + self.extra_cflags,
+            "ldflags": [self.arch_flag] + ld,
             "defines": [f"-D{d}" for d in (defines + self.extra_defines)]
         }
 

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -98,10 +98,10 @@ def test_extra_flags_via_conf():
 
     t.run("install . -pr:h=profile -pr:b=profile")
     content = t.load(MesonToolchain.native_filename)
-    assert "cpp_args = ['-flag0', '-other=val', '-flag1', '-flag2', '-Ddefine1=0', '-D_GLIBCXX_USE_CXX11_ABI=0']" in content
-    assert "c_args = ['-flag0', '-other=val', '-flag3', '-flag4', '-Ddefine1=0']" in content
-    assert "c_link_args = ['-flag0', '-other=val', '-flag5', '-flag6']" in content
-    assert "cpp_link_args = ['-flag0', '-other=val', '-flag5', '-flag6']" in content
+    assert "cpp_args = ['-flag0', '-other=val', '-m64', '-flag1', '-flag2', '-Ddefine1=0', '-D_GLIBCXX_USE_CXX11_ABI=0']" in content
+    assert "c_args = ['-flag0', '-other=val', '-m64', '-flag3', '-flag4', '-Ddefine1=0']" in content
+    assert "c_link_args = ['-flag0', '-other=val', '-m64', '-flag5', '-flag6']" in content
+    assert "cpp_link_args = ['-flag0', '-other=val', '-m64', '-flag5', '-flag6']" in content
 
 
 def test_extra_flags_via_toolchain():
@@ -138,10 +138,32 @@ def test_extra_flags_via_toolchain():
             "profile": profile})
     t.run("install . -pr:h=profile -pr:b=profile")
     content = t.load(MesonToolchain.native_filename)
-    assert "cpp_args = ['-flag0', '-other=val', '-flag1', '-flag2', '-Ddefine1=0', '-D_GLIBCXX_USE_CXX11_ABI=0']" in content
-    assert "c_args = ['-flag0', '-other=val', '-flag3', '-flag4', '-Ddefine1=0']" in content
-    assert "c_link_args = ['-flag0', '-other=val', '-flag5', '-flag6']" in content
-    assert "cpp_link_args = ['-flag0', '-other=val', '-flag5', '-flag6']" in content
+    assert "cpp_args = ['-flag0', '-other=val', '-m64', '-flag1', '-flag2', '-Ddefine1=0', '-D_GLIBCXX_USE_CXX11_ABI=0']" in content
+    assert "c_args = ['-flag0', '-other=val', '-m64', '-flag3', '-flag4', '-Ddefine1=0']" in content
+    assert "c_link_args = ['-flag0', '-other=val', '-m64', '-flag5', '-flag6']" in content
+    assert "cpp_link_args = ['-flag0', '-other=val', '-m64', '-flag5', '-flag6']" in content
+
+
+def test_custom_arch_flag_via_toolchain():
+    t = TestClient()
+    conanfile = textwrap.dedent("""
+    from conan import ConanFile
+    from conan.tools.meson import MesonToolchain
+    class Pkg(ConanFile):
+        settings = "os", "compiler", "arch", "build_type"
+        def generate(self):
+            tc = MesonToolchain(self)
+            tc.arch_flag = "-mmy-flag"
+            tc.generate()
+    """)
+    t.save({"conanfile.py": conanfile})
+    t.run("install .")
+    content = t.load(MesonToolchain.native_filename)
+    assert re.search(r"c_args =.+-mmy-flag.+", content)
+    assert re.search(r"c_link_args =.+-mmy-flag.+", content)
+    assert re.search(r"cpp_args =.+-mmy-flag.+", content)
+    assert re.search(r"cpp_link_args =.+-mmy-flag.+", content)
+
 
 
 def test_linker_scripts_via_conf():
@@ -169,8 +191,8 @@ def test_linker_scripts_via_conf():
 
     t.run("install . -pr:b=profile -pr=profile")
     content = t.load(MesonToolchain.native_filename)
-    assert "c_link_args = ['-flag0', '-other=val', '-flag5', '-flag6', '-T\"/linker/scripts/flash.ld\"', '-T\"/linker/scripts/extra_data.ld\"']" in content
-    assert "cpp_link_args = ['-flag0', '-other=val', '-flag5', '-flag6', '-T\"/linker/scripts/flash.ld\"', '-T\"/linker/scripts/extra_data.ld\"']" in content
+    assert "c_link_args = ['-flag0', '-other=val', '-m64', '-flag5', '-flag6', '-T\"/linker/scripts/flash.ld\"', '-T\"/linker/scripts/extra_data.ld\"']" in content
+    assert "cpp_link_args = ['-flag0', '-other=val', '-m64', '-flag5', '-flag6', '-T\"/linker/scripts/flash.ld\"', '-T\"/linker/scripts/extra_data.ld\"']" in content
 
 
 def test_correct_quotes():


### PR DESCRIPTION
Changelog: Fix: Added `arch_flag` as a public attribute to the `MesonToolchain` generator.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/17624