### PR TITLE
--build=compatible docstring

### DIFF
--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -19,6 +19,10 @@ _help_build_policies = '''Optional, specify which packages to build from source.
                        reference matches the pattern. The pattern uses 'fnmatch' style wildcards.
     --build=missing:[pattern] Build from source if a compatible binary does not exist, only for
                               packages matching pattern.
+    --build=compatible:[pattern] (Experimental) Build from source if a compatible binary does not
+                                 exist, and the requested package is invalid, the closest package
+                                 binary following the defined compatibility policies (method and
+                                 compatibility.py)
 '''
 
 

--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -7,14 +7,14 @@ _help_build_policies = '''Optional, specify which packages to build from source.
     '--build' options on one command line is allowed.
     Possible values:
 
-    --build="*"        Force build from source for all packages.
     --build=never      Disallow build for all packages, use binary packages or fail if a binary
                        package is not found, it cannot be combined with other '--build' options.
     --build=missing    Build packages from source whose binary package is not found.
     --build=cascade    Build packages from source that have at least one dependency being built from
                        source.
     --build=[pattern]  Build packages from source whose package reference matches the pattern. The
-                       pattern uses 'fnmatch' style wildcards.
+                       pattern uses 'fnmatch' style wildcards, so '--build="*"' will build everything
+                       from source.
     --build=~[pattern] Excluded packages, which will not be built from the source, whose package
                        reference matches the pattern. The pattern uses 'fnmatch' style wildcards.
     --build=missing:[pattern] Build from source if a compatible binary does not exist, only for


### PR DESCRIPTION
Changelog: Feature: Make public documented (and experimental) the ``--build=compatible:[pattern]`` build mode, to allow building other configurations different than the current one when the current one is invalid and binary compatibility defines compatible binaries.
Docs: https://github.com/conan-io/docs/pull/3963

Close https://github.com/conan-io/conan/issues/17627