### PR TITLE
Fix `conan config clean` not resetting default file structure

### DIFF
--- a/conan/api/subapi/config.py
+++ b/conan/api/subapi/config.py
@@ -208,7 +208,7 @@ class ConfigAPI:
         packages_folder = self.global_conf.get("core.cache:storage_path") or os.path.join(self.home(), "p")
         for content in contents:
             content_path = os.path.join(self.home(), content)
-            if content_path == packages_folder or content == "version.txt":
+            if content_path == packages_folder:
                 continue
             ConanOutput().debug(f"Removing {content_path}")
             if os.path.isdir(content_path):

--- a/conan/cli/commands/config.py
+++ b/conan/cli/commands/config.py
@@ -138,7 +138,7 @@ def config_show(conan_api, parser, subparser, *args):
 @conan_subcommand()
 def config_clean(conan_api, parser, subparser, *args):
     """
-    Clean the configuration files in the Conan home folder. (Keeping installed packages)
+    (Experimental) Clean the configuration files in the Conan home folder, while keeping installed packages
     """
     parser.parse_args(*args)
     conan_api.config.clean()

--- a/test/integration/command/config_test.py
+++ b/test/integration/command/config_test.py
@@ -235,7 +235,9 @@ def test_config_clean(storage_path):
     assert os.path.exists(os.path.join(tc.cache_folder, "extensions"))
     assert not os.path.exists(os.path.join(tc.cache_folder, "extensions", "compatibility", "mycomp.py"))
     assert os.path.exists(absolut_storage_path)
+    # This will error because the call to clean will remove the profiles
     tc.run("create .", assert_error=True)
+    # Works after regenerating them!
     tc.run("profile detect")
     tc.run("create .")
 

--- a/test/integration/command/config_test.py
+++ b/test/integration/command/config_test.py
@@ -232,8 +232,12 @@ def test_config_clean(storage_path):
     assert "bar" not in tc.out
     tc.run("config show core.upload:retry")
     assert "7" not in tc.out
-    assert not os.path.exists(os.path.join(tc.cache_folder, "extensions"))
+    assert os.path.exists(os.path.join(tc.cache_folder, "extensions"))
+    assert not os.path.exists(os.path.join(tc.cache_folder, "extensions", "compatibility", "mycomp.py"))
     assert os.path.exists(absolut_storage_path)
+    tc.run("create .", assert_error=True)
+    tc.run("profile detect")
+    tc.run("create .")
 
 
 def test_config_reinit():


### PR DESCRIPTION
Changelog: Bugfix: Fix `conan config clean` not regenerating every necessary file.
Docs: Omit
