### PR TITLE
Protect access to CppInfo private property required_components

### DIFF
--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -649,7 +649,7 @@ class CppInfo:
         return getattr(self._package, attr)
 
     def __setattr__(self, attr, value):
-        if attr in ("components", "default_components", "_package", "_aggregated"):
+        if attr in ("components", "default_components", "_package", "_aggregated", "required_components"):
             super(CppInfo, self).__setattr__(attr, value)
         else:
             setattr(self._package, attr, value)

--- a/test/unittests/model/build_info/components_test.py
+++ b/test/unittests/model/build_info/components_test.py
@@ -15,6 +15,10 @@ class CppInfoComponentsTest(unittest.TestCase):
         self.assertListEqual(cpp_info.components["libb"].includedirs, ["include", "includewhat"])
         self.assertListEqual(cpp_info.components["libc"].libs, ["thelibc"])
 
+        with self.assertRaises(AttributeError):
+            cpp_info.required_components = ["liba::liba"]
+            cpp_info.components["comp"].required_components = ["liba::liba"]
+
     def test_no_components_inside_components(self):
         cpp_info = CppInfo()
         with self.assertRaises(AttributeError):

--- a/test/unittests/model/build_info/components_test.py
+++ b/test/unittests/model/build_info/components_test.py
@@ -17,7 +17,6 @@ class CppInfoComponentsTest(unittest.TestCase):
 
         with self.assertRaises(AttributeError):
             cpp_info.required_components = ["liba::liba"]
-            cpp_info.components["comp"].required_components = ["liba::liba"]
 
     def test_no_components_inside_components(self):
         cpp_info = CppInfo()


### PR DESCRIPTION
Changelog: Fix: Protect erroneous assignment of ``cpp_info/components.required_components = xxx``, for ``required_components`` property. Now it will raise a proper error.
Docs: omit

Regarding the issue of CCI, one recipe was overriding the internal property `required_components`. This should have triggered an exception beforehand.
 
https://github.com/conan-io/conan-center-index/issues/26455

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
