### PR TITLE
Add mcf threading model for GCC on Windows to the default_settings

### DIFF
--- a/conan/internal/default_settings.py
+++ b/conan/internal/default_settings.py
@@ -113,7 +113,7 @@ compiler:
                     "13", "13.1", "13.2", "13.3",
                     "14", "14.1", "14.2"]
         libcxx: [libstdc++, libstdc++11]
-        threads: [null, posix, win32]  # Windows MinGW
+        threads: [null, posix, win32, mcf]  # Windows MinGW
         exception: [null, dwarf2, sjlj, seh]  # Windows MinGW
         cppstd: [null, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23, 26, gnu26]
         cstd: [null, 99, gnu99, 11, gnu11, 17, gnu17, 23, gnu23]


### PR DESCRIPTION
Changelog: Feature: Add ``mcf`` threading for ``gcc`` MinGW compiler `settings.yml`.
Docs: https://github.com/conan-io/docs/pull/4011

Since the introduction of the mingw-builds/13.2.0 with [this PR]( https://github.com/conan-io/conan-center-index/pull/23481), GCC now support an additional threading model which is called "mcf".

But this setting is missing from the default configuration which in practice means that `mingw-builds` is not working out of the box, see [packag_info()](https://github.com/conan-io/conan-center-index/blob/master/recipes/mingw-builds/all/conanfile.py#L94)


- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
