### PR TITLE
Fix 200% untar progress issue by avoiding a second read of file

### DIFF
--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -377,7 +377,7 @@ def untargz(filename, destination=".", pattern=None, strip_root=False, extract_f
                         if member.isdir() or len(splits) > 1:
                             common_folder = splits[0]  # Find the root folder
                         else:
-                            raise ConanException("The tgz file does not have any folder in the root and strip_root is enabled")
+                            raise ConanException("Can't untar a tgz containing files in the root with strip_root enabled")
                     if not name.startswith(common_folder):
                         raise ConanException("The tgz file contains more than 1 folder in the root")
 

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -360,33 +360,37 @@ def untargz(filename, destination=".", pattern=None, strip_root=False, extract_f
         f = getattr(tarfile, f"{extract_filter}_filter", None) if extract_filter else None
         tarredgzippedFile.extraction_filter = f or (lambda member_, _: member_)
         if not pattern and not strip_root:
+            # Simple case: extract everything
             tarredgzippedFile.extractall(destination)
         else:
-            members = tarredgzippedFile.getmembers()
+            # Read members one by one and process them
+            common_folder = None
+            for member in tarredgzippedFile:
+                if pattern and not fnmatch(member.name, pattern):
+                    continue  # Skip files that don’t match the pattern
 
-            if pattern:
-                members = list(filter(lambda m: fnmatch(m.name, pattern),
-                                      tarredgzippedFile.getmembers()))
-            if strip_root:
-                names = [member.name.replace("\\", "/") for member in members]
-                common_folder = os.path.commonprefix(names).split("/", 1)[0]
-                if not common_folder and len(names) > 1:
-                    raise ConanException("The tgz file contains more than 1 folder in the root")
-                if len(names) == 1 and len(names[0].split("/", 1)) == 1:
-                    raise ConanException("The tgz file contains a file in the root")
-                # Remove the directory entry if present
-                members = [m for m in members if m.name != common_folder]
-                for member in members:
+                if strip_root:
                     name = member.name.replace("\\", "/")
-                    member.name = name.split("/", 1)[1]
-                    member.path = member.name
-                    if member.linkpath.startswith(common_folder):
-                        # https://github.com/conan-io/conan/issues/11065
-                        linkpath = member.linkpath.replace("\\", "/")
-                        member.linkpath = linkpath.split("/", 1)[1]
-                        member.linkname = member.linkpath
-            tarredgzippedFile.extractall(destination, members=members)
+                    if not common_folder:
+                        splits = name.split("/", 1)
+                        # First case for a plain folder in the root
+                        if member.isdir() or len(splits) > 1:
+                            common_folder = splits[0]  # Find the root folder
+                        else:
+                            raise ConanException("The tgz file does not have any folder in the root and strip_root is enabled")
+                    if not name.startswith(common_folder):
+                        raise ConanException("The tgz file contains more than 1 folder in the root")
 
+                    # Adjust the member's name for extraction
+                    member.name = name[len(common_folder) + 1:]
+                    member.path = member.name
+                    if member.linkpath and member.linkpath.startswith(common_folder):
+                        # https://github.com/conan-io/conan/issues/11065
+                        member.linkpath = member.linkpath[len(common_folder) + 1:].replace("\\", "/")
+                        member.linkname = member.linkpath
+                # Extract file one by one, avoiding `extractall()` with members parameter:
+                # This will avoid a first whole file read resulting in a performant improvement around 25%
+                tarredgzippedFile.extract(member, path=destination)
 
 def check_sha1(conanfile, file_path, signature):
     """

--- a/conans/client/rest/file_uploader.py
+++ b/conans/client/rest/file_uploader.py
@@ -97,7 +97,7 @@ class FileUploader(object):
 
 
 class FileProgress(io.FileIO):
-    def __init__(self, path: str, msg: str = "Uploading", interval: float = 1, *args, **kwargs):
+    def __init__(self, path: str, msg: str = "Uploading", interval: float = 10, *args, **kwargs):
         super().__init__(path, *args, **kwargs)
         self._size = os.path.getsize(path)
         self._filename = os.path.basename(path)

--- a/test/unittests/tools/files/test_zipping.py
+++ b/test/unittests/tools/files/test_zipping.py
@@ -137,7 +137,7 @@ def test_untargz_with_strip_root_fails():
     dest_dir = temp_folder()
     with pytest.raises(ConanException) as error:
         unzip(conanfile, archive, dest_dir, strip_root=True)
-    assert "The tgz file contains more than 1 folder in the root" in str(error.value)
+    assert "Can't untar a tgz containing files in the root with strip_root enabled" in str(error.value)
 
 
 def test_untargz_with_strip_root_and_pattern():

--- a/test/unittests/util/files/strip_root_extract_test.py
+++ b/test/unittests/util/files/strip_root_extract_test.py
@@ -255,7 +255,7 @@ class TarExtractPlainTest(unittest.TestCase):
 
         # Extract without the subfolder
         extract_folder = temp_folder()
-        with self.assertRaisesRegex(ConanException, "The tgz file does not have any folder in the root and strip_root is enabled"):
+        with self.assertRaisesRegex(ConanException, "Can't untar a tgz containing files in the root with strip_root enabled"):
             unzip(ConanFileMock(), tgz_file, destination=extract_folder, strip_root=True)
 
     def test_invalid_flat_multiple_file(self):
@@ -270,5 +270,5 @@ class TarExtractPlainTest(unittest.TestCase):
 
         # Extract without the subfolder
         extract_folder = temp_folder()
-        with self.assertRaisesRegex(ConanException, "The tgz file does not have any folder in the root and strip_root is enabled"):
+        with self.assertRaisesRegex(ConanException, "Can't untar a tgz containing files in the root with strip_root enabled"):
             unzip(ConanFileMock(), tgz_file, destination=extract_folder, strip_root=True)

--- a/test/unittests/util/files/strip_root_extract_test.py
+++ b/test/unittests/util/files/strip_root_extract_test.py
@@ -255,5 +255,20 @@ class TarExtractPlainTest(unittest.TestCase):
 
         # Extract without the subfolder
         extract_folder = temp_folder()
-        with self.assertRaisesRegex(ConanException, "The tgz file contains a file in the root"):
+        with self.assertRaisesRegex(ConanException, "The tgz file does not have any folder in the root and strip_root is enabled"):
+            unzip(ConanFileMock(), tgz_file, destination=extract_folder, strip_root=True)
+
+    def test_invalid_flat_multiple_file(self):
+        tmp_folder = temp_folder()
+        with chdir(tmp_folder):
+            save("file1", "contentsfile1")
+            save("file2", "contentsfile2")
+
+        zip_folder = temp_folder()
+        tgz_file = os.path.join(zip_folder, "file.tar.gz")
+        self._compress_folder(tmp_folder, tgz_file)
+
+        # Extract without the subfolder
+        extract_folder = temp_folder()
+        with self.assertRaisesRegex(ConanException, "The tgz file does not have any folder in the root and strip_root is enabled"):
             unzip(ConanFileMock(), tgz_file, destination=extract_folder, strip_root=True)


### PR DESCRIPTION
Changelog: Fix: Improve untar performance.
Docs: omit

Calling `TarFile.getmembers()` forces a complete IO read of the tar file.
The same happens when calling `TarFile.extractall(members=members)` for the first time.

This PR aims to fix the reported issue of having untar progress exceeding 100% occasionated by calling `seek(0)` twice, one in the first read querying all files and a second for the actual uncompression.

### Details:
Perform the decompression in a single IO loop by iterating over compressed files without actually reading them, filtering and uncompressing when needed one at a time.

### Benchmarks:

#### develop2 untar code
```
$ time conan source recipes/boost/all --version 1.86.0                                                                   
```
<details>

```
conanfile.py (boost/1.86.0): Calling source() in /Users/perseo/sources/conan-center-index/recipes/boost/all/src
conanfile.py (boost/1.86.0): Source ['https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2', 'https://sourceforge.net/projects/boost/files/boost/1.86.0/boost_1_86_0.tar.bz2'] retrieved from local download cache
conanfile.py (boost/1.86.0): Unzipping boost_1_86_0.tar.bz2 to /Users/perseo/sources/conan-center-index/recipes/boost/all/src
Uncompressing boost_1_86_0.tar.bz2: 5%
Uncompressing boost_1_86_0.tar.bz2: 10%
Uncompressing boost_1_86_0.tar.bz2: 22%
Uncompressing boost_1_86_0.tar.bz2: 30%
Uncompressing boost_1_86_0.tar.bz2: 42%
Uncompressing boost_1_86_0.tar.bz2: 54%
Uncompressing boost_1_86_0.tar.bz2: 62%
Uncompressing boost_1_86_0.tar.bz2: 71%
Uncompressing boost_1_86_0.tar.bz2: 79%
Uncompressing boost_1_86_0.tar.bz2: 89%
Uncompressing boost_1_86_0.tar.bz2: 95%
Uncompressing boost_1_86_0.tar.bz2: 100%
Uncompressing boost_1_86_0.tar.bz2: 103%
Uncompressing boost_1_86_0.tar.bz2: 105%
Uncompressing boost_1_86_0.tar.bz2: 106%
Uncompressing boost_1_86_0.tar.bz2: 108%
Uncompressing boost_1_86_0.tar.bz2: 112%
Uncompressing boost_1_86_0.tar.bz2: 121%
Uncompressing boost_1_86_0.tar.bz2: 124%
Uncompressing boost_1_86_0.tar.bz2: 127%
Uncompressing boost_1_86_0.tar.bz2: 130%
Uncompressing boost_1_86_0.tar.bz2: 139%
Uncompressing boost_1_86_0.tar.bz2: 146%
Uncompressing boost_1_86_0.tar.bz2: 152%
Uncompressing boost_1_86_0.tar.bz2: 156%
Uncompressing boost_1_86_0.tar.bz2: 161%
Uncompressing boost_1_86_0.tar.bz2: 165%
Uncompressing boost_1_86_0.tar.bz2: 170%
Uncompressing boost_1_86_0.tar.bz2: 172%
Uncompressing boost_1_86_0.tar.bz2: 176%
Uncompressing boost_1_86_0.tar.bz2: 179%
Uncompressing boost_1_86_0.tar.bz2: 184%
Uncompressing boost_1_86_0.tar.bz2: 189%
Uncompressing boost_1_86_0.tar.bz2: 193%
Uncompressing boost_1_86_0.tar.bz2: 195%
Uncompressing boost_1_86_0.tar.bz2: 196%
Uncompressing boost_1_86_0.tar.bz2: 199%
conanfile.py (boost/1.86.0): Apply patch (conan): Optional flag to specify iconv from either libc of libiconv
conan source recipes/boost/all    25,42s user 10,91s system 94% cpu 38,446 total
```
</details>

#### New changes
```
$  time conan source recipes/boost/all --version 1.86.0
```
<details>

```
conanfile.py (boost/1.86.0): Calling source() in /Users/perseo/sources/conan-center-index/recipes/boost/all/src
conanfile.py (boost/1.86.0): Source ['https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2', 'https://sourceforge.net/projects/boost/files/boost/1.86.0/boost_1_86_0.tar.bz2'] retrieved from local download cache
conanfile.py (boost/1.86.0): Unzipping boost_1_86_0.tar.bz2 to /Users/perseo/sources/conan-center-index/recipes/boost/all/src
Uncompressing boost_1_86_0.tar.bz2: 1%
Uncompressing boost_1_86_0.tar.bz2: 4%
Uncompressing boost_1_86_0.tar.bz2: 5%
Uncompressing boost_1_86_0.tar.bz2: 7%
Uncompressing boost_1_86_0.tar.bz2: 9%
Uncompressing boost_1_86_0.tar.bz2: 11%
Uncompressing boost_1_86_0.tar.bz2: 18%
Uncompressing boost_1_86_0.tar.bz2: 21%
Uncompressing boost_1_86_0.tar.bz2: 24%
Uncompressing boost_1_86_0.tar.bz2: 28%
Uncompressing boost_1_86_0.tar.bz2: 31%
Uncompressing boost_1_86_0.tar.bz2: 41%
Uncompressing boost_1_86_0.tar.bz2: 47%
Uncompressing boost_1_86_0.tar.bz2: 52%
Uncompressing boost_1_86_0.tar.bz2: 56%
Uncompressing boost_1_86_0.tar.bz2: 61%
Uncompressing boost_1_86_0.tar.bz2: 64%
Uncompressing boost_1_86_0.tar.bz2: 69%
Uncompressing boost_1_86_0.tar.bz2: 72%
Uncompressing boost_1_86_0.tar.bz2: 74%
Uncompressing boost_1_86_0.tar.bz2: 77%
Uncompressing boost_1_86_0.tar.bz2: 82%
Uncompressing boost_1_86_0.tar.bz2: 87%
Uncompressing boost_1_86_0.tar.bz2: 92%
Uncompressing boost_1_86_0.tar.bz2: 94%
Uncompressing boost_1_86_0.tar.bz2: 95%
Uncompressing boost_1_86_0.tar.bz2: 96%
conanfile.py (boost/1.86.0): Apply patch (conan): Optional flag to specify iconv from either libc of libiconv
conan source recipes/boost/all    15,30s user 10,32s system 89% cpu 28,726 total
```
</details>

The results show a 25% impact on uncompression efficiency

Closes https://github.com/conan-io/conan/issues/17697

----

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
