### PR TITLE
Fix test issues and warnings

### DIFF
--- a/.github/actions/test-coverage/action.yml
+++ b/.github/actions/test-coverage/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: true
 
   duration:
-    description: 'Tests maximum duration'
+    description: 'Show N slowest test durations (N=0 for all)'
     required: true
     default: '10'
 

--- a/.github/actions/test-coverage/action.yml
+++ b/.github/actions/test-coverage/action.yml
@@ -30,7 +30,7 @@ runs:
         if: ${{ inputs.tests }}
         shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
         run: |
-          pytest ${{ inputs.tests }} --durations=${{ inputs.duration }} -n ${{ inputs.workers }} ${{ github.ref == 'refs/heads/develop2' && '--cov=conan --cov=conans --cov=test --cov-report=term-missing:skip-covered' || '' }}
+          pytest ${{ inputs.tests }} --durations=${{ inputs.duration }} -n ${{ inputs.workers }} ${{ github.ref == 'refs/heads/develop2' && '--cov=conan --cov=conans --cov=test --cov-report=' || '' }}
 
       - name: Rename coverage file
         if: github.ref == 'refs/heads/develop2'

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -88,7 +88,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           test-type: ${{ matrix.test-type }}
           tests: test/${{ matrix.test-type }}
-          duration: 20
 
   linux_docker_tests:
     needs: build_container
@@ -120,5 +119,4 @@ jobs:
           python-version: ${{ matrix.python-version }}
           test-type: docker
           tests: '-m docker_runner -rs'
-          duration: 20
           workers: 1

--- a/.github/workflows/osx-tests.yml
+++ b/.github/workflows/osx-tests.yml
@@ -172,4 +172,3 @@ jobs:
           python-version: ${{ matrix.python-version }}
           test-type: ${{ matrix.test-type }}
           tests: test/${{ matrix.test-type }}
-          duration: 20

--- a/.github/workflows/win-tests.yml
+++ b/.github/workflows/win-tests.yml
@@ -54,7 +54,6 @@ jobs:
           python-version: ${{ matrix.python-version }}
           test-type: unit-integration
           tests: test/unittests test/integration
-          duration: 100
 
   functional_tests:
     runs-on: windows-2022
@@ -249,4 +248,3 @@ jobs:
           python-version: ${{ matrix.python-version }}
           test-type: functional
           tests: test/functional
-          duration: 100

--- a/test/integration/configuration/conf/test_conf_copy.py
+++ b/test/integration/configuration/conf/test_conf_copy.py
@@ -18,7 +18,7 @@ def test_copy_conaninfo_conf():
     assert "tools.deployer:symlinks" in result
     assert "user.myconf:cmake-test" in result
 
-    pattern = ["tools\..*"]
+    pattern = ["tools..*"]
     conf.define("tools.info.package_id:confs", pattern)
     result = conf.copy_conaninfo_conf().dumps()
     assert "tools.info.package_id:confs=%s" % pattern in result

--- a/test/integration/configuration/conf/test_conf_copy.py
+++ b/test/integration/configuration/conf/test_conf_copy.py
@@ -18,7 +18,7 @@ def test_copy_conaninfo_conf():
     assert "tools.deployer:symlinks" in result
     assert "user.myconf:cmake-test" in result
 
-    pattern = ["tools..*"]
+    pattern = [r"tools\..*"]
     conf.define("tools.info.package_id:confs", pattern)
     result = conf.copy_conaninfo_conf().dumps()
     assert "tools.info.package_id:confs=%s" % pattern in result

--- a/test/integration/toolchains/microsoft/test_nmakedeps.py
+++ b/test/integration/toolchains/microsoft/test_nmakedeps.py
@@ -41,11 +41,11 @@ def test_nmakedeps():
     bat_file = client.load("conannmakedeps.bat")
     # Checking that defines are added to CL
     for flag in (
-        R'/D"TEST_DEFINITION1"', '/D"TEST_DEFINITION2#0"',
-        R'/D"TEST_DEFINITION3#"', '/D"TEST_DEFINITION4#"foo""',
-        R'/D"TEST_DEFINITION5#"__declspec(dllexport)""',
-        R'/D"TEST_DEFINITION6#"foo bar""',
-        R'/D"TEST_DEFINITION7#7"'
+        r'/D"TEST_DEFINITION1"', '/D"TEST_DEFINITION2#0"',
+        r'/D"TEST_DEFINITION3#"', '/D"TEST_DEFINITION4#"foo""',
+        r'/D"TEST_DEFINITION5#"__declspec\(dllexport\)""',
+        r'/D"TEST_DEFINITION6#"foo bar""',
+        r'/D"TEST_DEFINITION7#7"'
     ):
         assert re.search(fr'set "CL=%CL%.*\s{flag}(?:\s|")', bat_file)
     # Checking that libs and system libs are added to _LINK_

--- a/test/integration/toolchains/microsoft/test_nmakedeps.py
+++ b/test/integration/toolchains/microsoft/test_nmakedeps.py
@@ -41,11 +41,11 @@ def test_nmakedeps():
     bat_file = client.load("conannmakedeps.bat")
     # Checking that defines are added to CL
     for flag in (
-        '/D"TEST_DEFINITION1"', '/D"TEST_DEFINITION2#0"',
-        '/D"TEST_DEFINITION3#"', '/D"TEST_DEFINITION4#"foo""',
-        '/D"TEST_DEFINITION5#"__declspec\(dllexport\)""',
-        '/D"TEST_DEFINITION6#"foo bar""',
-        '/D"TEST_DEFINITION7#7"'
+        R'/D"TEST_DEFINITION1"', '/D"TEST_DEFINITION2#0"',
+        R'/D"TEST_DEFINITION3#"', '/D"TEST_DEFINITION4#"foo""',
+        R'/D"TEST_DEFINITION5#"__declspec(dllexport)""',
+        R'/D"TEST_DEFINITION6#"foo bar""',
+        R'/D"TEST_DEFINITION7#7"'
     ):
         assert re.search(fr'set "CL=%CL%.*\s{flag}(?:\s|")', bat_file)
     # Checking that libs and system libs are added to _LINK_

--- a/test/unittests/tools/files_patch_test.py
+++ b/test/unittests/tools/files_patch_test.py
@@ -90,7 +90,7 @@ class ToolsFilesPatchTest(unittest.TestCase):
             class PatchConan(ConanFile):
                 def source(self):
                     patch(self, self.source_folder, "example.patch", strip=1)""")
-        patch = dedent(R"""
+        patch = dedent(r"""
             --- a\src\oldfile
             +++ b/dev/null
             @@ -0,1 +0,0 @@

--- a/test/unittests/tools/files_patch_test.py
+++ b/test/unittests/tools/files_patch_test.py
@@ -90,7 +90,7 @@ class ToolsFilesPatchTest(unittest.TestCase):
             class PatchConan(ConanFile):
                 def source(self):
                     patch(self, self.source_folder, "example.patch", strip=1)""")
-        patch = dedent("""
+        patch = dedent(R"""
             --- a\src\oldfile
             +++ b/dev/null
             @@ -0,1 +0,0 @@


### PR DESCRIPTION
Changelog: omit
Docs: omit

Close https://github.com/conan-io/conan/issues/17736#event-16228685511

- [x] Remove the coverage output from the logs, too verbose there, they are in the web already
- [x] Fix the warnings in the test suite due to non escaped strings in regex and the like
- [x] Reduce the duration report to the slowest 10 tests
- [ ] Fix the webob warning, might need to update the test-dependency WebTest