### PR TITLE
Ignore `cgi` deprecation warning on CI 

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -49,7 +49,7 @@ jobs:
       options: --user conan
     strategy:
       matrix:
-        python-version: [3.12.3, 3.9.2, 3.8.6, 3.6.15]
+        python-version: [3.13, 3.9, 3.8, 3.6]
         test-type: [unittests, integration, functional]
         include:
         - test-type: unittests
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.12, 3.9]
+        python-version: [3.13, 3.9]
     name: Docker Runner Tests (${{ matrix.python-version }})
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/conans/requirements_dev.txt
+++ b/conans/requirements_dev.txt
@@ -3,7 +3,7 @@ pytest-xdist  # To launch in N cores with pytest -n
 parameterized>=0.6.3
 mock>=1.3.0, <1.4.0
 WebTest>=3.0.0, <4
-legacy-cgi     # Give support to WebTest which depends on WebOb which still uses CGI, deprecated since python 3.13
+legacy-cgi; python_version >= "3.12"     # Give support to WebTest which depends on WebOb which still uses CGI, deprecated since python 3.13
 bottle
 PyJWT
 pluginbase

--- a/conans/requirements_dev.txt
+++ b/conans/requirements_dev.txt
@@ -3,6 +3,7 @@ pytest-xdist  # To launch in N cores with pytest -n
 parameterized>=0.6.3
 mock>=1.3.0, <1.4.0
 WebTest>=3.0.0, <4
+legacy-cgi     # Give support to WebTest which depends on WebOb which still uses CGI, deprecated since python 3.13
 bottle
 PyJWT
 pluginbase

--- a/conans/requirements_dev.txt
+++ b/conans/requirements_dev.txt
@@ -3,7 +3,7 @@ pytest-xdist  # To launch in N cores with pytest -n
 parameterized>=0.6.3
 mock>=1.3.0, <1.4.0
 WebTest>=3.0.0, <4
-legacy-cgi; python_version >= "3.12"     # Give support to WebTest which depends on WebOb which still uses CGI, deprecated since python 3.13
+legacy-cgi; python_version >= "3.10"     # Give support to WebTest which depends on WebOb which still uses CGI, deprecated since python 3.13
 bottle
 PyJWT
 pluginbase

--- a/conans/requirements_dev.txt
+++ b/conans/requirements_dev.txt
@@ -3,7 +3,6 @@ pytest-xdist  # To launch in N cores with pytest -n
 parameterized>=0.6.3
 mock>=1.3.0, <1.4.0
 WebTest>=3.0.0, <4
-legacy-cgi; python_version >= "3.10"     # Give support to WebTest which depends on WebOb which still uses CGI, deprecated since python 3.13
 bottle
 PyJWT
 pluginbase

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,5 @@ testpaths = 'test'
 markers =
    docker_runner: Mark tests that require Docker to run.
    artifactory_ready: These tests can be run against a full Artifactory
+filterwarnings =
+    ignore:'cgi' is deprecated:DeprecationWarning


### PR DESCRIPTION
Changelog: omit
Docs: omit

From https://github.com/conan-io/conan/issues/17736,
> Fix the WebOb warning, might need to update the test-dependency WebTest

Until https://github.com/Pylons/webob/issues/437 is resolved, the best approach is to use the `legacy-cgi` package, which will allow Conan to run in Python environments greater than 3.12.

### Edit
Recent versions of `WebOb` uses `legacy-cgi` as a substitute of `cgi` deprecated module since python 3.13.
This means it is safe to ignore the `pytest` warning complaining about `cgi` deprecation.

Also, updated python versions used in `linux-tests.yml`.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
