### PR TITLE
Fix: Collect submodules for conans.model

### DIFF
--- a/pyinstaller.py
+++ b/pyinstaller.py
@@ -104,6 +104,7 @@ def pyinstall(source_folder, onefile=False):
               "--hidden-import=pathlib "
               # Modules that can be imported in ConanFile conan.tools and errors
               "--collect-submodules=conan.cli.commands "
+              "--collect-submodules=conans.model "
               "--hidden-import=conan.errors "
               "--hidden-import=conan.tools.microsoft "
               "--hidden-import=conan.tools.gnu --hidden-import=conan.tools.cmake "


### PR DESCRIPTION
Should fix the following error for artifactory extensions when bundling with pyinstaller: 
```
ERROR: Error loading custom command art2.cmd_build_info: No module named 'conans.model' 
ERROR: Error loading custom command art2.cmd_promote: No module named 'conans.model' 
ERROR: Error loading custom command art2.cmd_property: No module named 'conans.model'
```

Changelog: Fix import errors on artifactory extensions, when bundling with pyinstaller
Docs: Omit
Closes #17767 
- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
