### PR TITLE
[tools] Add chmod in tools.files

### DIFF
--- a/conan/tools/files/__init__.py
+++ b/conan/tools/files/__init__.py
@@ -1,6 +1,6 @@
 from conan.tools.files.files import load, save, mkdir, rmdir, rm, ftp_download, download, get, \
     rename, chdir, unzip, replace_in_file, collect_libs, check_md5, check_sha1, check_sha256, \
-    move_folder_contents
+    move_folder_contents, chmod
 
 from conan.tools.files.patches import patch, apply_conandata_patches, export_conandata_patches
 from conan.tools.files.packager import AutoPackager

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -287,7 +287,7 @@ def chmod(conanfile, path:str, read:bool=None, write:bool=None, execute:bool=Non
         permissions = [
             (read, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH),
             (write, stat.S_IWUSR),
-            (execute, stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH & ~stat.S_ISUID & ~stat.S_ISGID)
+            (execute, stat.S_IXUSR | stat.S_IXGRP)
         ]
         for enabled, mask in permissions:
             if enabled is None:

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -1,5 +1,6 @@
 import gzip
 import os
+import stat
 import platform
 import shutil
 import subprocess
@@ -261,6 +262,43 @@ def chdir(conanfile, newdir):
         yield
     finally:
         os.chdir(old_path)
+
+
+def chmod(conanfile, path:str, read:bool, write:bool, execute:bool, recursive:bool=False):
+    """
+    Change the permissions of a file or directory. The same as the Unix command chmod, but simplified.
+
+    :param conanfile: The current recipe object. Always use ``self``.
+    :param path: Path to the file or directory to change the permissions.
+    :param read: If ``True``, the file or directory will have read permissions for any user.
+    :param write: If ``True``, the file or directory will have write permissions for any user.
+    :param execute: If ``True``, the file or directory will have execute permissions for any user.
+    :param recursive: (Optional, Defaulted to ``False``) If ``True``, the permissions will be applied
+    """
+    if not os.path.exists(path):
+        raise ConanException(f"Could not change permission: Path \"{path}\" does not exist.")
+
+    def _change_permission(it_path:str):
+        mode = os.stat(it_path).st_mode
+        permission_map = {
+            read: stat.S_IREAD | stat.S_IRGRP | stat.S_IROTH,
+            write: stat.S_IWRITE | stat.S_IWGRP | stat.S_IWOTH,
+            execute: stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH
+        }
+        for enabled, mask in permission_map.items():
+            if enabled:
+                mode |= mask
+            else:
+                mode &= ~mask
+        os.chmod(it_path, mode)
+
+    if recursive:
+        for root, _, files in os.walk(path):
+            _change_permission(root)
+            for file in files:
+                _change_permission(os.path.join(root, file))
+    else:
+        _change_permission(path)
 
 
 def unzip(conanfile, filename, destination=".", keep_permissions=False, pattern=None,

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -284,7 +284,7 @@ def chmod(conanfile, path:str, read:bool=None, write:bool=None, execute:bool=Non
         permissions = [
             (read, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH),
             (write, stat.S_IWUSR),
-            (execute, stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+            (execute, stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH & ~stat.S_ISUID & ~stat.S_ISGID)
         ]
         for enabled, mask in permissions:
             if enabled is None:

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -267,6 +267,7 @@ def chdir(conanfile, newdir):
 def chmod(conanfile, path:str, read:bool, write:bool, execute:bool, recursive:bool=False):
     """
     Change the permissions of a file or directory. The same as the Unix command chmod, but simplified.
+    It skips in case running on Windows.
 
     :param conanfile: The current recipe object. Always use ``self``.
     :param path: Path to the file or directory to change the permissions.
@@ -275,17 +276,21 @@ def chmod(conanfile, path:str, read:bool, write:bool, execute:bool, recursive:bo
     :param execute: If ``True``, the file or directory will have execute permissions for any user.
     :param recursive: (Optional, Defaulted to ``False``) If ``True``, the permissions will be applied
     """
+    if platform.system() == "Windows":
+        conanfile.output.debug("Skipping tools.files.chmod on Windows.")
+        return
+
     if not os.path.exists(path):
         raise ConanException(f"Could not change permission: Path \"{path}\" does not exist.")
 
     def _change_permission(it_path:str):
         mode = os.stat(it_path).st_mode
-        permission_map = {
-            read: stat.S_IREAD | stat.S_IRGRP | stat.S_IROTH,
-            write: stat.S_IWRITE | stat.S_IWGRP | stat.S_IWOTH,
-            execute: stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH
-        }
-        for enabled, mask in permission_map.items():
+        permissions = [
+            (read, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH),
+            (write, stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH),
+            (execute, stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        ]
+        for enabled, mask in permissions:
             if enabled:
                 mode |= mask
             else:
@@ -294,7 +299,6 @@ def chmod(conanfile, path:str, read:bool, write:bool, execute:bool, recursive:bo
 
     if recursive:
         for root, _, files in os.walk(path):
-            _change_permission(root)
             for file in files:
                 _change_permission(os.path.join(root, file))
     else:

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -271,7 +271,7 @@ def chmod(conanfile, path:str, read:bool=None, write:bool=None, execute:bool=Non
 
     :param conanfile: The current recipe object. Always use ``self``.
     :param path: Path to the file or directory to change the permissions.
-    :param read: If ``True``, the file or directory will have read permissions for any user.
+    :param read: If ``True``, the file or directory will have read permissions for owner user.
     :param write: If ``True``, the file or directory will have write permissions for owner user.
     :param execute: If ``True``, the file or directory will have execute permissions for owner user.
     :param recursive: If ``True``, the permissions will be applied
@@ -285,7 +285,7 @@ def chmod(conanfile, path:str, read:bool=None, write:bool=None, execute:bool=Non
     def _change_permission(it_path:str):
         mode = os.stat(it_path).st_mode
         permissions = [
-            (read, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH),
+            (read, stat.S_IRUSR),
             (write, stat.S_IWUSR),
             (execute, stat.S_IXUSR)
         ]

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -267,7 +267,7 @@ def chdir(conanfile, newdir):
 def chmod(conanfile, path:str, read:bool=None, write:bool=None, execute:bool=None, recursive:bool=False):
     """
     Change the permissions of a file or directory. The same as the Unix command chmod, but simplified.
-    It skips in case running on Windows.
+    On Windows is limited to changing write permission only.
 
     :param conanfile: The current recipe object. Always use ``self``.
     :param path: Path to the file or directory to change the permissions.

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -273,7 +273,7 @@ def chmod(conanfile, path:str, read:bool=None, write:bool=None, execute:bool=Non
     :param path: Path to the file or directory to change the permissions.
     :param read: If ``True``, the file or directory will have read permissions for any user.
     :param write: If ``True``, the file or directory will have write permissions for owner user.
-    :param execute: If ``True``, the file or directory will have execute permissions for any user.
+    :param execute: If ``True``, the file or directory will have execute permissions for owner user.
     :param recursive: If ``True``, the permissions will be applied
     """
     if read is None and write is None and execute is None:
@@ -287,7 +287,7 @@ def chmod(conanfile, path:str, read:bool=None, write:bool=None, execute:bool=Non
         permissions = [
             (read, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH),
             (write, stat.S_IWUSR),
-            (execute, stat.S_IXUSR | stat.S_IXGRP)
+            (execute, stat.S_IXUSR)
         ]
         for enabled, mask in permissions:
             if enabled is None:

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -276,6 +276,9 @@ def chmod(conanfile, path:str, read:bool=None, write:bool=None, execute:bool=Non
     :param execute: If ``True``, the file or directory will have execute permissions for any user.
     :param recursive: If ``True``, the permissions will be applied
     """
+    if read is None and write is None and execute is None:
+        raise ConanException("Could not change permission: At least one of the permissions should be set.")
+
     if not os.path.exists(path):
         raise ConanException(f"Could not change permission: Path \"{path}\" does not exist.")
 

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -264,7 +264,7 @@ def chdir(conanfile, newdir):
         os.chdir(old_path)
 
 
-def chmod(conanfile, path:str, read:bool, write:bool, execute:bool, recursive:bool=False):
+def chmod(conanfile, path:str, read:bool=None, write:bool=None, execute:bool=None, recursive:bool=False):
     """
     Change the permissions of a file or directory. The same as the Unix command chmod, but simplified.
     It skips in case running on Windows.
@@ -272,14 +272,10 @@ def chmod(conanfile, path:str, read:bool, write:bool, execute:bool, recursive:bo
     :param conanfile: The current recipe object. Always use ``self``.
     :param path: Path to the file or directory to change the permissions.
     :param read: If ``True``, the file or directory will have read permissions for any user.
-    :param write: If ``True``, the file or directory will have write permissions for any user.
+    :param write: If ``True``, the file or directory will have write permissions for owner user.
     :param execute: If ``True``, the file or directory will have execute permissions for any user.
-    :param recursive: (Optional, Defaulted to ``False``) If ``True``, the permissions will be applied
+    :param recursive: If ``True``, the permissions will be applied
     """
-    if platform.system() == "Windows":
-        conanfile.output.debug("Skipping tools.files.chmod on Windows.")
-        return
-
     if not os.path.exists(path):
         raise ConanException(f"Could not change permission: Path \"{path}\" does not exist.")
 
@@ -287,11 +283,13 @@ def chmod(conanfile, path:str, read:bool, write:bool, execute:bool, recursive:bo
         mode = os.stat(it_path).st_mode
         permissions = [
             (read, stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH),
-            (write, stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH),
+            (write, stat.S_IWUSR),
             (execute, stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
         ]
         for enabled, mask in permissions:
-            if enabled:
+            if enabled is None:
+                continue
+            elif enabled:
                 mode |= mask
             else:
                 mode &= ~mask

--- a/test/unittests/tools/files/test_chmod.py
+++ b/test/unittests/tools/files/test_chmod.py
@@ -3,50 +3,44 @@ import platform
 import stat
 import pytest
 
+from conan.errors import ConanException
 from conan.tools.files import chmod
 from conan.test.utils.mocks import ConanFileMock
 from conan.test.utils.tools import temp_folder, save_files
 
 
-@pytest.fixture
-def no_permission_file():
-    tmp = temp_folder()
-    save_files(tmp, {"file.txt": "foobar"})
-    file_path = os.path.join(tmp, "file.txt")
-    os.chmod(file_path, 0o000)
-    file_mode = os.stat(file_path).st_mode
-    assert stat.S_IMODE(file_mode) == 0
-    return file_path
-
-
-@pytest.mark.skipif(platform.system() == "Windows", reason="chmod is not available in Windows")
+@pytest.mark.skipif(platform.system() == "Windows", reason="validate full permissions only in Unix")
 @pytest.mark.parametrize("read,write,execute,expected", [
-    (True, True, True, 0o777),
-    (False, True, False, 0o222),
+    (True, True, True, 0o755),
+    (False, True, False, 0o200),
     (False, False, True, 0o111),
     (True, False, True, 0o555),
-    (True, True, False, 0o666),
+    (True, True, False, 0o644),
     (True, False, False, 0o444),
     (False, False, False, 0o000),])
-def test_chmod_single_file(no_permission_file, read, write, execute, expected):
+def test_chmod_single_file(read, write, execute, expected):
     """
     This test is to validate the function chmod.
 
     The function should change the file permissions to the expected value only.
     """
+    tmp = temp_folder()
+    save_files(tmp, {"file.txt": "foobar"})
+    file_path = os.path.join(tmp, "file.txt")
+    os.chmod(file_path, 0o000)
     conanfile = ConanFileMock()
-    chmod(conanfile, no_permission_file, read=read, write=write, execute=execute, recursive=False)
-    file_mode = os.stat(no_permission_file).st_mode
+    chmod(conanfile, file_path, read=read, write=write, execute=execute, recursive=False)
+    file_mode = os.stat(file_path).st_mode
     assert stat.S_IMODE(file_mode) == expected
 
 
-@pytest.mark.skipif(platform.system() == "Windows", reason="chmod is not available in Windows")
+@pytest.mark.skipif(platform.system() == "Windows", reason="validate full permissions only in Unix")
 @pytest.mark.parametrize("read,write,execute,expected", [
-    (True, True, True, 0o777),
-    (False, True, False, 0o222),
+    (True, True, True, 0o755),
+    (False, True, False, 0o200),
     (False, False, True, 0o111),
     (True, False, True, 0o555),
-    (True, True, False, 0o666),
+    (True, True, False, 0o644),
     (True, False, False, 0o444),
     (False, False, False, 0o000),])
 def test_chmod_recursive(read, write, execute, expected):
@@ -68,12 +62,27 @@ def test_chmod_recursive(read, write, execute, expected):
             assert stat.S_IMODE(file_mode) == expected
 
 
-@pytest.mark.skipif(platform.system() != "Windows", reason="Only to validate no breaking on Windows")
-def test_chmod_windows():
+def test_invalid_path():
     """
-    This test is to validate that the function does not break on Windows only.
+    This test is to validate the function chmod.
 
-    The function is not expected to work on Windows, so it should not change the file permissions.
+    The function should raise an exception if the path does not exist.
     """
     conanfile = ConanFileMock()
-    chmod(conanfile, "invalid_path", read=True, write=True, execute=True, recursive=False)
+    with pytest.raises(ConanException) as error:
+        chmod(conanfile, "invalid_path", read=True, write=True, execute=True, recursive=False)
+    assert 'Could not change permission: Path "invalid_path" does not exist.' in str(error.value)
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Validate read-only permissions only in Windows")
+def test_chmod_windows():
+    """
+    This test is to validate the function chmod in Windows.
+    """
+    tmp = temp_folder()
+    save_files(tmp, {"file.txt": "foobar"})
+    file_path = os.path.join(tmp, "file.txt")
+    os.chmod(file_path, 0o000)
+    conanfile = ConanFileMock()
+    chmod(conanfile, file_path, read=True, write=True, execute=True, recursive=False)
+    assert os.access(file_path, os.W_OK)

--- a/test/unittests/tools/files/test_chmod.py
+++ b/test/unittests/tools/files/test_chmod.py
@@ -11,10 +11,10 @@ from conan.test.utils.tools import temp_folder, save_files
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="validate full permissions only in Unix")
 @pytest.mark.parametrize("read,write,execute,expected", [
-    (True, True, True, 0o754),
+    (True, True, True, 0o744),
     (False, True, False, 0o200),
-    (False, False, True, 0o110),
-    (True, False, True, 0o554),
+    (False, False, True, 0o100),
+    (True, False, True, 0o544),
     (True, True, False, 0o644),
     (True, False, False, 0o444),
     (False, False, False, 0o000),])
@@ -34,10 +34,10 @@ def test_chmod_single_file(read, write, execute, expected):
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="validate full permissions only in Unix")
 @pytest.mark.parametrize("read,write,execute,expected", [
-    (True, True, True, 0o754),
+    (True, True, True, 0o744),
     (False, True, False, 0o200),
-    (False, False, True, 0o110),
-    (True, False, True, 0o554),
+    (False, False, True, 0o100),
+    (True, False, True, 0o544),
     (True, True, False, 0o644),
     (True, False, False, 0o444),
     (False, False, False, 0o000),])

--- a/test/unittests/tools/files/test_chmod.py
+++ b/test/unittests/tools/files/test_chmod.py
@@ -1,0 +1,79 @@
+import os
+import platform
+import stat
+import pytest
+
+from conan.tools.files import chmod
+from conan.test.utils.mocks import ConanFileMock
+from conan.test.utils.tools import temp_folder, save_files
+
+
+@pytest.fixture
+def no_permission_file():
+    tmp = temp_folder()
+    save_files(tmp, {"file.txt": "foobar"})
+    file_path = os.path.join(tmp, "file.txt")
+    os.chmod(file_path, 0o000)
+    file_mode = os.stat(file_path).st_mode
+    assert stat.S_IMODE(file_mode) == 0
+    return file_path
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="chmod is not available in Windows")
+@pytest.mark.parametrize("read,write,execute,expected", [
+    (True, True, True, 0o777),
+    (False, True, False, 0o222),
+    (False, False, True, 0o111),
+    (True, False, True, 0o555),
+    (True, True, False, 0o666),
+    (True, False, False, 0o444),
+    (False, False, False, 0o000),])
+def test_chmod_single_file(no_permission_file, read, write, execute, expected):
+    """
+    This test is to validate the function chmod.
+
+    The function should change the file permissions to the expected value only.
+    """
+    conanfile = ConanFileMock()
+    chmod(conanfile, no_permission_file, read=read, write=write, execute=execute, recursive=False)
+    file_mode = os.stat(no_permission_file).st_mode
+    assert stat.S_IMODE(file_mode) == expected
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="chmod is not available in Windows")
+@pytest.mark.parametrize("read,write,execute,expected", [
+    (True, True, True, 0o777),
+    (False, True, False, 0o222),
+    (False, False, True, 0o111),
+    (True, False, True, 0o555),
+    (True, True, False, 0o666),
+    (True, False, False, 0o444),
+    (False, False, False, 0o000),])
+def test_chmod_recursive(read, write, execute, expected):
+    """
+    This test is to validate the function chmod.
+
+    The function should change the file permissions to the expected value only.
+    """
+    tmp = temp_folder()
+    save_files(tmp, {"foobar/qux/file.txt": "foobar",
+                          "foobar/file.txt": "qux",
+                          "foobar/foo/file.txt": "foobar"})
+    folder_path = os.path.join(tmp, "foobar")
+    conanfile = ConanFileMock()
+    chmod(conanfile, folder_path, read=read, write=write, execute=execute, recursive=True)
+    for root, _, files in os.walk(folder_path):
+        for file in files:
+            file_mode = os.stat(os.path.join(root, file)).st_mode
+            assert stat.S_IMODE(file_mode) == expected
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Only to validate no breaking on Windows")
+def test_chmod_windows():
+    """
+    This test is to validate that the function does not break on Windows only.
+
+    The function is not expected to work on Windows, so it should not change the file permissions.
+    """
+    conanfile = ConanFileMock()
+    chmod(conanfile, "invalid_path", read=True, write=True, execute=True, recursive=False)

--- a/test/unittests/tools/files/test_chmod.py
+++ b/test/unittests/tools/files/test_chmod.py
@@ -11,10 +11,10 @@ from conan.test.utils.tools import temp_folder, save_files
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="validate full permissions only in Unix")
 @pytest.mark.parametrize("read,write,execute,expected", [
-    (True, True, True, 0o755),
+    (True, True, True, 0o754),
     (False, True, False, 0o200),
-    (False, False, True, 0o111),
-    (True, False, True, 0o555),
+    (False, False, True, 0o110),
+    (True, False, True, 0o554),
     (True, True, False, 0o644),
     (True, False, False, 0o444),
     (False, False, False, 0o000),])
@@ -34,10 +34,10 @@ def test_chmod_single_file(read, write, execute, expected):
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="validate full permissions only in Unix")
 @pytest.mark.parametrize("read,write,execute,expected", [
-    (True, True, True, 0o755),
+    (True, True, True, 0o754),
     (False, True, False, 0o200),
-    (False, False, True, 0o111),
-    (True, False, True, 0o555),
+    (False, False, True, 0o110),
+    (True, False, True, 0o554),
     (True, True, False, 0o644),
     (True, False, False, 0o444),
     (False, False, False, 0o000),])


### PR DESCRIPTION
Changelog: Feature: Integrate chmod feature in `tools.files`.
Docs: https://github.com/conan-io/docs/pull/4038

The `tools.files.chmod` is a wrapper for `os.chmod`, simplifying it's usage.

It will change permissions only related to the file's owner and will follow `os.chmod` behavior as well. On Windows, chmod is limited to writing permission changes; adding executable permission is out of scope. 

Reference: https://docs.python.org/3/library/os.html#os.chmod

closes #8003

/cc @memsharded 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
