### PR TITLE
Add checks for duplicated refs when downloading from backup source

### DIFF
--- a/conans/client/downloaders/caching_file_downloader.py
+++ b/conans/client/downloaders/caching_file_downloader.py
@@ -61,6 +61,7 @@ class SourcesCachingDownloader:
         with download_cache.lock(sha256):
             remove_if_dirty(cached_path)
 
+            url = None
             if os.path.exists(cached_path):
                 self._output.info(f"Source {urls} retrieved from local download cache")
             else:
@@ -72,16 +73,17 @@ class SourcesCachingDownloader:
 
                         is_last = backup_url is backups_urls[-1]
                         if backup_url == "origin":  # recipe defined URLs
-                            if self._origin_download(urls, cached_path, retry, retry_wait,
-                                                     verify_ssl, auth, headers, md5, sha1, sha256,
-                                                     is_last):
+                            url = self._origin_download(urls, cached_path, retry, retry_wait,
+                                                        verify_ssl, auth, headers, md5, sha1, sha256,
+                                                        is_last)
+                            if url:
                                 break
                         else:
                             if self._backup_download(backup_url, backups_urls, sha256, cached_path,
                                                      urls, is_last):
                                 break
-
-            download_cache.update_backup_sources_json(cached_path, self._conanfile, urls)
+            if url:
+                download_cache.update_backup_sources_json(cached_path, self._conanfile, url)
             # Everything good, file in the cache, just copy it to final destination
             mkdir(os.path.dirname(file_path))
             shutil.copy2(cached_path, file_path)
@@ -91,8 +93,11 @@ class SourcesCachingDownloader:
         """ download from the internet, the urls provided by the recipe (mirrors).
         """
         try:
-            self._download_from_urls(urls, cached_path, retry, retry_wait,
+            url = self._download_from_urls(urls, cached_path, retry, retry_wait,
                                      verify_ssl, auth, headers, md5, sha1, sha256)
+            if not is_last:
+                self._output.info(f"Sources for {urls} found in origin")
+            return url
         except ConanException as e:
             if is_last:
                 raise
@@ -100,10 +105,6 @@ class SourcesCachingDownloader:
                 # TODO: Improve printing of AuthenticationException
                 self._output.warning(f"Sources for {urls} failed in 'origin': {e}")
                 self._output.warning("Checking backups")
-        else:
-            if not is_last:
-                self._output.info(f"Sources for {urls} found in origin")
-            return True
 
     def _backup_download(self, backup_url, backups_urls, sha256, cached_path, urls, is_last):
         """ download from a Conan backup sources file server, like an Artifactory generic repo
@@ -143,7 +144,7 @@ class SourcesCachingDownloader:
                 else:
                     self._file_downloader.download(url, file_path, retry, retry_wait, verify_ssl,
                                                    auth, True, headers, md5, sha1, sha256)
-                return  # Success! Return to caller
+                return url  # Success! Return to caller
             except Exception as error:
                 if url != urls[-1]:  # If it is not the last one, do not raise, warn and move to next
                     msg = f"Could not download from the URL {url}: {error}."

--- a/conans/client/downloaders/download_cache.py
+++ b/conans/client/downloaders/download_cache.py
@@ -109,7 +109,7 @@ class DownloadCache:
         return files_to_upload
 
     @staticmethod
-    def update_backup_sources_json(cached_path, conanfile, urls):
+    def update_backup_sources_json(cached_path, conanfile, url):
         """ create or update the sha256.json file with the references and new urls used
         """
         summary_path = cached_path + ".json"
@@ -127,21 +127,19 @@ class DownloadCache:
 
         from urllib.parse import urlparse
 
-        if not isinstance(urls, (list, tuple)):
-            urls = [urls]
-        current_filenames = set(os.path.basename(urlparse(url).path) for url in urls)
+        current_filename = os.path.basename(urlparse(url).path)
 
         for ref, previous_urls in summary["references"].items():
             if ref == summary_key or "unknown" in (ref, summary_key):
                 continue
             prev_filenames = set(os.path.basename(urlparse(url).path) for url in previous_urls)
-            if not current_filenames.difference(prev_filenames):
-                raise ConanException("This backup source has already been downloaded from different URLs. "
+            if current_filename in prev_filenames:
+                raise ConanException("This backup source has already been downloaded from a different URLs. "
                                      "There's probably an issue in your declared sources. "
                                      "If you have a valid use-case, please report it to the Conan team.")
 
         existing_urls = summary["references"].setdefault(summary_key, [])
-        existing_urls.extend(url for url in urls if url not in existing_urls)
+        existing_urls.append(url)
         conanfile.output.verbose(f"Updating ${summary_path} summary file")
         summary_dump = json.dumps(summary)
         conanfile.output.debug(f"New summary: ${summary_dump}")

--- a/conans/client/downloaders/download_cache.py
+++ b/conans/client/downloaders/download_cache.py
@@ -120,6 +120,9 @@ class DownloadCache:
 
         try:
             summary_key = str(conanfile.ref)
+            if set(summary["references"].keys()).difference({"unknown", summary_key}):
+                warn = "A different reference has already downloaded the sources associated with the current package"
+                conanfile.output.warning(warn, warn_tag="risk")
         except AttributeError:
             # The recipe path would be different between machines
             # So best we can do is to set this as unknown

--- a/conans/client/downloaders/download_cache.py
+++ b/conans/client/downloaders/download_cache.py
@@ -120,16 +120,26 @@ class DownloadCache:
 
         try:
             summary_key = str(conanfile.ref)
-            if set(summary["references"].keys()).difference({"unknown", summary_key}):
-                warn = "A different reference has already downloaded the sources associated with the current package"
-                conanfile.output.warning(warn, warn_tag="risk")
         except AttributeError:
             # The recipe path would be different between machines
             # So best we can do is to set this as unknown
             summary_key = "unknown"
 
+        from urllib.parse import urlparse
+
         if not isinstance(urls, (list, tuple)):
             urls = [urls]
+        current_filenames = set(os.path.basename(urlparse(url).path) for url in urls)
+
+        for ref, previous_urls in summary["references"].items():
+            if ref == summary_key or "unknown" in (ref, summary_key):
+                continue
+            prev_filenames = set(os.path.basename(urlparse(url).path) for url in previous_urls)
+            if not current_filenames.difference(prev_filenames):
+                raise ConanException("This backup source has already been downloaded from different URLs. "
+                                     "There's probably an issue in your declared sources. "
+                                     "If you have a valid use-case, please report it to the Conan team.")
+
         existing_urls = summary["references"].setdefault(summary_key, [])
         existing_urls.extend(url for url in urls if url not in existing_urls)
         conanfile.output.verbose(f"Updating ${summary_path} summary file")

--- a/test/integration/cache/backup_sources_test.py
+++ b/test/integration/cache/backup_sources_test.py
@@ -51,7 +51,8 @@ class TestDownloadCacheBackupSources:
                     name = "pkg"
                     version = "1.0"
                     def source(self):
-                        download(self, "http://localhost.mirror:5000/myfile.txt", "myfile.txt",
+                        fname = self.user if self.user else ""
+                        download(self, "http://localhost.mirror:5000/myfile" + fname + ".txt", "myfile.txt",
                                  sha256="{sha256}")
                 """)
             client.save({"conanfile.py": conanfile})
@@ -75,7 +76,7 @@ class TestDownloadCacheBackupSources:
             client.run("create . --user=barbarian --channel=stable")
             content = json.loads(load(os.path.join(tmp_folder, "s", sha256 + ".json")))
             assert content["references"]["pkg/1.0@barbarian/stable"] == \
-                   ["http://localhost.mirror:5000/myfile.txt"]
+                   ["http://localhost.mirror:5000/myfilebarbarian.txt"]
 
     @pytest.fixture(autouse=True)
     def _setup(self):
@@ -407,7 +408,6 @@ class TestDownloadCacheBackupSources:
         client.run("source .")
         assert f"Source http://localhost:{http_server.port}/internet/myfile.txt retrieved from local download cache" in client.out
         assert "CONTENT: Hello, world!" in client.out
-        assert "A different reference has already downloaded" not in self.client.out
 
     def test_download_sources_multiurl(self):
         http_server_base_folder_internet = os.path.join(self.file_server.store, "internet")
@@ -459,7 +459,6 @@ class TestDownloadCacheBackupSources:
         rmdir(self.download_cache_folder)
         self.client.run("source .")
         assert f"Sources for {self.file_server.fake_url}/internet/myfile.txt found in remote backup {self.file_server.fake_url}/downloader/" in self.client.out
-        assert "A different reference has already downloaded" not in self.client.out
 
     def test_list_urls_miss(self):
         def custom_download(this, url, *args, **kwargs):
@@ -519,7 +518,6 @@ class TestDownloadCacheBackupSources:
         self.client.save({"conanfile.py": conanfile})
         self.client.run("create .")
         assert f"Sources for {self.file_server.fake_url}/internal_error/myfile.txt found in remote backup {self.file_server.fake_url}/backup2/" in self.client.out
-        assert "A different reference has already downloaded" not in self.client.out
 
     def test_ok_when_origin_authorization_error(self):
         client = TestClient(default_server_user=True, light=True)
@@ -587,7 +585,6 @@ class TestDownloadCacheBackupSources:
 
         client.run("upload * -c -r=default")
         assert f"Could not update summary '{sha256}.json' in backup sources server" in client.out
-        assert "A different reference has already downloaded" not in self.client.out
 
     def test_ok_when_origin_bad_sha256(self):
         http_server_base_folder_internet = os.path.join(self.file_server.store, "internet")
@@ -619,7 +616,6 @@ class TestDownloadCacheBackupSources:
         self.client.run("create .")
         assert f"Sources for {self.file_server.fake_url}/internet/myfile.txt found in remote backup {self.file_server.fake_url}/backup2/" in self.client.out
         assert "sha256 signature failed for" in self.client.out
-        assert "A different reference has already downloaded" not in self.client.out
 
     def test_warn_when_duplicated_sha256(self):
         http_server_base_folder_internet = os.path.join(self.file_server.store, "internet")
@@ -647,8 +643,8 @@ class TestDownloadCacheBackupSources:
         self.client.run("create .")
 
         self.client.save({"conanfile.py": conanfile % "2.0"})
-        self.client.run("create .")
-        assert "A different reference has already downloaded" in self.client.out
+        self.client.run("create .", assert_error=True)
+        assert "This backup source has already been downloaded from different URLs" in self.client.out
 
     def test_export_then_upload_workflow(self):
         mkdir(os.path.join(self.download_cache_folder, "s"))
@@ -743,7 +739,6 @@ class TestDownloadCacheBackupSources:
 
         self.client.save({"conanfile.py": conanfile})
         self.client.run("source .")
-        assert "A different reference has already downloaded" not in self.client.out
         self.client.run("cache backup-upload")
         # This used to crash because we were trying to list a missing dir if only exports were made
         assert "[Errno 2] No such file or directory" not in self.client.out
@@ -816,7 +811,6 @@ class TestDownloadCacheBackupSources:
         else:
             self.client.run("source .")
         assert f"{sha256} is dirty, removing it" in self.client.out
-        assert "A different reference has already downloaded" not in self.client.out
 
     @pytest.mark.skip("Recover when .dirty files are properly handled")
     @pytest.mark.parametrize("exception", [Exception, ConanException])

--- a/test/integration/cache/backup_sources_test.py
+++ b/test/integration/cache/backup_sources_test.py
@@ -407,6 +407,7 @@ class TestDownloadCacheBackupSources:
         client.run("source .")
         assert f"Source http://localhost:{http_server.port}/internet/myfile.txt retrieved from local download cache" in client.out
         assert "CONTENT: Hello, world!" in client.out
+        assert "A different reference has already downloaded" not in self.client.out
 
     def test_download_sources_multiurl(self):
         http_server_base_folder_internet = os.path.join(self.file_server.store, "internet")
@@ -458,6 +459,7 @@ class TestDownloadCacheBackupSources:
         rmdir(self.download_cache_folder)
         self.client.run("source .")
         assert f"Sources for {self.file_server.fake_url}/internet/myfile.txt found in remote backup {self.file_server.fake_url}/downloader/" in self.client.out
+        assert "A different reference has already downloaded" not in self.client.out
 
     def test_list_urls_miss(self):
         def custom_download(this, url, *args, **kwargs):
@@ -517,6 +519,7 @@ class TestDownloadCacheBackupSources:
         self.client.save({"conanfile.py": conanfile})
         self.client.run("create .")
         assert f"Sources for {self.file_server.fake_url}/internal_error/myfile.txt found in remote backup {self.file_server.fake_url}/backup2/" in self.client.out
+        assert "A different reference has already downloaded" not in self.client.out
 
     def test_ok_when_origin_authorization_error(self):
         client = TestClient(default_server_user=True, light=True)
@@ -584,6 +587,7 @@ class TestDownloadCacheBackupSources:
 
         client.run("upload * -c -r=default")
         assert f"Could not update summary '{sha256}.json' in backup sources server" in client.out
+        assert "A different reference has already downloaded" not in self.client.out
 
     def test_ok_when_origin_bad_sha256(self):
         http_server_base_folder_internet = os.path.join(self.file_server.store, "internet")
@@ -615,6 +619,36 @@ class TestDownloadCacheBackupSources:
         self.client.run("create .")
         assert f"Sources for {self.file_server.fake_url}/internet/myfile.txt found in remote backup {self.file_server.fake_url}/backup2/" in self.client.out
         assert "sha256 signature failed for" in self.client.out
+        assert "A different reference has already downloaded" not in self.client.out
+
+    def test_warn_when_duplicated_sha256(self):
+        http_server_base_folder_internet = os.path.join(self.file_server.store, "internet")
+
+        save(os.path.join(http_server_base_folder_internet, "myfile.txt"), "Hello, world!")
+
+        sha256 = "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3"
+
+        conanfile = textwrap.dedent(f"""
+           from conan import ConanFile
+           from conan.tools.files import download
+           class Pkg2(ConanFile):
+               name = "pkg"
+               version = "%s"
+               def source(self):
+                   download(self, "{self.file_server.fake_url}/internet/myfile.txt", "myfile.txt",
+                            sha256="{sha256}")
+           """)
+
+        self.client.save_home(
+            {"global.conf": f"core.sources:download_cache={self.download_cache_folder}\n"
+                            f"core.sources:download_urls=['{self.file_server.fake_url}/backup', 'origin']\n"})
+
+        self.client.save({"conanfile.py": conanfile % "1.0"})
+        self.client.run("create .")
+
+        self.client.save({"conanfile.py": conanfile % "2.0"})
+        self.client.run("create .")
+        assert "A different reference has already downloaded" in self.client.out
 
     def test_export_then_upload_workflow(self):
         mkdir(os.path.join(self.download_cache_folder, "s"))
@@ -709,6 +743,7 @@ class TestDownloadCacheBackupSources:
 
         self.client.save({"conanfile.py": conanfile})
         self.client.run("source .")
+        assert "A different reference has already downloaded" not in self.client.out
         self.client.run("cache backup-upload")
         # This used to crash because we were trying to list a missing dir if only exports were made
         assert "[Errno 2] No such file or directory" not in self.client.out
@@ -781,6 +816,7 @@ class TestDownloadCacheBackupSources:
         else:
             self.client.run("source .")
         assert f"{sha256} is dirty, removing it" in self.client.out
+        assert "A different reference has already downloaded" not in self.client.out
 
     @pytest.mark.skip("Recover when .dirty files are properly handled")
     @pytest.mark.parametrize("exception", [Exception, ConanException])

--- a/test/integration/cache/backup_sources_test.py
+++ b/test/integration/cache/backup_sources_test.py
@@ -60,9 +60,9 @@ class TestDownloadCacheBackupSources:
 
             assert 2 == len(os.listdir(os.path.join(tmp_folder, "s")))
             content = json.loads(load(os.path.join(tmp_folder, "s", sha256 + ".json")))
-            assert "http://localhost.mirror:5000/myfile.txt" in content["references"]["unknown"]
-            assert "http://localhost:5000/myfile.txt" in content["references"]["unknown"]
-            assert len(content["references"]["unknown"]) == 2
+            # Not updated because we didn't actually fetch from the mirror
+            assert "http://localhost.mirror:5000/myfile.txt" not in content["references"]["unknown"]
+            assert len(content["references"]["unknown"]) == 1
 
             # Ensure the cache is working and we didn't break anything by modifying the summary
             client.run("source .")


### PR DESCRIPTION
Changelog: Feature: Add checks for duplicated refs when downloading from backup source
Docs: Omit

To check with the team and see if this is not giving false positives