### PR TITLE
Fix conan.tools.files.collect_libs() not handling files with multiple file extensions.

### DIFF
--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -493,6 +493,12 @@ def collect_libs(conanfile, folder=None):
                 real_lib = os.path.basename(os.path.realpath(os.path.join(lib_folder, f)))
                 if real_lib not in ref_libs or len(f) < len(ref_libs[real_lib]):
                     ref_libs[real_lib] = f
+            else: # file containing multiple file extensions, such as `libnode.so.108`.
+                split_file = f.split(".")
+                if len(split_file) >= 2 AND split_file[1] == "so":
+                    real_lib = os.path.basename(os.path.realpath(os.path.join(lib_folder, f)))
+                    if real_lib not in ref_libs or len(f) < len(ref_libs[real_lib]):
+                        ref_libs[real_lib] = f
 
     result = []
     for f in ref_libs.values():


### PR DESCRIPTION
Libraries on Linux often have a version number behind their file extension. E.g. `libnode.so.108`. In our case, we are building libnode downstream and it automatically gets its version appended by its build system. I felt like changing the behaviour of collect_libs() to include files like that can save someone else some headache, since people might expect collect_libs() to just find the libraries regardless of them having weird names. In our case, it took us an entire week to figure this out, since it only caused visible errors at the end of our entire build process.

Changelog: (Fix): Fix conan.tools.files.collect_libs() not handling .so files with multiple file extensions, such as libnode.so.108.
Docs: https://github.com/conan-io/docs/pull/XXXX Todo



- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
