### PR TITLE
add warning for local-recipes-idnex used with revisions

### DIFF
--- a/conans/client/rest_client_local_recipe_index.py
+++ b/conans/client/rest_client_local_recipe_index.py
@@ -138,6 +138,9 @@ class RestApiClientLocalRecipesIndex:
     def get_recipe_revision_reference(self, ref):
         new_ref = self._export_recipe(ref)
         if new_ref != ref:
+            ConanOutput().warning(f"A specific revision '{ref.repr_notime()}' was requested, but it "
+                                  "doesn't match the current available revision in source. The "
+                                  "local-recipes-index can't provide a specific revision")
             raise RecipeNotFoundException(ref)
         return new_ref
 


### PR DESCRIPTION
Changelog: Feature: Add a warning if a specific revision different than the current one is requested to a ``local-recipes-index`` remote.
Docs: Omit

close https://github.com/conan-io/conan/issues/17814