### PR TITLE
[fix] The deployer runtime_deploy should preserve symlinks

### DIFF
--- a/conan/internal/deploy.py
+++ b/conan/internal/deploy.py
@@ -1,6 +1,7 @@
 import filecmp
 import os
 import shutil
+import fnmatch
 
 from conan.internal.cache.home_paths import HomePaths
 from conan.api.output import ConanOutput
@@ -99,6 +100,8 @@ def full_deploy(graph, output_folder):
 def runtime_deploy(graph, output_folder):
     """
     Deploy all the shared libraries and the executables of the dependencies in a flat directory.
+
+    It preserves symlinks in case the configuration tools.deployer:symlinks is True.
     """
     conanfile = graph.root.conanfile
     output = ConanOutput(scope="runtime_deploy")
@@ -125,7 +128,7 @@ def runtime_deploy(graph, output_folder):
             if not os.path.isdir(libdir):
                 output.warning(f"{dep.ref} {libdir} does not exist")
                 continue
-            count += _flatten_directory(dep, libdir, output_folder, symlinks, [".dylib", ".so"])
+            count += _flatten_directory(dep, libdir, output_folder, symlinks, [".dylib*", ".so*"])
 
         output.info(f"Copied {count} files from {dep.ref}")
     conanfile.output.success(f"Runtime deployed to folder: {output_folder}")
@@ -142,7 +145,7 @@ def _flatten_directory(dep, src_dir, output_dir, symlinks, extension_filter=None
     output = ConanOutput(scope="runtime_deploy")
     for src_dirpath, _, src_filenames in os.walk(src_dir, followlinks=symlinks):
         for src_filename in src_filenames:
-            if extension_filter and not any(src_filename.endswith(ext) for ext in extension_filter):
+            if extension_filter and not any(fnmatch.fnmatch(src_filename, f'*{ext}') for ext in extension_filter):
                 continue
 
             src_filepath = os.path.join(src_dirpath, src_filename)
@@ -156,7 +159,7 @@ def _flatten_directory(dep, src_dir, output_dir, symlinks, extension_filter=None
 
             try:
                 file_count += 1
-                shutil.copy2(src_filepath, dest_filepath, follow_symlinks=symlinks)
+                shutil.copy2(src_filepath, dest_filepath, follow_symlinks=not symlinks)
                 output.verbose(f"Copied {src_filepath} into {output_dir}")
             except Exception as e:
                 if "WinError 1314" in str(e):

--- a/conan/internal/deploy.py
+++ b/conan/internal/deploy.py
@@ -150,6 +150,10 @@ def _flatten_directory(dep, src_dir, output_dir, symlinks, extension_filter=None
 
             src_filepath = os.path.join(src_dirpath, src_filename)
             dest_filepath = os.path.join(output_dir, src_filename)
+
+            if not symlinks and os.path.islink(src_filepath):
+                continue
+
             if os.path.exists(dest_filepath):
                 if filecmp.cmp(src_filepath, dest_filepath):  # Be efficient, do not copy
                     output.verbose(f"{dest_filepath} exists with same contents, skipping copy")

--- a/conan/internal/deploy.py
+++ b/conan/internal/deploy.py
@@ -163,6 +163,8 @@ def _flatten_directory(dep, src_dir, output_dir, symlinks, extension_filter=None
 
             try:
                 file_count += 1
+                # INFO: When follow_symlinks is false, and src is a symbolic link, it tries to
+                # copy all metadata from the src symbolic link to the newly created dst link
                 shutil.copy2(src_filepath, dest_filepath, follow_symlinks=not symlinks)
                 output.verbose(f"Copied {src_filepath} into {output_dir}")
             except Exception as e:

--- a/test/functional/command/test_install_deploy.py
+++ b/test/functional/command/test_install_deploy.py
@@ -511,8 +511,10 @@ class TestRuntimeDeployer:
         expected = sorted(["pkga.so", "pkgb.so", "pkga.dll"])
         assert sorted(os.listdir(os.path.join(c.current_folder, "myruntime"))) == expected
 
-
-def test_runtime_deploy_symlinks():
+@pytest.mark.parametrize("symlink, expected",
+                         [(True, ["libfoo.so.0.1.0", "libfoo.so.0", "libfoo.so"]),
+                          (False, ["libfoo.so.0.1.0",])])
+def test_runtime_deploy_symlinks(symlink, expected):
     """ The deployer runtime_deploy should preserve symlinks when deploying shared libraries
     """
     c = TestClient()
@@ -531,15 +533,16 @@ def test_runtime_deploy_symlinks():
     c.save({"foo/conanfile.py": conanfile,
             "foo/lib/libfoo.so.0.1.0": "",})
     c.run("export-pkg foo/ --name=foo --version=0.1.0")
-    c.run("install --requires=foo/0.1.0 --deployer=runtime_deploy --deployer-folder=output")
+    c.run(f"install --requires=foo/0.1.0 --deployer=runtime_deploy --deployer-folder=output -c:a tools.deployer:symlinks={symlink}")
 
-    expected = sorted(["libfoo.so.0.1.0", "libfoo.so.0", "libfoo.so"])
-    assert sorted(os.listdir(os.path.join(c.current_folder, "output"))) == expected
-    assert os.path.islink(os.path.join(c.current_folder, "output", "libfoo.so.0"))
-    assert os.path.islink(os.path.join(c.current_folder, "output", "libfoo.so"))
-    assert not os.path.isabs(os.readlink(os.path.join(c.current_folder, "output", "libfoo.so")))
-    assert not os.path.isabs(os.readlink(os.path.join(c.current_folder, "output", "libfoo.so.0")))
-    assert not os.path.islink(os.path.join(c.current_folder, "output", "libfoo.so.0.1.0"))
+    sorted_expected = sorted(expected)
+    assert sorted(os.listdir(os.path.join(c.current_folder, "output"))) == sorted_expected
+    if symlink:
+        assert os.path.islink(os.path.join(c.current_folder, "output", "libfoo.so.0"))
+        assert os.path.islink(os.path.join(c.current_folder, "output", "libfoo.so"))
+        assert not os.path.isabs(os.readlink(os.path.join(c.current_folder, "output", "libfoo.so")))
+        assert not os.path.isabs(os.readlink(os.path.join(c.current_folder, "output", "libfoo.so.0")))
+        assert not os.path.islink(os.path.join(c.current_folder, "output", "libfoo.so.0.1.0"))
 
 
 def test_deployer_errors():

--- a/test/functional/command/test_install_deploy.py
+++ b/test/functional/command/test_install_deploy.py
@@ -437,79 +437,104 @@ def test_deploy_incorrect_folder():
         assert "ERROR: Deployer folder cannot be created" in c.out
 
 
-class TestRuntimeDeployer:
-    def test_runtime_deploy(self):
-        c = TestClient()
-        conanfile = textwrap.dedent("""
+def test_runtime_deploy():
+    c = TestClient()
+    conanfile = textwrap.dedent("""
+       from conan import ConanFile
+       from conan.tools.files import copy
+       class Pkg(ConanFile):
+           package_type = "shared-library"
+           def package(self):
+               copy(self, "*.so", src=self.build_folder, dst=self.package_folder)
+               copy(self, "*.dll", src=self.build_folder, dst=self.package_folder)
+       """)
+    c.save({"pkga/conanfile.py": conanfile,
+            "pkga/lib/pkga.so": "",
+            "pkga/bin/pkga.dll": "",
+            "pkgb/conanfile.py": conanfile,
+            "pkgb/lib/pkgb.so": ""})
+    c.run("export-pkg pkga --name=pkga --version=1.0")
+    c.run("export-pkg pkgb --name=pkgb --version=1.0")
+    c.run("install --requires=pkga/1.0 --requires=pkgb/1.0 --deployer=runtime_deploy "
+          "--deployer-folder=myruntime -vvv")
+
+    expected = sorted(["pkga.so", "pkgb.so", "pkga.dll"])
+    assert sorted(os.listdir(os.path.join(c.current_folder, "myruntime"))) == expected
+
+def test_runtime_not_deploy():
+    # https://github.com/conan-io/conan/issues/16712
+    # If no run=False (no package-type), then no runtime is deployed
+    c = TestClient()
+    conanfile = textwrap.dedent("""
+       from conan import ConanFile
+       from conan.tools.files import copy
+       class Pkg(ConanFile):
+           def package(self):
+               copy(self, "*.so", src=self.build_folder, dst=self.package_folder)
+               copy(self, "*.dll", src=self.build_folder, dst=self.package_folder)
+       """)
+    c.save({"pkga/conanfile.py": conanfile,
+            "pkga/lib/pkga.so": "",
+            "pkga/bin/pkga.dll": ""})
+    c.run("export-pkg pkga --name=pkga --version=1.0")
+    c.run("install --requires=pkga/1.0 --deployer=runtime_deploy --deployer-folder=myruntime")
+    assert os.listdir(os.path.join(c.current_folder, "myruntime")) == []
+
+def test_runtime_deploy_components():
+    c = TestClient()
+    conanfile = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+        from conan.tools.files import copy
+        class Pkg(ConanFile):
+           package_type = "shared-library"
+           def package(self):
+               copy(self, "*.so", src=self.build_folder,
+                    dst=os.path.join(self.package_folder, "a"))
+               copy(self, "*.dll", src=self.build_folder,
+                    dst=os.path.join(self.package_folder, "b"))
+           def package_info(self):
+               self.cpp_info.components["a"].libdirs = ["a"]
+               self.cpp_info.components["b"].bindirs = ["b"]
+       """)
+    c.save({"pkga/conanfile.py": conanfile,
+            "pkga/lib/pkga.so": "",
+            "pkga/bin/pkga.dll": "",
+            "pkgb/conanfile.py": conanfile,
+            "pkgb/lib/pkgb.so": ""})
+    c.run("export-pkg pkga --name=pkga --version=1.0")
+    c.run("export-pkg pkgb --name=pkgb --version=1.0")
+    c.run("install --requires=pkga/1.0 --requires=pkgb/1.0 --deployer=runtime_deploy "
+          "--deployer-folder=myruntime -vvv")
+
+    expected = sorted(["pkga.so", "pkgb.so", "pkga.dll"])
+    assert sorted(os.listdir(os.path.join(c.current_folder, "myruntime"))) == expected
+
+
+def test_runtime_deploy_symlinks():
+    """ The deployer runtime_deploy should preserve symlinks when deploying shared libraries
+    """
+    c = TestClient()
+    conanfile = textwrap.dedent("""
            from conan import ConanFile
            from conan.tools.files import copy
+           import os
            class Pkg(ConanFile):
                package_type = "shared-library"
                def package(self):
-                   copy(self, "*.so", src=self.build_folder, dst=self.package_folder)
-                   copy(self, "*.dll", src=self.build_folder, dst=self.package_folder)
+                   copy(self, "libfoo.so.0.1.0", src=self.build_folder, dst=self.package_folder)
+                   os.symlink(src=os.path.join(self.package_folder, "libfoo.so.0.1.0"),
+                                dst=os.path.join(self.package_folder, "libfoo.so.0"))
+                   os.symlink(src=os.path.join(self.package_folder, "libfoo.so.0"),
+                               dst=os.path.join(self.package_folder, "libfoo.so"))
            """)
-        c.save({"pkga/conanfile.py": conanfile,
-                "pkga/lib/pkga.so": "",
-                "pkga/bin/pkga.dll": "",
-                "pkgb/conanfile.py": conanfile,
-                "pkgb/lib/pkgb.so": ""})
-        c.run("export-pkg pkga --name=pkga --version=1.0")
-        c.run("export-pkg pkgb --name=pkgb --version=1.0")
-        c.run("install --requires=pkga/1.0 --requires=pkgb/1.0 --deployer=runtime_deploy "
-              "--deployer-folder=myruntime -vvv")
+    c.save({"foo/conanfile.py": conanfile,
+            "foo/lib/libfoo.so.0.1.0": "",})
+    c.run("export-pkg foo/ --name=foo --version=0.1.0")
+    c.run("install --requires=foo/0.1.0 --deployer=runtime_deploy --deployer-folder=output")
 
-        expected = sorted(["pkga.so", "pkgb.so", "pkga.dll"])
-        assert sorted(os.listdir(os.path.join(c.current_folder, "myruntime"))) == expected
-
-    def test_runtime_not_deploy(self):
-        # https://github.com/conan-io/conan/issues/16712
-        # If no run=False (no package-type), then no runtime is deployed
-        c = TestClient()
-        conanfile = textwrap.dedent("""
-           from conan import ConanFile
-           from conan.tools.files import copy
-           class Pkg(ConanFile):
-               def package(self):
-                   copy(self, "*.so", src=self.build_folder, dst=self.package_folder)
-                   copy(self, "*.dll", src=self.build_folder, dst=self.package_folder)
-           """)
-        c.save({"pkga/conanfile.py": conanfile,
-                "pkga/lib/pkga.so": "",
-                "pkga/bin/pkga.dll": ""})
-        c.run("export-pkg pkga --name=pkga --version=1.0")
-        c.run("install --requires=pkga/1.0 --deployer=runtime_deploy --deployer-folder=myruntime")
-        assert os.listdir(os.path.join(c.current_folder, "myruntime")) == []
-
-    def test_runtime_deploy_components(self):
-        c = TestClient()
-        conanfile = textwrap.dedent("""
-            import os
-            from conan import ConanFile
-            from conan.tools.files import copy
-            class Pkg(ConanFile):
-               package_type = "shared-library"
-               def package(self):
-                   copy(self, "*.so", src=self.build_folder,
-                        dst=os.path.join(self.package_folder, "a"))
-                   copy(self, "*.dll", src=self.build_folder,
-                        dst=os.path.join(self.package_folder, "b"))
-               def package_info(self):
-                   self.cpp_info.components["a"].libdirs = ["a"]
-                   self.cpp_info.components["b"].bindirs = ["b"]
-           """)
-        c.save({"pkga/conanfile.py": conanfile,
-                "pkga/lib/pkga.so": "",
-                "pkga/bin/pkga.dll": "",
-                "pkgb/conanfile.py": conanfile,
-                "pkgb/lib/pkgb.so": ""})
-        c.run("export-pkg pkga --name=pkga --version=1.0")
-        c.run("export-pkg pkgb --name=pkgb --version=1.0")
-        c.run("install --requires=pkga/1.0 --requires=pkgb/1.0 --deployer=runtime_deploy "
-              "--deployer-folder=myruntime -vvv")
-
-        expected = sorted(["pkga.so", "pkgb.so", "pkga.dll"])
-        assert sorted(os.listdir(os.path.join(c.current_folder, "myruntime"))) == expected
+    expected = sorted(["libfoo.so.0.1.0", "libfoo.so.0", "libfoo.so"])
+    assert sorted(os.listdir(os.path.join(c.current_folder, "output"))) == expected
 
 
 def test_deployer_errors():

--- a/test/functional/command/test_install_deploy.py
+++ b/test/functional/command/test_install_deploy.py
@@ -511,7 +511,6 @@ class TestRuntimeDeployer:
         expected = sorted(["pkga.so", "pkgb.so", "pkga.dll"])
         assert sorted(os.listdir(os.path.join(c.current_folder, "myruntime"))) == expected
 
-# This test requires in Windows to have symlinks enabled, otherwise it will fail
 @pytest.mark.parametrize("symlink, expected",
                          [(True, ["libfoo.so.0.1.0", "libfoo.so.0", "libfoo.so"]),
                           (False, ["libfoo.so.0.1.0",])])
@@ -538,7 +537,8 @@ def test_runtime_deploy_symlinks(symlink, expected):
 
     sorted_expected = sorted(expected)
     assert sorted(os.listdir(os.path.join(c.current_folder, "output"))) == sorted_expected
-    if symlink:
+    # INFO: This test requires in Windows to have symlinks enabled, otherwise it will fail
+    if symlink and platform.system() != "Windows":
         link_so_0 = os.path.join(c.current_folder, "output", "libfoo.so.0")
         link_so = os.path.join(c.current_folder, "output", "libfoo.so")
         lib = os.path.join(c.current_folder, "output", "libfoo.so.0.1.0")

--- a/test/functional/command/test_install_deploy.py
+++ b/test/functional/command/test_install_deploy.py
@@ -539,11 +539,16 @@ def test_runtime_deploy_symlinks(symlink, expected):
     sorted_expected = sorted(expected)
     assert sorted(os.listdir(os.path.join(c.current_folder, "output"))) == sorted_expected
     if symlink:
-        assert os.path.islink(os.path.join(c.current_folder, "output", "libfoo.so.0"))
-        assert os.path.islink(os.path.join(c.current_folder, "output", "libfoo.so"))
-        assert not os.path.isabs(os.readlink(os.path.join(c.current_folder, "output", "libfoo.so")))
-        assert not os.path.isabs(os.readlink(os.path.join(c.current_folder, "output", "libfoo.so.0")))
-        assert not os.path.islink(os.path.join(c.current_folder, "output", "libfoo.so.0.1.0"))
+        link_so_0 = os.path.join(c.current_folder, "output", "libfoo.so.0")
+        link_so = os.path.join(c.current_folder, "output", "libfoo.so")
+        lib = os.path.join(c.current_folder, "output", "libfoo.so.0.1.0")
+        assert os.path.islink(link_so_0)
+        assert os.path.islink(link_so)
+        assert not os.path.isabs(os.readlink(link_so_0))
+        assert not os.path.isabs(os.readlink(os.path.join(link_so)))
+        assert os.path.realpath(link_so) == os.path.realpath(link_so_0)
+        assert os.path.realpath(link_so_0) == os.path.realpath(lib)
+        assert not os.path.islink(lib)
 
 
 def test_deployer_errors():

--- a/test/functional/command/test_install_deploy.py
+++ b/test/functional/command/test_install_deploy.py
@@ -518,16 +518,15 @@ def test_runtime_deploy_symlinks():
     c = TestClient()
     conanfile = textwrap.dedent("""
            from conan import ConanFile
-           from conan.tools.files import copy
+           from conan.tools.files import copy, chdir
            import os
            class Pkg(ConanFile):
                package_type = "shared-library"
                def package(self):
-                   copy(self, "libfoo.so.0.1.0", src=self.build_folder, dst=self.package_folder)
-                   os.symlink(src=os.path.join(self.package_folder, "libfoo.so.0.1.0"),
-                                dst=os.path.join(self.package_folder, "libfoo.so.0"))
-                   os.symlink(src=os.path.join(self.package_folder, "libfoo.so.0"),
-                               dst=os.path.join(self.package_folder, "libfoo.so"))
+                   copy(self, "*.so*", src=self.build_folder, dst=self.package_folder)
+                   with chdir(self, os.path.join(self.package_folder, "lib")):
+                       os.symlink(src="libfoo.so.0.1.0", dst="libfoo.so.0")
+                       os.symlink(src="libfoo.so.0", dst="libfoo.so")
            """)
     c.save({"foo/conanfile.py": conanfile,
             "foo/lib/libfoo.so.0.1.0": "",})
@@ -536,6 +535,11 @@ def test_runtime_deploy_symlinks():
 
     expected = sorted(["libfoo.so.0.1.0", "libfoo.so.0", "libfoo.so"])
     assert sorted(os.listdir(os.path.join(c.current_folder, "output"))) == expected
+    assert os.path.islink(os.path.join(c.current_folder, "output", "libfoo.so.0"))
+    assert os.path.islink(os.path.join(c.current_folder, "output", "libfoo.so"))
+    assert not os.path.isabs(os.readlink(os.path.join(c.current_folder, "output", "libfoo.so")))
+    assert not os.path.isabs(os.readlink(os.path.join(c.current_folder, "output", "libfoo.so.0")))
+    assert not os.path.islink(os.path.join(c.current_folder, "output", "libfoo.so.0.1.0"))
 
 
 def test_deployer_errors():

--- a/test/functional/command/test_install_deploy.py
+++ b/test/functional/command/test_install_deploy.py
@@ -437,78 +437,79 @@ def test_deploy_incorrect_folder():
         assert "ERROR: Deployer folder cannot be created" in c.out
 
 
-def test_runtime_deploy():
-    c = TestClient()
-    conanfile = textwrap.dedent("""
-       from conan import ConanFile
-       from conan.tools.files import copy
-       class Pkg(ConanFile):
-           package_type = "shared-library"
-           def package(self):
-               copy(self, "*.so", src=self.build_folder, dst=self.package_folder)
-               copy(self, "*.dll", src=self.build_folder, dst=self.package_folder)
-       """)
-    c.save({"pkga/conanfile.py": conanfile,
-            "pkga/lib/pkga.so": "",
-            "pkga/bin/pkga.dll": "",
-            "pkgb/conanfile.py": conanfile,
-            "pkgb/lib/pkgb.so": ""})
-    c.run("export-pkg pkga --name=pkga --version=1.0")
-    c.run("export-pkg pkgb --name=pkgb --version=1.0")
-    c.run("install --requires=pkga/1.0 --requires=pkgb/1.0 --deployer=runtime_deploy "
-          "--deployer-folder=myruntime -vvv")
+class TestRuntimeDeployer:
+    def test_runtime_deploy(self):
+        c = TestClient()
+        conanfile = textwrap.dedent("""
+           from conan import ConanFile
+           from conan.tools.files import copy
+           class Pkg(ConanFile):
+               package_type = "shared-library"
+               def package(self):
+                   copy(self, "*.so", src=self.build_folder, dst=self.package_folder)
+                   copy(self, "*.dll", src=self.build_folder, dst=self.package_folder)
+           """)
+        c.save({"pkga/conanfile.py": conanfile,
+                "pkga/lib/pkga.so": "",
+                "pkga/bin/pkga.dll": "",
+                "pkgb/conanfile.py": conanfile,
+                "pkgb/lib/pkgb.so": ""})
+        c.run("export-pkg pkga --name=pkga --version=1.0")
+        c.run("export-pkg pkgb --name=pkgb --version=1.0")
+        c.run("install --requires=pkga/1.0 --requires=pkgb/1.0 --deployer=runtime_deploy "
+              "--deployer-folder=myruntime -vvv")
 
-    expected = sorted(["pkga.so", "pkgb.so", "pkga.dll"])
-    assert sorted(os.listdir(os.path.join(c.current_folder, "myruntime"))) == expected
+        expected = sorted(["pkga.so", "pkgb.so", "pkga.dll"])
+        assert sorted(os.listdir(os.path.join(c.current_folder, "myruntime"))) == expected
 
-def test_runtime_not_deploy():
-    # https://github.com/conan-io/conan/issues/16712
-    # If no run=False (no package-type), then no runtime is deployed
-    c = TestClient()
-    conanfile = textwrap.dedent("""
-       from conan import ConanFile
-       from conan.tools.files import copy
-       class Pkg(ConanFile):
-           def package(self):
-               copy(self, "*.so", src=self.build_folder, dst=self.package_folder)
-               copy(self, "*.dll", src=self.build_folder, dst=self.package_folder)
-       """)
-    c.save({"pkga/conanfile.py": conanfile,
-            "pkga/lib/pkga.so": "",
-            "pkga/bin/pkga.dll": ""})
-    c.run("export-pkg pkga --name=pkga --version=1.0")
-    c.run("install --requires=pkga/1.0 --deployer=runtime_deploy --deployer-folder=myruntime")
-    assert os.listdir(os.path.join(c.current_folder, "myruntime")) == []
+    def test_runtime_not_deploy(self):
+        # https://github.com/conan-io/conan/issues/16712
+        # If no run=False (no package-type), then no runtime is deployed
+        c = TestClient()
+        conanfile = textwrap.dedent("""
+           from conan import ConanFile
+           from conan.tools.files import copy
+           class Pkg(ConanFile):
+               def package(self):
+                   copy(self, "*.so", src=self.build_folder, dst=self.package_folder)
+                   copy(self, "*.dll", src=self.build_folder, dst=self.package_folder)
+           """)
+        c.save({"pkga/conanfile.py": conanfile,
+                "pkga/lib/pkga.so": "",
+                "pkga/bin/pkga.dll": ""})
+        c.run("export-pkg pkga --name=pkga --version=1.0")
+        c.run("install --requires=pkga/1.0 --deployer=runtime_deploy --deployer-folder=myruntime")
+        assert os.listdir(os.path.join(c.current_folder, "myruntime")) == []
 
-def test_runtime_deploy_components():
-    c = TestClient()
-    conanfile = textwrap.dedent("""
-        import os
-        from conan import ConanFile
-        from conan.tools.files import copy
-        class Pkg(ConanFile):
-           package_type = "shared-library"
-           def package(self):
-               copy(self, "*.so", src=self.build_folder,
-                    dst=os.path.join(self.package_folder, "a"))
-               copy(self, "*.dll", src=self.build_folder,
-                    dst=os.path.join(self.package_folder, "b"))
-           def package_info(self):
-               self.cpp_info.components["a"].libdirs = ["a"]
-               self.cpp_info.components["b"].bindirs = ["b"]
-       """)
-    c.save({"pkga/conanfile.py": conanfile,
-            "pkga/lib/pkga.so": "",
-            "pkga/bin/pkga.dll": "",
-            "pkgb/conanfile.py": conanfile,
-            "pkgb/lib/pkgb.so": ""})
-    c.run("export-pkg pkga --name=pkga --version=1.0")
-    c.run("export-pkg pkgb --name=pkgb --version=1.0")
-    c.run("install --requires=pkga/1.0 --requires=pkgb/1.0 --deployer=runtime_deploy "
-          "--deployer-folder=myruntime -vvv")
+    def test_runtime_deploy_components(self):
+        c = TestClient()
+        conanfile = textwrap.dedent("""
+            import os
+            from conan import ConanFile
+            from conan.tools.files import copy
+            class Pkg(ConanFile):
+               package_type = "shared-library"
+               def package(self):
+                   copy(self, "*.so", src=self.build_folder,
+                        dst=os.path.join(self.package_folder, "a"))
+                   copy(self, "*.dll", src=self.build_folder,
+                        dst=os.path.join(self.package_folder, "b"))
+               def package_info(self):
+                   self.cpp_info.components["a"].libdirs = ["a"]
+                   self.cpp_info.components["b"].bindirs = ["b"]
+           """)
+        c.save({"pkga/conanfile.py": conanfile,
+                "pkga/lib/pkga.so": "",
+                "pkga/bin/pkga.dll": "",
+                "pkgb/conanfile.py": conanfile,
+                "pkgb/lib/pkgb.so": ""})
+        c.run("export-pkg pkga --name=pkga --version=1.0")
+        c.run("export-pkg pkgb --name=pkgb --version=1.0")
+        c.run("install --requires=pkga/1.0 --requires=pkgb/1.0 --deployer=runtime_deploy "
+              "--deployer-folder=myruntime -vvv")
 
-    expected = sorted(["pkga.so", "pkgb.so", "pkga.dll"])
-    assert sorted(os.listdir(os.path.join(c.current_folder, "myruntime"))) == expected
+        expected = sorted(["pkga.so", "pkgb.so", "pkga.dll"])
+        assert sorted(os.listdir(os.path.join(c.current_folder, "myruntime"))) == expected
 
 
 def test_runtime_deploy_symlinks():

--- a/test/functional/command/test_install_deploy.py
+++ b/test/functional/command/test_install_deploy.py
@@ -537,17 +537,19 @@ def test_runtime_deploy_symlinks(symlink, expected):
 
     sorted_expected = sorted(expected)
     assert sorted(os.listdir(os.path.join(c.current_folder, "output"))) == sorted_expected
+    link_so_0 = os.path.join(c.current_folder, "output", "libfoo.so.0")
+    link_so = os.path.join(c.current_folder, "output", "libfoo.so")
+    lib = os.path.join(c.current_folder, "output", "libfoo.so.0.1.0")
     # INFO: This test requires in Windows to have symlinks enabled, otherwise it will fail
     if symlink and platform.system() != "Windows":
-        link_so_0 = os.path.join(c.current_folder, "output", "libfoo.so.0")
-        link_so = os.path.join(c.current_folder, "output", "libfoo.so")
-        lib = os.path.join(c.current_folder, "output", "libfoo.so.0.1.0")
         assert os.path.islink(link_so_0)
         assert os.path.islink(link_so)
         assert not os.path.isabs(os.readlink(link_so_0))
         assert not os.path.isabs(os.readlink(os.path.join(link_so)))
         assert os.path.realpath(link_so) == os.path.realpath(link_so_0)
         assert os.path.realpath(link_so_0) == os.path.realpath(lib)
+        assert not os.path.islink(lib)
+    else:
         assert not os.path.islink(lib)
 
 

--- a/test/functional/command/test_install_deploy.py
+++ b/test/functional/command/test_install_deploy.py
@@ -511,6 +511,7 @@ class TestRuntimeDeployer:
         expected = sorted(["pkga.so", "pkgb.so", "pkga.dll"])
         assert sorted(os.listdir(os.path.join(c.current_folder, "myruntime"))) == expected
 
+# This test requires in Windows to have symlinks enabled, otherwise it will fail
 @pytest.mark.parametrize("symlink, expected",
                          [(True, ["libfoo.so.0.1.0", "libfoo.so.0", "libfoo.so"]),
                           (False, ["libfoo.so.0.1.0",])])


### PR DESCRIPTION
Changelog: Fix: runtime_deploy preserves symbolic links along with their libraries.
Docs: https://github.com/conan-io/docs/pull/3992

When some application links to a shared on Linux, it keeps its name expected to be loaded at runtime. The current `runtime_deploy` only provides `*.so` but doesn't preserve original symlinks, failing the application when running. 

Still, there is a case of preserving subfolders in the structure, but I don't want to include it in this PR to keep it as simple as possible.

Related to #16938

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
