### PR TITLE
Removed intermediate python versions in CI matrix

### DIFF
--- a/.ci/docker/conan-tests
+++ b/.ci/docker/conan-tests
@@ -7,6 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV PY36=3.6.15 \
     PY38=3.8.6 \
     PY39=3.9.2 \
+    PY310=3.10.16 \
     PY312=3.12.3 \
     PY313=3.13.0 \
     CMAKE_3_15=/usr/share/cmake-3.15.7/bin/cmake \
@@ -95,6 +96,7 @@ RUN curl https://pyenv.run | bash && \
     pyenv install $PY36 && \
     pyenv install $PY38 && \
     pyenv install $PY39 && \
+    pyenv install $PY310 && \
     pyenv install $PY312 && \
     pyenv install $PY313 && \
     pyenv global $PY39 && \

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -3,6 +3,7 @@ name: Linux tests
 on:
   workflow_call:
 
+
 jobs:
   build_container:
     runs-on: ubuntu-latest
@@ -49,7 +50,7 @@ jobs:
       options: --user conan
     strategy:
       matrix:
-        python-version: [3.13, 3.6]
+        python-version: ${{ github.ref == 'refs/heads/develop2' && fromJson('["3.13", "3.6"]') || fromJson('["3.10"]') }}
         test-type: [unittests, integration, functional]
         include:
         - test-type: unittests
@@ -97,7 +98,9 @@ jobs:
       options: --user conan
     strategy:
       matrix:
-        python-version: [3.13, 3.6]
+        # Use modern versions due to docker incompatibility with python <3.8
+        python-version: ${{ github.event_name != 'pull_request' && fromJson('["3.13", "3.9"]') || fromJson('["3.10"]') }}
+
     name: Docker Runner Tests (${{ matrix.python-version }})
     steps:
       - name: Checkout code

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -49,7 +49,7 @@ jobs:
       options: --user conan
     strategy:
       matrix:
-        python-version: [3.14, 3.6]
+        python-version: [3.13, 3.6]
         test-type: [unittests, integration, functional]
         include:
         - test-type: unittests
@@ -97,7 +97,7 @@ jobs:
       options: --user conan
     strategy:
       matrix:
-        python-version: [3.14, 3.6]
+        python-version: [3.13, 3.6]
     name: Docker Runner Tests (${{ matrix.python-version }})
     steps:
       - name: Checkout code

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -49,7 +49,7 @@ jobs:
       options: --user conan
     strategy:
       matrix:
-        python-version: [3.13, 3.6]
+        python-version: [3.14, 3.6]
         test-type: [unittests, integration, functional]
         include:
         - test-type: unittests
@@ -92,18 +92,27 @@ jobs:
   linux_docker_tests:
     needs: build_container
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/conan-tests:${{ needs.build_container.outputs.image_tag }}
+      options: --user conan
     strategy:
       matrix:
-        python-version: [3.13, 3.6]
+        python-version: [3.14, 3.6]
     name: Docker Runner Tests (${{ matrix.python-version }})
     steps:
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: |
+          pyenv global ${{ matrix.python-version }}
+          python --version
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -49,7 +49,7 @@ jobs:
       options: --user conan
     strategy:
       matrix:
-        python-version: [3.13, 3.9, 3.8, 3.6]
+        python-version: [3.13, 3.6]
         test-type: [unittests, integration, functional]
         include:
         - test-type: unittests
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.13, 3.9]
+        python-version: [3.13, 3.6]
     name: Docker Runner Tests (${{ matrix.python-version }})
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/osx-tests.yml
+++ b/.github/workflows/osx-tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.13
+          python-version: '3.x'
 
       - name: Cache pip packages
         id: cache-pip
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.13, 3.6]
+        python-version: ['3.x', '3.8']
         test-type: [unittests, integration, functional]
         include:
         - test-type: unittests

--- a/.github/workflows/osx-tests.yml
+++ b/.github/workflows/osx-tests.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.8
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.13
 
       - name: Cache pip packages
         id: cache-pip
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.8, 3.12, 3.13]
+        python-version: [3.13, 3.6]
         test-type: [unittests, integration, functional]
         include:
         - test-type: unittests

--- a/.github/workflows/osx-tests.yml
+++ b/.github/workflows/osx-tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.13
+          python-version: '3.10'
 
       - name: Cache pip packages
         id: cache-pip
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.13, 3.8]
+        python-version: ${{ github.ref == 'refs/heads/develop2' && fromJson('["3.13", "3.8"]') || fromJson('["3.10"]') }}
         test-type: [unittests, integration, functional]
         include:
         - test-type: unittests

--- a/.github/workflows/osx-tests.yml
+++ b/.github/workflows/osx-tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: 3.13
 
       - name: Cache pip packages
         id: cache-pip
@@ -114,7 +114,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.x', '3.8']
+        python-version: [3.13, 3.8]
         test-type: [unittests, integration, functional]
         include:
         - test-type: unittests

--- a/.github/workflows/win-tests.yml
+++ b/.github/workflows/win-tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        python-version: [3.13, 3.6]
+        python-version: ${{ github.ref == 'refs/heads/develop2' && fromJson('["3.13", "3.6"]') || fromJson('["3.10"]') }}
     name: Unit & Integration Tests (${{ matrix.python-version }})
     steps:
       - name: Checkout code
@@ -59,8 +59,7 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        python-version: [3.13, 3.6]
-
+        python-version: ${{ github.ref == 'refs/heads/develop2' && fromJson('["3.13", "3.6"]') || fromJson('["3.10"]') }}
     name: Functional Tests (${{ matrix.python-version }})
     steps:
       - name: Checkout code

--- a/.github/workflows/win-tests.yml
+++ b/.github/workflows/win-tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        python-version: [3.13, 3.6]
+        python-version: ['3.x', '3.6']
     name: Unit & Integration Tests (${{ matrix.python-version }})
     steps:
       - name: Checkout code
@@ -59,7 +59,7 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        python-version: [3.13, 3.6]
+        python-version: ['3.x', '3.6']
 
     name: Functional Tests (${{ matrix.python-version }})
     steps:

--- a/.github/workflows/win-tests.yml
+++ b/.github/workflows/win-tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        python-version: ['3.x', '3.6']
+        python-version: [3.13, 3.6]
     name: Unit & Integration Tests (${{ matrix.python-version }})
     steps:
       - name: Checkout code
@@ -59,7 +59,7 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        python-version: ['3.x', '3.6']
+        python-version: [3.13, 3.6]
 
     name: Functional Tests (${{ matrix.python-version }})
     steps:

--- a/.github/workflows/win-tests.yml
+++ b/.github/workflows/win-tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        python-version: [3.13, 3.8, 3.6]
+        python-version: [3.13, 3.6]
     name: Unit & Integration Tests (${{ matrix.python-version }})
     steps:
       - name: Checkout code
@@ -59,7 +59,7 @@ jobs:
     runs-on: windows-2022
     strategy:
       matrix:
-        python-version: [3.13, 3.8, 3.6]
+        python-version: [3.13, 3.6]
 
     name: Functional Tests (${{ matrix.python-version }})
     steps:


### PR DESCRIPTION
Changelog: omit
Docs: omit

Remove intermediate python versions in CI to save resources.
The minimum python version still supported by conan is 3.6. 

Changes across python versions (simplified):
* Python 3.8 introduced `:=` (walrus operator).
* Python 3.9+ deprecated `collections.OrderedDict` instantiation without from `collections`.
* Python 3.13 removes some legacy modules (e.g., `cgi` and `optparse`).

We will only test the oldest supported version (3.6) and the newest Python version (3.13).
This pipeline will ensure complete compatibility across all intervals; if a breaking change is introduced, one of the jobs will fail.

Close https://github.com/conan-io/conan/issues/17835

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
