### PR TITLE
added prefix_FOUND for extra variables in Find.cmake modules

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/config.py
+++ b/conan/tools/cmake/cmakedeps/templates/config.py
@@ -112,5 +112,12 @@ class ConfigTemplate(CMakeDepsFileTemplate):
                                           REQUIRED_VARS {{ file_name }}_VERSION
                                           VERSION_VAR {{ file_name }}_VERSION)
         mark_as_advanced({{ file_name }}_FOUND {{ file_name }}_VERSION)
+
+        {% for prefix in additional_variables_prefixes %}
+        set({{ prefix }}_FOUND 1)
+        set({{ prefix }}_VERSION "{{ version }}")
+        mark_as_advanced({{ prefix }}_FOUND {{ prefix }}_VERSION)
+        {% endfor %}
+
         {% endif %}
         """)

--- a/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -715,6 +715,7 @@ def test_cmakedeps_set_legacy_variable_name():
     conanfile = base_conanfile + """
     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "CMakeFileName")
+        self.cpp_info.set_property("cmake_find_mode", "both")
     """
     client.save({"dep/conanfile.py": conanfile})
     client.run("create dep")
@@ -725,6 +726,9 @@ def test_cmakedeps_set_legacy_variable_name():
     cmake_variables = ["VERSION_STRING", "INCLUDE_DIRS", "INCLUDE_DIR", "LIBRARIES", "DEFINITIONS"]
     for variable in cmake_variables:
         assert f"CMakeFileName_{variable}" in dep_config
+    dep_find = client.load("FindCMakeFileName.cmake")
+    for variable in cmake_variables:
+        assert f"CMakeFileName_{variable}" in dep_find
 
     consumer_conanfile = textwrap.dedent("""
         from conan import ConanFile
@@ -751,6 +755,16 @@ def test_cmakedeps_set_legacy_variable_name():
         assert f"CMakeFileName_{variable}" in dep_config
         assert f"PREFIX_{variable}" in dep_config
         assert f"prefix_{variable}" in dep_config
+
+    dep_find = client.load(os.path.join("consumer", "FindCMakeFileName.cmake"))
+    for variable in cmake_variables:
+        assert f"CMakeFileName_{variable}" in dep_find
+        assert f"PREFIX_{variable}" in dep_find
+        assert f"prefix_{variable}" in dep_find
+    assert "set(prefix_FOUND 1)" in dep_find
+    assert "set(PREFIX_FOUND 1)" in dep_find
+    assert 'set(prefix_VERSION "1.0")' in dep_find
+    assert 'set(PREFIX_VERSION "1.0")' in dep_find
 
     conanfile = base_conanfile + """
     def package_info(self):
@@ -901,10 +915,10 @@ def test_alias_cmakedeps_set_property():
              """)})
     tc.run("create dep")
     tc.run("install .")
-    targetsData = tc.load("depTargets.cmake")
-    assert "add_library(dep::dep" in targetsData
-    assert "add_library(alias" in targetsData
-    assert "add_library(dep::other_name" in targetsData
+    targets_data = tc.load("depTargets.cmake")
+    assert "add_library(dep::dep" in targets_data
+    assert "add_library(alias" in targets_data
+    assert "add_library(dep::other_name" in targets_data
 
-    assert "add_library(component_alias" in targetsData
-    assert "add_library(dep::my_aliased_component" in targetsData
+    assert "add_library(component_alias" in targets_data
+    assert "add_library(dep::my_aliased_component" in targets_data


### PR DESCRIPTION
Changelog: Feature: ``CMakeDeps`` generated ``Findxxxx.cmake`` files now can define ``{prefix}_FOUND`` and ``{prefix}_VERSION`` for the ``cmake_additional_variables_prefixes``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/17483