### PR TITLE
[runtime_deploy] Respect subfolders in order to preserve symlinks

### DIFF
--- a/test/functional/command/test_install_deploy.py
+++ b/test/functional/command/test_install_deploy.py
@@ -559,7 +559,7 @@ def test_runtime_deploy_subfolder():
     c = TestClient()
     conanfile = textwrap.dedent("""
            from conan import ConanFile
-           from conan.tools.files import copy, chdir
+           from conan.tools.files import copy
            import os
            class Pkg(ConanFile):
                package_type = "shared-library"
@@ -573,10 +573,37 @@ def test_runtime_deploy_subfolder():
     c.run("export-pkg foo/ --name=foo --version=0.1.0")
     c.run(f"install --requires=foo/0.1.0 --deployer=runtime_deploy --deployer-folder=output")
 
-    assert os.listdir(os.path.join(c.current_folder, "output")) == ["libfoo.so"]
-    assert os.listdir(os.path.join(c.current_folder, "output", "subfolder")) == ["libbar.so"]
+    assert os.listdir(os.path.join(c.current_folder, "output")) == ["libfoo.so", "subfolder"]
+    assert os.listdir(os.path.join(c.current_folder, "output", "subfolder")) == ["libbar.so", "subsubfolder"]
     assert os.listdir(os.path.join(c.current_folder, "output", "subfolder", "subsubfolder")) == ["libqux.so"]
 
+
+def test_runtime_deploy_subfolder_symlink():
+    """ The deployer runtime_deploy should preserve subfolder structure when deploying shared
+        libraries with symlinks
+    """
+    c = TestClient()
+    conanfile = textwrap.dedent("""
+           from conan import ConanFile
+           from conan.tools.files import copy, chdir, mkdir
+           import os
+           class Pkg(ConanFile):
+               package_type = "shared-library"
+               def package(self):
+                   copy(self, "*.so*", src=self.build_folder, dst=self.package_folder)
+                   with chdir(self, os.path.join(self.package_folder, "lib")):
+                        os.symlink(src="subfolder/libfoo.so.1.0", dst="libfoo.so.1")
+                        os.symlink(src="libfoo.so.1", dst="libfoo.so")
+           """)
+    c.save({"foo/conanfile.py": conanfile,
+            "foo/lib/subfolder/libfoo.so.1.0": "",})
+    c.run("export-pkg foo/ --name=foo --version=0.1.0")
+    c.run(f"install --requires=foo/0.1.0 --deployer=runtime_deploy --deployer-folder=output")
+
+    assert sorted(os.listdir(os.path.join(c.current_folder, "output"))) == ["libfoo.so", "libfoo.so.1" , "subfolder"]
+    assert os.listdir(os.path.join(c.current_folder, "output", "subfolder")) == ["libfoo.so.1.0"]
+    assert os.path.islink(os.path.join(c.current_folder, "output", "libfoo.so.1"))
+    assert os.path.islink(os.path.join(c.current_folder, "output", "libfoo.so"))
 
 def test_deployer_errors():
     c = TestClient()

--- a/test/functional/command/test_install_deploy.py
+++ b/test/functional/command/test_install_deploy.py
@@ -564,7 +564,7 @@ def test_runtime_deploy_subfolder():
            class Pkg(ConanFile):
                package_type = "shared-library"
                def package(self):
-                   copy(self, "*.so*", src=self.build_folder, dst=self.package_folder)
+                   copy(self, "*.so*", src=self.build_folder, dst=self.package_folder, keep_path=True)
            """)
     c.save({"foo/conanfile.py": conanfile,
             "foo/lib/libfoo.so": "",
@@ -573,9 +573,9 @@ def test_runtime_deploy_subfolder():
     c.run("export-pkg foo/ --name=foo --version=0.1.0")
     c.run(f"install --requires=foo/0.1.0 --deployer=runtime_deploy --deployer-folder=output")
 
-    assert os.listdir(os.path.join(c.current_folder, "output")) == ["libfoo.so", "subfolder"]
-    assert os.listdir(os.path.join(c.current_folder, "output", "subfolder")) == ["libbar.so", "subsubfolder"]
-    assert os.listdir(os.path.join(c.current_folder, "output", "subfolder", "subsubfolder")) == ["libqux.so"]
+    assert sorted(os.listdir(os.path.join(c.current_folder, "output"))) == ["libfoo.so", "subfolder"]
+    assert sorted(os.listdir(os.path.join(c.current_folder, "output", "subfolder"))) == ["libbar.so", "subsubfolder"]
+    assert sorted(os.listdir(os.path.join(c.current_folder, "output", "subfolder", "subsubfolder"))) == ["libqux.so"]
 
 
 def test_runtime_deploy_subfolder_symlink():
@@ -598,12 +598,22 @@ def test_runtime_deploy_subfolder_symlink():
     c.save({"foo/conanfile.py": conanfile,
             "foo/lib/subfolder/libfoo.so.1.0": "",})
     c.run("export-pkg foo/ --name=foo --version=0.1.0")
-    c.run(f"install --requires=foo/0.1.0 --deployer=runtime_deploy --deployer-folder=output")
+    c.run(f"install --requires=foo/0.1.0 --deployer=runtime_deploy --deployer-folder=output -c:a tools.deployer:symlinks=True")
 
-    assert sorted(os.listdir(os.path.join(c.current_folder, "output"))) == ["libfoo.so", "libfoo.so.1" , "subfolder"]
     assert os.listdir(os.path.join(c.current_folder, "output", "subfolder")) == ["libfoo.so.1.0"]
-    assert os.path.islink(os.path.join(c.current_folder, "output", "libfoo.so.1"))
-    assert os.path.islink(os.path.join(c.current_folder, "output", "libfoo.so"))
+    # INFO: This test requires in Windows to have symlinks enabled, otherwise it will fail
+    if platform.system() != "Windows":
+        assert sorted(os.listdir(os.path.join(c.current_folder, "output"))) == ["libfoo.so", "libfoo.so.1" , "subfolder"]
+        link_so_0 = os.path.join(c.current_folder, "output", "libfoo.so.1")
+        link_so = os.path.join(c.current_folder, "output", "libfoo.so")
+        lib = os.path.join(c.current_folder, "output", "subfolder", "libfoo.so.1.0")
+        assert os.path.islink(link_so_0)
+        assert os.path.islink(link_so)
+        assert not os.path.isabs(os.readlink(link_so_0))
+        assert not os.path.isabs(os.readlink(os.path.join(link_so)))
+        assert os.path.realpath(link_so) == os.path.realpath(link_so_0)
+        assert os.path.realpath(link_so_0) == os.path.realpath(lib)
+
 
 def test_deployer_errors():
     c = TestClient()

--- a/test/functional/command/test_install_deploy.py
+++ b/test/functional/command/test_install_deploy.py
@@ -553,6 +553,31 @@ def test_runtime_deploy_symlinks(symlink, expected):
         assert not os.path.islink(lib)
 
 
+def test_runtime_deploy_subfolder():
+    """ The deployer runtime_deploy should preserve subfolder structure when deploying shared libraries
+    """
+    c = TestClient()
+    conanfile = textwrap.dedent("""
+           from conan import ConanFile
+           from conan.tools.files import copy, chdir
+           import os
+           class Pkg(ConanFile):
+               package_type = "shared-library"
+               def package(self):
+                   copy(self, "*.so*", src=self.build_folder, dst=self.package_folder)
+           """)
+    c.save({"foo/conanfile.py": conanfile,
+            "foo/lib/libfoo.so": "",
+            "foo/lib/subfolder/libbar.so": "",
+            "foo/lib/subfolder/subsubfolder/libqux.so": "",})
+    c.run("export-pkg foo/ --name=foo --version=0.1.0")
+    c.run(f"install --requires=foo/0.1.0 --deployer=runtime_deploy --deployer-folder=output")
+
+    assert os.listdir(os.path.join(c.current_folder, "output")) == ["libfoo.so"]
+    assert os.listdir(os.path.join(c.current_folder, "output", "subfolder")) == ["libbar.so"]
+    assert os.listdir(os.path.join(c.current_folder, "output", "subfolder", "subsubfolder")) == ["libqux.so"]
+
+
 def test_deployer_errors():
     c = TestClient()
     c.save({"conanfile.txt": "",

--- a/test/functional/command/test_install_deploy.py
+++ b/test/functional/command/test_install_deploy.py
@@ -508,8 +508,9 @@ class TestRuntimeDeployer:
         c.run("install --requires=pkga/1.0 --requires=pkgb/1.0 --deployer=runtime_deploy "
               "--deployer-folder=myruntime -vvv")
 
-        expected = sorted(["pkga.so", "pkgb.so", "pkga.dll"])
-        assert sorted(os.listdir(os.path.join(c.current_folder, "myruntime"))) == expected
+        assert sorted(os.listdir(os.path.join(c.current_folder, "myruntime"))) == sorted(["bin", "lib"])
+        assert sorted(os.listdir(os.path.join(c.current_folder, "myruntime", "lib"))) == sorted(['pkga.so', 'pkgb.so'])
+        assert sorted(os.listdir(os.path.join(c.current_folder, "myruntime", "bin"))) == sorted(['pkga.dll'])
 
 @pytest.mark.parametrize("symlink, expected",
                          [(True, ["libfoo.so.0.1.0", "libfoo.so.0", "libfoo.so"]),


### PR DESCRIPTION
Changelog: Fix: Preserve subfolders for `runtime_deploy` deployer.
Docs: https://github.com/conan-io/docs/pull/4205

fixes #16938

Related to https://github.com/conan-io/conan/pull/17824



This PR is the second part of changing the `runtime_deploy`, addressing the comment https://github.com/conan-io/conan/issues/16938#issuecomment-2362284595.

When having subfolders in the lib or bin package folder, the same the same will be preserved. This situation avoids broken symlinks, for instance, we consume libfoo.so, but it's a symlink and points to subfolber/libfoo.so.1.0. 

----

Open to discussion:

When doing this fix occurred me the following case:

Users may have problems with LD_LIBRARY_PATH if there are separate libraries in the subfolder. Maybe, we could include a new conf, like `tools.deployer.runtime:flatten`, when `True`, we move all artifacts for the top folder, and fix the relative symlinks, for instance:

```
conan install foo/0.1.0 --deployer=runtime_deploy --deployer-folder=output

# tools.deployer.runtime:flatten=False/None (default)
ls -R output/
libfoo.so -> subfolder/libfoo.so.1
subfolder/libfoo.so.1 -> subfolder/libfoo.so.1.0

# tools.deployer.runtime:flatten=True
ls -l output/
libfoo.so -> libfoo.so.1
libfoo.so.1 -> libfoo.so.1.0
```
