### PR TITLE
disallow relative paths in ConanAPI constructor

### DIFF
--- a/conan/api/conan_api.py
+++ b/conan/api/conan_api.py
@@ -1,3 +1,4 @@
+import os
 import sys
 
 from conan.api.output import init_colorama
@@ -35,6 +36,8 @@ class ConanAPI:
         version = sys.version_info
         if version.major == 2 or version.minor < 6:
             raise ConanException("Conan needs Python >= 3.6")
+        if cache_folder is not None and not os.path.isabs(cache_folder):
+            raise ConanException("cache_folder has to be an absolute path")
 
         init_colorama(sys.stderr)
         self.workspace = WorkspaceAPI(self)

--- a/test/integration/conan_api/test_profile_api.py
+++ b/test/integration/conan_api/test_profile_api.py
@@ -1,0 +1,11 @@
+import pytest
+
+from conan.api.conan_api import ConanAPI
+from conan.errors import ConanException
+
+
+def test_profile_api():
+    # It must be an absolute path
+    with pytest.raises(ConanException) as e:
+        ConanAPI(cache_folder="test")
+    assert "cache_folder has to be an absolute path" in str(e.value)


### PR DESCRIPTION
Changelog: Fix: Raise if a relative path is passed to ``ConanAPI()`` constructor
Docs: Omit

Close https://github.com/conan-io/conan/issues/17850
