### PR TITLE
Fix cmake target not generated with CMake2 generator when only system…

### DIFF
--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -154,7 +154,7 @@ class TargetConfigurationTemplate2:
         return libs
 
     def _get_cmake_lib(self, info, components, pkg_folder, pkg_folder_var):
-        if info.exe or not (info.includedirs or info.libs):
+        if info.exe or not (info.includedirs or info.libs or info.system_libs):
             return
 
         includedirs = ";".join(self._path(i, pkg_folder, pkg_folder_var)


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

…_libs are defined


When trying to use the recipes in conan-center-index which refer to system version   such as xorg/system   or opengl/system, the generated target cmake file do not contain the required target when using the CMakeDep2 generator as it only defined system_libs in cpp_info.  This PR attempt to fix this

