### PR TITLE
fix issues with local-recipes-index in presence of workspace home_folder

### DIFF
--- a/conan/api/conan_api.py
+++ b/conan/api/conan_api.py
@@ -32,6 +32,10 @@ class ConanAPI:
     not be created directly.
     """
     def __init__(self, cache_folder=None):
+        """
+        :param cache_folder: Conan cache/home folder. It will have less priority than the
+                             "home_folder" defined in a Workspace.
+        """
 
         version = sys.version_info
         if version.major == 2 or version.minor < 6:

--- a/conans/client/rest_client_local_recipe_index.py
+++ b/conans/client/rest_client_local_recipe_index.py
@@ -65,11 +65,9 @@ class RestApiClientLocalRecipesIndex:
         local_recipes_index_path = os.path.join(local_recipes_index_path, ".conan")
         repo_folder = self._remote.url
 
-        from conan.internal.conan_app import ConanApp
-        from conan.api.conan_api import ConanAPI
-        conan_api = ConanAPI(local_recipes_index_path)
-        self._app = ConanApp(conan_api)
-        self._hook_manager = HookManager(HomePaths(conan_api.home_folder).hooks_path)
+        from conan.internal.conan_app import LocalRecipesIndexApp
+        self._app = LocalRecipesIndexApp(local_recipes_index_path)
+        self._hook_manager = HookManager(HomePaths(local_recipes_index_path).hooks_path)
         self._layout = _LocalRecipesIndexLayout(repo_folder)
 
     def call_method(self, method_name, *args, **kwargs):


### PR DESCRIPTION
Changelog: Fix: Avoid workspace incorrectly defining a "local-recipes-index" auxiliary cache.
Docs: Omit
