### PR TITLE
Fix/warn deduce find location

### DIFF
--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -527,7 +527,9 @@ class _Component:
                 if lib_found:
                     if len(lib_found) > 1:
                         lib_found.sort()
-                        out.warning(f"There were several matches for Lib {libname}: {lib_found}")
+                        found, _ = os.path.splitext(os.path.basename(lib_found[0]))
+                        if found != libname:
+                            out.warning(f"There were several matches for Lib {libname}: {lib_found}")
                     return lib_found[0].replace("\\", "/")
 
         out = ConanOutput(scope=str(conanfile))

--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -528,7 +528,7 @@ class _Component:
                     if len(lib_found) > 1:
                         lib_found.sort()
                         found, _ = os.path.splitext(os.path.basename(lib_found[0]))
-                        if found != libname:
+                        if found != libname and found != f"lib{libname}":
                             out.warning(f"There were several matches for Lib {libname}: {lib_found}")
                     return lib_found[0].replace("\\", "/")
 

--- a/test/unittests/model/build_info/test_deduce_locations.py
+++ b/test/unittests/model/build_info/test_deduce_locations.py
@@ -234,12 +234,14 @@ def test_warning_windows_if_more_than_one_dll(conanfile):
     assert result.type == "shared-library"
 
 
-def test_multiple_matches_exact_match(conanfile):
+@pytest.mark.parametrize("prefix", [True, False])
+def test_multiple_matches_exact_match(conanfile, prefix):
     # If the match is perfect, do not warn
     folder = temp_folder()
-    save(os.path.join(folder, "libdir", "mylib.a"), "")
-    save(os.path.join(folder, "libdir", "mylib_imp.a"), "")
-    save(os.path.join(folder, "libdir", "mylib_other.a"), "")
+    prefix = "lib" if prefix else ""
+    save(os.path.join(folder, "libdir", f"{prefix}mylib.a"), "")
+    save(os.path.join(folder, "libdir", f"{prefix}mylib_imp.a"), "")
+    save(os.path.join(folder, "libdir", f"{prefix}mylib_other.a"), "")
 
     cppinfo = CppInfo()
     cppinfo.libdirs = ["libdir"]
@@ -250,5 +252,5 @@ def test_multiple_matches_exact_match(conanfile):
     with redirect_output(output):
         result = cppinfo.deduce_full_cpp_info(conanfile)
     assert "WARN: There were several matches for Lib mylib" not in output
-    assert result.location == f"{folder}/libdir/mylib.a"
+    assert result.location == f"{folder}/libdir/{prefix}mylib.a"
     assert result.type == "static-library"

--- a/test/unittests/model/build_info/test_deduce_locations.py
+++ b/test/unittests/model/build_info/test_deduce_locations.py
@@ -4,8 +4,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from conan.test.utils.mocks import ConanFileMock
+from conan.test.utils.mocks import ConanFileMock, RedirectedTestOutput
 from conan.test.utils.test_files import temp_folder
+from conan.test.utils.tools import redirect_output
 from conan.tools.files import save
 from conan.internal.model.cpp_info import CppInfo
 from conan.internal.model.pkg_type import PackageType
@@ -225,6 +226,29 @@ def test_warning_windows_if_more_than_one_dll(conanfile):
     cppinfo.libs = ["mylib"]
     cppinfo.set_relative_base_folder(folder)
     folder = folder.replace("\\", "/")
-    result = cppinfo.deduce_full_cpp_info(conanfile)
+    output = RedirectedTestOutput()  # Initialize each command
+    with redirect_output(output):
+        result = cppinfo.deduce_full_cpp_info(conanfile)
+    assert "WARN: There were several matches for Lib mylib" in output
     assert result.location == f"{folder}/bindir/libx.dll"
     assert result.type == "shared-library"
+
+
+def test_multiple_matches_exact_match(conanfile):
+    # If the match is perfect, do not warn
+    folder = temp_folder()
+    save(os.path.join(folder, "libdir", "mylib.a"), "")
+    save(os.path.join(folder, "libdir", "mylib_imp.a"), "")
+    save(os.path.join(folder, "libdir", "mylib_other.a"), "")
+
+    cppinfo = CppInfo()
+    cppinfo.libdirs = ["libdir"]
+    cppinfo.libs = ["mylib"]
+    cppinfo.set_relative_base_folder(folder)
+    folder = folder.replace("\\", "/")
+    output = RedirectedTestOutput()  # Initialize each command
+    with redirect_output(output):
+        result = cppinfo.deduce_full_cpp_info(conanfile)
+    assert "WARN: There were several matches for Lib mylib" not in output
+    assert result.location == f"{folder}/libdir/mylib.a"
+    assert result.type == "static-library"


### PR DESCRIPTION
Changelog: Fix: Do not warn in auto-deduce location for exact library matches.
Docs: Omit

Close https://github.com/conan-io/conan/issues/17884
