### PR TITLE
Fix tool.SBOM.cyclonedx with empty components

### DIFF
--- a/conan/tools/sbom/cyclonedx.py
+++ b/conan/tools/sbom/cyclonedx.py
@@ -80,7 +80,7 @@ def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, **kwar
         "metadata": {
             "component": {
                 "author": "Conan",
-                "bom-ref": special_id if has_special_root_node else f"pkg:conan/{c.name}@{c.ref.version}?rref={c.ref.revision}",
+                "bom-ref": special_id if has_special_root_node else f"pkg:conan/{conanfile.name}@{conanfile.ref.version}?rref={conanfile.ref.revision}",
                 "name": name if name else name_default,
                 "type": "library"
             },

--- a/test/functional/sbom/test_cyclonedx.py
+++ b/test/functional/sbom/test_cyclonedx.py
@@ -262,6 +262,24 @@ def test_sbom_generation_install_path_txt(hook_setup_post_generate):
     tc.run("install .")
     assert os.path.exists(os.path.join(tc.current_folder, "sbom", "sbom.cdx.json"))
 
+def test_sbom_with_special_root_node(hook_setup_post_generate):
+    tc = hook_setup_post_generate
+    package_name = "foo"
+
+    conanfile =  textwrap.dedent("""
+            from conan import ConanFile
+            class FooPackage(ConanFile):
+                name = "foo"
+                version = "1.0"
+                package_type = "build-scripts"
+    """)
+    tc.save({"conanfile.py": conanfile})
+    tc.run("create .")
+    create_layout = tc.created_layout()
+    assert os.path.exists(os.path.join(create_layout.build(), "sbom", "sbom.cdx.json"))
+    with open(os.path.join(create_layout.build(), "sbom", "sbom.cdx.json"), 'r') as file:
+        sbom_json = json.load(file)
+        assert package_name in sbom_json["metadata"]["component"]["name"]
 
 @pytest.mark.parametrize("name, result", [
     ("None", "conan-sbom"),


### PR DESCRIPTION
Changelog: BugFix: Add correct info in metadata + prevent crash when no component is associated to root_node.
Docs: Omit


Fix issue #17924

- [x] Refer to the issue that supports this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
