### PR TITLE
sqlite3 localdb: using single quotes for strings backport (#16123)

### DIFF
--- a/conans/client/store/localdb.py
+++ b/conans/client/store/localdb.py
@@ -76,7 +76,7 @@ class LocalDB(object):
         with self._connect() as connection:
             try:
                 statement = connection.cursor()
-                statement.execute('select user, token, refresh_token from %s where remote_url="%s"'
+                statement.execute("select user, token, refresh_token from %s where remote_url='%s'"
                                   % (REMOTES_USER_TABLE, remote_url))
                 rs = statement.fetchone()
                 if not rs:


### PR DESCRIPTION
A newer version of sqlite3 breaks double quotes on 1.x
https://www.reddit.com/r/freebsd/comments/1chb82b/sqlite3_pkg_just_became_stricter_with_quoting/

There are multiple issues relevant for this bug, for example:
https://github.com/conan-io/conan/issues/13446
https://github.com/conan-io/conan/issues/16115
The latter was fixed on v2.x here:
https://github.com/conan-io/conan/pull/16123
But 1.x still suffers from this, and some of us are still stuck on 1.x, so before we can update to 2.x, could we have this fix please?

Thanks