### PR TITLE
improve jinja2 failure error messages

### DIFF
--- a/conan/__init__.py
+++ b/conan/__init__.py
@@ -2,5 +2,5 @@ from conan.internal.model.conan_file import ConanFile
 from conan.internal.model.workspace import Workspace
 from conan.internal.model.version import Version
 
-__version__ = '2.14.0-dev'
+__version__ = '2.15.0-dev'
 conan_version = Version(__version__)

--- a/conan/__init__.py
+++ b/conan/__init__.py
@@ -2,5 +2,5 @@ from conan.internal.model.conan_file import ConanFile
 from conan.internal.model.workspace import Workspace
 from conan.internal.model.version import Version
 
-__version__ = '2.15.0-dev'
+__version__ = '2.14.0'
 conan_version = Version(__version__)

--- a/conan/internal/api/profile/profile_loader.py
+++ b/conan/internal/api/profile/profile_loader.py
@@ -126,9 +126,9 @@ class ProfileLoader:
         # Always include the root Conan home "profiles" folder as secondary route for loading
         # imports and includes from jinja2 templates.
         loader_paths = [base_path, profiles_folder]
-        rtemplate = Environment(loader=FileSystemLoader(loader_paths)).from_string(text)
 
         try:
+            rtemplate = Environment(loader=FileSystemLoader(loader_paths)).from_string(text)
             text = rtemplate.render(context)
         except Exception as e:
             raise ConanException(f"Error while rendering the profile template file '{profile_path}'. "


### PR DESCRIPTION
Changelog: Fix: Improve error message when ``jinja2`` profile rendering fails due to unexpected syntax.
Docs: Omit

Close https://github.com/conan-io/conan/issues/17932