### PR TITLE
Use correct attribute type instead of package_type

### DIFF
--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -81,13 +81,16 @@ class TargetConfigurationTemplate2:
                         assert required_pkg == required_comp
                         comp = None
                         default_target = f"{dep.ref.name}::{dep.ref.name}"  # replace_requires
+                        link = pkg_type is not PackageType.SHARED 
                     else:
                         comp = required_comp
                         default_target = f"{required_pkg}::{required_comp}"
+                        link = not (pkg_type is PackageType.SHARED and
+                                dep_comp.type is PackageType.SHARED)
+
                     dep_target = self._cmakedeps.get_property("cmake_target_name", dep, comp)
                     dep_target = dep_target or default_target
-                    link = not (pkg_type is PackageType.SHARED and
-                                dep_comp.type is PackageType.SHARED)
+
                     result[dep_target] = link
         return result
 

--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -65,7 +65,7 @@ class TargetConfigurationTemplate2:
                                                           required_comp)
                 dep_target = dep_target or f"{pkg_name}::{required_comp}"
                 link = not (pkg_type is PackageType.SHARED and
-                            dep_comp.package_type is PackageType.SHARED)
+                            dep_comp.type is PackageType.SHARED)
                 result[dep_target] = link
             else:  # Different package
                 try:
@@ -87,7 +87,7 @@ class TargetConfigurationTemplate2:
                     dep_target = self._cmakedeps.get_property("cmake_target_name", dep, comp)
                     dep_target = dep_target or default_target
                     link = not (pkg_type is PackageType.SHARED and
-                                dep_comp.package_type is PackageType.SHARED)
+                                dep_comp.type is PackageType.SHARED)
                     result[dep_target] = link
         return result
 

--- a/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
@@ -245,3 +245,41 @@ def test_consuming_cpp_info_with_components_dependency_from_other_package():
     c.run("create pkg --name=pkg --version=0.1 -c tools.cmake.cmakedeps:new=will_break_next")
     # it doesn't break
     assert "find_package(pkg)" in c.out
+
+
+    def test_consuming_cpp_info_transitively_by_requiring_root_component_in_another_component_from_another_package():
+    c = TestClient()
+    dependent_conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        class Dependent(ConanFile):
+            settings = "os", "compiler", "arch", "build_type"
+            name = 'dependent'
+        """)
+
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        class Pkg(ConanFile):
+            settings = "os", "compiler", "arch", "build_type"
+            def requirements(self):
+                self.requires('dependent/0.1')
+            def package_info(self):
+                self.cpp_info.type = 'shared-library'
+                self.cpp_info.requires = ['dependent::dependent']
+        """)
+    test_package = textwrap.dedent("""
+        from conan import ConanFile
+        class TestPkg(ConanFile):
+            settings = "os", "compiler", "arch", "build_type"
+            generators = "VirtualRunEnv", "CMakeDeps"
+
+            def requirements(self):
+                self.requires(self.tested_reference_str)
+
+            def test(self):
+                pass
+        """)
+    c.save({"dependent/conanfile.py": dependent_conanfile,
+            "main/conanfile.py": conanfile,
+            "main/test_package/conanfile.py":test_package})
+    c.run("create ./dependent/ --name=dependent --version=0.1 -c tools.cmake.cmakedeps:new=will_break_next")
+    c.run("create ./main/ --name=pkg --version=0.1 -c tools.cmake.cmakedeps:new=will_break_next")

--- a/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
@@ -209,19 +209,39 @@ def test_consuming_cpp_info_with_components_dependency_from_same_package():
                 self.cpp_info.components["lib_extended"].type = 'shared-library'
                 self.cpp_info.components["lib_extended"].requires = ['lib']
         """)
-    test_package = textwrap.dedent("""
-        from conan import ConanFile
-        class TestPkg(ConanFile):
-            settings = "os", "compiler", "arch", "build_type"
-            generators = "VirtualRunEnv", "CMakeDeps"
-
-            def requirements(self):
-                self.requires(self.tested_reference_str)
-
-            def test(self):
-                pass
-        """)
     c.save({"conanfile.py": conanfile,
-            "test_package/conanfile.py":test_package})
-
+            "test_package/conanfile.py": GenConanfile().with_settings("build_type")
+                                                       .with_test("pass")
+                                                       .with_generator("CMakeDeps")})
     c.run("create . --name=pkg --version=0.1 -c tools.cmake.cmakedeps:new=will_break_next")
+    # it doesn't break
+    assert "find_package(pkg)" in c.out
+
+
+def test_consuming_cpp_info_with_components_dependency_from_other_package():
+    c = TestClient()
+    dep = textwrap.dedent("""
+        from conan import ConanFile
+        class Pkg(ConanFile):
+            name = "dep"
+            version = "0.1"
+            def package_info(self):
+                self.cpp_info.components["lib"].type = 'shared-library'
+    """)
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        class Pkg(ConanFile):
+            requires = "dep/0.1"
+            def package_info(self):
+                self.cpp_info.components["lib"].type = 'shared-library'
+                self.cpp_info.components["lib"].requires = ['dep::lib']
+        """)
+    c.save({"dep/conanfile.py": dep,
+            "pkg/conanfile.py": conanfile,
+            "pkg/test_package/conanfile.py": GenConanfile().with_settings("build_type")
+                                                           .with_test("pass")
+                                                           .with_generator("CMakeDeps")})
+    c.run("create dep")
+    c.run("create pkg --name=pkg --version=0.1 -c tools.cmake.cmakedeps:new=will_break_next")
+    # it doesn't break
+    assert "find_package(pkg)" in c.out

--- a/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
@@ -247,7 +247,7 @@ def test_consuming_cpp_info_with_components_dependency_from_other_package():
     assert "find_package(pkg)" in c.out
 
 
-    def test_consuming_cpp_info_transitively_by_requiring_root_component_in_another_component_from_another_package():
+def test_consuming_cpp_info_transitively_by_requiring_root_component_in_another_component_from_another_package():
     c = TestClient()
     dependent_conanfile = textwrap.dedent("""
         from conan import ConanFile


### PR DESCRIPTION
Changelog: Fix: `_Component()` has no `package_type` property.
Docs: Omit

Closes: #17942 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.