### PR TITLE
custom generator class serialization fix

### DIFF
--- a/conan/internal/model/conan_file.py
+++ b/conan/internal/model/conan_file.py
@@ -150,7 +150,8 @@ class ConanFile:
         result["options_definitions"] = self.options.possible_values
 
         if self.generators is not None:
-            result["generators"] = list(self.generators)
+            result["generators"] = list(s.__name__ if isinstance(s, type) else s
+                                        for s in self.generators)
         if self.license is not None:
             result["license"] = list(self.license) if not isinstance(self.license, str) else self.license
 

--- a/test/integration/generators/test_generators_from_br.py
+++ b/test/integration/generators/test_generators_from_br.py
@@ -1,3 +1,4 @@
+import json
 import textwrap
 
 from conan.test.utils.tools import TestClient
@@ -89,3 +90,30 @@ def test_inject_vars():
     content = tc.load("conanbuild.sh")
     assert "conantest.sh" in content
     assert "envars_generator2.sh" in content
+
+
+def test_json_serialization_error():
+    c = TestClient()
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+
+        class MyGenerator:
+            def __init__(self, conanfile):
+                self._conanfile = conanfile
+
+            def generate(self):
+                pass
+
+        class MyToolReq(ConanFile):
+            name = "mygenerator-tool"
+            version = "1.0"
+
+            def package_info(self):
+                self.generator_info = [MyGenerator]
+        """)
+
+    c.save({"tool/conanfile.py": conanfile})
+    c.run("create tool")
+    c.run("install --tool-requires=mygenerator-tool/1.0 --format=json")
+    graph = json.loads(c.stdout)
+    assert graph["graph"]["nodes"]["0"]["generators"] == ["MyGenerator"]


### PR DESCRIPTION
Changelog: Bugfix: Avoid crash of ``--format=json`` serialization when custom generators inside tool-requires are referenced by class, not by name.
Docs: Omit

Close https://github.com/conan-io/conan/issues/17948
