### PR TITLE
[cpp_info] More prio to exact match libs

### DIFF
--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -554,11 +554,18 @@ class _Component:
         else:
             lib_sanitized = re.escape(libname)
             component_sanitized = re.escape(library_name)
-            regex_static = re.compile(rf"(?:lib)?{lib_sanitized}(?:[._-].+)?\.(?:a|lib)")
-            regex_shared = re.compile(rf"(?:lib)?{lib_sanitized}(?:[._-].+)?\.(?:so|dylib)")
+            # At first, exact match
+            regex_static = re.compile(rf"(?:lib)?{lib_sanitized}\.(?:a|lib)")
+            regex_shared = re.compile(rf"(?:lib)?{lib_sanitized}\.(?:so|dylib)")
             regex_dll = re.compile(rf".*(?:{lib_sanitized}|{component_sanitized}).*\.dll")
             static_location = _find_matching(libdirs, regex_static)
             shared_location = _find_matching(libdirs, regex_shared)
+            if not any([static_location, shared_location]):
+                # Let's extend a little bit the pattern search
+                regex_wider_static = re.compile(rf"(?:lib)?{lib_sanitized}(?:[._-].+)?\.(?:a|lib)")
+                regex_wider_shared = re.compile(rf"(?:lib)?{lib_sanitized}(?:[._-].+)?\.(?:so|dylib)")
+                static_location = _find_matching(libdirs, regex_wider_static)
+                shared_location = _find_matching(libdirs, regex_wider_shared)
             if static_location or not shared_location:
                 dll_location = _find_matching(bindirs, regex_dll)
 

--- a/test/unittests/model/build_info/test_deduce_locations.py
+++ b/test/unittests/model/build_info/test_deduce_locations.py
@@ -245,7 +245,7 @@ def test_warning_windows_if_more_than_one_dll(conanfile):
 
 
 @pytest.mark.parametrize("prefix", [True, False])
-def test_multiple_matches_exact_match(conanfile, prefix):
+def test_multiple_matches_exact_match(prefix, conanfile):
     # If the match is perfect, do not warn
     folder = temp_folder()
     prefix = "lib" if prefix else ""
@@ -263,4 +263,23 @@ def test_multiple_matches_exact_match(conanfile, prefix):
         result = cppinfo.deduce_full_cpp_info(conanfile)
     assert "WARN: There were several matches for Lib mylib" not in output
     assert result.location == f"{folder}/libdir/{prefix}mylib.a"
+    assert result.type == "static-library"
+
+
+
+@pytest.mark.parametrize("lib_name, libs", [
+    ("harfbuzz", ["harfbuzz-icu.lib", "harfbuzz.lib"]),
+])
+def test_several_libs(lib_name, libs, conanfile):
+    folder = temp_folder()
+    for lib in libs:
+        save(os.path.join(folder, "libdir", lib), "")
+
+    cppinfo = CppInfo()
+    cppinfo.libdirs = ["libdir"]
+    cppinfo.libs = [lib_name]
+    cppinfo.set_relative_base_folder(folder)
+    folder = folder.replace("\\", "/")
+    result = cppinfo.deduce_full_cpp_info(conanfile)
+    assert result.location == f"{folder}/libdir/{lib_name}.lib"
     assert result.type == "static-library"

--- a/test/unittests/model/build_info/test_deduce_locations.py
+++ b/test/unittests/model/build_info/test_deduce_locations.py
@@ -270,7 +270,12 @@ def test_multiple_matches_exact_match(prefix, conanfile):
 @pytest.mark.parametrize("lib_name, libs", [
     ("harfbuzz", ["harfbuzz-icu.lib", "harfbuzz.lib"]),
 ])
-def test_several_libs(lib_name, libs, conanfile):
+def test_several_libs_and_exact_match(lib_name, libs, conanfile):
+    """
+    Testing that we're keeping the exact match at first instead the similar one
+
+    Issue related: https://github.com/conan-io/conan/issues/17974
+    """
     folder = temp_folder()
     for lib in libs:
         save(os.path.join(folder, "libdir", lib), "")


### PR DESCRIPTION
Changelog: Bugfix: `CppInfo.auto_deduce_location` method gives more prio to exact match.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/17974