### PR TITLE
use single quotes for string literals in sql query

### DIFF
--- a/conans/client/store/localdb.py
+++ b/conans/client/store/localdb.py
@@ -76,7 +76,7 @@ class LocalDB(object):
         with self._connect() as connection:
             try:
                 statement = connection.cursor()
-                statement.execute('select user, token, refresh_token from %s where remote_url="%s"'
+                statement.execute('select user, token, refresh_token from %s where remote_url=\'%s\''
                                   % (REMOTES_USER_TABLE, remote_url))
                 rs = statement.fetchone()
                 if not rs:


### PR DESCRIPTION
Changelog: Bugfix: #17978 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.

