### PR TITLE
[MesonToolchain] Added subsystem field

### DIFF
--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -6,10 +6,10 @@ from conan.tools.build import cmd_args_to_string
 from conan.errors import ConanException
 
 
-def is_apple_os(conanfile):
+def is_apple_os(conanfile, build_context=False):
     """returns True if OS is Apple one (Macos, iOS, watchOS, tvOS or visionOS)"""
-    os_ = conanfile.settings.get_safe("os")
-    return str(os_) in ['Macos', 'iOS', 'watchOS', 'tvOS', 'visionOS']
+    settings = conanfile.settings_build if build_context else conanfile.settings
+    return str(settings.get_safe("os")) in ['Macos', 'iOS', 'watchOS', 'tvOS', 'visionOS']
 
 
 def _to_apple_arch(arch, default=None):

--- a/conan/tools/meson/helpers.py
+++ b/conan/tools/meson/helpers.py
@@ -68,6 +68,17 @@ _cppstd_map = {
 }
 
 
+def get_apple_subsystem(apple_sdk):
+    return {
+        "iphoneos": "ios",
+        "iphonesimulator": "ios-simulator",
+        "appletvos": "tvos",
+        "appletvsimulator": "tvos-simulator",
+        "watchos": "watchos",
+        "watchsimulator": "watchos-simulator",
+    }.get(apple_sdk, "macos")
+
+
 def to_meson_machine(machine_os, machine_arch):
     """Gets the OS system info as the Meson machine context.
 

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -116,6 +116,21 @@ def test_apple_meson_cross_building_subsystem():
     cpu = 'armv8'
     endian = 'little'""")
     assert machines_settings in content
+    # Let's check that it does not appear if cross-compiling to other non-Apple-OS
+    cross = textwrap.dedent("""
+    [settings]
+    arch=armv8
+    build_type=Release
+    compiler=gcc
+    compiler.cppstd=gnu17
+    compiler.libcxx=libstdc++11
+    compiler.version=13
+    os=Linux
+    """)
+    t.save({"host": cross})
+    t.run("install . -pr:h host -pr:b build")
+    content = t.load(MesonToolchain.cross_filename)
+    assert "subsystem =" not in content
 
 
 def test_extra_flags_via_conf():

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -68,6 +68,56 @@ def test_apple_meson_keep_user_custom_flags():
     assert "cpp_link_args = ['-isysroot', '/other/sdk/path', '-arch', 'myarch', '-otherminversion=10.7', '-stdlib=libc++']" in content
 
 
+def test_apple_meson_cross_building_subsystem():
+    """
+    Issue related: https://github.com/conan-io/conan/issues/17873
+    """
+    default = textwrap.dedent("""
+    [settings]
+    os=Macos
+    arch=x86_64
+    compiler=apple-clang
+    compiler.version=12.0
+    compiler.libcxx=libc++
+    build_type=Release
+    """)
+    cross = textwrap.dedent("""
+    [settings]
+    os = iOS
+    os.version = 10.0
+    os.sdk = iphoneos
+    arch = armv8
+    compiler = apple-clang
+    compiler.version = 12.0
+    compiler.libcxx = libc++
+
+    [conf]
+    tools.apple:sdk_path=/my/sdk/path
+    """)
+    t = TestClient()
+    t.save({"conanfile.py": GenConanfile(name="app", version="1.0")
+                            .with_settings("os", "arch", "compiler", "build_type")
+                            .with_generator("MesonToolchain"),
+            "build": default,
+            "host": cross})
+    t.run("install . -pr:h host -pr:b build")
+    content = t.load(MesonToolchain.cross_filename)
+    machines_settings = textwrap.dedent("""\
+    [build_machine]
+    system = 'darwin'
+    subsystem = 'macos'
+    cpu_family = 'x86_64'
+    cpu = 'x86_64'
+    endian = 'little'
+    [host_machine]
+    system = 'darwin'
+    subsystem = 'ios'
+    cpu_family = 'aarch64'
+    cpu = 'armv8'
+    endian = 'little'""")
+    assert machines_settings in content
+
+
 def test_extra_flags_via_conf():
     profile = textwrap.dedent("""
         [settings]

--- a/test/unittests/tools/meson/test_meson.py
+++ b/test/unittests/tools/meson/test_meson.py
@@ -1,8 +1,11 @@
 import textwrap
 
+import pytest
+
 from conan.tools.meson import Meson
 from conan.internal.model.conf import ConfDefinition
 from conan.test.utils.mocks import ConanFileMock, MockSettings
+from conan.tools.meson.helpers import get_apple_subsystem
 
 
 def test_meson_build():
@@ -25,3 +28,16 @@ def test_meson_build():
     meson.build()
 
     assert '-j10' in str(conanfile.command)
+
+
+@pytest.mark.parametrize("apple_sdk, subsystem", [
+    ("iphoneos", "ios"),
+    ("iphonesimulator", "ios-simulator"),
+    ("appletvos", "tvos"),
+    ("appletvsimulator", "tvos-simulator"),
+    ("watchos", "watchos"),
+    ("watchsimulator", "watchos-simulator"),
+    (None, "macos")
+])
+def test_meson_subsystem_helper(apple_sdk, subsystem):
+    assert get_apple_subsystem(apple_sdk) == subsystem


### PR DESCRIPTION
Changelog: Feature: Added `subsystem` field in MesonToolchain if cross-compiling between Apple OSs.
Changelog: Feature: Added new kwarg `build_context`to `is_apple_os` helper function.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/17873


**Note**: This field is new since Meson >= 1.2.0, but I've checked with Meson == 0.57.0 and it does nothing. It's not a breaking change 😁 
