### PR TITLE
[regression] `untargz` fails extracting some folders

### DIFF
--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -371,7 +371,7 @@ def untargz(filename, destination=".", pattern=None, strip_root=False, extract_f
                 names = [member.name.replace("\\", "/") for member in members]
                 common_folder = os.path.commonprefix(names).split("/", 1)[0]
                 if not common_folder and len(names) > 1:
-                    raise ConanException("Can't untar a tgz containing files in the root with strip_root enabled")
+                    raise ConanException("The tgz file contains more than 1 folder in the root")
                 if len(names) == 1 and len(names[0].split("/", 1)) == 1:
                     raise ConanException("The tgz file contains a file in the root")
                 # Remove the directory entry if present

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -356,41 +356,37 @@ def unzip(conanfile, filename, destination=".", keep_permissions=False, pattern=
 def untargz(filename, destination=".", pattern=None, strip_root=False, extract_filter=None):
     # NOT EXPOSED at `conan.tools.files` but used in tests
     import tarfile
-    with FileProgress(filename, msg="Uncompressing") as fileobj, tarfile.TarFile.open(fileobj=fileobj, mode='r:*') as tarredgzippedFile:
+    with tarfile.TarFile.open(filename, mode='r:*') as tarredgzippedFile:
         f = getattr(tarfile, f"{extract_filter}_filter", None) if extract_filter else None
         tarredgzippedFile.extraction_filter = f or (lambda member_, _: member_)
         if not pattern and not strip_root:
-            # Simple case: extract everything
             tarredgzippedFile.extractall(destination)
         else:
-            # Read members one by one and process them
-            common_folder = None
-            for member in tarredgzippedFile:
-                if pattern and not fnmatch(member.name, pattern):
-                    continue  # Skip files that don’t match the pattern
+            members = tarredgzippedFile.getmembers()
 
-                if strip_root:
+            if pattern:
+                members = list(filter(lambda m: fnmatch(m.name, pattern),
+                                      tarredgzippedFile.getmembers()))
+            if strip_root:
+                names = [member.name.replace("\\", "/") for member in members]
+                common_folder = os.path.commonprefix(names).split("/", 1)[0]
+                if not common_folder and len(names) > 1:
+                    raise ConanException("The tgz file contains more than 1 folder in the root")
+                if len(names) == 1 and len(names[0].split("/", 1)) == 1:
+                    raise ConanException("The tgz file contains a file in the root")
+                # Remove the directory entry if present
+                members = [m for m in members if m.name != common_folder]
+                for member in members:
                     name = member.name.replace("\\", "/")
-                    if not common_folder:
-                        splits = name.split("/", 1)
-                        # First case for a plain folder in the root
-                        if member.isdir() or len(splits) > 1:
-                            common_folder = splits[0]  # Find the root folder
-                        else:
-                            raise ConanException("Can't untar a tgz containing files in the root with strip_root enabled")
-                    if not name.startswith(common_folder):
-                        raise ConanException("The tgz file contains more than 1 folder in the root")
-
-                    # Adjust the member's name for extraction
-                    member.name = name[len(common_folder) + 1:]
+                    member.name = name.split("/", 1)[1]
                     member.path = member.name
-                    if member.linkpath and member.linkpath.startswith(common_folder):
+                    if member.linkpath.startswith(common_folder):
                         # https://github.com/conan-io/conan/issues/11065
-                        member.linkpath = member.linkpath[len(common_folder) + 1:].replace("\\", "/")
+                        linkpath = member.linkpath.replace("\\", "/")
+                        member.linkpath = linkpath.split("/", 1)[1]
                         member.linkname = member.linkpath
-                # Extract file one by one, avoiding `extractall()` with members parameter:
-                # This will avoid a first whole file read resulting in a performant improvement around 25%
-                tarredgzippedFile.extract(member, path=destination)
+            tarredgzippedFile.extractall(destination, members=members)
+
 
 def check_sha1(conanfile, file_path, signature):
     """

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -371,7 +371,7 @@ def untargz(filename, destination=".", pattern=None, strip_root=False, extract_f
                 names = [member.name.replace("\\", "/") for member in members]
                 common_folder = os.path.commonprefix(names).split("/", 1)[0]
                 if not common_folder and len(names) > 1:
-                    raise ConanException("The tgz file contains more than 1 folder in the root")
+                    raise ConanException("Can't untar a tgz containing files in the root with strip_root enabled")
                 if len(names) == 1 and len(names[0].split("/", 1)) == 1:
                     raise ConanException("The tgz file contains a file in the root")
                 # Remove the directory entry if present

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -362,29 +362,32 @@ def untargz(filename, destination=".", pattern=None, strip_root=False, extract_f
         if not pattern and not strip_root:
             tarredgzippedFile.extractall(destination)
         else:
-            members = tarredgzippedFile.getmembers()
+            common_folder = None
+            members = []
+            for member in tarredgzippedFile:
+                if pattern and not fnmatch(member.name, pattern):
+                    continue  # Skip files that don’t match the pattern
 
-            if pattern:
-                members = list(filter(lambda m: fnmatch(m.name, pattern),
-                                      tarredgzippedFile.getmembers()))
-            if strip_root:
-                names = [member.name.replace("\\", "/") for member in members]
-                common_folder = os.path.commonprefix(names).split("/", 1)[0]
-                if not common_folder and len(names) > 1:
-                    raise ConanException("The tgz file contains more than 1 folder in the root")
-                if len(names) == 1 and len(names[0].split("/", 1)) == 1:
-                    raise ConanException("The tgz file contains a file in the root")
-                # Remove the directory entry if present
-                members = [m for m in members if m.name != common_folder]
-                for member in members:
+                if strip_root:
                     name = member.name.replace("\\", "/")
-                    member.name = name.split("/", 1)[1]
+                    if not common_folder:
+                        splits = name.split("/", 1)
+                        # First case for a plain folder in the root
+                        if member.isdir() or len(splits) > 1:
+                            common_folder = splits[0]  # Find the root folder
+                        else:
+                            raise ConanException("Can't untar a tgz containing files in the root with strip_root enabled")
+                    if not name.startswith(common_folder):
+                        raise ConanException("The tgz file contains more than 1 folder in the root")
+                    # Adjust the member's name for extraction
+                    member.name = name[len(common_folder) + 1:]
                     member.path = member.name
-                    if member.linkpath.startswith(common_folder):
+                    if member.linkpath and member.linkpath.startswith(common_folder):
                         # https://github.com/conan-io/conan/issues/11065
-                        linkpath = member.linkpath.replace("\\", "/")
-                        member.linkpath = linkpath.split("/", 1)[1]
+                        member.linkpath = member.linkpath[len(common_folder) + 1:].replace("\\", "/")
                         member.linkname = member.linkpath
+                # Let's gather each member
+                members.append(member)
             tarredgzippedFile.extractall(destination, members=members)
 
 

--- a/test/unittests/util/files/strip_root_extract_test.py
+++ b/test/unittests/util/files/strip_root_extract_test.py
@@ -255,7 +255,7 @@ class TarExtractPlainTest(unittest.TestCase):
 
         # Extract without the subfolder
         extract_folder = temp_folder()
-        with self.assertRaisesRegex(ConanException, "Can't untar a tgz containing files in the root with strip_root enabled"):
+        with self.assertRaisesRegex(ConanException, "The tgz file contains a file in the root"):
             unzip(ConanFileMock(), tgz_file, destination=extract_folder, strip_root=True)
 
     def test_invalid_flat_multiple_file(self):
@@ -270,5 +270,46 @@ class TarExtractPlainTest(unittest.TestCase):
 
         # Extract without the subfolder
         extract_folder = temp_folder()
-        with self.assertRaisesRegex(ConanException, "Can't untar a tgz containing files in the root with strip_root enabled"):
+        with self.assertRaisesRegex(ConanException, "The tgz file contains more than 1 folder in the root"):
             unzip(ConanFileMock(), tgz_file, destination=extract_folder, strip_root=True)
+
+
+def _compress_root_folder(folder, tgz_path, root_folder_name="root"):
+    """
+    Compress the whole folder adding withing the tar file also the folders. For instance:
+
+    $ tar -tf '/tmp/folder/file.tar.gz'
+    root/
+    root/parent/
+    root/parent/bin/
+    root/parent/bin/file1
+    root/parent/bin/file2
+    """
+    with open(tgz_path, "wb") as tgz_handle:
+        tgz = gzopen_without_timestamps("name", mode="w", fileobj=tgz_handle)
+        files, _ = gather_files(folder)
+        tgz.add(root_folder_name, arcname=os.path.basename(root_folder_name))
+        tgz.close()
+
+
+def test_decompressing_folders_with_different_modes():
+    """
+    When compressed folders come with restrictive permissions, untar() function should not
+    raise a PermissionError.
+
+    Issue related: https://github.com/conan-io/conan/issues/17987
+    """
+    tmp_folder = temp_folder()
+    tgz_folder = temp_folder()
+    tgz_file = os.path.join(tgz_folder, "file.tar.gz")
+    with chdir(tmp_folder):
+        save("root/parent/bin/file1", "contentsfile1")
+        save("root/parent/bin/file2", "contentsfile2")
+        os.chmod(os.path.join("root", "parent"), mode=0o555)
+        os.chmod(os.path.join("root", "parent", "bin"), mode=0o700)
+        _compress_root_folder(tmp_folder, tgz_file, root_folder_name="root")
+
+    # Tgz unzipped regularly
+    extract_folder = temp_folder()
+    # Do not raise any PermissionError
+    untargz(tgz_file, destination=extract_folder, strip_root=True)

--- a/test/unittests/util/files/strip_root_extract_test.py
+++ b/test/unittests/util/files/strip_root_extract_test.py
@@ -255,7 +255,7 @@ class TarExtractPlainTest(unittest.TestCase):
 
         # Extract without the subfolder
         extract_folder = temp_folder()
-        with self.assertRaisesRegex(ConanException, "The tgz file contains a file in the root"):
+        with self.assertRaisesRegex(ConanException, "Can't untar a tgz containing files in the root with strip_root enabled"):
             unzip(ConanFileMock(), tgz_file, destination=extract_folder, strip_root=True)
 
     def test_invalid_flat_multiple_file(self):
@@ -270,7 +270,7 @@ class TarExtractPlainTest(unittest.TestCase):
 
         # Extract without the subfolder
         extract_folder = temp_folder()
-        with self.assertRaisesRegex(ConanException, "The tgz file contains more than 1 folder in the root"):
+        with self.assertRaisesRegex(ConanException, "Can't untar a tgz containing files in the root with strip_root enabled"):
             unzip(ConanFileMock(), tgz_file, destination=extract_folder, strip_root=True)
 
 


### PR DESCRIPTION
Changelog: Bugfix: `untargz()` method was failing if directories had a more restrictive mode. 
Docs: omit
Closes: https://github.com/conan-io/conan/issues/17987

Now, it does not show the file percentage until we find a better solution for that:

**Python 3.12.3** (works as expected)

```
conanfile.py (test/1.0): Downloading 142.8MB x-tools-x86_64-bionic-linux-gnu-gcc14.tar.xz
conanfile.py (test/1.0): Unzipping x-tools-x86_64-bionic-linux-gnu-gcc14.tar.xz to /tmp/tmp52l7sgb4
```

The key part is here (from `tarfile.py`):

```python
class TarFile(object):
    # ....

    def extractall(self, path=".", members=None, *, numeric_owner=False,
                   filter=None):
        # ...
        for member in members:
            tarinfo = self._get_extract_tarinfo(member, filter_function, path)
            if tarinfo is None:
                continue
            if tarinfo.isdir():
                # For directories, delay setting attributes until later,
                # since permissions can interfere with extraction and
                # extracting contents can reset mtime.
                directories.append(tarinfo)
            self._extract_one(tarinfo, path, set_attrs=not tarinfo.isdir(),
                              numeric_owner=numeric_owner)

        # Do some stuff with directories
```
In a nutshell, it's not setting the attributes for those directories at that point, it's done later. It's not the same as it's done by the `extract()` method.
