### PR TITLE
fix msbuild commandline when executing msbuild from within autotools toolchain

### DIFF
--- a/conan/tools/microsoft/msbuild.py
+++ b/conan/tools/microsoft/msbuild.py
@@ -13,7 +13,7 @@ def msbuild_verbosity_cmd_line_arg(conanfile):
             "quiet": "Quiet",
             "verbose": "Detailed",
         }.get(verbosity)
-        return f'/verbosity:{verbosity}'
+        return f'-verbosity:{verbosity}'
     return ""
 
 
@@ -48,14 +48,14 @@ class MSBuild(object):
     def command(self, sln, targets=None):
         """
         Gets the ``msbuild`` command line. For instance,
-        :command:`msbuild "MyProject.sln" /p:Configuration=<conf> /p:Platform=<platform>`.
+        :command:`msbuild.exe "MyProject.sln" -p:Configuration=<conf> -p:Platform=<platform>`.
 
         :param sln: ``str`` name of Visual Studio ``*.sln`` file
         :param targets: ``targets`` is an optional argument, defaults to ``None``, and otherwise it is a list of targets to build
         :return: ``str`` msbuild command line.
         """
         # TODO: Enable output_binary_log via config
-        cmd = ('msbuild "%s" /p:Configuration="%s" /p:Platform=%s'
+        cmd = ('msbuild.exe "%s" -p:Configuration="%s" -p:Platform=%s'
                % (sln, self.build_type, self.platform))
 
         verbosity = msbuild_verbosity_cmd_line_arg(self._conanfile)
@@ -65,12 +65,12 @@ class MSBuild(object):
         maxcpucount = self._conanfile.conf.get("tools.microsoft.msbuild:max_cpu_count",
                                                check_type=int)
         if maxcpucount is not None:
-            cmd += f" /m:{maxcpucount}" if maxcpucount > 0 else " /m"
+            cmd += f" -m:{maxcpucount}" if maxcpucount > 0 else " -m"
 
         if targets:
             if not isinstance(targets, list):
                 raise ConanException("targets argument should be a list")
-            cmd += " /target:{}".format(";".join(targets))
+            cmd += " -target:{}".format(";".join(targets))
 
         return cmd
 

--- a/test/functional/toolchains/gnu/autotools/test_win_bash.py
+++ b/test/functional/toolchains/gnu/autotools/test_win_bash.py
@@ -1,5 +1,6 @@
 import platform
 import textwrap
+import os
 
 import pytest
 
@@ -149,3 +150,112 @@ def test_conf_inherited_in_test_package():
     client.run("create . -s:b os=Windows -s:h os=Windows")
     assert "are needed to run commands in a Windows subsystem" not in client.out
     assert "aclocal (GNU automake)" in client.out
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows")
+@pytest.mark.tool("msys2")
+def test_msys2_and_msbuild():
+    """ Check that msbuild can be executed in msys2 environment
+
+    # https://github.com/conan-io/conan/issues/15627
+    """
+    client = TestClient(path_with_spaces=False)
+    profile_win = textwrap.dedent(f"""
+        include(default)
+        [conf]
+        tools.microsoft.bash:subsystem=msys2
+        tools.microsoft.bash:path=bash
+        """)
+
+    main = gen_function_cpp(name="main")
+    # The autotools support for "cl" compiler (VS) is very limited, linking with deps doesn't
+    # work but building a simple app do
+    makefile_am = gen_makefile_am(main="main", main_srcs="main.cpp")
+    configure_ac = gen_configure_ac()
+
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.gnu import Autotools
+        from conan.tools.microsoft import MSBuild
+
+        class TestConan(ConanFile):
+            settings = "os", "compiler", "arch", "build_type"
+            exports_sources = "configure.ac", "Makefile.am", "main.cpp", "MyProject.vcxproj"
+            generators = "AutotoolsToolchain"
+            win_bash = True
+
+            def build(self):
+                # These commands will run in bash activating first the vcvars and
+                # then inside the bash activating the
+                self.run("aclocal")
+                self.run("autoconf")
+                self.run("automake --add-missing --foreign")
+                autotools = Autotools(self)
+                autotools.configure()
+                autotools.make()
+                autotools.install()
+                msbuild = MSBuild(self)
+                msbuild.build("MyProject.vcxproj")
+        """)
+
+    # A minimal project is sufficient - here just copy the application file to another directory
+    my_vcxproj = """<?xml version="1.0" encoding="utf-8"?>
+        <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+        <ItemGroup Label="ProjectConfigurations">
+        <ProjectConfiguration Include="Debug|Win32">
+          <Configuration>Debug</Configuration>
+          <Platform>Win32</Platform>
+        </ProjectConfiguration>
+        <ProjectConfiguration Include="Release|Win32">
+          <Configuration>Release</Configuration>
+          <Platform>Win32</Platform>
+        </ProjectConfiguration>
+        <ProjectConfiguration Include="Debug|x64">
+          <Configuration>Debug</Configuration>
+          <Platform>x64</Platform>
+        </ProjectConfiguration>
+        <ProjectConfiguration Include="Release|x64">
+          <Configuration>Release</Configuration>
+          <Platform>x64</Platform>
+        </ProjectConfiguration>
+      </ItemGroup>
+      <PropertyGroup Label="Globals">
+        <ProjectGuid>{B58316C0-C78A-4E9B-AE8F-5D6368CE3840}</ProjectGuid>
+        <Keyword>Win32Proj</Keyword>
+      </PropertyGroup>
+      <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+      <PropertyGroup>
+        <ConfigurationType>Application</ConfigurationType>
+        <PlatformToolset>v141</PlatformToolset>
+      </PropertyGroup>
+      <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+      <ImportGroup Label="PropertySheets">
+        <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+      </ImportGroup>
+      <PropertyGroup>
+        <OutDir>$(ProjectDir)msbuild_out</OutDir>
+      </PropertyGroup>
+      <ItemDefinitionGroup>
+      </ItemDefinitionGroup>
+      <ItemGroup>
+        <Content Include="$(ProjectDir)main.exe">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+      </ItemGroup>
+      <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+    </Project>
+    """
+
+    client.save({"conanfile.py": conanfile,
+                 "configure.ac": configure_ac,
+                 "Makefile.am": makefile_am,
+                 "main.cpp": main,
+                 "profile_win": profile_win,
+                 "MyProject.vcxproj": my_vcxproj})
+    client.run("build . -pr=profile_win")
+    # Run application in msbuild output directory
+    client.run_command(os.path.join("msbuild_out", "main.exe"))
+    check_exe_run(client.out, "main", "msvc", None, "Release", "x86_64", None)
+
+    bat_contents = client.load("conanbuild.bat")
+    assert "conanvcvars.bat" in bat_contents

--- a/test/functional/toolchains/microsoft/test_msbuild.py
+++ b/test/functional/toolchains/microsoft/test_msbuild.py
@@ -459,7 +459,7 @@ class TestWin:
         client.run(f"create . {settings_h} -c tools.microsoft.msbuild:vs_version={ide_version} -c tools.build:verbosity=verbose -c tools.compilation:verbosity=verbose")
 
         assert "MSBUILD : error MSB1001: Unknown switch" not in client.out
-        assert "/verbosity:Detailed" in client.out
+        assert "-verbosity:Detailed" in client.out
 
         # Prepare the actual consumer package
         client.save({"conanfile.py": self.conanfile,

--- a/test/integration/configuration/conf/test_conf_profile.py
+++ b/test/integration/configuration/conf/test_conf_profile.py
@@ -40,7 +40,7 @@ def test_cmake_no_config(client):
         """)
     client.save({"myprofile": profile})
     client.run("create . --name=pkg --version=0.1 -pr=myprofile")
-    assert "/verbosity" not in client.out
+    assert "-verbosity" not in client.out
 
 
 def test_cmake_config(client):
@@ -57,7 +57,7 @@ def test_cmake_config(client):
         """)
     client.save({"myprofile": profile})
     client.run("create . --name=pkg --version=0.1 -pr=myprofile")
-    assert "/verbosity:Quiet" in client.out
+    assert "-verbosity:Quiet" in client.out
 
 
 def test_cmake_config_error(client):
@@ -91,9 +91,9 @@ def test_cmake_config_package(client):
         """)
     client.save({"myprofile": profile})
     client.run("create . --name=pkg --version=0.1 -pr=myprofile")
-    assert "/verbosity" not in client.out
+    assert "-verbosity" not in client.out
     client.run("create . --name=dep --version=0.1 -pr=myprofile")
-    assert "/verbosity:Quiet" in client.out
+    assert "-verbosity:Quiet" in client.out
 
 
 def test_cmake_config_package_not_scoped(client):
@@ -110,9 +110,9 @@ def test_cmake_config_package_not_scoped(client):
         """)
     client.save({"myprofile": profile})
     client.run("create . --name=pkg --version=0.1 -pr=myprofile")
-    assert "/verbosity:Quiet" in client.out
+    assert "-verbosity:Quiet" in client.out
     client.run("create . --name=dep --version=0.1 -pr=myprofile")
-    assert "/verbosity:Quiet" in client.out
+    assert "-verbosity:Quiet" in client.out
 
 
 def test_config_profile_forbidden(client):
@@ -152,7 +152,7 @@ def test_msbuild_config():
         """)
     client.save({"myprofile": profile})
     client.run("create . --name=pkg --version=0.1 -pr=myprofile")
-    assert "/verbosity:Quiet" in client.out
+    assert "-verbosity:Quiet" in client.out
 
 
 def test_msbuild_compile_options():

--- a/test/unittests/tools/microsoft/test_msbuild.py
+++ b/test/unittests/tools/microsoft/test_msbuild.py
@@ -25,7 +25,7 @@ def test_msbuild_targets():
     msbuild = MSBuild(conanfile)
     cmd = msbuild.command('project.sln', targets=["static", "shared"])
 
-    assert '/target:static;shared' in cmd
+    assert '-target:static;shared' in cmd
 
 
 def test_msbuild_cpu_count():
@@ -40,12 +40,12 @@ def test_msbuild_cpu_count():
 
     msbuild = MSBuild(conanfile)
     cmd = msbuild.command('project.sln')
-    assert 'msbuild "project.sln" /p:Configuration="Release" /p:Platform=x64 /m:23' == cmd
+    assert 'msbuild.exe "project.sln" -p:Configuration="Release" -p:Platform=x64 -m:23' == cmd
 
     c.loads("tools.microsoft.msbuild:max_cpu_count=0")
     conanfile.conf = c.get_conanfile_conf(None)
     cmd = msbuild.command('project.sln')
-    assert 'msbuild "project.sln" /p:Configuration="Release" /p:Platform=x64 /m' == cmd
+    assert 'msbuild.exe "project.sln" -p:Configuration="Release" -p:Platform=x64 -m' == cmd
 
 
 def test_msbuild_toolset():


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Fixes: #15627 

Fixes msbuild commandline when executing msbuild from within autotools toolchain.
