### PR TITLE
Let backup selection remove `unknown` refs

### DIFF
--- a/conans/client/downloaders/download_cache.py
+++ b/conans/client/downloaders/download_cache.py
@@ -100,9 +100,10 @@ class DownloadCache:
                 raise ConanException(f"Missing metadata file for backup source {blob_path}")
             metadata = json.loads(load(metadata_path))
             refs = metadata["references"]
-            # unknown entries are not uploaded at this moment unless no package_list is passed
             for ref, urls in refs.items():
-                if not has_excluded_urls(urls) and (package_list is None or ref in all_refs):
+                if not has_excluded_urls(urls) and (not only_upload
+                                                    or package_list is None
+                                                    or ref in all_refs):
                     files_to_upload.append(metadata_path)
                     files_to_upload.append(blob_path)
                     break

--- a/test/integration/cache/backup_sources_test.py
+++ b/test/integration/cache/backup_sources_test.py
@@ -204,7 +204,6 @@ class TestDownloadCacheBackupSources:
         assert f"File {self.file_server.fake_url}/mycompanystorage/mycompanyfile.txt not found in {self.file_server.fake_url}/backups/" in self.client.out
 
     def test_unknown_handling(self):
-        http_server_base_folder_backups = os.path.join(self.file_server.store, "backups")
         http_server_base_folder_internet = os.path.join(self.file_server.store, "internet")
 
         save(os.path.join(http_server_base_folder_internet, "myfile.txt"), "Hello, world!")
@@ -232,12 +231,14 @@ class TestDownloadCacheBackupSources:
         contents = json.loads(load(json_path))
         assert "unknown" in contents["references"]
 
+        s_folder = os.path.join(self.download_cache_folder, "s")
+        assert len(os.listdir(s_folder)) == 2
+
         self.client.run("export .")
         self.client.run("upload * -c -r=default")
         assert "No backup sources files to upload" in self.client.out
 
         self.client.run("cache clean --backup-sources")
-        s_folder = os.path.join(self.download_cache_folder, "s")
         assert len(os.listdir(s_folder)) == 0
 
     def test_download_origin_first(self):


### PR DESCRIPTION
Changelog: Fix: Remove backup sources from unknown refs when calling `conan cache clean`.
Docs: Omit

Closes https://github.com/conan-io/conan/issues/17919

