### PR TITLE
fix global_conf composition with profiles

### DIFF
--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -610,18 +610,16 @@ class ConfDefinition:
         else:
             self._pattern_confs[pattern] = conf
 
-    def rebase_conf_definition(self, other):
+    def rebase_conf_definition(self, global_conf):
         """
         for taking the new global.conf and composing with the profile [conf]
-        :type other: ConfDefinition
+        :type global_conf: ConfDefinition
         """
-        for pattern, conf in other._pattern_confs.items():
-            new_conf = conf.filter_user_modules()  # Creates a copy, filtered
-            existing = self._pattern_confs.get(pattern)
-            if existing:
-                existing.compose_conf(new_conf)
-            else:
-                self._pattern_confs[pattern] = new_conf
+        result = ConfDefinition()
+        result._pattern_confs = global_conf._pattern_confs.copy()
+        result.update_conf_definition(self)
+        self._pattern_confs = result._pattern_confs
+        return
 
     def update(self, key, value, profile=False, method="define"):
         """

--- a/test/integration/graph/test_skip_build.py
+++ b/test/integration/graph/test_skip_build.py
@@ -1,3 +1,4 @@
+import re
 import textwrap
 
 from conan.test.assets.genconanfile import GenConanfile
@@ -46,3 +47,38 @@ def test_graph_skip_build_test():
     c.run("install app -c tools.graph:skip_build=True --build=pkg/*", assert_error=True)
     assert "ERROR: Package pkg/1.0 skipped its test/tool requires with tools.graph:skip_build, " \
            "but was marked to be built " in c.out
+
+
+def test_skip():
+    # https://github.com/conan-io/conan/issues/13439
+    c = TestClient()
+    global_conf = textwrap.dedent("""
+        tools.graph:skip_test=True
+        tools.build:skip_test=True
+        """)
+    c.save_home({"global.conf": global_conf})
+    c.save({"pkga/conanfile.py": GenConanfile("pkga", "1.0.0"),
+            "pkgb/conanfile.py": GenConanfile("pkgb", "1.0.0").with_test_requires("pkga/1.0.0"),
+            "pkgc/conanfile.py": GenConanfile("pkgc", "1.0.0").with_test_requires("pkgb/1.0.0")})
+    c.run("create pkga")
+    c.run("create pkgb")
+
+    # Always skipped
+    c.run("install pkgc")
+    # correct, pkga and pkgb are not in the output at all, they have been skipped
+    assert "pkga" not in c.out
+    assert "pkgb" not in c.out
+
+    # not skipping test-requires
+    c.run("install pkgc -c tools.graph:skip_test=False")
+    # correct, pkga and pkgb are not skipped now
+    assert "pkga" in c.out
+    assert "pkgb" in c.out
+    # but pkga binary is not really necessary
+    assert re.search(r"Skipped binaries(\s*)pkga/1.0.0", c.out)
+
+    # skipping all but the current one
+    c.run("install pkgc -c &:tools.graph:skip_test=False")
+    # correct, only pkga  is skipped now
+    assert "pkga" not in c.out
+    assert "pkgb" in c.out


### PR DESCRIPTION
Changelog: Bugfix: Fix ``global.conf`` precedence over profiles ``[conf]`` and order change of per-package pattern confs.
Docs: Omit

Close https://github.com/conan-io/conan/issues/13439
