### PR TITLE
Improve tools.chmod method description with pynumdoc

### DIFF
--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -283,7 +283,7 @@ def chmod(conanfile, path:str, read:bool=None, write:bool=None, execute:bool=Non
     read : Optional[bool], optional
         If ``True``, the file or directory will be given read permissions for owner user.
         If ``False``, the read permission will be removed.
-        If ``None``, the file or directory will not be changed.
+        If ``None``, the read permission will be left unchanged.
     write : Optional[bool], optional
         If ``True``, the file or directory will have write permissions for owner user.
         If ``False``, the file or directory will not have write permissions for owner user.

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -296,7 +296,7 @@ def chmod(conanfile, path:str, read:Optional[bool]=None, write:Optional[bool]=No
         If ``False``, the execution permission will be removed.
         If ``None``, the file or directory will not be changed.
         Defaults to None.
-    recursive : bool, optional
+    recursive : bool
         If ``True``, the permissions will be applied recursively to all files and directories
         inside the specified directory. If ``False``, only the specified file or directory will
         be changed. Defaults to False.

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -265,7 +265,7 @@ def chdir(conanfile, newdir):
         os.chdir(old_path)
 
 
-def chmod(conanfile, path:str, read:Optional[bool]=None, write:Optional[bool]=None, execute:Optional[bool]=None, recursive:Optional[bool]=False):
+def chmod(conanfile, path:str, read:Optional[bool]=None, write:Optional[bool]=None, execute:Optional[bool]=None, recursive:bool=False):
     """Change file or directory permissions cross-platform.
 
     .. versionadded:: 2.15

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -281,7 +281,7 @@ def chmod(conanfile, path:str, read:bool=None, write:bool=None, execute:bool=Non
     path : str
         Path to the file or directory whose permissions will be changed.
     read : Optional[bool], optional
-        If ``True``, the file or directory will have read permissions for owner user.
+        If ``True``, the file or directory will be given read permissions for owner user.
         If ``False``, the file or directory will not have read permissions for owner user.
         If ``None``, the file or directory will not be changed.
     write : Optional[bool], optional

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -279,7 +279,7 @@ def chmod(conanfile, path:str, read:bool=None, write:bool=None, execute:bool=Non
     conanfile : object
         The current recipe object. Always use ``self``.
     path : str
-        Path to the file or directory to change the permissions.
+        Path to the file or directory whose permissions will be changed.
     read : Optional[bool], optional
         If ``True``, the file or directory will have read permissions for owner user.
         If ``False``, the file or directory will not have read permissions for owner user.

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -282,7 +282,7 @@ def chmod(conanfile, path:str, read:bool=None, write:bool=None, execute:bool=Non
         Path to the file or directory whose permissions will be changed.
     read : Optional[bool], optional
         If ``True``, the file or directory will be given read permissions for owner user.
-        If ``False``, the file or directory will not have read permissions for owner user.
+        If ``False``, the read permission will be removed.
         If ``None``, the file or directory will not be changed.
     write : Optional[bool], optional
         If ``True``, the file or directory will have write permissions for owner user.

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -265,16 +265,49 @@ def chdir(conanfile, newdir):
 
 
 def chmod(conanfile, path:str, read:bool=None, write:bool=None, execute:bool=None, recursive:bool=False):
-    """
-    Change the permissions of a file or directory. The same as the Unix command chmod, but simplified.
+    """Change file or directory permissions cross-platform.
+
+    .. versionadded:: 2.15
+
+    This function is a simple wrapper around the chmod Unix command, but it is cross-platform supported.
+    It is indicated to use it instead of os.stat + os.chmod, as it only changes the permissions of the
+    directory or file for the owner and avoids issues with the umask.
     On Windows is limited to changing write permission only.
 
-    :param conanfile: The current recipe object. Always use ``self``.
-    :param path: Path to the file or directory to change the permissions.
-    :param read: If ``True``, the file or directory will have read permissions for owner user.
-    :param write: If ``True``, the file or directory will have write permissions for owner user.
-    :param execute: If ``True``, the file or directory will have execute permissions for owner user.
-    :param recursive: If ``True``, the permissions will be applied
+    Parameters
+    ----------
+    conanfile : object
+        The current recipe object. Always use ``self``.
+    path : str
+        Path to the file or directory to change the permissions.
+    read : Optional[bool], optional
+        If ``True``, the file or directory will have read permissions for owner user.
+        If ``False``, the file or directory will not have read permissions for owner user.
+        If ``None``, the file or directory will not be changed.
+    write : Optional[bool], optional
+        If ``True``, the file or directory will have write permissions for owner user.
+        If ``False``, the file or directory will not have write permissions for owner user.
+        If ``None``, the file or directory will not be changed.
+    execute : Optional[bool], optional
+        If ``True``, the file or directory will have execute permissions for owner user.
+        If ``False``, the file or directory will not have execute permissions for owner user.
+        If ``None``, the file or directory will not be changed.
+    recursive : bool, optional
+        If ``True``, the permissions will be applied recursively to all files and directories
+        inside the specified directory. If ``False``, only the specified file or directory will
+        be changed. Defaults to False.
+
+    Returns
+    -------
+    None
+
+    Examples
+    --------
+    .. code-block:: python
+        :caption: Add execution permission to a packaged bash script
+
+        from conan.tools.files import chmod
+        chmod(self, os.path.join(self.package_folder, "bin", "script.sh"), execute=True)
     """
     if read is None and write is None and execute is None:
         raise ConanException("Could not change permission: At least one of the permissions should be set.")

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -4,6 +4,7 @@ import stat
 import platform
 import shutil
 import subprocess
+from typing import Optional
 from contextlib import contextmanager
 from fnmatch import fnmatch
 from shutil import which
@@ -264,7 +265,7 @@ def chdir(conanfile, newdir):
         os.chdir(old_path)
 
 
-def chmod(conanfile, path:str, read:bool=None, write:bool=None, execute:bool=None, recursive:bool=False):
+def chmod(conanfile, path:str, read:Optional[bool]=None, write:Optional[bool]=None, execute:Optional[bool]=None, recursive:Optional[bool]=False):
     """Change file or directory permissions cross-platform.
 
     .. versionadded:: 2.15
@@ -280,18 +281,21 @@ def chmod(conanfile, path:str, read:bool=None, write:bool=None, execute:bool=Non
         The current recipe object. Always use ``self``.
     path : str
         Path to the file or directory whose permissions will be changed.
-    read : Optional[bool], optional
+    read : bool, optional
         If ``True``, the file or directory will be given read permissions for owner user.
         If ``False``, the read permission will be removed.
         If ``None``, the read permission will be left unchanged.
-    write : Optional[bool], optional
-        If ``True``, the file or directory will have write permissions for owner user.
-        If ``False``, the file or directory will not have write permissions for owner user.
+        Defaults to None.
+    write : bool, optional
+        If ``True``, the file or directory will be given write permissions for owner user.
+        If ``False``, the write permission will be removed.
         If ``None``, the file or directory will not be changed.
-    execute : Optional[bool], optional
-        If ``True``, the file or directory will have execute permissions for owner user.
-        If ``False``, the file or directory will not have execute permissions for owner user.
+        Defaults to None.
+    execute : bool, optional
+        If ``True``, the file or directory will be given execute permissions for owner user.
+        If ``False``, the execution permission will be removed.
         If ``None``, the file or directory will not be changed.
+        Defaults to None.
     recursive : bool, optional
         If ``True``, the permissions will be applied recursively to all files and directories
         inside the specified directory. If ``False``, only the specified file or directory will


### PR DESCRIPTION
This PR is a follow-up of the previous https://github.com/conan-io/conan/pull/17800, by updating only its docstring, following [numpydoc format](https://numpydoc.readthedocs.io/en/latest/format.html), which can be forwarded to the Conan docs without extra effort there.

The idea comes from https://github.com/conan-io/docs/pull/4038#issuecomment-2761151858

Changelog: Omit
Docs: Omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
