### PR TITLE
Fix runners after refactor on #17961

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -96,9 +96,6 @@ jobs:
   linux_docker_tests:
     needs: build_container
     runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/${{ github.repository_owner }}/conan-tests:${{ needs.build_container.outputs.image_tag }}
-      options: --user conan
     strategy:
       matrix:
         # Use modern versions due to docker incompatibility with python <3.8

--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -107,9 +107,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        run: |
-          pyenv global ${{ matrix.python-version }}
-          python --version
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
 
       - name: Cache pip
         uses: actions/cache@v4

--- a/conan/api/subapi/command.py
+++ b/conan/api/subapi/command.py
@@ -59,4 +59,4 @@ class CommandAPI:
             except KeyError:
                 raise ConanException(f"Invalid runner type '{runner_type}'. "
                                      f"Allowed values: {', '.join(runner_instances_map.keys())}")
-            return runner_instance(profile_host.runner)
+            return runner_instance

--- a/test/functional/command/runner_test.py
+++ b/test/functional/command/runner_test.py
@@ -7,7 +7,7 @@ from conan.test.assets.cmake import gen_cmakelists
 from conan.test.assets.sources import gen_function_h, gen_function_cpp
 
 
-def docker_skip(test_image=None):
+def docker_skip(test_image='ubuntu:24.04'):
     try:
         try:
             docker_client = docker.from_env()
@@ -37,7 +37,7 @@ def dockerfile_path(name=None):
 
 
 @pytest.mark.docker_runner
-@pytest.mark.skipif(docker_skip('ubuntu:22.04'), reason="Only docker running")
+@pytest.mark.skipif(docker_skip(), reason="Only docker running")
 def test_create_docker_runner_cache_shared():
     """
     Tests the ``conan create . ``
@@ -81,7 +81,7 @@ def test_create_docker_runner_cache_shared():
 
 
 @pytest.mark.docker_runner
-@pytest.mark.skipif(docker_skip('ubuntu:22.04'), reason="Only docker running")
+@pytest.mark.skipif(docker_skip(), reason="Only docker running")
 def test_create_docker_runner_cache_shared_profile_from_cache():
     """
     Tests the ``conan create . ``
@@ -125,7 +125,7 @@ def test_create_docker_runner_cache_shared_profile_from_cache():
 
 
 @pytest.mark.docker_runner
-@pytest.mark.skipif(docker_skip('ubuntu:22.04'), reason="Only docker running")
+@pytest.mark.skipif(docker_skip(), reason="Only docker running")
 def test_create_docker_runner_cache_shared_profile_folder():
     """
     Tests the ``conan create . ``
@@ -169,7 +169,7 @@ def test_create_docker_runner_cache_shared_profile_folder():
     assert "Removing container" in client.out
 
 @pytest.mark.docker_runner
-@pytest.mark.skipif(docker_skip('ubuntu:22.04'), reason="Only docker running")
+@pytest.mark.skipif(docker_skip(), reason="Only docker running")
 def test_create_docker_runner_dockerfile_folder_path():
     """
     Tests the ``conan create . ``
@@ -240,7 +240,7 @@ def test_create_docker_runner_dockerfile_folder_path():
 
 
 @pytest.mark.docker_runner
-@pytest.mark.skipif(docker_skip('ubuntu:22.04'), reason="Only docker running")
+@pytest.mark.skipif(docker_skip(), reason="Only docker running")
 def test_create_docker_runner_profile_default_folder():
     """
     Tests the ``conan create . ``
@@ -286,7 +286,7 @@ def test_create_docker_runner_profile_default_folder():
 
 
 @pytest.mark.docker_runner
-@pytest.mark.skipif(docker_skip('ubuntu:22.04'), reason="Only docker running")
+@pytest.mark.skipif(docker_skip(), reason="Only docker running")
 def test_create_docker_runner_dockerfile_file_path():
     """
     Tests the ``conan create . ``
@@ -331,7 +331,7 @@ def test_create_docker_runner_dockerfile_file_path():
 
 
 @pytest.mark.docker_runner
-@pytest.mark.skipif(docker_skip('ubuntu:22.04'), reason="Only docker running")
+@pytest.mark.skipif(docker_skip(), reason="Only docker running")
 @pytest.mark.parametrize("build_type,shared", [("Release", False), ("Debug", True)])
 def test_create_docker_runner_with_ninja(build_type, shared):
     conanfile = textwrap.dedent("""
@@ -396,7 +396,7 @@ def test_create_docker_runner_with_ninja(build_type, shared):
     assert "main: {}!".format(build_type) in client.out
 
 @pytest.mark.docker_runner
-@pytest.mark.skipif(docker_skip('ubuntu:22.04'), reason="Only docker running")
+@pytest.mark.skipif(docker_skip(), reason="Only docker running")
 def test_create_docker_runner_from_configfile():
     """
     Tests the ``conan create . ``
@@ -451,7 +451,7 @@ def test_create_docker_runner_from_configfile():
 
 
 @pytest.mark.docker_runner
-@pytest.mark.skipif(docker_skip('ubuntu:22.04'), reason="Only docker running")
+@pytest.mark.skipif(docker_skip(), reason="Only docker running")
 def test_create_docker_runner_from_configfile_with_args():
     """
     Tests the ``conan create . ``
@@ -515,7 +515,7 @@ def test_create_docker_runner_from_configfile_with_args():
     docker_client.networks.get("my-network").remove()
 
 @pytest.mark.docker_runner
-@pytest.mark.skipif(docker_skip('ubuntu:22.04'), reason="Only docker running")
+@pytest.mark.skipif(docker_skip(), reason="Only docker running")
 def test_create_docker_runner_default_build_profile():
     """
     Tests the ``conan create . ``
@@ -552,7 +552,7 @@ def test_create_docker_runner_default_build_profile():
 
 
 @pytest.mark.docker_runner
-@pytest.mark.skipif(docker_skip('ubuntu:22.04'), reason="Only docker running")
+@pytest.mark.skipif(docker_skip(), reason="Only docker running")
 def test_create_docker_runner_in_subfolder():
     client = TestClient()
     conanfile = textwrap.dedent("""

--- a/test/functional/command/runner_test.py
+++ b/test/functional/command/runner_test.py
@@ -7,7 +7,7 @@ from conan.test.assets.cmake import gen_cmakelists
 from conan.test.assets.sources import gen_function_h, gen_function_cpp
 
 
-def docker_skip(test_image='ubuntu:24.04'):
+def docker_skip(test_image='ubuntu:22.04'):
     try:
         try:
             docker_client = docker.from_env()


### PR DESCRIPTION
Changelog: omit
Docs: omit


This PR fixes two issues related with conan runners:

1. An error introduced in #17961 where an invalid runner instance were being returned instead of a runner class

2. Make runner tests run again in GitHub actions. This PR https://github.com/conan-io/conan/pull/17839 forced the github job to use a custom docker image instead which does not have enabled docker in docker feature, making pytest to skip all the conan runner tests 