### PR TITLE
[wip] pass -rpath-link via CMakeToolchain

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -270,6 +270,28 @@ class ArchitectureBlock(Block):
                 "thread_flags_list": thread_flags_list}
 
 
+class RpathLinkFlagsBlock(Block):
+    # TODO: should do this only on Linux, or toggled by an opt-in conf
+    template = textwrap.dedent("""\
+        # Pass -rpath-link pointing to all directories with runtime libraries
+        {% if rpath_link_flags %}
+        string(APPEND CONAN_EXE_LINKER_FLAGS " {{ rpath_link_flags }}")
+        string(APPEND CONAN_SHARED_LINKER_FLAGS " {{ rpath_link_flags }}")
+        {% endif %}
+        """)
+    
+    def context(self):
+
+        runtime_dirs = []
+        host_req = self._conanfile.dependencies.filter({"build": False}).values()
+        for req in host_req:
+            cppinfo = req.cpp_info.aggregated_components()
+            runtime_dirs.extend(cppinfo.libdirs)
+
+        rpath_link_flags = "-Wl,-rpath-link=" + ":".join(runtime_dirs) if runtime_dirs else None
+        return {"rpath_link_flags": rpath_link_flags}
+    
+
 class LinkerScriptsBlock(Block):
     template = textwrap.dedent("""\
         # Add linker flags from tools.build:linker_scripts conf

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -14,7 +14,7 @@ from conan.tools.cmake.toolchain.blocks import ExtraVariablesBlock, ToolchainBlo
     AndroidSystemBlock, AppleSystemBlock, FPicBlock, ArchitectureBlock, GLibCXXBlock, VSRuntimeBlock, \
     CppStdBlock, ParallelBlock, CMakeFlagsInitBlock, TryCompileBlock, FindFiles, PkgConfigBlock, \
     SkipRPath, SharedLibBock, OutputDirsBlock, ExtraFlagsBlock, CompilersBlock, LinkerScriptsBlock, \
-    VSDebuggerEnvironment, VariablesBlock, PreprocessorBlock
+    VSDebuggerEnvironment, VariablesBlock, PreprocessorBlock, RpathLinkFlagsBlock
 from conan.tools.cmake.utils import is_multi_configuration
 from conan.tools.env import VirtualBuildEnv, VirtualRunEnv
 from conan.tools.intel import IntelCC
@@ -104,6 +104,7 @@ class CMakeToolchain:
                                        ("fpic", FPicBlock),
                                        ("arch_flags", ArchitectureBlock),
                                        ("linker_scripts", LinkerScriptsBlock),
+                                       ("rpath_link_flags", RpathLinkFlagsBlock),
                                        ("libcxx", GLibCXXBlock),
                                        ("vs_runtime", VSRuntimeBlock),
                                        ("vs_debugger_environment", VSDebuggerEnvironment),


### PR DESCRIPTION
CMake itself tries to pass `-rpath` (and `-rpath-link`) to the linker (via the compiler). However we know this is not sufficient in _some_ scenarios:

* In legacy CMakeDeps, in some cases CMake does not have enough information to derive the correct -rpath-link, and it fails - mostly when cross-compiling in the presence of a sysroot. Conan knows all the directories in the host context that may contain runtime libraries, so we can pass `-rpath-link` globally for the entire build. This would solve problems such as this https://github.com/conan-io/conan-center-index/pull/25195 - which are recurrent in Conan Center, not that even with the new CMakeDeps, there are corner cases
* When *not* cross-building, but when having a `--sysroot`, CMake only passes `-rpath` (even correctly, pointing to the directories in the Conan cache) - but in the presence of a sysroot the linker will re-root them in a way that it won't find them inside the sysroot (and fail) 
* Some recipes in Conan Center have one of the following hacks sometimes when the linker cannot find indirect runtime dependencies:

Either:
A)
```
        if self.settings.os == "Linux":
            # Workaround for: https://github.com/conan-io/conan/issues/13560
            libdirs_host = [l for dependency in self.dependencies.host.values() for l in dependency.cpp_info.aggregated_components().libdirs]
            tc.variables["CMAKE_BUILD_RPATH"] = ";".join(libdirs_host)
```

or
B) 
```
        if not cross_building(self):
            vrenv = VirtualRunEnv(self)
            vrenv.generate(scope="build")
```


A) does not work when we are crossbuilding and we have a sysroot (because the linker reroots them)
B) does not work when crossbuilding (so the recipe may build fine when doing a native build due to this workaround, but wont fully support crossbuilding when using shared libraries), but even when *not* crossbuilding, it wont work if using a sysroot, or using a toolchain for a separate distro (think `poco` where os=Linux and arch=x86_64).  It also introduces risks of runtime clashes when the libraries for the _host_ are picked up by executables that run at build time.


Passing `-rpath-link` via the toolchain would remove the need for workarounds and mitigate all of the cases above, including the corner cases where Conan + (new) CMakeDeps + CMake cannot correctly derive that `-rpath-link` is needed.


WIP: still needs tests and probably a flag to control behaviour