### PR TITLE
fix x86 CMAKE_SYSTEM_PROCESSOR definition

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -1015,8 +1015,7 @@ class GenericSystemBlock(Block):
                 return "Generic-ELF"
             return cmake_system_name_map.get(os_host, os_host)
         elif arch_host is not None and arch_host != arch_build:
-            if not ((arch_build == "x86_64") and (arch_host == "x86") or
-                    (arch_build == "sparcv9") and (arch_host == "sparc") or
+            if not ((arch_build == "sparcv9") and (arch_host == "sparc") or
                     (arch_build == "ppc64") and (arch_host == "ppc32")):
                 return cmake_system_name_map.get(os_host, os_host)
 

--- a/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1237,11 +1237,11 @@ def test_find_program_for_tool_requires(single_profile):
     """)
 
     client.save({"conanfile.py": conanfile,
-                "libfoo.so": "",
-                "foobin": "",
-                "host_profile": host_profile,
-                "build_profile": build_profile
-                })
+                 "libfoo.so": "",
+                 "foobin": "",
+                 "host_profile": host_profile,
+                 "build_profile": build_profile
+                 })
 
     client.run("create . -pr:b build_profile -pr:h build_profile")
     build_context_package_folder = re.search(r"Package folder ([\w\W]+).conan2([\w\W]+)", str(client.out)).group(2).strip()
@@ -2006,7 +2006,7 @@ def test_cmake_toolchain_crossbuild_set_cmake_compiler():
 
     c.save({"android": android,
             "conanfile.py": conanfile,
-            "CMakeLists.txt": cmake,})
+            "CMakeLists.txt": cmake})
     # first run works ok
     c.run('build . --profile:host=android')
     assert 'sdk: 1.0.0' in c.out
@@ -2070,6 +2070,7 @@ def test_msvc_x86():
     conanfile = textwrap.dedent("""
         from conan import ConanFile
         from conan.tools.cmake import CMake, cmake_layout
+        from conan.tools.build import cross_building
 
         class Recipe(ConanFile):
             name = "cmake_test"
@@ -2081,6 +2082,7 @@ def test_msvc_x86():
                 cmake_layout(self)
 
             def build(self):
+                self.output.info(f"IS CROSS_BUILD: {cross_building(self)}")
                 cmake = CMake(self)
                 cmake.configure()
         """)
@@ -2089,12 +2091,15 @@ def test_msvc_x86():
         project(foo LANGUAGES NONE)
         message(STATUS "CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
         message(STATUS "CMAKE_SYSTEM_PROCESSOR: ${CMAKE_SYSTEM_PROCESSOR}")
+        message(STATUS "CMAKE_CROSSCOMPILING: ${CMAKE_CROSSCOMPILING}")
         """)
     c.save({"conanfile.py": conanfile,
             "CMakeLists.txt": cmake})
     c.run("build . -s arch=x86")
+    assert "conanfile.py (cmake_test/1.0): IS CROSS_BUILD: True" in c.out
     assert "CMAKE_SYSTEM_NAME: Windows" in c.out
     assert "CMAKE_SYSTEM_PROCESSOR: x86" in c.out
+    assert "CMAKE_CROSSCOMPILING: TRUE" in c.out
     toolchain = c.load("build/generators/conan_toolchain.cmake")
     assert "set(CMAKE_SYSTEM_NAME Windows)" in toolchain
     assert "set(CMAKE_SYSTEM_PROCESSOR x86)" in toolchain

--- a/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -2085,17 +2085,31 @@ def test_msvc_x86():
                 self.output.info(f"IS CROSS_BUILD: {cross_building(self)}")
                 cmake = CMake(self)
                 cmake.configure()
+                cmake.build()
         """)
     cmake = textwrap.dedent("""
         cmake_minimum_required(VERSION 3.15)
-        project(foo LANGUAGES NONE)
+        project(foo LANGUAGES CXX)
+
         message(STATUS "CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
         message(STATUS "CMAKE_SYSTEM_PROCESSOR: ${CMAKE_SYSTEM_PROCESSOR}")
         message(STATUS "CMAKE_CROSSCOMPILING: ${CMAKE_CROSSCOMPILING}")
+
+        add_executable(mytool main.cpp)
+        add_custom_command(TARGET mytool POST_BUILD COMMAND $<TARGET_FILE:mytool>)
+        """)
+    main = textwrap.dedent("""
+        #include<iostream>
+        int main() {
+           std::cout << \"Running tool!!!";
+           return 0;
+        }
         """)
     c.save({"conanfile.py": conanfile,
-            "CMakeLists.txt": cmake})
+            "CMakeLists.txt": cmake,
+            "main.cpp": main})
     c.run("build . -s arch=x86")
+    assert "Running tool!!!" in c.out
     assert "conanfile.py (cmake_test/1.0): IS CROSS_BUILD: True" in c.out
     assert "CMAKE_SYSTEM_NAME: Windows" in c.out
     assert "CMAKE_SYSTEM_PROCESSOR: x86" in c.out

--- a/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -2060,3 +2060,41 @@ def test_cmake_toolchain_language_c():
     else:
         client.run("build . -s compiler.cppstd=11")
         # It doesn't fail
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="MSVC only")
+@pytest.mark.tool("cmake")
+def test_msvc_x86():
+    # https://github.com/conan-io/conan/issues/18074
+    c = TestClient()
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.cmake import CMake, cmake_layout
+
+        class Recipe(ConanFile):
+            name = "cmake_test"
+            version = "1.0"
+            settings = "os", "build_type", "compiler", "arch"
+            generators = "CMakeToolchain"
+
+            def layout(self):
+                cmake_layout(self)
+
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+        """)
+    cmake = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.15)
+        project(foo LANGUAGES NONE)
+        message(STATUS "CMAKE_SYSTEM_NAME: ${CMAKE_SYSTEM_NAME}")
+        message(STATUS "CMAKE_SYSTEM_PROCESSOR: ${CMAKE_SYSTEM_PROCESSOR}")
+        """)
+    c.save({"conanfile.py": conanfile,
+            "CMakeLists.txt": cmake})
+    c.run("build . -s arch=x86")
+    assert "CMAKE_SYSTEM_NAME: Windows" in c.out
+    assert "CMAKE_SYSTEM_PROCESSOR: x86" in c.out
+    toolchain = c.load("build/generators/conan_toolchain.cmake")
+    assert "set(CMAKE_SYSTEM_NAME Windows)" in toolchain
+    assert "set(CMAKE_SYSTEM_PROCESSOR x86)" in toolchain

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -264,8 +264,8 @@ def test_no_cross_build_arch():
     client.run("install . --profile:build=linux64 --profile:host=linux32")
     toolchain = client.load("conan_toolchain.cmake")
 
-    assert "CMAKE_SYSTEM_NAME" not in toolchain
-    assert "CMAKE_SYSTEM_PROCESSOR " not in toolchain
+    assert "set(CMAKE_SYSTEM_NAME Linux)" in toolchain
+    assert "set(CMAKE_SYSTEM_PROCESSOR x86)" in toolchain
 
 
 def test_cross_build_conf():


### PR DESCRIPTION
Changelog: Bugfix: CMAKE_SYSTEM_PROCESSOR should be x86 when ``arch=x86`` in ``x86_64`` systems
Docs: Omit


Close https://github.com/conan-io/docs/issues/4061