### PR TITLE
fix MSBuildDeps docstring

### DIFF
--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -94,9 +94,10 @@ class MSBuildDeps:
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
         """
         self._conanfile = conanfile
-        #: Defines the build type. By default, ``settings.build_type``.
+        #: Defines the build type. By default, the value of ``settings.build_type``.
         self.configuration = conanfile.settings.build_type
-        #: Defines the configuration key used to conditionate on which property sheet to import.
+        #: Defines the configuration key used to conditionally select which property sheet to
+        #: import (defaults to ``"Configuration"``).
         self.configuration_key = "Configuration"
         # TODO: This platform is not exactly the same as ``msbuild_arch``, because it differs
         # in x86=>Win32
@@ -105,7 +106,8 @@ class MSBuildDeps:
                          'x86_64': 'x64',
                          'armv7': 'ARM',
                          'armv8': 'ARM64'}.get(str(conanfile.settings.arch))
-        #: Defines the platform key used to conditionate on which property sheet to import.
+        #: Defines the platform key used to conditionally select which property sheet to
+        #: import (defaults to ``"Platform"``).
         self.platform_key = "Platform"
         ca_exclude = "tools.microsoft.msbuilddeps:exclude_code_analysis"
         #: List of packages names patterns to add Visual Studio ``CAExcludePath`` property


### PR DESCRIPTION
Changelog: Feature: Document publicly the ``MSBuildDeps.platform`` attribute to allow customization for wix projects needing ``x86`` value.
Docs: https://github.com/conan-io/docs/pull/4050

For https://github.com/conan-io/conan/issues/18063