### PR TITLE
apply apple configs to Autotools/Gnu/Meson toolchains

### DIFF
--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -328,3 +328,28 @@ def fix_apple_shared_install_name(conanfile):
     # there is nothing to do.
     if substitutions:
         _fix_executables(conanfile, substitutions)
+
+
+def apple_extra_flags(conanfile):
+    if not is_apple_os(conanfile):
+        return []
+    enable_bitcode = conanfile.conf.get("tools.apple:enable_bitcode", check_type=bool)
+    enable_arc = conanfile.conf.get("tools.apple:enable_arc", check_type=bool)
+    enable_visibility = conanfile.conf.get("tools.apple:enable_visibility", check_type=bool)
+    is_debug = conanfile.settings.get_safe('build_type') == "Debug"
+
+    flags = []
+    if enable_bitcode:
+        if is_debug:
+            flags.append("-fembed-bitcode-marker")
+        else:
+            flags.append("-fembed-bitcode")
+    if enable_arc:
+        flags.append("-fobjc-arc")
+    if enable_arc is False:
+        flags.append("-fno-objc-arc")
+    if enable_visibility:
+        flags.append("-fvisibility=default")
+    if enable_visibility is False:
+        flags.extend(["-fvisibility=hidden", "-fvisibility-inlines-hidden"])
+    return flags

--- a/conan/tools/gnu/gnutoolchain.py
+++ b/conan/tools/gnu/gnutoolchain.py
@@ -2,7 +2,7 @@ import os
 
 from conan.internal import check_duplicated_generator
 from conan.internal.internal_tools import raise_on_universal_arch
-from conan.tools.apple.apple import is_apple_os, resolve_apple_flags
+from conan.tools.apple.apple import is_apple_os, resolve_apple_flags, apple_extra_flags
 from conan.tools.build import cmd_args_to_string, save_toolchain_args
 from conan.tools.build.cross_building import cross_building
 from conan.tools.build.flags import architecture_flag, build_type_flags, cppstd_flag, \
@@ -104,6 +104,7 @@ class GnuToolchain:
         # -isysroot makes all includes for your library relative to the build directory
         self.apple_isysroot_flag = isysroot_flag
         self.apple_min_version_flag = min_flag
+        self.apple_extra_flags = apple_extra_flags(conanfile)
         # Default initial environment flags
         self._initialize_default_extra_env()
 
@@ -245,6 +246,7 @@ class GnuToolchain:
         ret = [self.libcxx, self.cppstd, self.arch_flag, fpic, self.msvc_runtime_flag,
                self.sysroot_flag]
         apple_flags = [self.apple_isysroot_flag, self.apple_arch_flag, self.apple_min_version_flag]
+        apple_flags += self.apple_extra_flags
         conf_flags = self._conanfile.conf.get("tools.build:cxxflags", default=[], check_type=list)
         vs_flag = self._add_msvc_flags(self.extra_cxxflags)
         ret = ret + self.build_type_flags + apple_flags + self.extra_cxxflags + vs_flag + conf_flags
@@ -255,6 +257,7 @@ class GnuToolchain:
         fpic = "-fPIC" if self.fpic else None
         ret = [self.arch_flag, fpic, self.msvc_runtime_flag, self.sysroot_flag]
         apple_flags = [self.apple_isysroot_flag, self.apple_arch_flag, self.apple_min_version_flag]
+        apple_flags += self.apple_extra_flags
         conf_flags = self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
         vs_flag = self._add_msvc_flags(self.extra_cflags)
         ret = ret + self.build_type_flags + apple_flags + self.extra_cflags + vs_flag + conf_flags
@@ -264,6 +267,7 @@ class GnuToolchain:
     def ldflags(self):
         ret = [self.arch_flag, self.sysroot_flag]
         apple_flags = [self.apple_isysroot_flag, self.apple_arch_flag, self.apple_min_version_flag]
+        apple_flags += self.apple_extra_flags
         conf_flags = self._conanfile.conf.get("tools.build:sharedlinkflags", default=[],
                                               check_type=list)
         conf_flags.extend(self._conanfile.conf.get("tools.build:exelinkflags", default=[],

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -7,7 +7,7 @@ from conan.errors import ConanException
 from conan.internal import check_duplicated_generator
 from conan.internal.internal_tools import raise_on_universal_arch
 from conan.tools.apple.apple import is_apple_os, apple_min_version_flag, \
-    resolve_apple_flags
+    resolve_apple_flags, apple_extra_flags
 from conan.tools.build.cross_building import cross_building
 from conan.tools.build.flags import libcxx_flags, architecture_flag
 from conan.tools.env import VirtualBuildEnv
@@ -338,6 +338,8 @@ class MesonToolchain:
         self.apple_isysroot_flag = []
         #: Apple minimum binary version flag as a list, e.g., ``["-mios-version-min", "10.8"]``
         self.apple_min_version_flag = []
+        #: Apple bitcode, visibility and arc flags
+        self.apple_extra_flags = apple_extra_flags(self._conanfile)
         #: Defines the Meson ``objc`` variable. Defaulted to ``None``, if if any Apple OS ``clang``
         self.objc = None
         #: Defines the Meson ``objcpp`` variable. Defaulted to ``None``, if if any Apple OS ``clang++``
@@ -443,6 +445,10 @@ class MesonToolchain:
         defines = self._conanfile_conf.get("tools.build:defines", default=[], check_type=list)
         sys_root = [f"--sysroot={self._sys_root}"] if self._sys_root else [""]
         ld = sharedlinkflags + exelinkflags + linker_script_flags + sys_root + self.extra_ldflags
+        # Apple extra flags from confs (visibilty, bitcode, arc)
+        cxxflags += self.apple_extra_flags
+        cflags += self.apple_extra_flags
+        ld += self.apple_extra_flags
         return {
             "cxxflags": [self.arch_flag] + cxxflags + sys_root + self.extra_cxxflags,
             "cflags": [self.arch_flag] + cflags + sys_root + self.extra_cflags,


### PR DESCRIPTION
Changelog: Bugfix: Apply Apple ``bitcode``, ``visibility`` and ``arc`` confs to ``Autootools/Gnu/Meson Toolchains``
Docs: Omit

Supersedes https://github.com/conan-io/conan/pull/15027
Close https://github.com/conan-io/conan/issues/12197