### PR TITLE
adding build_args for conan graph build-order with editables

### DIFF
--- a/conans/client/graph/install_graph.py
+++ b/conans/client/graph/install_graph.py
@@ -290,7 +290,7 @@ class _InstallConfiguration:
                     self.depends.append(dep.dst.pref)
 
     def _build_args(self):
-        if self.binary != BINARY_BUILD:
+        if self.binary not in (BINARY_BUILD, BINARY_EDITABLE_BUILD):
             return None
         cmd = f"--requires={self.ref}" if self.context == "host" else f"--tool-requires={self.ref}"
         compatible = "compatible:" if self.info and self.info.get("compatibility_delta") else ""

--- a/conans/client/graph/install_graph.py
+++ b/conans/client/graph/install_graph.py
@@ -66,7 +66,7 @@ class _InstallPackageReference:
         self.nodes.append(node)
 
     def _build_args(self):
-        if self.binary != BINARY_BUILD:
+        if self.binary not in (BINARY_BUILD, BINARY_EDITABLE_BUILD):
             return None
         cmd = f"--requires={self.ref}" if self.context == "host" else f"--tool-requires={self.ref}"
         compatible = "compatible:" if self.info and self.info.get("compatibility_delta") else ""

--- a/test/integration/command/info/test_info_build_order.py
+++ b/test/integration/command/info/test_info_build_order.py
@@ -887,9 +887,16 @@ def test_info_build_order_editable():
             "consumer/conanfile.txt": "[requires]\npkg/0.1"})
     c.run("editable add dep")
     c.run("export pkg")
+    
     c.run("graph build-order consumer --build=missing --build=editable -f=json --order-by=recipe")
     bo_json = json.loads(c.stdout)
-
     pkg = bo_json["order"][0][0]["packages"][0][0]
+    assert pkg["binary"] == "EditableBuild"
+    assert pkg["build_args"] == "--requires=dep/0.1 --build=dep/0.1"
+
+    c.run("graph build-order consumer --build=missing --build=editable -f=json "
+          "--order-by=configuration")
+    bo_json = json.loads(c.stdout)
+    pkg = bo_json["order"][0][0]
     assert pkg["binary"] == "EditableBuild"
     assert pkg["build_args"] == "--requires=dep/0.1 --build=dep/0.1"

--- a/test/integration/command/info/test_info_build_order.py
+++ b/test/integration/command/info/test_info_build_order.py
@@ -804,9 +804,8 @@ def test_multi_configuration_profile_args():
 
 def test_build_order_space_in_options():
     tc = TestClient(light=True)
-    tc.save({"dep/conanfile.py": GenConanfile("dep", "1.0")
-                .with_option("flags", ["ANY", None])
-                .with_option("extras", ["ANY", None]),
+    tc.save({"dep/conanfile.py": GenConanfile("dep", "1.0").with_option("flags", ["ANY", None])
+                                                           .with_option("extras", ["ANY", None]),
              "conanfile.txt": textwrap.dedent("""
              [requires]
              dep/1.0
@@ -879,3 +878,18 @@ def test_build_order_build_context_compatible():
                                 "bar/1.0": ["5e4ffcc1ff33697a4ee96f66f0d2228ec458f25c", "Build"]})
         c.assert_listed_binary({"foo/1.0": ["4e2ae338231ae18d0d43b9e119404d2b2c416758", "Build"]},
                                build=True)
+
+
+def test_info_build_order_editable():
+    c = TestClient()
+    c.save({"dep/conanfile.py": GenConanfile("dep", "0.1"),
+            "pkg/conanfile.py": GenConanfile("pkg", "0.1").with_requires("dep/0.1"),
+            "consumer/conanfile.txt": "[requires]\npkg/0.1"})
+    c.run("editable add dep")
+    c.run("export pkg")
+    c.run("graph build-order consumer --build=missing --build=editable -f=json --order-by=recipe")
+    bo_json = json.loads(c.stdout)
+
+    pkg = bo_json["order"][0][0]["packages"][0][0]
+    assert pkg["binary"] == "EditableBuild"
+    assert pkg["build_args"] == "--requires=dep/0.1 --build=dep/0.1"


### PR DESCRIPTION
Changelog: Fix: Allow ``conan graph build-order`` to output ``build_args`` for "editable" packages.
Docs: Omit

Close https://github.com/conan-io/conan/issues/18096
