### PR TITLE
[testing] Add validation for concurrent cache in Conan

### DIFF
--- a/test/functional/test_parallel_cache.py
+++ b/test/functional/test_parallel_cache.py
@@ -7,7 +7,6 @@ from conan.test.utils.tools import TestClient
 
 def run_parallel_and_check_errors(test_client, operation_func, num_tasks=10, *args):
     """Run operations in parallel and check for expected errors"""
-    exceptions = []
     parallel_known_errors = [
         "Folder might be busy or open",
         "conanfile.py not found",

--- a/test/functional/test_parallel_cache.py
+++ b/test/functional/test_parallel_cache.py
@@ -5,7 +5,7 @@ from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
 
 
-def run_parallel_and_check_errors(test_client, operation_func, num_tasks=4, *args):
+def run_parallel_and_check_errors(test_client, operation_func, num_tasks=10, *args):
     """Run operations in parallel and check for expected errors"""
     exceptions = []
     parallel_known_errors = [
@@ -17,16 +17,18 @@ def run_parallel_and_check_errors(test_client, operation_func, num_tasks=4, *arg
         "raise ConanException",
         "WinError 3",
     ]
-    with concurrent.futures.ThreadPoolExecutor(max_workers=num_tasks) as executor:
-        try:
-            futures = [executor.submit(operation_func, test_client, i, *args) for i in range(num_tasks)]
-            done_tasks, _ = concurrent.futures.wait(futures, return_when=concurrent.futures.FIRST_EXCEPTION)
+    exceptions = []
+    while not exceptions:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=num_tasks) as executor:
+            try:
+                futures = [executor.submit(operation_func, test_client, i, *args) for i in range(num_tasks)]
+                done_tasks, _ = concurrent.futures.wait(futures, return_when=concurrent.futures.FIRST_EXCEPTION)
 
-            for task in done_tasks:
-                if task.exception():
-                    exceptions.append(task.exception())
-        finally:
-            executor.shutdown(wait=False, cancel_futures=True)
+                for task in done_tasks:
+                    if task.exception():
+                        exceptions.append(task.exception())
+            finally:
+                executor.shutdown(wait=False, cancel_futures=True)
 
     for err in exceptions:
         str_err = str(err)

--- a/test/functional/test_parallel_cache.py
+++ b/test/functional/test_parallel_cache.py
@@ -1,0 +1,55 @@
+import concurrent.futures
+import pytest
+from conan.test.assets.genconanfile import GenConanfile
+from conan.test.utils.tools import TestClient
+
+_parallel_options = [
+    '-o "&:foo=True" -o "&:qux=True" -o "&:baz=True"',
+    '-o "&:foo=False" -o "&:qux=True" -o "&:baz=True"',
+    '-o "&:foo=True" -o "&:qux=False" -o "&:baz=True"',
+    '-o "&:foo=True" -o "&:qux=True" -o "&:baz=False"',
+]
+
+
+def _build_package(build_id, test_client):
+    try:
+        test_client.run(f"create . {_parallel_options[build_id]}")
+    except Exception:
+        pass
+
+
+@pytest.mark.tool("cmake")
+def test_parallel_cache():
+    """Run multiple builds in parallel to test the cache concurrency support in Conan.
+
+    This test creates a package with multiple options and builds it in parallel using
+    different combinations of options. The goal is to ensure that the cache can handle
+    concurrent builds without any issues.
+
+    There is no support for this feature in Conan at this moment, but is desired.
+    """
+    num_builds = len(_parallel_options)
+    test_client = TestClient()
+    test_client.run("new cmake_lib -d name=parallel -d version=0.1.0")
+    test_client.save({"conanfile.py": GenConanfile("parallel", "0.1.0")
+                      .with_option("foo", [True, False])
+                      .with_option("qux", [True, False])
+                      .with_option("baz", [True, False])
+                      .with_default_option("foo", False)
+                      .with_default_option("qux", False)
+                      .with_default_option("baz", False)})
+
+    exceptions = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=num_builds) as executor:
+        try:
+            future_to_build = {executor.submit(_build_package, i, test_client): i for i in range(num_builds)}
+            done_tasks, not_done_tasks = concurrent.futures.wait(future_to_build, return_when=concurrent.futures.FIRST_EXCEPTION)
+            for task in done_tasks:
+                if task.exception():
+                    exceptions.append(task.exception())
+        finally:
+            executor.shutdown(wait=False, cancel_futures=True)
+        assert exceptions
+        for error in exceptions:
+            assert "Folder might be busy or open" in str(error) or \
+                   "conanfile.py not found" in str(error)

--- a/test/functional/test_parallel_cache.py
+++ b/test/functional/test_parallel_cache.py
@@ -27,7 +27,6 @@ def run_parallel_and_check_errors(test_client, operation_func, num_tasks=4, *arg
         finally:
             executor.shutdown(wait=False, cancel_futures=True)
 
-    assert exceptions, "No exceptions were raised, but parallel operations should fail"
     for err in exceptions:
         str_err = str(err)
         assert [perror for perror in parallel_known_errors if perror in str_err], f"Unexpected error: {str_err}"

--- a/test/functional/test_parallel_cache.py
+++ b/test/functional/test_parallel_cache.py
@@ -14,7 +14,8 @@ def run_parallel_and_check_errors(test_client, operation_func, num_tasks=4, *arg
         "[Errno 17] File exists",
         "[Errno 2] No such file or directory"
         "assert os.path.isfile(path)",
-        "raise ConanException"
+        "raise ConanException",
+        "WinError 3",
     ]
     with concurrent.futures.ThreadPoolExecutor(max_workers=num_tasks) as executor:
         try:

--- a/test/functional/test_parallel_cache.py
+++ b/test/functional/test_parallel_cache.py
@@ -1,55 +1,90 @@
 import concurrent.futures
 import pytest
+from conan.test.utils.test_files import temp_folder
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
 
-_parallel_options = [
-    '-o "&:foo=True" -o "&:qux=True" -o "&:baz=True"',
-    '-o "&:foo=False" -o "&:qux=True" -o "&:baz=True"',
-    '-o "&:foo=True" -o "&:qux=False" -o "&:baz=True"',
-    '-o "&:foo=True" -o "&:qux=True" -o "&:baz=False"',
-]
 
-
-def _build_package(build_id, test_client):
-    try:
-        test_client.run(f"create . {_parallel_options[build_id]}")
-    except Exception:
-        pass
-
-
-@pytest.mark.tool("cmake")
-def test_parallel_cache():
-    """Run multiple builds in parallel to test the cache concurrency support in Conan.
-
-    This test creates a package with multiple options and builds it in parallel using
-    different combinations of options. The goal is to ensure that the cache can handle
-    concurrent builds without any issues.
-
-    There is no support for this feature in Conan at this moment, but is desired.
-    """
-    num_builds = len(_parallel_options)
-    test_client = TestClient()
-    test_client.run("new cmake_lib -d name=parallel -d version=0.1.0")
-    test_client.save({"conanfile.py": GenConanfile("parallel", "0.1.0")
-                      .with_option("foo", [True, False])
-                      .with_option("qux", [True, False])
-                      .with_option("baz", [True, False])
-                      .with_default_option("foo", False)
-                      .with_default_option("qux", False)
-                      .with_default_option("baz", False)})
-
+def run_parallel_and_check_errors(test_client, operation_func, num_tasks=4, *args):
+    """Run operations in parallel and check for expected errors"""
     exceptions = []
-    with concurrent.futures.ThreadPoolExecutor(max_workers=num_builds) as executor:
+    parallel_known_errors = [
+        "Folder might be busy or open",
+        "conanfile.py not found",
+        "[Errno 17] File exists",
+        "[Errno 2] No such file or directory"
+        "assert os.path.isfile(path)",
+        "raise ConanException"
+    ]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=num_tasks) as executor:
         try:
-            future_to_build = {executor.submit(_build_package, i, test_client): i for i in range(num_builds)}
-            done_tasks, not_done_tasks = concurrent.futures.wait(future_to_build, return_when=concurrent.futures.FIRST_EXCEPTION)
+            futures = [executor.submit(operation_func, test_client, i, *args) for i in range(num_tasks)]
+            done_tasks, _ = concurrent.futures.wait(futures, return_when=concurrent.futures.FIRST_EXCEPTION)
+
             for task in done_tasks:
                 if task.exception():
                     exceptions.append(task.exception())
         finally:
             executor.shutdown(wait=False, cancel_futures=True)
-        assert exceptions
-        for error in exceptions:
-            assert "Folder might be busy or open" in str(error) or \
-                   "conanfile.py not found" in str(error)
+
+    assert exceptions, "No exceptions were raised, but parallel operations should fail"
+    for err in exceptions:
+        str_err = str(err)
+        assert [perror for perror in parallel_known_errors if perror in str_err], f"Unexpected error: {str_err}"
+
+
+def test_parallel_config():
+    """Run multiple conan config install in parallel to test the cache concurrency support."""
+    def config_install(test_client, _, cache_folder):
+        try:
+            test_client.run(f"config install {cache_folder} --type=dir")
+        except Exception:
+            pass
+
+    cache_folder = temp_folder(path_with_spaces=False)
+    test_client_cache = TestClient(cache_folder=cache_folder)
+    test_client_cache.run("profile detect --force")
+    test_client = TestClient()
+
+    run_parallel_and_check_errors(test_client, config_install, 4, cache_folder)
+
+
+def test_parallel_export():
+    """Run multiple conan export in parallel to test the cache concurrency support."""
+    def export(test_client, _):
+        try:
+            test_client.run("export .")
+        except Exception:
+            pass
+
+    test_client = TestClient()
+    test_client.save({"conanfile.py": GenConanfile("parallel", "0.1.0")})
+
+    run_parallel_and_check_errors(test_client, export, 4)
+
+
+@pytest.mark.tool("cmake")
+def test_parallel_create():
+    """Run multiple builds in parallel to test the cache concurrency support."""
+    def create(test_client, i):
+        options = [
+            '-o "&:foo=True" -o "&:qux=True" -o "&:baz=True"',
+            '-o "&:foo=False" -o "&:qux=True" -o "&:baz=True"',
+            '-o "&:foo=True" -o "&:qux=False" -o "&:baz=True"',
+            '-o "&:foo=True" -o "&:qux=True" -o "&:baz=False"',
+        ]
+        try:
+            test_client.run(f"create . {options[i]}")
+        except Exception:
+            pass
+
+    test_client = TestClient()
+    test_client.save({"conanfile.py": GenConanfile("parallel", "0.1.0")
+                    .with_option("foo", [True, False])
+                    .with_option("qux", [True, False])
+                    .with_option("baz", [True, False])
+                    .with_default_option("foo", False)
+                    .with_default_option("qux", False)
+                    .with_default_option("baz", False)})
+
+    run_parallel_and_check_errors(test_client, create, 4)

--- a/test/functional/test_parallel_cache.py
+++ b/test/functional/test_parallel_cache.py
@@ -12,7 +12,7 @@ def run_parallel_and_check_errors(test_client, operation_func, num_tasks=4, *arg
         "Folder might be busy or open",
         "conanfile.py not found",
         "[Errno 17] File exists",
-        "[Errno 2] No such file or directory"
+        "[Errno 2] No such file or directory",
         "assert os.path.isfile(path)",
         "raise ConanException",
         "WinError 3",


### PR DESCRIPTION
Hello!

This new validation introduces a test for concurrent. This initial validation started in this gist: https://gist.github.com/uilianries/e0438f6ac92f8444a1cb89c6faa3a4a7

So far, we found some conflicts:

- The test package uses the same folder when building, so parallel build will overwrite it
- Export source and Export will overwrite the same artifacts
- The result in Mac is a busy/locked file and folder 

/cc @AbrilRBS @memsharded 

Changelog: Omit
Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
