### PR TITLE
fix missing ARM64EC platform in MSBuild

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -15,7 +15,7 @@ from conan.tools.build.cross_building import cross_building
 from conan.tools.cmake.toolchain import CONAN_TOOLCHAIN_FILENAME
 from conan.tools.cmake.utils import is_multi_configuration
 from conan.tools.intel import IntelCC
-from conan.tools.microsoft.visual import msvc_version_to_toolset_version
+from conan.tools.microsoft.visual import msvc_version_to_toolset_version, msvc_platform_from_arch
 from conan.internal.api.install.generators import relativize_path
 from conans.client.subsystems import deduce_subsystem, WINDOWS
 from conan.errors import ConanException
@@ -991,11 +991,7 @@ class GenericSystemBlock(Block):
             return settings.get_safe("os.platform")
 
         if compiler in ("msvc", "clang") and generator and "Visual" in generator:
-            return {"x86": "Win32",
-                    "x86_64": "x64",
-                    "armv7": "ARM",
-                    "armv8": "ARM64",
-                    "arm64ec": "ARM64EC"}.get(arch)
+            return msvc_platform_from_arch(arch)
         return None
 
     def _get_generic_system_name(self):

--- a/conan/tools/microsoft/layout.py
+++ b/conan/tools/microsoft/layout.py
@@ -1,7 +1,7 @@
 import os
 
-from conan.tools.microsoft.msbuild import msbuild_arch
 from conan.errors import ConanException
+from conan.tools.microsoft.visual import msvc_platform_from_arch
 
 
 def vs_layout(conanfile):
@@ -26,7 +26,7 @@ def vs_layout(conanfile):
         raise ConanException("The 'vs_layout' requires the 'arch' setting")
 
     if arch != "None" and arch != "x86":
-        msvc_arch = msbuild_arch(arch)
+        msvc_arch = msvc_platform_from_arch(arch)
         if not msvc_arch:
             raise ConanException(f"The 'vs_layout' doesn't work with the arch '{arch}'. "
                                  "Accepted architectures: 'x86', 'x86_64', 'armv7', 'armv8'")

--- a/conan/tools/microsoft/msbuild.py
+++ b/conan/tools/microsoft/msbuild.py
@@ -1,4 +1,5 @@
 from conan.errors import ConanException
+from conan.tools.microsoft.visual import msvc_platform_from_arch
 
 
 def msbuild_verbosity_cmd_line_arg(conanfile):
@@ -17,14 +18,7 @@ def msbuild_verbosity_cmd_line_arg(conanfile):
     return ""
 
 
-def msbuild_arch(arch):
-    return {'x86': 'x86',
-            'x86_64': 'x64',
-            'armv7': 'ARM',
-            'armv8': 'ARM64'}.get(str(arch))
-
-
-class MSBuild(object):
+class MSBuild:
     """
     MSBuild build helper class
     """
@@ -39,11 +33,11 @@ class MSBuild(object):
         # if platforms:
         #    msvc_arch.update(platforms)
         arch = conanfile.settings.get_safe("arch")
-        msvc_arch = msbuild_arch(arch)
+        msvc_platform = msvc_platform_from_arch(arch)
         if conanfile.settings.get_safe("os") == "WindowsCE":
-            msvc_arch = conanfile.settings.get_safe("os.platform")
+            msvc_platform = conanfile.settings.get_safe("os.platform")
         #: Defines the platform name, e.g., ``ARM`` if ``settings.arch == "armv7"``.
-        self.platform = msvc_arch
+        self.platform = msvc_platform
 
     def command(self, sln, targets=None):
         """

--- a/conan/tools/microsoft/msbuild.py
+++ b/conan/tools/microsoft/msbuild.py
@@ -33,7 +33,8 @@ class MSBuild:
         # if platforms:
         #    msvc_arch.update(platforms)
         arch = conanfile.settings.get_safe("arch")
-        msvc_platform = msvc_platform_from_arch(arch)
+        # MSVC default platform for VS projects is "x86", not "Win32" (but CMake default is "Win32")
+        msvc_platform = msvc_platform_from_arch(arch) if arch != "x86" else "x86"
         if conanfile.settings.get_safe("os") == "WindowsCE":
             msvc_platform = conanfile.settings.get_safe("os.platform")
         #: Defines the platform name, e.g., ``ARM`` if ``settings.arch == "armv7"``.

--- a/conan/tools/microsoft/msbuilddeps.py
+++ b/conan/tools/microsoft/msbuilddeps.py
@@ -10,6 +10,7 @@ from conan.internal import check_duplicated_generator
 from conan.errors import ConanException
 from conan.internal.api.install.generators import relativize_path
 from conan.internal.model.dependencies import get_transitive_requires
+from conan.tools.microsoft.visual import msvc_platform_from_arch
 from conans.util.files import load, save
 
 VALID_LIB_EXTENSIONS = (".so", ".lib", ".a", ".dylib", ".bc")
@@ -102,10 +103,7 @@ class MSBuildDeps:
         # TODO: This platform is not exactly the same as ``msbuild_arch``, because it differs
         # in x86=>Win32
         #: Platform name, e.g., ``Win32`` if ``settings.arch == "x86"``.
-        self.platform = {'x86': 'Win32',
-                         'x86_64': 'x64',
-                         'armv7': 'ARM',
-                         'armv8': 'ARM64'}.get(str(conanfile.settings.arch))
+        self.platform = msvc_platform_from_arch(str(conanfile.settings.arch))
         #: Defines the platform key used to conditionally select which property sheet to
         #: import (defaults to ``"Platform"``).
         self.platform_key = "Platform"

--- a/conan/tools/microsoft/toolchain.py
+++ b/conan/tools/microsoft/toolchain.py
@@ -7,7 +7,8 @@ from jinja2 import Template
 from conan.internal import check_duplicated_generator
 from conan.tools.build import build_jobs
 from conan.tools.intel.intel_cc import IntelCC
-from conan.tools.microsoft.visual import VCVars, msvs_toolset, msvc_runtime_flag
+from conan.tools.microsoft.visual import VCVars, msvs_toolset, msvc_runtime_flag, \
+    msvc_platform_from_arch
 from conan.errors import ConanException
 from conans.util.files import save, load
 
@@ -77,13 +78,9 @@ class MSBuildToolchain(object):
         self.properties = {}
 
     def _name_condition(self, settings):
+        platform = msvc_platform_from_arch(settings.get_safe("arch"))
         props = [("Configuration", self.configuration),
-                 # TODO: refactor, put in common with MSBuildDeps. Beware this is != msbuild_arch
-                 #  because of Win32
-                 ("Platform", {'x86': 'Win32',
-                               'x86_64': 'x64',
-                               'armv7': 'ARM',
-                               'armv8': 'ARM64'}.get(settings.get_safe("arch")))]
+                 ("Platform", platform)]
 
         name = "".join("_%s" % v for _, v in props if v is not None)
         condition = " And ".join("'$(%s)' == '%s'" % (k, v) for k, v in props if v is not None)

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -12,6 +12,14 @@ from conans.util.files import save
 CONAN_VCVARS = "conanvcvars"
 
 
+def msvc_platform_from_arch(arch):
+    return {"x86": "Win32",
+            "x86_64": "x64",
+            "armv7": "ARM",
+            "armv8": "ARM64",
+            "arm64ec": "ARM64EC"}.get(arch)
+
+
 def check_min_vs(conanfile, version, raise_invalid=True):
     """
     This is a helper method to allow the migration of 1.X -> 2.0 and VisualStudio -> msvc settings


### PR DESCRIPTION
Changelog: Fix: Add ``ARM64EC`` platform in ``MSBuild``, it was missing.
Docs: https://github.com/conan-io/docs/pull/4079


