### PR TITLE
[gnu] Toolchains adding `libexecdir` variable

### DIFF
--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -310,7 +310,8 @@ class AutotoolsToolchain:
                                        _get_argument("libdir", "libdirs"),
                                        _get_argument("includedir", "includedirs"),
                                        _get_argument("oldincludedir", "includedirs"),
-                                       _get_argument("datarootdir", "resdirs")])
+                                       _get_argument("datarootdir", "resdirs"),
+                                       _get_argument("libexecdir", "bindirs")])
         return [el for el in configure_install_flags if el]
 
     @staticmethod

--- a/conan/tools/gnu/gnutoolchain.py
+++ b/conan/tools/gnu/gnutoolchain.py
@@ -298,8 +298,8 @@ class GnuToolchain:
         # If someone want arguments but not the defaults can pass them in args manually
         for flag_name, cppinfo_name in [("bindir", "bindirs"), ("sbindir", "bindirs"),
                                         ("libdir", "libdirs"), ("includedir", "includedirs"),
-                                        ("oldincludedir", "includedirs"),
-                                        ("datarootdir", "resdirs")]:
+                                        ("oldincludedir", "includedirs"), ("datarootdir", "resdirs"),
+                                        ("libexecdir", "bindirs")]:
             elements = getattr(self._conanfile.cpp.package, cppinfo_name)
             cppinfo_value = f"${{prefix}}/{elements[0]}" if elements else None
             if cppinfo_value:

--- a/test/functional/toolchains/gnu/autotools/test_ios.py
+++ b/test/functional/toolchains/gnu/autotools/test_ios.py
@@ -71,9 +71,10 @@ def test_ios():
     autoreconf_args = conanbuild["autoreconf_args"]
     build_arch = client.api.profiles.get_profile([client.api.profiles.get_default_build()]).settings['arch']
     build_arch = "aarch64" if build_arch == "armv8" else build_arch
-    assert configure_args == "--prefix=/ '--bindir=${prefix}/bin' '--sbindir=${prefix}/bin' " \
-                             "'--libdir=${prefix}/lib' '--includedir=${prefix}/include' " \
-                             "'--oldincludedir=${prefix}/include' '--datarootdir=${prefix}/res' " \
-                             f"--host=aarch64-apple-ios --build={build_arch}-apple-darwin"
+    assert configure_args == ("--prefix=/ '--bindir=${prefix}/bin' '--sbindir=${prefix}/bin' "
+                              "'--libdir=${prefix}/lib' '--includedir=${prefix}/include' "
+                              "'--oldincludedir=${prefix}/include' '--datarootdir=${prefix}/res' "
+                              "'--libexecdir=${prefix}/bin' --host=aarch64-apple-ios "
+                              f"--build={build_arch}-apple-darwin")
     assert make_args == ""
     assert autoreconf_args == "--force --install"

--- a/test/integration/toolchains/gnu/test_gnutoolchain.py
+++ b/test/integration/toolchains/gnu/test_gnutoolchain.py
@@ -517,7 +517,7 @@ def test_toolchain_and_default_dirs(toolchain):
     os=Macos
     """)
     c.save({"conanfile.txt": f"[generators]\n{toolchain}", "host": default})
-    c.run("install . -pr host")
+    c.run("install . -pr:a host")
     tc = c.load("conanbuild.conf")
     for arg in ['--bindir=${prefix}/bin', '--sbindir=${prefix}/bin', '--libdir=${prefix}/lib',
                 '--includedir=${prefix}/include', '--oldincludedir=${prefix}/include',

--- a/test/integration/toolchains/gnu/test_gnutoolchain.py
+++ b/test/integration/toolchains/gnu/test_gnutoolchain.py
@@ -510,8 +510,14 @@ def test_toolchain_and_default_dirs(toolchain):
     Issue: https://github.com/conan-io/conan/issues/12020
     """
     c = TestClient()
-    c.save({"conanfile.txt": f"[generators]\n{toolchain}"})
-    c.run("install .")
+    default = textwrap.dedent("""
+    [settings]
+    arch=armv8
+    build_type=Release
+    os=Macos
+    """)
+    c.save({"conanfile.txt": f"[generators]\n{toolchain}", "host": default})
+    c.run("install . -pr host")
     tc = c.load("conanbuild.conf")
     for arg in ['--bindir=${prefix}/bin', '--sbindir=${prefix}/bin', '--libdir=${prefix}/lib',
                 '--includedir=${prefix}/include', '--oldincludedir=${prefix}/include',

--- a/test/integration/toolchains/gnu/test_gnutoolchain.py
+++ b/test/integration/toolchains/gnu/test_gnutoolchain.py
@@ -1,7 +1,7 @@
 import os
 import platform
-import textwrap
 import re
+import textwrap
 
 import pytest
 
@@ -502,3 +502,18 @@ def test_conf_extra_apple_flags(toolchain):
     assert 'CXXFLAGS="$CXXFLAGS -fno-objc-arc -fvisibility=hidden -fvisibility-inlines-hidden"' in tc
     assert 'CFLAGS="$CFLAGS -fno-objc-arc -fvisibility=hidden -fvisibility-inlines-hidden"' in tc
     assert 'LDFLAGS="$LDFLAGS -fno-objc-arc -fvisibility=hidden -fvisibility-inlines-hidden"' in tc
+
+
+@pytest.mark.parametrize("toolchain", ["GnuToolchain", "AutotoolsToolchain"])
+def test_toolchain_and_default_dirs(toolchain):
+    """
+    Issue: https://github.com/conan-io/conan/issues/12020
+    """
+    c = TestClient()
+    c.save({"conanfile.txt": f"[generators]\n{toolchain}"})
+    c.run("install .")
+    tc = c.load("conanbuild.conf")
+    for arg in ['--bindir=${prefix}/bin', '--sbindir=${prefix}/bin', '--libdir=${prefix}/lib',
+                '--includedir=${prefix}/include', '--oldincludedir=${prefix}/include',
+                '--libexecdir=${prefix}/bin']:
+        assert arg in tc


### PR DESCRIPTION
Changelog: Feature: Added `libexecdir` variable to `AutotoolsToolchain` and `GnuToolchain`
Docs: omit
Closes: https://github.com/conan-io/conan/issues/12020
