### PR TITLE
Make `audit_providers.json` save with `0o600` permissions

### DIFF
--- a/conan/api/subapi/audit.py
+++ b/conan/api/subapi/audit.py
@@ -160,3 +160,5 @@ def _load_providers(providers_path):
 
 def _save_providers(providers_path, providers):
     save(providers_path, json.dumps(providers, indent=4))
+    # Make readable & writeable only by current user
+    os.chmod(providers_path, 0o600)

--- a/conan/api/subapi/audit.py
+++ b/conan/api/subapi/audit.py
@@ -10,7 +10,7 @@ from conan.internal.model.recipe_ref import RecipeReference
 from conans.util.files import save, load
 
 CONAN_CENTER_AUDIT_PROVIDER_NAME = "conancenter"
-CYPHER_KEY = os.environ.pop('CONAN_AUDIT_ENCRYPTION_KEY', "private")
+CYPHER_KEY = "private"
 
 
 class AuditAPI:

--- a/conan/api/subapi/audit.py
+++ b/conan/api/subapi/audit.py
@@ -10,7 +10,7 @@ from conan.internal.model.recipe_ref import RecipeReference
 from conans.util.files import save, load
 
 CONAN_CENTER_AUDIT_PROVIDER_NAME = "conancenter"
-CYPHER_KEY = "private"
+CYPHER_KEY = os.environ.pop('CONAN_AUDIT_ENCRYPTION_KEY', "private")
 
 
 class AuditAPI:

--- a/test/integration/command/test_audit.py
+++ b/test/integration/command/test_audit.py
@@ -1,5 +1,6 @@
 import json
 import os
+import platform
 import sys
 from contextlib import contextmanager
 
@@ -105,6 +106,13 @@ def test_conan_audit_paths():
             "it using: 'conan audit provider add conancenter --url=https://audit.conan.io/ "
             "--type=conan-center-proxy --token=<token>'") in tc.out
     assert "If you don't have a valid token, register at: https://audit.conan.io/register." in tc.out
+
+    if platform.system() != "Windows":
+        providers_stat = os.stat(os.path.join(tc.cache_folder, "audit_providers.json"))
+        # Assert that only the current user can read/write the file
+        assert providers_stat.st_uid == os.getuid()
+        assert providers_stat.st_gid == os.getgid()
+        assert providers_stat.st_mode & 0o777 == 0o600
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10),


### PR DESCRIPTION
Changelog: Fix: Make `audit_providers.json` read/writeable only by owner.
Docs: Omit

