### PR TITLE
[feature] Raise error for conan audit scan when severity level reaches threshold

### DIFF
--- a/conan/cli/commands/audit.py
+++ b/conan/cli/commands/audit.py
@@ -20,10 +20,30 @@ def _add_provider_arg(subparser):
     subparser.add_argument("-p", "--provider", help="Provider to use for scanning")
 
 
+def _parse_error_threshold(result: dict, error_level: float) -> None:
+    """Mark the result as error if any of the vulnerabilities has a severity greater than or equal to
+       The error_level reflects the severity level configured by the user. As it uses float and CVSS
+       score is limited to 10.0, users can use any higher number to skip it.
+
+       :param result: Conan audit scan result. It's expected to find cvss there
+       :param error_level: Threshold to raise an error in case of matching the severity level
+       :return: None
+    """
+    if "conan_error" not in result:
+        for ref in result["data"]:
+            for edge in result["data"][ref]["vulnerabilities"]["edges"]:
+                preferred_base_score = float(edge["node"]["cvss"].get("preferredBaseScore", 0.0))
+                if preferred_base_score >= error_level:
+                    result.update(
+                        {"conan_error":
+                             "The conan audit command exceeded the threshold severity level."})
+                    break
+
+
 @conan_subcommand(formatters={"text": text_vuln_formatter,
                               "json": json_vuln_formatter,
                               "html": html_vuln_formatter})
-def audit_scan(conan_api: ConanAPI, parser, subparser, *args):
+def audit_scan(conan_api: ConanAPI, parser, subparser, *args) -> dict:
     """
     Scan a given recipe for vulnerabilities in its dependencies.
     """
@@ -32,6 +52,10 @@ def audit_scan(conan_api: ConanAPI, parser, subparser, *args):
     # TODO: Do we then want to hide it in the --help?
     subparser.add_argument("--build-require", action='store_true', default=False,
                            help='Whether the provided reference is a build-require')
+    subparser.add_argument("-sl", "--severity-level", action="store", default=9.0, type=float,
+                           help="Set threshold for severity level to raise an error. "
+                                "By default raises an error for any critical CVSS (9.0 or higher). "
+                                " Use 100.0 to disable it.")
 
     _add_provider_arg(subparser)
     args = parser.parse_args(*args)
@@ -69,7 +93,9 @@ def audit_scan(conan_api: ConanAPI, parser, subparser, *args):
 
     provider = conan_api.audit.get_provider(args.provider or CONAN_CENTER_AUDIT_PROVIDER_NAME)
 
-    return conan_api.audit.scan(deps_graph, provider)
+    scan_result = conan_api.audit.scan(deps_graph, provider)
+    _parse_error_threshold(scan_result, args.severity_level)
+    return scan_result
 
 
 @conan_subcommand(formatters={"text": text_vuln_formatter,

--- a/conan/cli/commands/audit.py
+++ b/conan/cli/commands/audit.py
@@ -36,7 +36,8 @@ def _parse_error_threshold(result: dict, error_level: float) -> None:
                 if preferred_base_score >= error_level:
                     result.update(
                         {"conan_error":
-                             "The conan audit command exceeded the threshold severity level."})
+                             f"The package {ref} has a CVSS score {preferred_base_score} and "
+                             f"exceeded the threshold severity level {error_level}."})
                     break
 
 

--- a/test/integration/command/test_audit.py
+++ b/test/integration/command/test_audit.py
@@ -37,7 +37,7 @@ def test_conan_audit_paths():
                                 "description": "Zip vulnerability",
                                 "severity": "Critical",
                                 "cvss": {
-                                    "preferredBaseScore": 9.8
+                                    "preferredBaseScore": 8.9
                                 },
                                 "aliases": [
                                     "CVE-2023-45853",
@@ -209,3 +209,67 @@ def test_audit_global_error_exception():
 
         tc.run("audit list zlib/1.2.11 -f html", assert_error=True)
         assert "ERROR: Fatal error." in tc.out
+
+
+@pytest.mark.parametrize("severity_level, threshold, should_fail", [
+    (1.0, None, False),
+    (8.9, None, False),
+    (9.0, None, True),
+    (9.1, None, True),
+    (5.0, 5.1, False),
+    (5.1, 5.1, True),
+    (5.2, 5.1, True),
+    (9.0, 11.0, False),
+])
+def test_audit_scan_threshold_error(severity_level, threshold, should_fail):
+    """In case the severity level is equal or higher than the found for a CVE,
+       the command should output the information as usual, and exit with non-success code error.
+    """
+    successful_response = {
+        "data": {
+            "query": {
+                "vulnerabilities": {
+                    "totalCount": 1,
+                    "edges": [
+                        {
+                            "node": {
+                                "name": "CVE-2023-45853",
+                                "description": "Zip vulnerability",
+                                "severity": "Critical",
+                                "cvss": {
+                                    "preferredBaseScore": severity_level
+                                },
+                                "aliases": [
+                                    "CVE-2023-45853",
+                                    "JFSA-2023-000272529"
+                                ],
+                                "advisories": [
+                                    {
+                                        "name": "CVE-2023-45853"
+                                    },
+                                    {
+                                        "name": "JFSA-2023-000272529"
+                                    }
+                                ],
+                                "references": [
+                                    "https://pypi.org/project/pyminizip/#history",
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+    tc = TestClient(light=True)
+
+    tc.save({"conanfile.py": GenConanfile("foobar", "0.1.0")})
+    tc.run("export .")
+    tc.run("audit provider auth conancenter --token=valid_token")
+
+    with proxy_response(200, successful_response):
+        severity_param = "" if threshold is None else f"-sl {threshold}"
+        tc.run(f"audit scan --requires=foobar/0.1.0 {severity_param}", assert_error=should_fail)
+        assert "foobar/0.1.0 1 vulnerability found" in tc.out
+        assert f"CVSS: {severity_level}" in tc.out

--- a/test/integration/command/test_audit.py
+++ b/test/integration/command/test_audit.py
@@ -273,3 +273,7 @@ def test_audit_scan_threshold_error(severity_level, threshold, should_fail):
         tc.run(f"audit scan --requires=foobar/0.1.0 {severity_param}", assert_error=should_fail)
         assert "foobar/0.1.0 1 vulnerability found" in tc.out
         assert f"CVSS: {severity_level}" in tc.out
+        if should_fail:
+            if threshold is None:
+                threshold = "9.0"
+            assert f"ERROR: The package foobar/0.1.0 has a CVSS score {severity_level} and exceeded the threshold severity level {threshold}" in tc.out


### PR DESCRIPTION
Hello!

This PR adds the command argument `--severity-level` to `conan audit scan. It works like a threshold, where the severity level will make the command exit with error code 1 (general error), in case it reaches the configured level or higher. 

By default, this new threshold is configured to **9.0**, Critical level, which means **it may break users** in case of finding those cases (e.g. OpenSSL).

Still, I'm not sure about 2 topics:

- Should we extend this argument to `conan audit list`, as both commands are actually checking for vulnerabilities? 
- Should we consider supporting boolean too, like `False`, to disable this threshold always?

Changelog: Feature: Add threshold for severity level in the conan audit scan command.
Docs: https://github.com/conan-io/docs/pull/4080

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
