### PR TITLE
add CMAKE_MODULE_PATH to CMakeConfigDeps for include(module)

### DIFF
--- a/conan/tools/cmake/cmakedeps2/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps2/cmakedeps.py
@@ -174,6 +174,7 @@ class _PathGenerator:
             "libdirs": "CMAKE_LIBRARY_PATH",
             "includedirs": "CMAKE_INCLUDE_PATH",
             "frameworkdirs": "CMAKE_FRAMEWORK_PATH",
+            "builddirs": "CMAKE_MODULE_PATH"
         }
         for req, dep in requirements:
             cppinfo = dep.cpp_info.aggregated_components()

--- a/conan/tools/cmake/cmakedeps2/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps2/cmakedeps.py
@@ -210,6 +210,10 @@ class _PathGenerator:
         {% if cmake_framework_path %}
         list(PREPEND CMAKE_FRAMEWORK_PATH {{ cmake_framework_path }})
         {% endif %}
+        # Definition of CMAKE_MODULE_PATH to be able to include(module)
+        {% if cmake_module_path %}
+        list(PREPEND CMAKE_MODULE_PATH {{ cmake_module_path }})
+        {% endif %}
         """)
         host_req = self._conanfile.dependencies.host
         build_req = self._conanfile.dependencies.direct_build
@@ -251,13 +255,15 @@ class _PathGenerator:
         cmake_library_path = self._get_cmake_paths(host_test_reqs, "libdirs")
         cmake_include_path = self._get_cmake_paths(host_test_reqs, "includedirs")
         cmake_framework_path = self._get_cmake_paths(host_test_reqs, "frameworkdirs")
+        cmake_module_path = self._get_cmake_paths(all_reqs, "builddirs")
         context = {"host_runtime_dirs": self._get_host_runtime_dirs(),
                    "pkg_paths": pkg_paths,
                    "cmake_program_path": _join_paths(self._conanfile, cmake_program_path),
                    "cmake_library_path": _join_paths(self._conanfile, cmake_library_path),
                    "cmake_include_path": _join_paths(self._conanfile, cmake_include_path),
                    "cmake_framework_path": _join_paths(self._conanfile, cmake_framework_path),
-        }
+                   "cmake_module_path": _join_paths(self._conanfile, cmake_module_path)
+                   }
         content = Template(template, trim_blocks=True, lstrip_blocks=True).render(context)
         save(self._conanfile, self._conan_cmakedeps_paths, content)
 

--- a/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new_paths.py
+++ b/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new_paths.py
@@ -141,7 +141,7 @@ class TestCMakeDepsPaths:
         """)
         consumer = textwrap.dedent("""
             cmake_minimum_required(VERSION 3.15)
-            project(MyHello)
+            project(MyHello NONE)
             find_program(HELLOPROG hello)
             if(HELLOPROG)
                 message(STATUS "Found hello prog: ${HELLOPROG}")
@@ -187,7 +187,7 @@ class TestCMakeDepsPaths:
         """)
         consumer = textwrap.dedent("""
             cmake_minimum_required(VERSION 3.15)
-            project(MyHello)
+            project(MyHello NONE)
             find_file(HELLOINC hello.h)
             find_library(HELLOLIB hello)
             if(HELLOINC)
@@ -218,9 +218,8 @@ class TestCMakeDepsPaths:
                 def package_info(self):
                     self.cpp_info.builddirs.append("cmake")
         """)
-        myowncmake = 'MESSAGE("MYOWNCMAKE FROM hello!")'
         c.save({"conanfile.py": conanfile,
-                "cmake/myowncmake.cmake": myowncmake})
+                "cmake/myowncmake.cmake": 'MESSAGE("MYOWNCMAKE FROM hello!")'})
         c.run("create . --name=hello --version=0.1")
 
         conanfile = textwrap.dedent(f"""
@@ -238,10 +237,52 @@ class TestCMakeDepsPaths:
             """)
         consumer = textwrap.dedent("""
             cmake_minimum_required(VERSION 3.15)
-            project(MyHello)
+            project(MyHello NONE)
             include(myowncmake)
         """)
         c.save({"conanfile.py": conanfile,
                 "CMakeLists.txt": consumer}, clean_first=True)
         c.run(f"build . -c tools.cmake.cmakedeps:new={new_value}")
+        assert "MYOWNCMAKE FROM hello!" in c.out
+
+    def test_include_modules_both_build_host(self):
+        c = TestClient()
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            from conan.tools.files import copy
+            class TestConan(ConanFile):
+                exports_sources = "*"
+                def package(self):
+                    copy(self, "*", self.source_folder, self.package_folder)
+                def package_info(self):
+                    self.cpp_info.builddirs.append("cmake")
+            """)
+        c.save({"conanfile.py": conanfile,
+                "cmake/myowncmake.cmake": 'MESSAGE("MYOWNCMAKE FROM hello!")'})
+        c.run("create . --name=hello --version=0.1")
+
+        conanfile = textwrap.dedent(f"""
+            from conan import ConanFile
+            from conan.tools.cmake import CMake
+            class PkgConan(ConanFile):
+                settings = "os", "compiler", "arch", "build_type"
+                requires = "hello/0.1"
+                tool_requires = "hello/0.1"
+                generators = "CMakeToolchain", "CMakeConfigDeps"
+
+                def build(self):
+                    cmake = CMake(self)
+                    cmake.configure()
+                    cmake.build()
+            """)
+        consumer = textwrap.dedent("""
+            cmake_minimum_required(VERSION 3.15)
+            project(MyHello NONE)
+            include(myowncmake)
+            """)
+        c.save({"conanfile.py": conanfile,
+                "CMakeLists.txt": consumer}, clean_first=True)
+        c.run(f"build . -c tools.cmake.cmakedeps:new={new_value}")
+        assert "conanfile.py: There is already a 'hello/0.1' package " \
+               "contributing to CMAKE_MODULE_PATH" in c.out
         assert "MYOWNCMAKE FROM hello!" in c.out


### PR DESCRIPTION
Changelog: Feature: add CMAKE_MODULE_PATH to CMakeConfigDeps for include(module).
Docs: Omit

Close https://github.com/conan-io/conan/issues/18155
