### PR TITLE
allowing CMakeConfigDeps components with multilib

### DIFF
--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -826,8 +826,9 @@ class CppInfo:
 
         result = CppInfo()  # clone it
         if self.libs and len(self.libs) > 1:  # expand in multiple components
-            ConanOutput().warning(f"{conanfile}: The 'cpp_info.libs' contain more than 1 library. "
-                                  "Define 'cpp_info.components' instead.")
+            ConanOutput(scope=str(conanfile)).warning(
+                "The 'cpp_info.libs' contain more than 1 library. "
+                "Define 'cpp_info.components' instead.", warn_tag="deprecated")
             assert not self.components, f"{conanfile} cpp_info shouldn't have .libs and .components"
             common = self._package.clone()
             common.libs = []
@@ -846,7 +847,30 @@ class CppInfo:
         else:
             result._package = self._package.clone()
             result.default_components = self.default_components
-            result.components = {k: v.clone() for k, v in self.components.items()}
+            new_components = {}
+            for k, v in self.components.items():
+                if v.libs and len(v.libs) > 1:
+                    ConanOutput(scope=str(conanfile)).warning(
+                        f"The 'cpp_info.components[{k}] contains more than 1 library. "
+                        "Define 1 component for each library instead.", warn_tag="deprecated")
+                    # Now the root, empty one
+                    common = v.clone()
+                    common.libs = []
+                    common.type = str(PackageType.HEADER)  # the type of components is a string!
+                    new_components[k] = common
+
+                    for lib in v.libs:
+                        c = _Component()
+                        c.type = v.type
+                        c.includedirs = v.includedirs
+                        c.libdirs = v.libdirs
+                        c.bindirs = v.bindirs
+                        c.libs = [lib]
+                        new_components[f"_{k}_{lib}"] = c
+                        common.requires.append(f"_{k}_{lib}")
+                else:
+                    new_components[k] = v.clone()
+            result.components = new_components
 
         result._package.deduce_locations(conanfile)
         for comp_name, comp in result.components.items():

--- a/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new.py
+++ b/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new.py
@@ -513,10 +513,7 @@ class TestLibsComponents:
         engine::world -> engine::physix, matrix::module
         """
         c = matrix_client_components
-
-        from conan.test.assets.sources import gen_function_h
         bots_h = gen_function_h(name="bots")
-        from conan.test.assets.sources import gen_function_cpp
         bots_cpp = gen_function_cpp(name="bots", includes=["bots", "physix"], calls=["physix"])
         physix_h = gen_function_h(name="physix")
         physix_cpp = gen_function_cpp(name="physix", includes=["physix", "vector"], calls=["vector"])
@@ -637,10 +634,7 @@ class TestLibsComponents:
         cpp_info.libs = ["lib1", "lib2"]
         """
         c = TestClient()
-
-        from conan.test.assets.sources import gen_function_h
         vector_h = gen_function_h(name="vector")
-        from conan.test.assets.sources import gen_function_cpp
         vector_cpp = gen_function_cpp(name="vector", includes=["vector"])
         module_h = gen_function_h(name="module")
         module_cpp = gen_function_cpp(name="module", includes=["module"])
@@ -725,16 +719,13 @@ class TestLibsComponents:
         assert "module: Release!" in c.out
         assert "vector: Release!" in c.out
 
-    @pytest.mark.skip()
     def test_libs_components_multilib_component(self):
         """
         cpp_info.components["mycomp"].libs = ["lib1", "lib2"]
         """
         c = TestClient()
 
-        from conan.test.assets.sources import gen_function_h
         vector_h = gen_function_h(name="vector")
-        from conan.test.assets.sources import gen_function_cpp
         vector_cpp = gen_function_cpp(name="vector", includes=["vector"])
         module_h = gen_function_h(name="module")
         module_cpp = gen_function_cpp(name="module", includes=["module"])

--- a/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new.py
+++ b/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new.py
@@ -81,6 +81,8 @@ class TestExes:
                     cmake.build()
             """)
         cmake = textwrap.dedent("""
+            set(CMAKE_C_COMPILER_WORKS 1)
+            set(CMAKE_C_ABI_COMPILED 1)
             cmake_minimum_required(VERSION 3.15)
             project(consumer C)
 
@@ -176,6 +178,8 @@ class TestExes:
                     cmake.build()
             """)
         cmake = textwrap.dedent("""
+            set(CMAKE_C_COMPILER_WORKS 1)
+            set(CMAKE_C_ABI_COMPILED 1)
             cmake_minimum_required(VERSION 3.15)
             project(consumer C)
 
@@ -236,6 +240,8 @@ class TestLibs:
 
         # This specific CMake fails for shared libraries with old CMakeDeps in Linux
         cmake = textwrap.dedent("""\
+            set(CMAKE_CXX_COMPILER_WORKS 1)
+            set(CMAKE_CXX_ABI_COMPILED 1)
             cmake_minimum_required(VERSION 3.15)
             project(gamelib CXX)
 
@@ -399,6 +405,8 @@ class TestLibsComponents:
         # TODO: Check that find_package(.. COMPONENTS nonexisting) fails
         c.run("new cmake_exe -d name=app -d version=0.1 -d requires=matrix/1.0")
         cmake = textwrap.dedent("""
+            set(CMAKE_CXX_COMPILER_WORKS 1)
+            set(CMAKE_CXX_ABI_COMPILED 1)
             cmake_minimum_required(VERSION 3.15)
             project(app CXX)
 
@@ -436,6 +444,8 @@ class TestLibsComponents:
             int main() { module();}
             """)
         cmake = textwrap.dedent("""
+            set(CMAKE_CXX_COMPILER_WORKS 1)
+            set(CMAKE_CXX_ABI_COMPILED 1)
             cmake_minimum_required(VERSION 3.15)
             project(app CXX)
 
@@ -464,6 +474,8 @@ class TestLibsComponents:
             int main() { module();}
             """)
         cmake = textwrap.dedent("""
+            set(CMAKE_CXX_COMPILER_WORKS 1)
+            set(CMAKE_CXX_ABI_COMPILED 1)
             cmake_minimum_required(VERSION 3.15)
             project(app CXX)
 
@@ -478,6 +490,8 @@ class TestLibsComponents:
         assert "Conan: Target declared imported STATIC library 'matrix::vector'" in c.out
         assert "Conan: Target declared imported STATIC library 'matrix::module'" in c.out
         cmake = textwrap.dedent("""
+            set(CMAKE_CXX_COMPILER_WORKS 1)
+            set(CMAKE_CXX_ABI_COMPILED 1)
             cmake_minimum_required(VERSION 3.15)
             project(app CXX)
 
@@ -586,6 +600,8 @@ class TestLibsComponents:
         c.save({}, clean_first=True)
         c.run("new cmake_exe -d name=app -d version=0.1 -d requires=engine/1.0")
         cmake = textwrap.dedent("""
+            set(CMAKE_CXX_COMPILER_WORKS 1)
+            set(CMAKE_CXX_ABI_COMPILED 1)
             cmake_minimum_required(VERSION 3.15)
             project(app CXX)
 
@@ -680,6 +696,8 @@ class TestLibsComponents:
         c.save({}, clean_first=True)
         c.run("new cmake_exe -d name=app -d version=0.1 -d requires=matrix/1.0")
         cmake = textwrap.dedent("""
+            set(CMAKE_CXX_COMPILER_WORKS 1)
+            set(CMAKE_CXX_ABI_COMPILED 1)
             cmake_minimum_required(VERSION 3.15)
             project(app CXX)
 
@@ -700,6 +718,102 @@ class TestLibsComponents:
         c.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
         assert "Conan: Target declared imported STATIC library 'matrix::_vector'" in c.out
         assert "Conan: Target declared imported STATIC library 'matrix::_module'" in c.out
+        assert "Conan: Target declared imported INTERFACE library 'MyMatrix::MyMatrix'" in c.out
+        assert "matrix::matrix" not in c.out
+
+        assert "vector: Release!" in c.out
+        assert "module: Release!" in c.out
+        assert "vector: Release!" in c.out
+
+    @pytest.mark.skip()
+    def test_libs_components_multilib_component(self):
+        """
+        cpp_info.components["mycomp"].libs = ["lib1", "lib2"]
+        """
+        c = TestClient()
+
+        from conan.test.assets.sources import gen_function_h
+        vector_h = gen_function_h(name="vector")
+        from conan.test.assets.sources import gen_function_cpp
+        vector_cpp = gen_function_cpp(name="vector", includes=["vector"])
+        module_h = gen_function_h(name="module")
+        module_cpp = gen_function_cpp(name="module", includes=["module"])
+
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            from conan.tools.cmake import CMake
+
+            class Matrix(ConanFile):
+                name = "matrix"
+                version = "1.0"
+                settings = "os", "compiler", "build_type", "arch"
+                generators = "CMakeToolchain"
+                exports_sources = "src/*", "CMakeLists.txt"
+
+                generators = "CMakeDeps", "CMakeToolchain"
+
+                def build(self):
+                    cmake = CMake(self)
+                    cmake.configure()
+                    cmake.build()
+
+                def package(self):
+                    cmake = CMake(self)
+                    cmake.install()
+
+                def package_info(self):
+                    self.cpp_info.set_property("cmake_target_name", "MyMatrix::MyMatrix")
+                    self.cpp_info.components["mycomp"].set_property("cmake_target_name",
+                                                                    "MyComp::MyComp")
+                    self.cpp_info.components["mycomp"].libs = ["module", "vector"]
+                  """)
+
+        cmakelists = textwrap.dedent("""
+            set(CMAKE_CXX_COMPILER_WORKS 1)
+            set(CMAKE_CXX_ABI_COMPILED 1)
+            cmake_minimum_required(VERSION 3.15)
+            project(matrix CXX)
+
+            add_library(module src/module.cpp)
+            add_library(vector src/vector.cpp)
+
+            set_target_properties(vector PROPERTIES PUBLIC_HEADER "src/vector.h")
+            set_target_properties(module PROPERTIES PUBLIC_HEADER "src/module.h")
+            install(TARGETS module vector)
+            """)
+        c.save({"src/module.h": module_h,
+                "src/module.cpp": module_cpp,
+                "src/vector.h": vector_h,
+                "src/vector.cpp": vector_cpp,
+                "CMakeLists.txt": cmakelists,
+                "conanfile.py": conanfile})
+        c.run("create .")
+
+        c.save({}, clean_first=True)
+        c.run("new cmake_exe -d name=app -d version=0.1 -d requires=matrix/1.0")
+        cmake = textwrap.dedent("""
+            set(CMAKE_CXX_COMPILER_WORKS 1)
+            set(CMAKE_CXX_ABI_COMPILED 1)
+            cmake_minimum_required(VERSION 3.15)
+            project(app CXX)
+
+            find_package(matrix CONFIG REQUIRED)
+
+            add_executable(app src/app.cpp)
+            target_link_libraries(app PRIVATE MyMatrix::MyMatrix)
+
+            install(TARGETS app)
+            """)
+        app_cpp = textwrap.dedent("""
+            #include "vector.h"
+            #include "module.h"
+            int main() { vector();module();}
+            """)
+        c.save({"CMakeLists.txt": cmake,
+                "src/app.cpp": app_cpp})
+        c.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
+        assert "Conan: Target declared imported STATIC library 'matrix::_mycomp_vector'" in c.out
+        assert "Conan: Target declared imported STATIC library 'matrix::_mycomp_module'" in c.out
         assert "Conan: Target declared imported INTERFACE library 'MyMatrix::MyMatrix'" in c.out
         assert "matrix::matrix" not in c.out
 
@@ -770,6 +884,8 @@ class TestHeaders:
                     cmake.build()
              """)
         cmake = textwrap.dedent("""
+            set(CMAKE_CXX_COMPILER_WORKS 1)
+            set(CMAKE_CXX_ABI_COMPILED 1)
             cmake_minimum_required(VERSION 3.15)
             project(app CXX)
             find_package(engine CONFIG REQUIRED)
@@ -834,6 +950,8 @@ class TestHeaders:
                     self.run(os.path.join(self.cpp.build.bindir, "app"))
              """)
         cmake = textwrap.dedent("""
+            set(CMAKE_CXX_COMPILER_WORKS 1)
+            set(CMAKE_CXX_ABI_COMPILED 1)
             cmake_minimum_required(VERSION 3.15)
             project(app CXX)
             find_package(engine CONFIG REQUIRED)
@@ -925,7 +1043,7 @@ def test_build_modules_custom_script(tool_requires):
         """)
     cmakelists = textwrap.dedent("""
         cmake_minimum_required(VERSION 3.15)
-        project(test)
+        project(test NONE)
         find_package(myfunctions CONFIG REQUIRED)
         myfunction()
         """)
@@ -989,6 +1107,8 @@ class TestProtobuf:
             }
             """)
         cmake = textwrap.dedent("""
+            set(CMAKE_CXX_COMPILER_WORKS 1)
+            set(CMAKE_CXX_ABI_COMPILED 1)
             cmake_minimum_required(VERSION 3.15)
             project(protobuf CXX)
 
@@ -1025,6 +1145,8 @@ class TestProtobuf:
                     self.run(os.path.join(self.cpp.build.bindir, "myapp"))
             """)
         cmake = textwrap.dedent("""
+            set(CMAKE_CXX_COMPILER_WORKS 1)
+            set(CMAKE_CXX_ABI_COMPILED 1)
             cmake_minimum_required(VERSION 3.15)
             project(consumer CXX)
 
@@ -1137,6 +1259,8 @@ class TestConfigs:
 
         # With modern CMake > 3.26 not necessary set(CMAKE_MAP_IMPORTED_CONFIG_DEBUG Release)
         cmake = textwrap.dedent("""
+            set(CMAKE_CXX_COMPILER_WORKS 1)
+            set(CMAKE_CXX_ABI_COMPILED 1)
             cmake_minimum_required(VERSION 3.27)
             project(app CXX)
             # set(CMAKE_MAP_IMPORTED_CONFIG_DEBUG Release)
@@ -1171,6 +1295,8 @@ class TestConfigs:
         c.run(f"install . -s &:build_type=Debug -c tools.cmake.cmakedeps:new={new_value}")
         # With modern CMake > 3.26 not necessary set(CMAKE_MAP_IMPORTED_CONFIG_DEBUG Release)
         cmake = textwrap.dedent("""
+            set(CMAKE_CXX_COMPILER_WORKS 1)
+            set(CMAKE_CXX_ABI_COMPILED 1)
             cmake_minimum_required(VERSION 3.27)
             project(app CXX)
             # set(CMAKE_MAP_IMPORTED_CONFIG_DEBUG Release)
@@ -1199,6 +1325,8 @@ class TestConfigs:
 
         # With modern CMake > 3.26 not necessary set(CMAKE_MAP_IMPORTED_CONFIG_DEBUG Release)
         cmake = textwrap.dedent("""
+            set(CMAKE_CXX_COMPILER_WORKS 1)
+            set(CMAKE_CXX_ABI_COMPILED 1)
             cmake_minimum_required(VERSION 3.27)
             project(app CXX)
             # set(CMAKE_MAP_IMPORTED_CONFIG_DEBUG Release)
@@ -1241,6 +1369,8 @@ class TestCMakeTry:
             """)
 
         cmakelist = textwrap.dedent("""\
+            set(CMAKE_CXX_COMPILER_WORKS 1)
+            set(CMAKE_CXX_ABI_COMPILED 1)
             cmake_minimum_required(VERSION 3.15)
             project(Hello LANGUAGES CXX)
 


### PR DESCRIPTION
Changelog: Feature: Allow ``CMakeConfigDeps`` to support components with multilibs (with deprecation warning).
Docs: Omit

Close https://github.com/conan-io/conan/issues/17885
Close https://github.com/conan-io/conan/issues/17785


Also added a bunch of ``set(CMAKE_C_COMPILER_WORKS 1)`` it lowers the testing time in Windows 1 min (out of 6 mins total time)