### PR TITLE
Add gcc 15.1

### DIFF
--- a/conan/internal/default_settings.py
+++ b/conan/internal/default_settings.py
@@ -112,7 +112,8 @@ compiler:
                     "11", "11.1", "11.2", "11.3", "11.4", "11.5",
                     "12", "12.1", "12.2", "12.3",  "12.4",
                     "13", "13.1", "13.2", "13.3",
-                    "14", "14.1", "14.2"]
+                    "14", "14.1", "14.2",
+                    "15.1"]
         libcxx: [libstdc++, libstdc++11]
         threads: [null, posix, win32, mcf]  # Windows MinGW
         exception: [null, dwarf2, sjlj, seh]  # Windows MinGW

--- a/test/unittests/client/build/cpp_std_flags_test.py
+++ b/test/unittests/client/build/cpp_std_flags_test.py
@@ -79,6 +79,13 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(_make_cppstd_flag("gcc", "14", "23"), '-std=c++23')
         self.assertEqual(_make_cppstd_flag("gcc", "14", "26"), '-std=c++26')
 
+        self.assertEqual(_make_cppstd_flag("gcc", "15", "11"), '-std=c++11')
+        self.assertEqual(_make_cppstd_flag("gcc", "15", "14"), '-std=c++14')
+        self.assertEqual(_make_cppstd_flag("gcc", "15", "17"), '-std=c++17')
+        self.assertEqual(_make_cppstd_flag("gcc", "15", "20"), '-std=c++20')
+        self.assertEqual(_make_cppstd_flag("gcc", "15", "23"), '-std=c++23')
+        self.assertEqual(_make_cppstd_flag("gcc", "15", "26"), '-std=c++26')
+
     def test_gcc_cppstd_defaults(self):
         self.assertEqual(_make_cppstd_default("gcc", "4"), "gnu98")
         self.assertEqual(_make_cppstd_default("gcc", "5"), "gnu98")
@@ -88,6 +95,7 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(_make_cppstd_default("gcc", "8.1"), "gnu14")
         self.assertEqual(_make_cppstd_default("gcc", "11"), "gnu17")
         self.assertEqual(_make_cppstd_default("gcc", "11.1"), "gnu17")
+        self.assertEqual(_make_cppstd_default("gcc", "15.1"), "gnu17")
 
     def test_clang_cppstd_flags(self):
         self.assertEqual(_make_cppstd_flag("clang", "2.0", "98"), None)


### PR DESCRIPTION
Changelog: Feature: Add support for GCC 15.1.
Docs: https://github.com/conan-io/docs/pull/4081

To be released Friday 25th, April, adding now so we don't miss it for the 2.16 release

* This GCC version changes the default cstd, but we currently don't model it. Should we at some point?
* No other noteworthy changes that would impact us