### PR TITLE
fixing tests for Windows + Python 3.12

### DIFF
--- a/test/unittests/tools/env/test_env.py
+++ b/test/unittests/tools/env/test_env.py
@@ -180,7 +180,7 @@ def test_profile():
 
 
 @pytest.fixture
-def env():
+def envvars():
     # Append and define operation over the same variable in Windows preserve order
     env = Environment()
     env.define("MyVar", "MyValueA")
@@ -211,7 +211,7 @@ def check_command_output(cmd, prevenv):
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows")
-def test_windows_case_insensitive_bat(env):
+def test_windows_case_insensitive_bat(envvars):
     display = textwrap.dedent("""\
         @echo off
         echo MyVar=%MyVar%!!
@@ -222,16 +222,17 @@ def test_windows_case_insensitive_bat(env):
     prevenv = {
         "MYVAR2": "OldValue2",
     }
+    prevenv.update(dict(os.environ.copy()))  # Necessary from Python 3.12, for SYSTEMROOT var
 
     with chdir(temp_folder()):
-        env.save_bat("test.bat")
+        envvars.save_bat("test.bat")
         save("display.bat", display)
         cmd = "test.bat && display.bat && deactivate_test.bat && display.bat"
         check_command_output(cmd, prevenv)
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows")
-def test_windows_case_insensitive_ps1(env):
+def test_windows_case_insensitive_ps1(envvars):
     display = textwrap.dedent("""\
         echo "MyVar=$env:MyVar!!"
         echo "MyVar1=$env:MyVar1!!"
@@ -244,7 +245,7 @@ def test_windows_case_insensitive_ps1(env):
     prevenv.update(dict(os.environ.copy()))
 
     with chdir(temp_folder()):
-        env.save_ps1("test.ps1")
+        envvars.save_ps1("test.ps1")
         save("display.ps1", display)
         cmd = "powershell.exe .\\test.ps1 ; .\\display.ps1 ; .\\deactivate_test.ps1 ; .\\display.ps1"
         check_command_output(cmd, prevenv)
@@ -274,28 +275,18 @@ def test_dict_access():
     # With previous values in the environment
     env = Environment()
     env.prepend("MyVar", "MyValue", separator="@")
-    old_env = dict(os.environ)
-    os.environ.update({"MyVar": "PreviousValue"})
-    env_vars = env.vars(ConanFileMock())
-    try:
+    with environment_update({"MyVar": "PreviousValue"}):
+        env_vars = env.vars(ConanFileMock())
         assert env_vars["MyVar"] == "MyValue@PreviousValue"
-    finally:
-        os.environ.clear()
-        os.environ.update(old_env)
 
     env = Environment()
     env.append_path("MyVar", "MyValue")
-    old_env = dict(os.environ)
-    os.environ.update({"MyVar": "PreviousValue"})
-    env_vars = env.vars(ConanFileMock())
-    env_vars._subsystem = WINDOWS
-    try:
+    with environment_update({"MyVar": "PreviousValue"}):
+        env_vars = env.vars(ConanFileMock())
+        env_vars._subsystem = WINDOWS
         assert env_vars["MyVar"] == "PreviousValue;MyValue"
         with env_vars.apply():
             assert os.getenv("MyVar") == "PreviousValue;MyValue"
-    finally:
-        os.environ.clear()
-        os.environ.update(old_env)
 
     assert list(env_vars.keys()) == ["MyVar"]
     assert dict(env_vars.items()) == {"MyVar": "MyValue"}

--- a/test/unittests/tools/env/test_env_files.py
+++ b/test/unittests/tools/env/test_env_files.py
@@ -76,6 +76,8 @@ def check_env_files_output(cmd_, prevenv):
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows")
 def test_env_files_bat(env, prevenv):
+    prevenv.update(dict(os.environ.copy()))  # Necessary from Python 3.12, for SYSTEMROOT var
+
     display = textwrap.dedent("""\
         @echo off
         echo MyVar=%MyVar%!!
@@ -164,13 +166,13 @@ def test_relative_paths():
     os.chmod(os.path.join(scripts_folder, "myhello.sh"), 0o777)
 
     with chdir(folder):
-        env = Environment()
-        env.define_path("PATH", scripts_folder)
+        myenv = Environment()
+        myenv.define_path("PATH", scripts_folder)
         conanfile = ConanFileMock()
         conanfile.folders._base_generators = folder
-        env = env.vars(conanfile)
-        env.save_bat("test.bat")
-        env.save_sh("test.sh")
+        myenv = myenv.vars(conanfile)
+        myenv.save_bat("test.bat")
+        myenv.save_sh("test.sh")
         if platform.system() == "Windows":
             test_bat = load("test.bat")
             assert r'set "PATH=%~dp0\myscripts"' in test_bat


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

This is failing for me in Python 3.12, not sure why it is passing in CI

From https://docs.python.org/3/library/subprocess.html

> Changed in version 3.12: Changed Windows shell search order for shell=True. The current directory and %PATH% are replaced with %COMSPEC% and %SystemRoot%\System32\cmd.exe. As a result, dropping a malicious program named cmd.exe into a current directory no longer works.

This can be problematic when the PATH entries in the environment variables do not define ``C:/Windows/System32`` path hardcoded (very typical, it happens in previous machines), but in newly freshly installed Windows 11, it might happen that the only entries in the PATH are ``%SystemRoot%/System32``, and that breaks in Python 3.12.

The result is that the ``subprocess.Popen().communicate()`` or ``subprocess.run(cmd, shell=True)`` doesn't find the shell, and the output is completely empty. Both stdout and stderr are empty. This was not Conan failing, but the test checks that were running ``subprocess``.

This PR adds ``prevenv.update(dict(os.environ.copy()))`` in the tests definition to make sure that the ``SystemRoot`` variable is passed to the child launched shell, otherwise the ``cmd.exe`` is not found and it fails.
