### PR TITLE
Add missing GCC 15 key to `settings.yml`

### DIFF
--- a/conan/internal/api/detect/detect_api.py
+++ b/conan/internal/api/detect/detect_api.py
@@ -461,14 +461,12 @@ def detect_gcc_compiler(compiler_exe="gcc"):
             if "clang" in out:
                 return None, None, None
 
+        # TODO: Add -dumpfullversion to always return major.minor
         ret, out = detect_runner('%s -dumpversion' % compiler_exe)
         if ret != 0:
             return None, None, None
         compiler = "gcc"
         installed_version = re.search(r"([0-9]+(\.[0-9])?)", out).group()
-        # Since GCC 7.1, -dumpversion return the major version number
-        # only ("7"). We must use -dumpfullversion to get the full version
-        # number ("7.1.1").
         if installed_version:
             ConanOutput(scope="detect_api").info("Found %s %s" % (compiler, installed_version))
             return compiler, Version(installed_version), compiler_exe

--- a/conan/internal/default_settings.py
+++ b/conan/internal/default_settings.py
@@ -113,7 +113,7 @@ compiler:
                     "12", "12.1", "12.2", "12.3",  "12.4",
                     "13", "13.1", "13.2", "13.3",
                     "14", "14.1", "14.2",
-                    "15.1"]
+                    "15", "15.1"]
         libcxx: [libstdc++, libstdc++11]
         threads: [null, posix, win32, mcf]  # Windows MinGW
         exception: [null, dwarf2, sjlj, seh]  # Windows MinGW


### PR DESCRIPTION
Changelog: Feature: Add missing GCC 15 key to `settings.yml`
Docs: https://github.com/conan-io/docs/pull/4084

This PR adds a missing `15` version for gcc, which is what the profiles detect by default.

In 2.17 we'll add `-dumpfullversion` to the `detect_gcc_compiler()` detect method