### PR TITLE
making paths relative in CMakeConfigDeps for deployers

### DIFF
--- a/conan/tools/cmake/cmakedeps2/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps2/cmakedeps.py
@@ -244,7 +244,8 @@ class _PathGenerator:
                     f = self._cmakedeps.get_cmake_filename(dep)
                     for filename in (f"{f}-config.cmake", f"{f}Config.cmake"):
                         if os.path.isfile(os.path.join(pkg_folder, filename)):
-                            pkg_paths[pkg_name] = pkg_folder
+                            pkg_paths[pkg_name] = relativize_path(pkg_folder, self._conanfile,
+                                                                  "${CMAKE_CURRENT_LIST_DIR}")
                 continue
 
             # If CMakeDeps generated, the folder is this one
@@ -292,6 +293,7 @@ class _PathGenerator:
             runtime_dirs = aggregated_cppinfo.bindirs if is_win else aggregated_cppinfo.libdirs
             for d in runtime_dirs:
                 d = d.replace("\\", "/")
+                d = relativize_path(d, self._conanfile, "${CMAKE_CURRENT_LIST_DIR}")
                 existing = host_runtime_dirs.setdefault(config, [])
                 if d not in existing:
                     existing.append(d)

--- a/conan/tools/cmake/cmakedeps2/config.py
+++ b/conan/tools/cmake/cmakedeps2/config.py
@@ -38,7 +38,6 @@ class ConfigTemplate2:
         build_modules_paths = [relativize_path(p, self._cmakedeps._conanfile,
                                                "${CMAKE_CURRENT_LIST_DIR}")
                                for p in build_modules_paths]
-        print("build_modules_paths:", build_modules_paths)
         components = self._cmakedeps.get_property("cmake_components", self._conanfile,
                                                   check_type=list)
         if components is None:  # Lets compute the default components names

--- a/conan/tools/cmake/cmakedeps2/config.py
+++ b/conan/tools/cmake/cmakedeps2/config.py
@@ -3,6 +3,8 @@ import textwrap
 import jinja2
 from jinja2 import Template
 
+from conan.internal.api.install.generators import relativize_path
+
 
 class ConfigTemplate2:
     """
@@ -33,6 +35,10 @@ class ConfigTemplate2:
         # FIXME: Proper escaping of paths for CMake and relativization
         # FIXME: build_module_paths coming from last config only
         build_modules_paths = [f.replace("\\", "/") for f in build_modules_paths]
+        build_modules_paths = [relativize_path(p, self._cmakedeps._conanfile,
+                                               "${CMAKE_CURRENT_LIST_DIR}")
+                               for p in build_modules_paths]
+        print("build_modules_paths:", build_modules_paths)
         components = self._cmakedeps.get_property("cmake_components", self._conanfile,
                                                   check_type=list)
         if components is None:  # Lets compute the default components names

--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -5,6 +5,7 @@ import jinja2
 from jinja2 import Template
 
 from conan.errors import ConanException
+from conan.internal.api.install.generators import relativize_path
 from conan.internal.model.pkg_type import PackageType
 from conans.client.graph.graph import CONTEXT_BUILD, CONTEXT_HOST
 
@@ -120,13 +121,16 @@ class TargetConfigurationTemplate2:
         include_dirs = definitions = libraries = None
         if not self._require.build:  # To add global variables for try_compile and legacy
             aggregated_cppinfo = cpp_info.aggregated_components()
-            # FIXME: Proper escaping of paths for CMake and relativization
-            include_dirs = ";".join(i.replace("\\", "/") for i in aggregated_cppinfo.includedirs)
+            # FIXME: Proper escaping of paths for CMake
+            incdirs = [relativize_path(i, self._cmakedeps._conanfile, "${CMAKE_CURRENT_LIST_DIR}")
+                       for i in aggregated_cppinfo.includedirs]
+            include_dirs = ";".join(incdirs)
             definitions = ""
             root_target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile)
             libraries = root_target_name or f"{pkg_name}::{pkg_name}"
 
-        # TODO: Missing find_modes
+        pkg_folder = relativize_path(pkg_folder, self._cmakedeps._conanfile,
+                                     "${CMAKE_CURRENT_LIST_DIR}")
         dependencies = self._get_dependencies()
         return {"dependencies": dependencies,
                 "pkg_folder": pkg_folder,

--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -122,8 +122,9 @@ class TargetConfigurationTemplate2:
         if not self._require.build:  # To add global variables for try_compile and legacy
             aggregated_cppinfo = cpp_info.aggregated_components()
             # FIXME: Proper escaping of paths for CMake
+            incdirs = [i.replace("\\", "/") for i in aggregated_cppinfo.includedirs]
             incdirs = [relativize_path(i, self._cmakedeps._conanfile, "${CMAKE_CURRENT_LIST_DIR}")
-                       for i in aggregated_cppinfo.includedirs]
+                       for i in incdirs]
             include_dirs = ";".join(incdirs)
             definitions = ""
             root_target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile)

--- a/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
@@ -99,7 +99,7 @@ def test_cmakedeps_deployer_relative_paths():
 
             def package_info(self):
                 self.cpp_info.includedirs = ["includea"]
-                self.cpp_info.libdirs = ["liba"]
+                self.cpp_info.libdirs = ["bina"]
                 self.cpp_info.bindirs = ["bina"]
                 crypto_module = os.path.join("share", "cmake", "crypto.cmake")
                 self.cpp_info.set_property("cmake_build_modules", [crypto_module])

--- a/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
@@ -30,9 +30,6 @@ def test_cmakedeps_direct_deps_paths():
             requires = "lib/1.0"
             settings = "os", "arch", "compiler", "build_type"
             generators = "CMakeDeps"
-            def build(self):
-                cmake = CMake(self)
-                cmake.configure()
     """)
     c.save({"conanfile.py": conanfile}, clean_first=True)
     c.run(f"install . -c tools.cmake.cmakedeps:new={new_value}")
@@ -76,24 +73,80 @@ def test_cmakedeps_transitive_paths():
     c.run("create .")
     conanfile = textwrap.dedent(f"""
         from conan import ConanFile
-        from conan.tools.cmake import CMake
         class PkgConan(ConanFile):
             requires = "libb/1.0"
             settings = "os", "arch", "compiler", "build_type"
             generators = "CMakeDeps"
-            def build(self):
-                cmake = CMake(self)
-                cmake.configure()
     """)
     c.save({"conanfile.py": conanfile}, clean_first=True)
     c.run(f"install . -c tools.cmake.cmakedeps:new={new_value}")
     cmake_paths = c.load("conan_cmakedeps_paths.cmake")
-    cmake_paths.replace("\\", "/")
     assert re.search(r"list\(PREPEND CMAKE_PROGRAM_PATH \".*/libb.*/p/binb\"\)", cmake_paths)
     assert not re.search(r"list\(PREPEND CMAKE_PROGRAM_PATH /bina\"", cmake_paths)
     assert re.search(r"list\(PREPEND CMAKE_LIBRARY_PATH \".*/libb.*/p/libb\" \".*/liba.*/p/liba\"\)", cmake_paths)
     assert re.search(r"list\(PREPEND CMAKE_INCLUDE_PATH \".*/libb.*/p/includeb\" \".*/liba.*/p/includea\"\)", cmake_paths)
 
+
+def test_cmakedeps_deployer_relative_paths():
+    c = TestClient()
+    conanfile = textwrap.dedent("""
+        import os
+        from conan.tools.files import copy
+        from conan import ConanFile
+        class TestConan(ConanFile):
+            name = "liba"
+            version = "1.0"
+
+            def package_info(self):
+                self.cpp_info.includedirs = ["includea"]
+                self.cpp_info.libdirs = ["liba"]
+                self.cpp_info.bindirs = ["bina"]
+                crypto_module = os.path.join("share", "cmake", "crypto.cmake")
+                self.cpp_info.set_property("cmake_build_modules", [crypto_module])
+    """)
+    c.save({"conanfile.py": conanfile})
+    c.run("create .")
+
+    conanfile_cmake = textwrap.dedent("""
+        import os
+        from conan.tools.files import save
+        from conan import ConanFile
+        class TestConan(ConanFile):
+            name = "libb"
+            version = "1.0"
+
+            def package(self):
+                save(self, os.path.join(self.package_folder, "libb-config.cmake"), "")
+            def package_info(self):
+                self.cpp_info.set_property("cmake_find_mode", "none")
+        """)
+
+    c.save({"conanfile.py": conanfile_cmake})
+    c.run("create .")
+    conanfile = textwrap.dedent(f"""
+        from conan import ConanFile
+        from conan.tools.cmake import CMake
+        class PkgConan(ConanFile):
+            requires = "liba/1.0", "libb/1.0"
+            settings = "os", "arch", "compiler", "build_type"
+            generators = "CMakeDeps"
+    """)
+    c.save({"conanfile.py": conanfile}, clean_first=True)
+
+    # Now with a deployment
+    c.run(f"install . -c tools.cmake.cmakedeps:new={new_value} --deployer=full_deploy")
+    cmake_paths = c.load("conan_cmakedeps_paths.cmake")
+    assert 'set(libb_DIR "${CMAKE_CURRENT_LIST_DIR}/full_deploy/host/libb/1.0")' in cmake_paths
+    assert ('set(CONAN_RUNTIME_LIB_DIRS "$<$<CONFIG:Release>:${CMAKE_CURRENT_LIST_DIR}'
+            '/full_deploy/host/liba/1.0/bina>"') in cmake_paths
+    liba_config = c.load("liba-config.cmake")
+    assert ('include("${CMAKE_CURRENT_LIST_DIR}/full_deploy/'
+            'host/liba/1.0/share/cmake/crypto.cmake")') in liba_config
+    liba_targets = c.load("liba-Targets-release.cmake")
+    assert ('set(liba_PACKAGE_FOLDER_RELEASE "${CMAKE_CURRENT_LIST_DIR}/full_deploy/'
+            'host/liba/1.0")') in liba_targets
+    assert ('set(liba_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/full_deploy/'
+            'host/liba/1.0/includea" )') in liba_targets
 
 def test_cmakeconfigdeps_recipe():
     c = TestClient()


### PR DESCRIPTION
Changelog: Fix: Make ``CMakeConfigDeps`` incubating generator paths relative for ``deployers``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/18180