### PR TITLE
[fix] CycloneDX 1.6 fix `authors` field and improve test

### DIFF
--- a/conan/tools/sbom/cyclonedx.py
+++ b/conan/tools/sbom/cyclonedx.py
@@ -163,7 +163,7 @@ def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, **kwar
 
     sbom_cyclonedx_1_6 = {
         **({"components": [{
-            **({"authors": [node.conanfile.author]} if node.conanfile.author else {}),
+            **({"authors": [{"name": node.conanfile.author}]} if node.conanfile.author else {}),
             "bom-ref": special_id if has_special_root_node else f"pkg:conan/{node.name}@{node.ref.version}?rref={node.ref.revision}",
             "description": node.conanfile.description,
             **({"externalReferences": [{
@@ -179,7 +179,7 @@ def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, **kwar
         **({"dependencies": dependencies} if dependencies else {}),
         "metadata": {
             "component": {
-                **({"authors": [conanfile.author]} if conanfile.author else {}),
+                **({"authors": [{"name": conanfile.author}]} if conanfile.author else {}),
                 "bom-ref": special_id if has_special_root_node else f"pkg:conan/{conanfile.name}@{conanfile.ref.version}?rref={conanfile.ref.revision}",
                 "name": name if name else name_default,
                 "type": "application" if conanfile.package_type == "application" else "library"

--- a/test/functional/sbom/test_cyclonedx.py
+++ b/test/functional/sbom/test_cyclonedx.py
@@ -321,16 +321,16 @@ def test_cyclonedx_check_content(cyclone_version):
     content = tc.load(cyclone_path)
     content_json = json.loads(content)
     if cyclone_version == 'cyclonedx_1_4':
-        assert content_json["metadata"]["component"]["author"]
+        assert content_json["metadata"]["component"]["author"] == 'conan-dev'
         assert content_json["metadata"]["component"]["type"] == 'application'
         assert content_json["metadata"]["tools"][0]
-        assert content_json["components"][0]["author"]
+        assert content_json["components"][0]["author"] == 'conan-dev'
         assert content_json["components"][0]["type"] == 'application'
     elif cyclone_version == 'cyclonedx_1_6':
         assert not content_json["metadata"]["component"].get("author")
-        assert content_json["metadata"]["component"]["authors"]
+        assert content_json["metadata"]["component"]["authors"][0]["name"] == 'conan-dev'
         assert content_json["metadata"]["component"]["type"] == 'application'
         assert content_json["metadata"]["tools"]["components"][0]
         assert not content_json["components"][0].get("author")
-        assert content_json["components"][0]["authors"]
+        assert content_json["components"][0]["authors"][0]["name"] == 'conan-dev'
         assert content_json["components"][0]["type"] == 'application'


### PR DESCRIPTION
Changelog: Fix: CycloneDX 1.6 authors field.
Docs: Omit

Close: https://github.com/conan-io/conan/issues/18203

The `authors` field in `metadata/component` and `components` are both objects and not strings. 
The test checking the SBOM content has also been fixed.

https://cyclonedx.org/docs/1.6/json/#metadata_component_authors
https://cyclonedx.org/docs/1.6/json/#components_items_authors


