### PR TITLE
Increase test coverage based on Codecov reports

### DIFF
--- a/test/functional/sbom/test_cyclonedx.py
+++ b/test/functional/sbom/test_cyclonedx.py
@@ -51,7 +51,7 @@ class TestCyclonedx:
         tc = TestClient()
         hook_path = os.path.join(tc.paths.hooks_path, "hook_sbom.py")
         save(hook_path, sbom_hook_post_package.format(cyclone_version=cyclone_version,
-                                                      add_build=True, add_tests=True))
+                                                      add_build=False, add_tests=False))
         return tc
 
     @pytest.fixture()
@@ -119,14 +119,14 @@ class TestCyclonedx:
     @pytest.mark.parametrize("l, n", [('"simple"', 1), ('"multi1", "multi2"', 2), ('("tuple1", "tuple2")', 2)])
     def test_multi_license(self, hook_setup_post_package, l, n):
         tc = hook_setup_post_package
-        conanfile = textwrap.dedent("""
+        conanfile = textwrap.dedent(f"""
             from conan import ConanFile
             class HelloConan(ConanFile):
                 name = 'foo'
                 version = '1.0'
-                license = %s
+                license = {l}
         """)
-        tc.save({"conanfile.py": conanfile % l})
+        tc.save({"conanfile.py": conanfile})
         tc.run("create .")
         create_layout = tc.created_layout()
         cyclone_path = os.path.join(create_layout.metadata(), "sbom.cdx.json")

--- a/test/functional/sbom/test_cyclonedx.py
+++ b/test/functional/sbom/test_cyclonedx.py
@@ -14,151 +14,16 @@ import json
 import os
 from conan.errors import ConanException
 from conan.api.output import ConanOutput
-from conan.tools.sbom import cyclonedx_1_4
+from conan.tools.sbom import {cyclone_version}
 
 def post_package(conanfile):
-    sbom_cyclonedx_1_4 = cyclonedx_1_4(conanfile, add_build=%s, add_tests=%s)
+    sbom_{cyclone_version} = {cyclone_version}(conanfile, add_build={add_build}, add_tests={add_tests})
     metadata_folder = conanfile.package_metadata_folder
     file_name = "sbom.cdx.json"
     with open(os.path.join(metadata_folder, file_name), 'w') as f:
-        json.dump(sbom_cyclonedx_1_4, f, indent=4)
-    ConanOutput().success(f"CYCLONEDX CREATED - {conanfile.package_metadata_folder}")
+        json.dump(sbom_{cyclone_version}, f, indent=4)
+    ConanOutput().success(f"CYCLONEDX CREATED - {{conanfile.package_metadata_folder}}")
 """
-
-@pytest.fixture()
-def hook_setup_post_package_default():
-    tc = TestClient()
-    hook_path = os.path.join(tc.paths.hooks_path, "hook_sbom.py")
-    save(hook_path, sbom_hook_post_package % ("False", "False"))
-    return tc
-
-@pytest.fixture()
-def hook_setup_post_package():
-    tc = TestClient()
-    hook_path = os.path.join(tc.paths.hooks_path, "hook_sbom.py")
-    save(hook_path, sbom_hook_post_package % ("True", "True"))
-    return tc
-
-
-@pytest.fixture()
-def hook_setup_post_package_no_tool_requires():
-    tc = TestClient()
-    hook_path = os.path.join(tc.paths.hooks_path, "hook_sbom.py")
-    save(hook_path, sbom_hook_post_package % ("False", "True"))
-    return tc
-
-
-@pytest.fixture()
-def hook_setup_post_package_no_test():
-    tc = TestClient()
-    hook_path = os.path.join(tc.paths.hooks_path, "hook_sbom.py")
-    save(hook_path, sbom_hook_post_package % ("True", "False"))
-    return tc
-
-
-@pytest.fixture()
-def hook_setup_post_package_tl(transitive_libraries):
-    tc = transitive_libraries
-    hook_path = os.path.join(tc.paths.hooks_path, "hook_sbom.py")
-    save(hook_path, sbom_hook_post_package % ("True", "True"))
-    return tc
-
-
-def test_sbom_generation_create(hook_setup_post_package_tl):
-    tc = hook_setup_post_package_tl
-    tc.run("new cmake_lib -d name=bar -d version=1.0 -d requires=engine/1.0 -f")
-    # bar -> engine/1.0 -> matrix/1.0
-    tc.run("create . -tf=")
-    bar_layout = tc.created_layout()
-    assert os.path.exists(os.path.join(bar_layout.metadata(), "sbom.cdx.json"))
-
-
-def test_sbom_generation_skipped_dependencies(hook_setup_post_package):
-    tc = hook_setup_post_package
-    tc.save({"dep/conanfile.py": GenConanfile("dep", "1.0"),
-             "app/conanfile.py": GenConanfile("app", "1.0")
-                                .with_package_type("application")
-                                .with_requires("dep/1.0"),
-             "conanfile.py": GenConanfile("foo", "1.0").with_tool_requires("app/1.0")})
-    tc.run("create dep")
-    tc.run("create app")
-    tc.run("create .")
-    create_layout = tc.created_layout()
-
-    cyclone_path = os.path.join(create_layout.metadata(), "sbom.cdx.json")
-    content = tc.load(cyclone_path)
-    # A skipped dependency also shows up in the sbom
-    assert "pkg:conan/dep@1.0?rref=6a99f55e933fb6feeb96df134c33af44" in content
-
-@pytest.mark.parametrize("l, n", [('"simple"', 1), ('"multi1", "multi2"', 2), ('("tuple1", "tuple2")', 2)])
-def test_multi_license(hook_setup_post_package, l, n):
-    tc = hook_setup_post_package
-    conanfile = textwrap.dedent("""
-        from conan import ConanFile
-        class HelloConan(ConanFile):
-            name = 'foo'
-            version = '1.0'
-            license = %s
-    """)
-    tc.save({"conanfile.py": conanfile % l})
-    tc.run("create .")
-    create_layout = tc.created_layout()
-    cyclone_path = os.path.join(create_layout.metadata(), "sbom.cdx.json")
-    content = json.loads(tc.load(cyclone_path))
-    assert len(content["components"][0]["licenses"]) == n
-
-def test_sbom_generation_no_tool_requires(hook_setup_post_package_no_tool_requires):
-    tc = hook_setup_post_package_no_tool_requires
-    tc.save({"app/conanfile.py": GenConanfile("app", "1.0")
-                                .with_package_type("application"),
-             "conanfile.py": GenConanfile("foo", "1.0").with_tool_requires("app/1.0")})
-    tc.run("create app")
-    tc.run("create .")
-    create_layout = tc.created_layout()
-
-    cyclone_path = os.path.join(create_layout.metadata(), "sbom.cdx.json")
-    content = tc.load(cyclone_path)
-
-    assert "pkg:conan/app" not in content
-
-
-def test_sbom_generation_transitive_test_requires(hook_setup_post_package_no_test):
-    tc = hook_setup_post_package_no_test
-    tc.save({"test_re/conanfile.py": GenConanfile("test_re", "1.0"),
-             "app/conanfile.py": GenConanfile("app", "1.0")
-                                .with_package_type("application")
-                                .with_test_requires("test_re/1.0"),
-             "conanfile.py": GenConanfile("foo", "1.0").with_tool_requires("app/1.0")})
-    tc.run("create test_re")
-
-    tc.run("create app")
-    create_layout = tc.created_layout()
-    cyclone_path = os.path.join(create_layout.metadata(), "sbom.cdx.json")
-    content = tc.load(cyclone_path)
-    assert "pkg:conan/test_re@1.0" not in content
-
-    tc.run("create .")
-    create_layout = tc.created_layout()
-    cyclone_path = os.path.join(create_layout.metadata(), "sbom.cdx.json")
-    content = tc.load(cyclone_path)
-    assert "pkg:conan/test_re@1.0" not in content
-
-
-def test_sbom_generation_dependency_test_require(hook_setup_post_package_no_test):
-    tc = hook_setup_post_package_no_test
-    tc.save({"special/conanfile.py": GenConanfile("special", "1.0"),
-             "foo/conanfile.py": GenConanfile("foo", "1.0")
-            .with_test_requires("special/1.0"),
-             "conanfile.py": GenConanfile("bar", "1.0").with_tool_requires("foo/1.0").with_require("special/1.0")})
-    tc.run("create special")
-    tc.run("create foo")
-
-    tc.run("create .")
-    create_layout = tc.created_layout()
-    cyclone_path = os.path.join(create_layout.metadata(), "sbom.cdx.json")
-    content = tc.load(cyclone_path)
-    assert "pkg:conan/special@1.0" in content
-
 
 # Using the sbom tool with "conan install"
 sbom_hook_post_generate = """
@@ -166,171 +31,312 @@ import json
 import os
 from conan.errors import ConanException
 from conan.api.output import ConanOutput
-from conan.tools.sbom import cyclonedx_1_4
+from conan.tools.sbom import {cyclone_version}
 
 def post_generate(conanfile):
-    sbom_cyclonedx_1_4 = cyclonedx_1_4(conanfile, name=%s)
+    sbom_{cyclone_version} = {cyclone_version}(conanfile, name={name})
     generators_folder = conanfile.generators_folder
     file_name = "sbom.cdx.json"
     os.mkdir(os.path.join(generators_folder, "sbom"))
     with open(os.path.join(generators_folder, "sbom", file_name), 'w') as f:
-        json.dump(sbom_cyclonedx_1_4, f, indent=4)
-    ConanOutput().success(f"CYCLONEDX CREATED - {conanfile.generators_folder}")
+        json.dump(sbom_{cyclone_version}, f, indent=4)
+    ConanOutput().success(f"CYCLONEDX CREATED - {{conanfile.generators_folder}}")
 """
 
-
-@pytest.fixture()
-def hook_setup_post_generate():
-    tc = TestClient()
-    hook_path = os.path.join(tc.paths.hooks_path, "hook_sbom.py")
-    save(hook_path, sbom_hook_post_generate % "None")
-    return tc
-
-
-def test_sbom_generation_install_requires(hook_setup_post_generate):
-    tc = hook_setup_post_generate
-    tc.save({"dep/conanfile.py": GenConanfile("dep", "1.0"),
-             "conanfile.py": GenConanfile("foo", "1.0").with_requires("dep/1.0")})
-    tc.run("export dep")
-    tc.run("create . --build=missing")
-
-    # cli -> foo -> dep
-    tc.run("install --requires=foo/1.0")
-    assert os.path.exists(os.path.join(tc.current_folder, "sbom", "sbom.cdx.json"))
-
-
-def test_sbom_generation_install_path(hook_setup_post_generate):
-    tc = hook_setup_post_generate
-    tc.save({"dep/conanfile.py": GenConanfile("dep", "1.0"),
-             "conanfile.py": GenConanfile("foo", "1.0").with_requires("dep/1.0")})
-    tc.run("create dep")
-
-    # foo -> dep
-    tc.run("install .")
-    assert os.path.exists(os.path.join(tc.current_folder, "sbom", "sbom.cdx.json"))
-
-
-def test_sbom_generation_install_path_consumer(hook_setup_post_generate):
-    tc = hook_setup_post_generate
-    tc.save({"dep/conanfile.py": GenConanfile("dep", "1.0"),
-             "conanfile.py": GenConanfile().with_requires("dep/1.0")})
-    tc.run("create dep")
-
-    # conanfile.py -> dep
-    tc.run("install .")
-    assert os.path.exists(os.path.join(tc.current_folder, "sbom", "sbom.cdx.json"))
-
-
-def test_sbom_generation_install_path_txt(hook_setup_post_generate):
-    tc = hook_setup_post_generate
-    tc.save({"dep/conanfile.py": GenConanfile("dep", "1.0"),
-             "conanfile.txt": textwrap.dedent(
-                 """
-                 [requires]
-                 dep/1.0
-                 """
-             )})
-    tc.run("create dep")
-
-    # foo -> dep
-    tc.run("install .")
-    assert os.path.exists(os.path.join(tc.current_folder, "sbom", "sbom.cdx.json"))
-
-def test_sbom_with_special_root_node(hook_setup_post_generate):
-    # In this test, we have only one node in the subgraph, which has build context, so the number
-    # of components after processing it is zero.
-    tc = hook_setup_post_generate
-    package_name = "foo"
-
-    conanfile =  textwrap.dedent("""
-            from conan import ConanFile
-            class FooPackage(ConanFile):
-                name = "foo"
-                version = "1.0"
-                package_type = "build-scripts"
-    """)
-    tc.save({"conanfile.py": conanfile})
-    tc.run("create .")
-    create_layout = tc.created_layout()
-    assert os.path.exists(os.path.join(create_layout.build(), "sbom", "sbom.cdx.json"))
-    with open(os.path.join(create_layout.build(), "sbom", "sbom.cdx.json"), 'r') as file:
-        sbom_json = json.load(file)
-        assert package_name in sbom_json["metadata"]["component"]["name"]
-
-@pytest.mark.parametrize("name, result", [
-    ("None", "conan-sbom"),
-    ('"custom-name"', "custom-name")
-])
-def test_sbom_generation_custom_name(name, result):
-    tc = TestClient()
-    hook_path = os.path.join(tc.paths.hooks_path, "hook_sbom.py")
-    save(hook_path, sbom_hook_post_generate % name)
-
-    tc.save({"conanfile.py": GenConanfile()})
-    tc.run("install .")
-    assert os.path.exists(os.path.join(tc.current_folder, "sbom", "sbom.cdx.json"))
-    assert f'"name": "{result}"' in tc.load(os.path.join(tc.current_folder, "sbom", "sbom.cdx.json"))
-
 @pytest.mark.parametrize("cyclone_version", ["cyclonedx_1_4", "cyclonedx_1_6"])
-def test_cyclonedx_check_content(cyclone_version):
-    _sbom_hook_post_package = textwrap.dedent("""
-    import json
-    import os
-    from conan.errors import ConanException
-    from conan.api.output import ConanOutput
-    from conan.tools.sbom import %s
+class TestCyclonedx:
 
-    def post_package(conanfile):
-        sbom_cyclonedx= %s(conanfile)
-        metadata_folder = conanfile.package_metadata_folder
-        file_name = "sbom.cdx.json"
-        with open(os.path.join(metadata_folder, file_name), 'w') as f:
-            json.dump(sbom_cyclonedx, f, indent=4)
-        ConanOutput().success(f"CYCLONEDX CREATED - {conanfile.package_metadata_folder}")
-    """)
-    tc = TestClient()
-    hook_path = os.path.join(tc.paths.hooks_path, "hook_sbom.py")
-    save(hook_path, _sbom_hook_post_package % (cyclone_version, cyclone_version))
-    conanfile_bar = textwrap.dedent("""
+    @pytest.fixture()
+    def hook_setup_post_package_default(self, cyclone_version):
+        tc = TestClient()
+        hook_path = os.path.join(tc.paths.hooks_path, "hook_sbom.py")
+        save(hook_path, sbom_hook_post_package.format(cyclone_version=cyclone_version,
+                                                      add_build=True, add_tests=True))
+        return tc
+
+    @pytest.fixture()
+    def hook_setup_post_package(self, cyclone_version):
+        tc = TestClient()
+        hook_path = os.path.join(tc.paths.hooks_path, "hook_sbom.py")
+        save(hook_path, sbom_hook_post_package.format(cyclone_version=cyclone_version,
+                                                      add_build=True, add_tests=True))
+        return tc
+
+
+    @pytest.fixture()
+    def hook_setup_post_package_no_tool_requires(self, cyclone_version):
+        tc = TestClient()
+        hook_path = os.path.join(tc.paths.hooks_path, "hook_sbom.py")
+        save(hook_path, sbom_hook_post_package.format(cyclone_version=cyclone_version,
+                                                      add_build=False, add_tests=True))
+        return tc
+
+
+    @pytest.fixture()
+    def hook_setup_post_package_no_test(self, cyclone_version):
+        tc = TestClient()
+        hook_path = os.path.join(tc.paths.hooks_path, "hook_sbom.py")
+        save(hook_path, sbom_hook_post_package.format(cyclone_version=cyclone_version,
+                                                      add_build=True, add_tests=False))
+        return tc
+
+
+    @pytest.fixture()
+    def hook_setup_post_package_tl(self, cyclone_version, transitive_libraries):
+        tc = transitive_libraries
+        hook_path = os.path.join(tc.paths.hooks_path, "hook_sbom.py")
+        save(hook_path, sbom_hook_post_package.format(cyclone_version=cyclone_version,
+                                                      add_build=True, add_tests=True))
+        return tc
+
+
+    def test_sbom_generation_create(self, hook_setup_post_package_tl):
+        tc = hook_setup_post_package_tl
+        tc.run("new cmake_lib -d name=bar -d version=1.0 -d requires=engine/1.0 -f")
+        # bar -> engine/1.0 -> matrix/1.0
+        tc.run("create . -tf=")
+        bar_layout = tc.created_layout()
+        assert os.path.exists(os.path.join(bar_layout.metadata(), "sbom.cdx.json"))
+
+
+    def test_sbom_generation_skipped_dependencies(self, hook_setup_post_package):
+        tc = hook_setup_post_package
+        tc.save({"dep/conanfile.py": GenConanfile("dep", "1.0"),
+                 "app/conanfile.py": GenConanfile("app", "1.0")
+                                    .with_package_type("application")
+                                    .with_requires("dep/1.0"),
+                 "conanfile.py": GenConanfile("foo", "1.0").with_tool_requires("app/1.0")})
+        tc.run("create dep")
+        tc.run("create app")
+        tc.run("create .")
+        create_layout = tc.created_layout()
+
+        cyclone_path = os.path.join(create_layout.metadata(), "sbom.cdx.json")
+        content = tc.load(cyclone_path)
+        # A skipped dependency also shows up in the sbom
+        assert "pkg:conan/dep@1.0?rref=6a99f55e933fb6feeb96df134c33af44" in content
+
+    @pytest.mark.parametrize("l, n", [('"simple"', 1), ('"multi1", "multi2"', 2), ('("tuple1", "tuple2")', 2)])
+    def test_multi_license(self, hook_setup_post_package, l, n):
+        tc = hook_setup_post_package
+        conanfile = textwrap.dedent("""
             from conan import ConanFile
             class HelloConan(ConanFile):
-                name = 'bar'
+                name = 'foo'
+                version = '1.0'
+                license = %s
+        """)
+        tc.save({"conanfile.py": conanfile % l})
+        tc.run("create .")
+        create_layout = tc.created_layout()
+        cyclone_path = os.path.join(create_layout.metadata(), "sbom.cdx.json")
+        content = json.loads(tc.load(cyclone_path))
+        assert len(content["components"][0]["licenses"]) == n
+
+    def test_sbom_generation_no_tool_requires(self, hook_setup_post_package_no_tool_requires):
+        tc = hook_setup_post_package_no_tool_requires
+        tc.save({"app/conanfile.py": GenConanfile("app", "1.0")
+                                    .with_package_type("application"),
+                 "conanfile.py": GenConanfile("foo", "1.0").with_tool_requires("app/1.0")})
+        tc.run("create app")
+        tc.run("create .")
+        create_layout = tc.created_layout()
+
+        cyclone_path = os.path.join(create_layout.metadata(), "sbom.cdx.json")
+        content = tc.load(cyclone_path)
+
+        assert "pkg:conan/app" not in content
+
+
+    def test_sbom_generation_transitive_test_requires(self, hook_setup_post_package_no_test):
+        tc = hook_setup_post_package_no_test
+        tc.save({"test_re/conanfile.py": GenConanfile("test_re", "1.0"),
+                 "app/conanfile.py": GenConanfile("app", "1.0")
+                                    .with_package_type("application")
+                                    .with_test_requires("test_re/1.0"),
+                 "conanfile.py": GenConanfile("foo", "1.0").with_tool_requires("app/1.0")})
+        tc.run("create test_re")
+
+        tc.run("create app")
+        create_layout = tc.created_layout()
+        cyclone_path = os.path.join(create_layout.metadata(), "sbom.cdx.json")
+        content = tc.load(cyclone_path)
+        assert "pkg:conan/test_re@1.0" not in content
+
+        tc.run("create .")
+        create_layout = tc.created_layout()
+        cyclone_path = os.path.join(create_layout.metadata(), "sbom.cdx.json")
+        content = tc.load(cyclone_path)
+        assert "pkg:conan/test_re@1.0" not in content
+
+
+    def test_sbom_generation_dependency_test_require(self, hook_setup_post_package_no_test):
+        tc = hook_setup_post_package_no_test
+        tc.save({"special/conanfile.py": GenConanfile("special", "1.0"),
+                 "foo/conanfile.py": GenConanfile("foo", "1.0")
+                .with_test_requires("special/1.0"),
+                 "conanfile.py": GenConanfile("bar", "1.0").with_tool_requires("foo/1.0").with_require("special/1.0")})
+        tc.run("create special")
+        tc.run("create foo")
+
+        tc.run("create .")
+        create_layout = tc.created_layout()
+        cyclone_path = os.path.join(create_layout.metadata(), "sbom.cdx.json")
+        content = tc.load(cyclone_path)
+        assert "pkg:conan/special@1.0" in content
+
+
+    @pytest.fixture()
+    def hook_setup_post_generate(self, cyclone_version):
+        tc = TestClient()
+        hook_path = os.path.join(tc.paths.hooks_path, "hook_sbom.py")
+        save(hook_path, sbom_hook_post_generate.format(cyclone_version=cyclone_version, name=None))
+        return tc
+
+
+    def test_sbom_generation_install_requires(self, hook_setup_post_generate):
+        tc = hook_setup_post_generate
+        tc.save({"dep/conanfile.py": GenConanfile("dep", "1.0"),
+                 "conanfile.py": GenConanfile("foo", "1.0").with_requires("dep/1.0")})
+        tc.run("export dep")
+        tc.run("create . --build=missing")
+
+        # cli -> foo -> dep
+        tc.run("install --requires=foo/1.0")
+        assert os.path.exists(os.path.join(tc.current_folder, "sbom", "sbom.cdx.json"))
+
+
+    def test_sbom_generation_install_path(self, hook_setup_post_generate):
+        tc = hook_setup_post_generate
+        tc.save({"dep/conanfile.py": GenConanfile("dep", "1.0"),
+                 "conanfile.py": GenConanfile("foo", "1.0").with_requires("dep/1.0")})
+        tc.run("create dep")
+
+        # foo -> dep
+        tc.run("install .")
+        assert os.path.exists(os.path.join(tc.current_folder, "sbom", "sbom.cdx.json"))
+
+
+    def test_sbom_generation_install_path_consumer(self, hook_setup_post_generate):
+        tc = hook_setup_post_generate
+        tc.save({"dep/conanfile.py": GenConanfile("dep", "1.0"),
+                 "conanfile.py": GenConanfile().with_requires("dep/1.0")})
+        tc.run("create dep")
+
+        # conanfile.py -> dep
+        tc.run("install .")
+        assert os.path.exists(os.path.join(tc.current_folder, "sbom", "sbom.cdx.json"))
+
+
+    def test_sbom_generation_install_path_txt(self, hook_setup_post_generate):
+        tc = hook_setup_post_generate
+        tc.save({"dep/conanfile.py": GenConanfile("dep", "1.0"),
+                 "conanfile.txt": textwrap.dedent(
+                     """
+                     [requires]
+                     dep/1.0
+                     """
+                 )})
+        tc.run("create dep")
+
+        # foo -> dep
+        tc.run("install .")
+        assert os.path.exists(os.path.join(tc.current_folder, "sbom", "sbom.cdx.json"))
+
+    def test_sbom_with_special_root_node(self, hook_setup_post_generate):
+        # In this test, we have only one node in the subgraph, which has build context, so the number
+        # of components after processing it is zero.
+        tc = hook_setup_post_generate
+        package_name = "foo"
+
+        conanfile =  textwrap.dedent("""
+                from conan import ConanFile
+                class FooPackage(ConanFile):
+                    name = "foo"
+                    version = "1.0"
+                    package_type = "build-scripts"
+        """)
+        tc.save({"conanfile.py": conanfile})
+        tc.run("create .")
+        create_layout = tc.created_layout()
+        assert os.path.exists(os.path.join(create_layout.build(), "sbom", "sbom.cdx.json"))
+        with open(os.path.join(create_layout.build(), "sbom", "sbom.cdx.json"), 'r') as file:
+            sbom_json = json.load(file)
+            assert package_name in sbom_json["metadata"]["component"]["name"]
+
+    @pytest.mark.parametrize("name, result", [
+        ("None", "conan-sbom"),
+        ('"custom-name"', "custom-name")
+    ])
+    def test_sbom_generation_custom_name(self, cyclone_version, name, result):
+        tc = TestClient()
+        hook_path = os.path.join(tc.paths.hooks_path, "hook_sbom.py")
+        save(hook_path, sbom_hook_post_generate.format(cyclone_version=cyclone_version, name=name))
+
+        tc.save({"conanfile.py": GenConanfile()})
+        tc.run("install .")
+        assert os.path.exists(os.path.join(tc.current_folder, "sbom", "sbom.cdx.json"))
+        assert f'"name": "{result}"' in tc.load(os.path.join(tc.current_folder, "sbom", "sbom.cdx.json"))
+
+    def test_cyclonedx_check_content(self, cyclone_version):
+        _sbom_hook_post_package = textwrap.dedent("""
+        import json
+        import os
+        from conan.errors import ConanException
+        from conan.api.output import ConanOutput
+        from conan.tools.sbom import {cyclone_version}
+
+        def post_package(conanfile):
+            sbom_cyclonedx= {cyclone_version}(conanfile)
+            metadata_folder = conanfile.package_metadata_folder
+            file_name = "sbom.cdx.json"
+            with open(os.path.join(metadata_folder, file_name), 'w') as f:
+                json.dump(sbom_cyclonedx, f, indent=4)
+            ConanOutput().success(f"CYCLONEDX CREATED - {{conanfile.package_metadata_folder}}")
+        """)
+        tc = TestClient()
+        hook_path = os.path.join(tc.paths.hooks_path, "hook_sbom.py")
+        save(hook_path, _sbom_hook_post_package.format(cyclone_version=cyclone_version))
+        conanfile_bar = textwrap.dedent("""
+                from conan import ConanFile
+                class HelloConan(ConanFile):
+                    name = 'bar'
+                    version = '1.0'
+                    author = 'conan-dev'
+                    package_type = 'application'
+            """)
+
+        conanfile_foo = textwrap.dedent("""
+            from conan import ConanFile
+            class HelloConan(ConanFile):
+                name = 'foo'
                 version = '1.0'
                 author = 'conan-dev'
                 package_type = 'application'
+
+                def requirements(self):
+                    self.requires("bar/1.0")
         """)
+        tc.save({"conanfile.py": conanfile_bar})
+        tc.run("create .")
+        tc.save({"conanfile.py": conanfile_foo})
+        tc.run("create .")
 
-    conanfile_foo = textwrap.dedent("""
-        from conan import ConanFile
-        class HelloConan(ConanFile):
-            name = 'foo'
-            version = '1.0'
-            author = 'conan-dev'
-            package_type = 'application'
-
-            def requirements(self):
-                self.requires("bar/1.0")
-    """)
-    tc.save({"conanfile.py": conanfile_bar})
-    tc.run("create .")
-    tc.save({"conanfile.py": conanfile_foo})
-    tc.run("create .")
-
-    create_layout = tc.created_layout()
-    cyclone_path = os.path.join(create_layout.metadata(), "sbom.cdx.json")
-    content = tc.load(cyclone_path)
-    content_json = json.loads(content)
-    if cyclone_version == 'cyclonedx_1_4':
-        assert content_json["metadata"]["component"]["author"] == 'conan-dev'
-        assert content_json["metadata"]["component"]["type"] == 'application'
-        assert content_json["metadata"]["tools"][0]
-        assert content_json["components"][0]["author"] == 'conan-dev'
-        assert content_json["components"][0]["type"] == 'application'
-    elif cyclone_version == 'cyclonedx_1_6':
-        assert not content_json["metadata"]["component"].get("author")
-        assert content_json["metadata"]["component"]["authors"][0]["name"] == 'conan-dev'
-        assert content_json["metadata"]["component"]["type"] == 'application'
-        assert content_json["metadata"]["tools"]["components"][0]
-        assert not content_json["components"][0].get("author")
-        assert content_json["components"][0]["authors"][0]["name"] == 'conan-dev'
-        assert content_json["components"][0]["type"] == 'application'
+        create_layout = tc.created_layout()
+        cyclone_path = os.path.join(create_layout.metadata(), "sbom.cdx.json")
+        content = tc.load(cyclone_path)
+        content_json = json.loads(content)
+        if cyclone_version == 'cyclonedx_1_4':
+            assert content_json["metadata"]["component"]["author"] == 'conan-dev'
+            assert content_json["metadata"]["component"]["type"] == 'application'
+            assert content_json["metadata"]["tools"][0]
+            assert content_json["components"][0]["author"] == 'conan-dev'
+            assert content_json["components"][0]["type"] == 'application'
+        elif cyclone_version == 'cyclonedx_1_6':
+            assert not content_json["metadata"]["component"].get("author")
+            assert content_json["metadata"]["component"]["authors"][0]["name"] == 'conan-dev'
+            assert content_json["metadata"]["component"]["type"] == 'application'
+            assert content_json["metadata"]["tools"]["components"][0]
+            assert not content_json["components"][0].get("author")
+            assert content_json["components"][0]["authors"][0]["name"] == 'conan-dev'
+            assert content_json["components"][0]["type"] == 'application'

--- a/test/integration/command/test_audit.py
+++ b/test/integration/command/test_audit.py
@@ -185,7 +185,7 @@ def test_conan_audit_private():
     # Now, remove the token as if the user didn't set it manually in the json
     providers = json.loads(tc.load_home("audit_providers.json"))
     providers["myprivate"].pop("token", None)
-    tc.save_home({"audit_providers.json", json.dumps(providers))
+    tc.save_home({"audit_providers.json": json.dumps(providers)})
 
     tc.run("audit list zlib/1.2.11 -p=myprivate", assert_error=True)
     assert "Missing authentication token for 'myprivate' provider" in tc.out

--- a/test/integration/command/test_audit.py
+++ b/test/integration/command/test_audit.py
@@ -183,12 +183,9 @@ def test_conan_audit_private():
     # TODO: If the CLI does not allow tokenless provider, should this case not be handled?
     tc.run("audit provider add myprivate --url=foo --type=private --token=f")
     # Now, remove the token as if the user didn't set it manually in the json
-    providers_json_path = os.path.join(tc.cache_folder, "audit_providers.json")
-    with open(providers_json_path, "r") as f:
-        providers_json = json.load(f)
-    providers_json["myprivate"].pop("token", None)
-    with open(providers_json_path, "w") as f:
-        json.dump(providers_json, f)
+    providers = json.loads(tc.load_home("audit_providers.json"))
+    providers["myprivate"].pop("token", None)
+    tc.save_home({"audit_providers.json", json.dumps(providers))
 
     tc.run("audit list zlib/1.2.11 -p=myprivate", assert_error=True)
     assert "Missing authentication token for 'myprivate' provider" in tc.out

--- a/test/integration/command/test_audit.py
+++ b/test/integration/command/test_audit.py
@@ -13,18 +13,18 @@ from conan.test.utils.tools import TestClient
 
 
 @contextmanager
-def proxy_response(status, data):
+def proxy_response(status, data, retry_after=60):
     with patch("conan.api.conan_api.RemotesAPI.requester") as conanRequesterMock:
         return_status = MagicMock()
         return_status.status_code = status
         return_status.json = MagicMock(return_value=data)
-        return_status.headers = {"retry-after": 60}
+        return_status.headers = {"retry-after": retry_after}
         conanRequesterMock.post = MagicMock(return_value=return_status)
 
         yield conanRequesterMock, return_status
 
 
-def test_conan_audit_paths():
+def test_conan_audit_proxy():
     successful_response = {
         "data": {
             "query": {
@@ -91,9 +91,28 @@ def test_conan_audit_paths():
         assert "You have exceeded the number of allowed requests" in tc.out
         assert "The limit will reset in 1 minute" in tc.out
 
+    with proxy_response(429, {"error": "Rate limit exceeded"}, retry_after=2 * 3600):
+        tc.run("audit list zlib/1.2.11", assert_error=True)
+        assert "You have exceeded the number of allowed requests" in tc.out
+        assert "The limit will reset in 2 hours and 0 minute" in tc.out
+
     with proxy_response(400, {"error": "Not found"}):
+        # Not finding a package should not be an error
         tc.run("audit list zlib/1.2.11")
         assert "Package 'zlib/1.2.11' not scanned: Not found." in tc.stdout
+
+    with proxy_response(403, {"error": "Error not shown"}):
+        tc.run("audit list zlib/1.2.11", assert_error=True)
+        assert "ERROR: Authentication error (403)" in tc.out
+        assert "Error not shown" not in tc.out
+
+    with proxy_response(500, {"error": "Internal error"}):
+        tc.run("audit list zlib/1.2.11", assert_error=True)
+        assert "Internal server error (500)" in tc.out
+
+    with proxy_response(405, {"error": "Method not allowed"}):
+        tc.run("audit list zlib/1.2.11", assert_error=True)
+        assert "Error in zlib/1.2.11 (405)" in tc.out
 
     tc.run("audit provider add myprivate --url=foo --type=private --token=valid_token")
 
@@ -114,6 +133,100 @@ def test_conan_audit_paths():
         assert providers_stat.st_uid == os.getuid()
         assert providers_stat.st_gid == os.getgid()
         assert providers_stat.st_mode & 0o777 == 0o600
+
+
+def test_conan_audit_private():
+    successful_response = {
+        "data": {
+            "query": {
+                "vulnerabilities": {
+                    "totalCount": 1,
+                    "edges": [
+                        {
+                            "node": {
+                                "name": "CVE-2023-45853",
+                                "description": "Zip vulnerability",
+                                "severity": "Critical",
+                                "cvss": {
+                                    "preferredBaseScore": 8.9
+                                },
+                                "aliases": [
+                                    "CVE-2023-45853",
+                                    "JFSA-2023-000272529"
+                                ],
+                                "advisories": [
+                                    {
+                                        "name": "CVE-2023-45853"
+                                    },
+                                    {
+                                        "name": "JFSA-2023-000272529"
+                                    }
+                                ],
+                                "references": [
+                                    "https://pypi.org/project/pyminizip/#history",
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+    tc = TestClient(light=True)
+
+    tc.save({"conanfile.py": GenConanfile("zlib", "1.2.11")})
+    tc.run("export .")
+
+    tc.run("list '*' -f=json", redirect_stdout="pkglist.json")
+
+    # TODO: If the CLI does not allow tokenless provider, should this case not be handled?
+    tc.run("audit provider add myprivate --url=foo --type=private --token=f")
+    # Now, remove the token as if the user didn't set it manually in the json
+    providers_json_path = os.path.join(tc.cache_folder, "audit_providers.json")
+    with open(providers_json_path, "r") as f:
+        providers_json = json.load(f)
+    providers_json["myprivate"].pop("token", None)
+    with open(providers_json_path, "w") as f:
+        json.dump(providers_json, f)
+
+    tc.run("audit list zlib/1.2.11 -p=myprivate", assert_error=True)
+    assert "Missing authentication token for 'myprivate' provider" in tc.out
+
+    tc.run("audit provider auth myprivate --token=valid_token")
+
+    with proxy_response(200, successful_response):
+        tc.run("audit list zlib/1.2.11 -p=myprivate")
+        assert "zlib/1.2.11 1 vulnerability found" in tc.out
+
+        tc.run("audit list -l=pkglist.json -p=myprivate")
+        assert "zlib/1.2.11 1 vulnerability found" in tc.out
+
+        tc.run("audit scan --requires=zlib/1.2.11  -p=myprivate")
+        assert "zlib/1.2.11 1 vulnerability found" in tc.out
+
+    # Now some common errors, like rate limited or missing lib, but it should not fail!
+    with proxy_response(400, {"errors": [{"message": "Ref not found"}]}):
+        # Not finding a package should not be an error
+        tc.run("audit list zlib/1.2.11 -p=myprivate")
+        assert "Package 'zlib/1.2.11' not scanned: Not found." in tc.stdout
+
+    with proxy_response(403, {"errors": [{"message": "Authentication error"}]}):
+        tc.run("audit list zlib/1.2.11 -p=myprivate")
+        assert "Unknown error" in tc.out
+
+    with proxy_response(500, {"errors": [{"message": "Internal error"}]}):
+        tc.run("audit list zlib/1.2.11 -p=myprivate")
+        assert "Unknown error" in tc.out
+
+    with proxy_response(405, {"errors": [{"message": "Method not allowed"}]}):
+        tc.run("audit list zlib/1.2.11 -p=myprivate")
+        assert "Unknown error" in tc.out
+
+    with proxy_response(404, {"errors": [{"message": "Not found"}]}):
+        tc.run("audit list zlib/1.2.11 -p=myprivate")
+        assert "An error occurred while connecting to the 'myprivate' provider" in tc.out
+
 
 
 @pytest.mark.skipif(sys.version_info < (3, 10),

--- a/test/unittests/util/detect_test.py
+++ b/test/unittests/util/detect_test.py
@@ -5,7 +5,8 @@ from unittest.mock import patch
 import pytest
 from parameterized import parameterized
 
-from conan.internal.api.detect.detect_api import _cc_compiler
+from conan.internal.api.detect.detect_api import _cc_compiler, detect_suncc_compiler, \
+    detect_intel_compiler
 from conan.internal.api.profile.detect import detect_defaults_settings
 from conan.internal.model.version import Version
 from conan.test.utils.mocks import RedirectedTestOutput
@@ -74,3 +75,12 @@ def test_detect_cc_versionings(detect_runner_mock, version_return, expected_vers
     detect_runner_mock.return_value = 0, version_return
     compiler, installed_version, compiler_exe = _cc_compiler()
     assert installed_version == Version(expected_version)
+
+@pytest.mark.parametrize("function,version_return,expected_version", [
+    [detect_suncc_compiler, "Sun C 5.13", ('sun-cc', Version("5.13"), 'cc')],
+    [detect_intel_compiler, "Intel C++ Compiler 2025.0", ('intel-cc', Version("2025.0"), 'icx')],
+])
+def test_detect_compiler(function, version_return, expected_version):
+    with mock.patch("conan.internal.api.detect.detect_api.detect_runner", mock.MagicMock(return_value=(0, version_return))):
+        ret = function()
+        assert ret == expected_version


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

One file done for now, will add more in the following days

* The ArtifactoryServer class is used in tests, just not when the coverage is active
* The `runners` feature is undertested, but there are some open PRs that address them already
