### PR TITLE
Add `--list` inputs to `conan cache clean` and `conan cache check-integrity`

### DIFF
--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -71,6 +71,8 @@ def cache_clean(conan_api: ConanAPI, parser, subparser, *args):
     (.tgz store) ones.
     """
     subparser.add_argument("pattern", nargs="?", help="Selection pattern for references to clean")
+    subparser.add_argument("-l", "--list", action=OnceArgument,
+                            help="Package list of packages to clean")
     subparser.add_argument("-s", "--source", action='store_true', default=False,
                            help="Clean source folders")
     subparser.add_argument("-b", "--build", action='store_true', default=False,
@@ -86,8 +88,17 @@ def cache_clean(conan_api: ConanAPI, parser, subparser, *args):
                                 "os=Windows AND (arch=x86 OR compiler=gcc)")
     args = parser.parse_args(*args)
 
-    ref_pattern = ListPattern(args.pattern or "*", rrev="*", package_id="*", prev="*")
-    package_list = conan_api.list.select(ref_pattern, package_query=args.package_query)
+    # If pattern is None, it will be replaced by "*"
+    if args.pattern and args.list:
+        raise ConanException("Cannot specify both pattern and list")
+
+    if args.list:
+        listfile = make_abs_path(args.list)
+        multi_package_list = MultiPackagesList.load(listfile)
+        package_list = multi_package_list["Local Cache"]
+    else:
+        ref_pattern = ListPattern(args.pattern or "*", rrev="*", package_id="*", prev="*")
+        package_list = conan_api.list.select(ref_pattern, package_query=args.package_query)
     if args.build or args.source or args.download or args.temp or args.backup_sources:
         conan_api.cache.clean(package_list, source=args.source, build=args.build,
                               download=args.download, temp=args.temp,

--- a/test/integration/command/cache/test_cache_clean.py
+++ b/test/integration/command/cache/test_cache_clean.py
@@ -24,7 +24,8 @@ def test_cache_clean(use_pkglist):
     assert os.path.exists(pkg_layout.download_package())
 
     if use_pkglist:
-        c.run("list *:* -f=json", redirect_stdout="pkglist.json")
+        c.run("list *:*#* -f=json", redirect_stdout="pkglist.json")
+        pkglist = c.load("pkglist.json")
     arg = "--list=pkglist.json" if use_pkglist else "*"
     c.run(f'cache clean {arg} -s -b')
     assert not os.path.exists(pkg_layout.build())

--- a/test/integration/command/cache/test_cache_clean.py
+++ b/test/integration/command/cache/test_cache_clean.py
@@ -1,13 +1,16 @@
 import os.path
 import re
 
+import pytest
+
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.test_files import temp_folder
 from conan.test.utils.tools import TestClient
 from conans.util.files import save
 
 
-def test_cache_clean():
+@pytest.mark.parametrize("use_pkglist", [True, False])
+def test_cache_clean(use_pkglist):
     c = TestClient(default_server_user=True)
     c.save({"conanfile.py": GenConanfile("pkg", "0.1").with_exports("*").with_exports_sources("*"),
             "sorces/file.txt": ""})
@@ -20,7 +23,10 @@ def test_cache_clean():
     assert os.path.exists(pkg_layout.build())
     assert os.path.exists(pkg_layout.download_package())
 
-    c.run('cache clean "*" -s -b')
+    if use_pkglist:
+        c.run("list *:* -f=json", redirect_stdout="pkglist.json")
+    arg = "--list=pkglist.json" if use_pkglist else "*"
+    c.run(f'cache clean {arg} -s -b')
     assert not os.path.exists(pkg_layout.build())
     assert not os.path.exists(ref_layout.source())
     assert os.path.exists(ref_layout.download_export())

--- a/test/integration/command/cache/test_cache_integrity.py
+++ b/test/integration/command/cache/test_cache_integrity.py
@@ -26,7 +26,7 @@ def test_cache_integrity(use_pkglist):
     save(conaninfo, "[settings]")
 
     if use_pkglist:
-        t.run("list *:* -f=json", redirect_stdout="pkglist.json")
+        t.run("list *:*#* -f=json", redirect_stdout="pkglist.json")
     arg = "--list=pkglist.json" if use_pkglist else "*"
 
     t.run(f"cache check-integrity {arg}", assert_error=True)

--- a/test/integration/command/cache/test_cache_integrity.py
+++ b/test/integration/command/cache/test_cache_integrity.py
@@ -1,11 +1,14 @@
 import os
 
+import pytest
+
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
 from conans.util.files import save
 
 
-def test_cache_integrity():
+@pytest.mark.parametrize("use_pkglist", [True, False])
+def test_cache_integrity(use_pkglist):
     t = TestClient()
     t.save({"conanfile.py": GenConanfile()})
     t.run("create . --name pkg1 --version 1.0")
@@ -22,7 +25,11 @@ def test_cache_integrity():
     conaninfo = os.path.join(layout.package(), "conaninfo.txt")
     save(conaninfo, "[settings]")
 
-    t.run("cache check-integrity *", assert_error=True)
+    if use_pkglist:
+        t.run("list *:* -f=json", redirect_stdout="pkglist.json")
+    arg = "--list=pkglist.json" if use_pkglist else "*"
+
+    t.run(f"cache check-integrity {arg}", assert_error=True)
     assert "pkg1/1.0: Integrity checked: ok" in t.out
     assert "pkg1/1.0:da39a3ee5e6b4b0d3255bfef95601890afd80709: Integrity checked: ok" in t.out
     assert "ERROR: pkg2/2.0:da39a3ee5e6b4b0d3255bfef95601890afd80709: Manifest mismatch" in t.out


### PR DESCRIPTION
Changelog: Feature: Add `--list` inputs to `conan cache clean` and `conan cache check-integrity`.
Docs: https://github.com/conan-io/docs/pull/4095

Closes https://github.com/conan-io/conan/issues/18217
The issue with this pkglist is that it needs to point to package revisions for most operations to be useful.

We still need to check if this is even useful given the restrictions
