### PR TITLE
fix incorrect test_package of python-requires warning

### DIFF
--- a/conan/api/subapi/graph.py
+++ b/conan/api/subapi/graph.py
@@ -2,7 +2,7 @@ from conan.api.output import ConanOutput
 from conan.internal.conan_app import ConanApp, ConanBasicApp
 from conan.internal.model.recipe_ref import ref_matches
 from conan.internal.graph.graph import Node, RECIPE_CONSUMER, CONTEXT_HOST, RECIPE_VIRTUAL, \
-    CONTEXT_BUILD, BINARY_MISSING
+    CONTEXT_BUILD, BINARY_MISSING, DepsGraph
 from conan.internal.graph.graph_binaries import GraphBinariesAnalyzer
 from conan.internal.graph.graph_builder import DepsGraphBuilder
 from conan.internal.graph.install_graph import InstallGraph, ProfileArgs
@@ -151,6 +151,17 @@ class GraphAPI:
                                      profile_build=profile_build, lockfile=lockfile,
                                      remotes=remotes, update=update, check_update=check_updates)
         return deps_graph
+
+    def load_python_requires(self, ref, lockfile, remotes, update):
+        app = ConanApp(self.conan_api)
+        conanfile = app.loader.load_virtual(python_requires=[ref], graph_lock=lockfile,
+                                            remotes=remotes, update=update)
+
+        # consumer_definer(conanfile, profile_host, profile_build)
+        root_node = Node(ref=None, conanfile=conanfile, context=CONTEXT_HOST, recipe=RECIPE_VIRTUAL)
+        dep_graph = DepsGraph()
+        dep_graph.add_node(root_node)
+        return dep_graph
 
     def load_graph(self, root_node, profile_host, profile_build, lockfile=None, remotes=None,
                    update=None, check_update=False):

--- a/conan/api/subapi/graph.py
+++ b/conan/api/subapi/graph.py
@@ -129,6 +129,12 @@ class GraphAPI:
                                                       update=update,
                                                       python_requires=python_requires)
 
+        if not requires and not tool_requires and python_requires is not None:
+            # This only happens at `conan create` for python-requires, the graph is not needed
+            # in fact, it can cause errors, if tool-requires injected
+            dep_graph = DepsGraph()
+            dep_graph.add_node(root_node)
+            return dep_graph
         # check_updates = args.check_updates if "check_updates" in args else False
         deps_graph = self.load_graph(root_node, profile_host=profile_host,
                                      profile_build=profile_build,
@@ -151,16 +157,6 @@ class GraphAPI:
                                      profile_build=profile_build, lockfile=lockfile,
                                      remotes=remotes, update=update, check_update=check_updates)
         return deps_graph
-
-    def load_graph_root_python_require(self, ref, lockfile, remotes, update):
-        app = ConanApp(self.conan_api)
-        conanfile = app.loader.load_virtual(python_requires=[ref], graph_lock=lockfile,
-                                            remotes=remotes, update=update)
-        # consumer_definer(conanfile, profile_host, profile_build)
-        root_node = Node(ref=None, conanfile=conanfile, context=CONTEXT_HOST, recipe=RECIPE_VIRTUAL)
-        dep_graph = DepsGraph()
-        dep_graph.add_node(root_node)
-        return dep_graph
 
     def load_graph(self, root_node, profile_host, profile_build, lockfile=None, remotes=None,
                    update=None, check_update=False):

--- a/conan/api/subapi/graph.py
+++ b/conan/api/subapi/graph.py
@@ -152,11 +152,10 @@ class GraphAPI:
                                      remotes=remotes, update=update, check_update=check_updates)
         return deps_graph
 
-    def load_python_requires(self, ref, lockfile, remotes, update):
+    def load_graph_root_python_require(self, ref, lockfile, remotes, update):
         app = ConanApp(self.conan_api)
         conanfile = app.loader.load_virtual(python_requires=[ref], graph_lock=lockfile,
                                             remotes=remotes, update=update)
-
         # consumer_definer(conanfile, profile_host, profile_build)
         root_node = Node(ref=None, conanfile=conanfile, context=CONTEXT_HOST, recipe=RECIPE_VIRTUAL)
         dep_graph = DepsGraph()

--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -69,8 +69,9 @@ def create(conan_api, parser, *args):
         args.build_test = args.build
 
     if is_python_require:
-        deps_graph = conan_api.graph.load_python_requires(ref, lockfile=lockfile,
-                                                         remotes=remotes, update=args.update)
+        deps_graph = conan_api.graph.load_graph_root_python_require(ref, lockfile=lockfile,
+                                                                    remotes=remotes,
+                                                                    update=args.update)
     else:
         requires = [ref] if not is_build else None
         tool_requires = [ref] if is_build else None

--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -75,6 +75,7 @@ def create(conan_api, parser, *args):
                                                          lockfile=lockfile,
                                                          remotes=remotes, update=args.update,
                                                          python_requires=[ref])
+        deps_graph = None  # TODO: This can be simplified, not necessary to load graph
     else:
         requires = [ref] if not is_build else None
         tool_requires = [ref] if is_build else None

--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -69,13 +69,8 @@ def create(conan_api, parser, *args):
         args.build_test = args.build
 
     if is_python_require:
-        deps_graph = conan_api.graph.load_graph_requires([], [],
-                                                         profile_host=profile_host,
-                                                         profile_build=profile_build,
-                                                         lockfile=lockfile,
-                                                         remotes=remotes, update=args.update,
-                                                         python_requires=[ref])
-        deps_graph = None  # TODO: This can be simplified, not necessary to load graph
+        deps_graph = conan_api.graph.load_python_requires(ref, lockfile=lockfile,
+                                                         remotes=remotes, update=args.update)
     else:
         requires = [ref] if not is_build else None
         tool_requires = [ref] if is_build else None

--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -69,9 +69,12 @@ def create(conan_api, parser, *args):
         args.build_test = args.build
 
     if is_python_require:
-        deps_graph = conan_api.graph.load_graph_root_python_require(ref, lockfile=lockfile,
-                                                                    remotes=remotes,
-                                                                    update=args.update)
+        deps_graph = conan_api.graph.load_graph_requires([], [],
+                                                         profile_host=profile_host,
+                                                         profile_build=profile_build,
+                                                         lockfile=lockfile,
+                                                         remotes=remotes, update=args.update,
+                                                         python_requires=[ref])
     else:
         requires = [ref] if not is_build else None
         tool_requires = [ref] if is_build else None

--- a/conan/cli/commands/test.py
+++ b/conan/cli/commands/test.py
@@ -55,12 +55,6 @@ def run_test(conan_api, path, ref, profile_host, profile_build, remotes, lockfil
                                                          update=update,
                                                          lockfile=lockfile,
                                                          tested_python_requires=tested_python_requires)
-    if isinstance(tested_python_requires, str):  # create python-require
-        conanfile = root_node.conanfile
-        if not getattr(conanfile, "python_requires", None) == "tested_reference_str":
-            ConanOutput().warning("test_package/conanfile.py should declare 'python_requires"
-                                  " = \"tested_reference_str\"'", warn_tag="deprecated")
-
     out = ConanOutput()
     out.title("Launching test_package")
     deps_graph = conan_api.graph.load_graph(root_node, profile_host=profile_host,

--- a/conan/internal/loader.py
+++ b/conan/internal/loader.py
@@ -12,6 +12,7 @@ import yaml
 
 from pathlib import Path
 
+from conan.api.output import ConanOutput
 from conan.tools.cmake import cmake_layout
 from conan.tools.google import bazel_layout
 from conan.tools.microsoft import vs_layout
@@ -60,6 +61,9 @@ class ConanFileLoader:
                 if getattr(conanfile, "python_requires", None) == "tested_reference_str":
                     conanfile.python_requires = tested_python_requires.repr_notime()
             elif tested_python_requires:
+                if getattr(conanfile, "python_requires", None) != "tested_reference_str":
+                    ConanOutput().warning("test_package/conanfile.py should declare 'python_requires"
+                                      " = \"tested_reference_str\"'", warn_tag="deprecated")
                 conanfile.python_requires = tested_python_requires
 
             if self._pyreq_loader:

--- a/test/integration/py_requires/python_requires_test.py
+++ b/test/integration/py_requires/python_requires_test.py
@@ -1097,9 +1097,11 @@ class TestTestPackagePythonRequire:
         c.save({"conanfile.py": conanfile,
                 "test_package/conanfile.py": test})
         c.run("create .")
+        assert "WARN: deprecated: test_package/conanfile.py" not in c.out
         assert "common/0.1 (test package): 42!!!" in c.out
 
         c.run("test test_package common/0.1")
+        assert "WARN: deprecated: test_package/conanfile.py" not in c.out
         assert "common/0.1 (test package): 42!!!" in c.out
 
     def test_test_package_python_requires_configs(self):

--- a/test/integration/py_requires/python_requires_test.py
+++ b/test/integration/py_requires/python_requires_test.py
@@ -1077,6 +1077,8 @@ class TestTestPackagePythonRequire:
         """
 
         c = TestClient(light=True)
+        c.save({"conanfile.py": GenConanfile("mytool", "0.1")})
+        c.run("create .")
         conanfile = textwrap.dedent("""
             from conan import ConanFile
             def mycommon():
@@ -1102,6 +1104,11 @@ class TestTestPackagePythonRequire:
 
         c.run("test test_package common/0.1")
         assert "WARN: deprecated: test_package/conanfile.py" not in c.out
+        assert "common/0.1 (test package): 42!!!" in c.out
+
+        c.save({"myprofile": "[tool_requires]\nmytool/0.1"})
+        c.run("create . -pr=myprofile")
+        print(c.out)
         assert "common/0.1 (test package): 42!!!" in c.out
 
     def test_test_package_python_requires_configs(self):

--- a/test/integration/py_requires/python_requires_test.py
+++ b/test/integration/py_requires/python_requires_test.py
@@ -1106,9 +1106,9 @@ class TestTestPackagePythonRequire:
         assert "WARN: deprecated: test_package/conanfile.py" not in c.out
         assert "common/0.1 (test package): 42!!!" in c.out
 
+        # https://github.com/conan-io/conan/issues/18224
         c.save({"myprofile": "[tool_requires]\nmytool/0.1"})
         c.run("create . -pr=myprofile")
-        print(c.out)
         assert "common/0.1 (test package): 42!!!" in c.out
 
     def test_test_package_python_requires_configs(self):


### PR DESCRIPTION
Changelog: Fix: Avoid incorrect warning in ``test_package`` of ``python_requires`` about "tested_reference_str".
Changelog: Bugfix: Allow to ``conan create`` a ``python-requires`` package with a profile that contains tool-requires.
Docs: Omit

Close https://github.com/conan-io/conan/issues/18224