### PR TITLE
conan cache save --no-source

### DIFF
--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -149,6 +149,7 @@ def cache_save(conan_api: ConanAPI, parser, subparser, *args):
                                 "If revision is not specified, it is assumed latest one.")
     subparser.add_argument("-l", "--list", help="Package list of packages to save")
     subparser.add_argument('--file', help="Save to this tgz file")
+    subparser.add_argument("--no-source", action="store_true", help="Exclude the sources")
     args = parser.parse_args(*args)
 
     if args.pattern is None and args.list is None:
@@ -164,7 +165,7 @@ def cache_save(conan_api: ConanAPI, parser, subparser, *args):
         ref_pattern = ListPattern(args.pattern)
         package_list = conan_api.list.select(ref_pattern)
     tgz_path = make_abs_path(args.file or "conan_cache_save.tgz")
-    conan_api.cache.save(package_list, tgz_path)
+    conan_api.cache.save(package_list, tgz_path, args.no_source)
     return {"results": {"Local Cache": package_list.serialize()}}
 
 


### PR DESCRIPTION
Changelog: Feature: New ``conan cache save ... --no-source`` to avoid storing downloaded sources in the `.tgz`.
Changelog: Bugfix: ``conan cache save`` no longer zips downloaded artifacts like ``conan_export.tgz`` and ``conan_sources.tgz``.
Docs: https://github.com/conan-io/docs/pull/4099

Close https://github.com/conan-io/conan/issues/18234
