### PR TITLE
adding subprocess to the profile jinja rendering

### DIFF
--- a/conan/internal/api/profile/profile_loader.py
+++ b/conan/internal/api/profile/profile_loader.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import subprocess
 from collections import OrderedDict, defaultdict
 
 from jinja2 import Environment, FileSystemLoader
@@ -118,6 +119,7 @@ class ProfileLoader:
         file_path = os.path.basename(profile_path)
         context = {"platform": platform,
                    "os": os,
+                   "subprocess": subprocess,
                    "profile_dir": base_path,
                    "profile_name": file_path,
                    "conan_version": conan_version,

--- a/test/integration/configuration/test_profile_jinja.py
+++ b/test/integration/configuration/test_profile_jinja.py
@@ -10,7 +10,9 @@ from conan.test.utils.env import environment_update
 
 def test_profile_template():
     client = TestClient()
-    tpl = textwrap.dedent("""
+    tpl = textwrap.dedent("""\
+        # This is just to check that subprocess is injected in the render and can be used
+        {% set check_output = subprocess.check_output %}
         [settings]
         os = {{ {"Darwin": "Macos"}.get(platform.system(), platform.system()) }}
         build_type = {{ os.getenv("MY_BUILD_TYPE") }}


### PR DESCRIPTION
Changelog: Feature: Add ``subprocess`` to the profile jinja rendering.
Docs: https://github.com/conan-io/docs/pull/4098

Close https://github.com/conan-io/conan/issues/16802
