### PR TITLE
Add header only template for conan new

### DIFF
--- a/conan/api/subapi/new.py
+++ b/conan/api/subapi/new.py
@@ -85,6 +85,7 @@ class NewAPI:
         from conan.internal.api.new.alias_new import alias_file
         from conan.internal.api.new.cmake_exe import cmake_exe_files
         from conan.internal.api.new.cmake_lib import cmake_lib_files
+        from conan.internal.api.new.header_lib import header_only_lib_files
         from conan.internal.api.new.meson_lib import meson_lib_files
         from conan.internal.api.new.meson_exe import meson_exe_files
         from conan.internal.api.new.msbuild_lib import msbuild_lib_files
@@ -101,6 +102,7 @@ class NewAPI:
         new_templates = {"basic": basic_file,
                          "cmake_lib": cmake_lib_files,
                          "cmake_exe": cmake_exe_files,
+                         "header_lib": header_only_lib_files,
                          "meson_lib": meson_lib_files,
                          "meson_exe": meson_exe_files,
                          "msbuild_lib": msbuild_lib_files,

--- a/conan/cli/commands/new.py
+++ b/conan/cli/commands/new.py
@@ -10,7 +10,7 @@ def new(conan_api, parser, *args):
     """
     parser.add_argument("template", help="Template name, "
                         "either a predefined built-in or a user-provided one. "
-                        "Available built-in templates: basic, cmake_lib, cmake_exe, "
+                        "Available built-in templates: basic, cmake_lib, cmake_exe, header_lib, "
                         "meson_lib, meson_exe, msbuild_lib, msbuild_exe, bazel_lib, bazel_exe, "
                         "autotools_lib, autotools_exe, local_recipes_index, workspace. "
                         "E.g. 'conan new cmake_lib -d name=hello -d version=0.1'. "

--- a/conan/internal/api/new/header_lib.py
+++ b/conan/internal/api/new/header_lib.py
@@ -1,0 +1,132 @@
+conanfile_sources_v2 = '''from conan import ConanFile
+from conan.tools.layout import basic_layout
+from conan.tools.files import copy
+
+class {{package_name}}Recipe(ConanFile):
+    name = "{{name}}"
+    version = "{{version}}"
+    package_type = "header-library"
+
+    # Optional metadata
+    license = "<Put the package license here>"
+    author = "<Put your name here> <And your email here>"
+    url = "<Package recipe repository url here, for issues about the package>"
+    description = "<Description of {{ name }} package here>"
+    topics = ("<Put some tag here>", "<here>", "<and here>")
+
+    # Sources are located in the same place as this recipe, copy them to the recipe
+    exports_sources = "include/*"
+
+    implements = ["auto_header_only"]
+
+    def layout(self):
+        basic_layout(self)
+    {% if requires is defined %}
+    def requirements(self):
+        {% for require in requires -%}
+        self.requires("{{ require }}")
+        {% endfor %}
+    {%- endif %}
+    {%- if tool_requires is defined %}
+    def build_requirements(self):
+        {% for require in tool_requires -%}
+        self.tool_requires("{{ require }}")
+        {% endfor %}
+    {%- endif %}
+
+    def package(self):
+        copy(self, "include/*", self.source_folder, self.package_folder)
+
+    def package_info(self):
+        self.cpp_info.bindirs = []
+        self.cpp_info.libdirs = []
+
+'''
+
+source_h = """#pragma once
+
+#include <iostream>
+#include <vector>
+#include <string>
+
+{% if requires is defined -%}
+{% for require in requires -%}
+#include "{{ as_name(require) }}.h"
+{% endfor %}
+{%- endif %}
+
+void {{package_name}}(){
+    {% if requires is defined -%}
+    {% for require in requires -%}
+    {{ as_name(require).replace(".", "_") }}();
+    {% endfor %}
+    {%- endif %}
+
+    std::cout << "{{package_name}}/{{version}} header only called" << std::endl;
+}
+
+
+void {{package_name}}_print_vector(const std::vector<std::string> &strings) {
+    for(std::vector<std::string>::const_iterator it = strings.begin(); it != strings.end(); ++it) {
+        std::cout << "{{package_name}}/{{version}} " << *it << std::endl;
+    }
+}
+"""
+
+test_conanfile_v2 = """import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+
+
+class {{package_name}}TestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def test(self):
+        if can_run(self):
+            cmd = os.path.join(self.cpp.build.bindir, "example")
+            self.run(cmd, env="conanrun")
+"""
+
+test_cmake_v2 = """cmake_minimum_required(VERSION 3.15)
+project(PackageTest CXX)
+
+find_package({{name}} CONFIG REQUIRED)
+
+add_executable(example src/example.cpp)
+target_link_libraries(example {{name}}::{{name}})
+"""
+
+
+test_main = """#include "{{name}}.h"
+#include <vector>
+#include <string>
+
+int main() {
+    {{package_name}}();
+
+    std::vector<std::string> vec;
+    vec.push_back("test_package");
+
+    {{package_name}}_print_vector(vec);
+}
+"""
+
+header_only_lib_files = {"conanfile.py": conanfile_sources_v2,
+                         "include/{{name}}.h": source_h,
+                         "test_package/conanfile.py": test_conanfile_v2,
+                         "test_package/src/example.cpp": test_main,
+                         "test_package/CMakeLists.txt": test_cmake_v2}

--- a/conan/internal/api/new/header_lib.py
+++ b/conan/internal/api/new/header_lib.py
@@ -17,6 +17,7 @@ class {{package_name}}Recipe(ConanFile):
     # Sources are located in the same place as this recipe, copy them to the recipe
     exports_sources = "include/*"
 
+    # Automatically manage the package ID clearing of settings and options
     implements = ["auto_header_only"]
 
     def layout(self):
@@ -25,12 +26,6 @@ class {{package_name}}Recipe(ConanFile):
     def requirements(self):
         {% for require in requires -%}
         self.requires("{{ require }}")
-        {% endfor %}
-    {%- endif %}
-    {%- if tool_requires is defined %}
-    def build_requirements(self):
-        {% for require in tool_requires -%}
-        self.tool_requires("{{ require }}")
         {% endfor %}
     {%- endif %}
 
@@ -65,12 +60,6 @@ void {{package_name}}(){
     std::cout << "{{package_name}}/{{version}} header only called" << std::endl;
 }
 
-
-void {{package_name}}_print_vector(const std::vector<std::string> &strings) {
-    for(std::vector<std::string>::const_iterator it = strings.begin(); it != strings.end(); ++it) {
-        std::cout << "{{package_name}}/{{version}} " << *it << std::endl;
-    }
-}
 """
 
 test_conanfile_v2 = """import os
@@ -117,11 +106,6 @@ test_main = """#include "{{name}}.h"
 
 int main() {
     {{package_name}}();
-
-    std::vector<std::string> vec;
-    vec.push_back("test_package");
-
-    {{package_name}}_print_vector(vec);
 }
 """
 

--- a/test/functional/command/test_new.py
+++ b/test/functional/command/test_new.py
@@ -1,0 +1,14 @@
+import pytest
+
+from conan.test.utils.tools import TestClient
+
+
+@pytest.mark.tool("cmake")
+def test_conan_new_compiles():
+    # TODO: Maybe add more templates that are not used in the rest of the test suite?
+    tc = TestClient()
+    tc.run("new header_lib -d name=hello -d version=1.0 -o=hello")
+    tc.run("new header_lib -d name=bye -d version=1.0 -d requires=hello/1.0 -o=bye")
+
+    tc.run("create hello")
+    tc.run("create bye")

--- a/test/functional/command/test_new.py
+++ b/test/functional/command/test_new.py
@@ -10,5 +10,5 @@ def test_conan_new_compiles():
     tc.run("new header_lib -d name=hello -d version=1.0 -o=hello")
     tc.run("new header_lib -d name=bye -d version=1.0 -d requires=hello/1.0 -o=bye")
 
-    tc.run("create hello")
+    tc.run("create hello -tf=")
     tc.run("create bye")


### PR DESCRIPTION
Changelog: Feature: Add `header_lib` template to `conan new`.
Docs: https://github.com/conan-io/docs/pull/4094


