### PR TITLE
Allow composition of conf values that are different categories of numbers

### DIFF
--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -263,6 +263,9 @@ class _ConfValue:
                 new_value = other._value.copy()
                 new_value.update(self._value)
                 self._value = new_value
+        elif issubclass(v_type, numbers.Number) and issubclass(o_type, numbers.Number):
+            # They might be different kind of numbers, so skip the check below
+            pass
         elif self._value is None or other._value is None:
             # It means any of those values were an "unset" so doing nothing because we don't
             # really know the original value type

--- a/test/integration/configuration/profile_test.py
+++ b/test/integration/configuration/profile_test.py
@@ -639,7 +639,9 @@ def test_consumer_invalid_profile_multiple_groups():
 
 def test_compose_numeric_values_scoped_pkg():
     tc = TestClient(light=True)
-    tc.save({"conanfile.py": GenConanfile("hello", "0.1"),
+    tc.save({"conanfile.py": GenConanfile("hello", "0.1")
+                .with_package("self.output.info('user.var.value: ' + str(self.conf.get('user.var:value')))"),
              "profile": """[conf]\nuser.var:value=8.1\nhello/*:user.var:value=10\n"""})
 
     tc.run("create . -pr=profile")
+    assert "user.var.value: 10" in tc.out

--- a/test/integration/configuration/profile_test.py
+++ b/test/integration/configuration/profile_test.py
@@ -636,3 +636,10 @@ def test_consumer_invalid_profile_multiple_groups():
                assert_error=True)
     assert ("ERROR: Error reading 'myprofs/myprofile' profile: ConfigParser: "
             "Duplicated section: [settings]") in client.out
+
+def test_compose_numeric_values_scoped_pkg():
+    tc = TestClient(light=True)
+    tc.save({"conanfile.py": GenConanfile("hello", "0.1"),
+             "profile": """[conf]\nuser.var:value=8.1\nhello/*:user.var:value=10\n"""})
+
+    tc.run("create . -pr=profile")

--- a/test/unittests/client/profile_loader/profile_loader_test.py
+++ b/test/unittests/client/profile_loader/profile_loader_test.py
@@ -252,3 +252,19 @@ def test_profile_core_confs_error(conf_name):
     with pytest.raises(ConanException) as exc:
         profile_loader.from_cli_args([], [], [], [conf_name], None)
     assert "[conf] 'core.*' configurations are not allowed in profiles" in str(exc.value)
+
+
+def test_profile_compose_numbers():
+    tmp = temp_folder()
+    txt = textwrap.dedent("""
+            [conf]
+            user.version:value=8.1
+            pkg/*:user.version:value=10
+            """)
+    current_profile_path = os.path.join(tmp, "default")
+    save(current_profile_path, txt)
+
+    profile_loader = ProfileLoader(cache_folder=temp_folder())  # If not used cache, will not error
+    profile = profile_loader.load_profile(current_profile_path)
+    assert profile.conf.get("user.version:value") == 8.1
+    assert profile.conf.get("pkg/*:user.version:value") == 10

--- a/test/unittests/model/test_conf.py
+++ b/test/unittests/model/test_conf.py
@@ -274,6 +274,13 @@ def test_compose_conf_dict_updates():
     assert c.dumps() == ("user.company:mydict={'2': 'b'}\n"
                          "user.company:mydict2={'1': 'a', '2': 'b'}\n")
 
+def test_compose_conf_numbers():
+    c = ConfDefinition()
+    c.loads("user.version:value=8.1\n"
+            "foo/*:user.version:value=10")
+    assert c.get("user.version:value") == 8.1
+    assert c.get("foo/*:version:value") == 10
+
 
 def test_conf_get_check_type_and_default():
     text = textwrap.dedent("""\

--- a/test/unittests/model/test_conf.py
+++ b/test/unittests/model/test_conf.py
@@ -2,6 +2,7 @@ import textwrap
 
 import pytest
 
+from conan.api.model import RecipeReference
 from conan.errors import ConanException
 from conan.internal.model.conf import ConfDefinition
 
@@ -279,7 +280,7 @@ def test_compose_conf_numbers():
     c.loads("user.version:value=8.1\n"
             "foo/*:user.version:value=10")
     assert c.get("user.version:value") == 8.1
-    assert c.get("foo/*:version:value") == 10
+    assert c.get_conanfile_conf(RecipeReference.loads("foo/1.0")).get("user.version:value") == 10
 
 
 def test_conf_get_check_type_and_default():


### PR DESCRIPTION
Changelog: Fix: Allow composition of conf values that are different categories of numbers.
Docs: Omit

Closes https://github.com/conan-io/conan/issues/18260