### PR TITLE
Sort overrides when serializing

### DIFF
--- a/conan/internal/graph/graph.py
+++ b/conan/internal/graph/graph.py
@@ -342,7 +342,9 @@ class Overrides:
         return self._overrides.items()
 
     def serialize(self):
-        return {k.repr_notime(): [e.repr_notime() if e else None for e in v]
+        return {k.repr_notime():
+                    sorted([e.repr_notime() if e else None for e in v],
+                           key= lambda e: "" if e is None else e)
                 for k, v in self._overrides.items()}
 
     @staticmethod


### PR DESCRIPTION
Changelog: Fix: Always sort overrides serialization.
Docs: Omit

Would close https://github.com/conan-io/conan/issues/18273 but need to check with the team if this is worth it