### PR TITLE
Coverage

### DIFF
--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -6,6 +6,7 @@ from io import BytesIO
 
 from conan.api.model import PackagesList
 from conan.api.output import ConanOutput
+from conan.internal.api.uploader import gzopen_without_timestamps
 from conan.internal.cache.cache import PkgCache
 from conan.internal.cache.conan_reference_layout import EXPORT_SRC_FOLDER, EXPORT_FOLDER, SRC_FOLDER, \
     METADATA, DOWNLOAD_EXPORT_FOLDER
@@ -16,7 +17,7 @@ from conan.errors import ConanException
 from conan.api.model import PkgReference
 from conan.api.model import RecipeReference
 from conan.internal.util.dates import revision_timestamp_now
-from conan.internal.util.files import rmdir, gzopen_without_timestamps, mkdir, remove
+from conan.internal.util.files import rmdir, mkdir, remove
 
 
 class CacheAPI:
@@ -133,7 +134,7 @@ class CacheAPI:
         name = os.path.basename(tgz_path)
         compresslevel = global_conf.get("core.gzip:compresslevel", check_type=int)
         with open(tgz_path, "wb") as tgz_handle:
-            tgz = gzopen_without_timestamps(name, mode="w", fileobj=tgz_handle,
+            tgz = gzopen_without_timestamps(name, fileobj=tgz_handle,
                                             compresslevel=compresslevel)
             for ref, ref_bundle in package_list.refs().items():
                 ref_layout = cache.recipe_layout(ref)

--- a/conan/internal/model/info.py
+++ b/conan/internal/model/info.py
@@ -24,15 +24,13 @@ class _VersionRepr:
             return str(self._version.major)
         return ".".join([str(self._version.major), 'Y', 'Z'])
 
-    def minor(self, fill=True):
+    def minor(self):
         if not isinstance(self._version.major.value, int):
             return str(self._version.major)
 
         v0 = str(self._version.major)
         v1 = str(self._version.minor) if self._version.minor is not None else "0"
-        if fill:
-            return ".".join([v0, v1, 'Z'])
-        return ".".join([v0, v1])
+        return ".".join([v0, v1, 'Z'])
 
     def patch(self):
         if not isinstance(self._version.major.value, int):
@@ -135,14 +133,6 @@ class RequirementInfo:
         self.package_id = None
         self.recipe_revision = None
 
-    def full_recipe_mode(self):
-        self.name = self._ref.name
-        self.version = self._ref.version
-        self.user = self._ref.user
-        self.channel = self._ref.channel
-        self.package_id = None
-        self.recipe_revision = None
-
     def full_package_mode(self):
         self.name = self._ref.name
         self.version = self._ref.version
@@ -167,6 +157,7 @@ class RequirementInfo:
         self.package_id = self._package_id
         self.recipe_revision = self._ref.revision
 
+    full_recipe_mode = full_version_mode
     recipe_revision_mode = full_mode  # to not break everything and help in upgrade
 
 

--- a/conan/internal/util/files.py
+++ b/conan/internal/util/files.py
@@ -328,33 +328,6 @@ def gather_files(folder):
     return file_dict, symlinked_folders
 
 
-# FIXME: This is very repeated with the tools.unzip, but wsa needed for config-install unzip
-def unzip(filename, destination="."):
-    from conan.tools.files.files import untargz  # FIXME, importing from conan.tools
-    if (filename.endswith(".tar.gz") or filename.endswith(".tgz") or
-            filename.endswith(".tbz2") or filename.endswith(".tar.bz2") or
-            filename.endswith(".tar")):
-        return untargz(filename, destination)
-    if filename.endswith(".gz"):
-        with gzip.open(filename, 'rb') as f:
-            file_content = f.read()
-        target_name = filename[:-3] if destination == "." else destination
-        save(target_name, file_content)
-        return
-    if filename.endswith(".tar.xz") or filename.endswith(".txz"):
-        return untargz(filename, destination)
-
-    import zipfile
-    full_path = os.path.normpath(os.path.join(os.getcwd(), destination))
-
-    with zipfile.ZipFile(filename, "r") as z:
-        zip_info = z.infolist()
-        extracted_size = 0
-        for file_ in zip_info:
-            extracted_size += file_.file_size
-            z.extract(file_, full_path)
-
-
 def human_size(size_bytes):
     """
     format a size in bytes into a 'human' file size, e.g. B, KB, MB, GB, TB, PB

--- a/conan/internal/util/files.py
+++ b/conan/internal/util/files.py
@@ -256,40 +256,6 @@ def mkdir(path):
     os.makedirs(path)
 
 
-def gzopen_without_timestamps(name, mode="r", fileobj=None, compresslevel=None, **kwargs):
-    """ !! Method overrided by laso to pass mtime=0 (!=None) to avoid time.time() was
-        setted in Gzip file causing md5 to change. Not possible using the
-        previous tarfile open because arguments are not passed to GzipFile constructor
-    """
-
-    if mode not in ("r", "w"):
-        raise ValueError("mode must be 'r' or 'w'")
-
-    try:
-        compresslevel = compresslevel if compresslevel is not None else 9  # default Gzip = 9
-        fileobj = gzip.GzipFile(name, mode, compresslevel, fileobj, mtime=0)
-    except OSError:
-        if fileobj is not None and mode == 'r':
-            raise tarfile.ReadError("not a gzip file")
-        raise
-
-    try:
-        # Format is forced because in Python3.8, it changed and it generates different tarfiles
-        # with different checksums, which break hashes of tgzs
-        # PAX_FORMAT is the default for Py38, lets make it explicit for older Python versions
-        t = tarfile.TarFile.taropen(name, mode, fileobj, format=tarfile.PAX_FORMAT, **kwargs)
-    except IOError:
-        fileobj.close()
-        if mode == 'r':
-            raise tarfile.ReadError("not a gzip file")
-        raise
-    except Exception:
-        fileobj.close()
-        raise
-    t._extfileobj = False
-    return t
-
-
 def tar_extract(fileobj, destination_dir):
     the_tar = tarfile.open(fileobj=fileobj)
     # NOTE: The errorlevel=2 has been removed because it was failing in Win10, it didn't allow to

--- a/conan/test/utils/test_files.py
+++ b/conan/test/utils/test_files.py
@@ -8,11 +8,11 @@ import tempfile
 import time
 from io import BytesIO
 
+from conan.internal.api.uploader import gzopen_without_timestamps
 from conan.tools.files.files import untargz
 from conan.internal.subsystems import get_cased_path
 from conan.errors import ConanException
 from conan.internal.paths import PACKAGE_TGZ_NAME
-from conan.internal.util.files import gzopen_without_timestamps
 
 
 def wait_until_removed(folder):
@@ -85,7 +85,7 @@ def tgz_with_contents(files, output_path=None):
     file_path = output_path or os.path.join(folder, "myfile.tar.gz")
 
     with open(file_path, "wb") as tgz_handle:
-        tgz = gzopen_without_timestamps("myfile.tar.gz", mode="w", fileobj=tgz_handle)
+        tgz = gzopen_without_timestamps("myfile.tar.gz", fileobj=tgz_handle)
 
         for name, content in files.items():
             info = tarfile.TarInfo(name=name)

--- a/test/unittests/util/files/strip_root_extract_test.py
+++ b/test/unittests/util/files/strip_root_extract_test.py
@@ -3,6 +3,7 @@ import tarfile
 import unittest
 import zipfile
 
+from conan.internal.api.uploader import gzopen_without_timestamps
 from conan.tools.files.files import untargz, unzip
 from conan.errors import ConanException
 from conan.internal.model.manifest import gather_files
@@ -11,7 +12,7 @@ from conan.test.utils.mocks import RedirectedTestOutput
 from conan.test.utils.test_files import temp_folder
 from conan.test.utils.tools import redirect_output
 from conan.internal.util.files import chdir, save
-from conan.internal.util.files import gzopen_without_timestamps, rmdir
+from conan.internal.util.files import rmdir
 
 
 class ZipExtractPlainTest(unittest.TestCase):
@@ -110,7 +111,7 @@ class TarExtractPlainTest(unittest.TestCase):
         # Create a tar.gz file with the files in the folder and an additional TarInfo entry
         # for the folder_entry (the gather files doesn't return empty dirs)
         with open(tgz_path, "wb") as tgz_handle:
-            tgz = gzopen_without_timestamps("name", mode="w", fileobj=tgz_handle)
+            tgz = gzopen_without_timestamps("name", fileobj=tgz_handle)
             if folder_entry:
                 # Create an empty folder in the tgz file
                 t = tarfile.TarInfo(folder_entry)
@@ -131,7 +132,7 @@ class TarExtractPlainTest(unittest.TestCase):
         tgz_path = os.path.join(tmp_folder, "foo.tgz")
 
         with open(tgz_path, "wb") as tgz_handle:
-            tgz = gzopen_without_timestamps("name", mode="w", fileobj=tgz_handle)
+            tgz = gzopen_without_timestamps("name", fileobj=tgz_handle)
 
             # Regular file
             info = tarfile.TarInfo(name="common/foo.txt")
@@ -286,7 +287,7 @@ def _compress_root_folder(folder, tgz_path, root_folder_name="root"):
     root/parent/bin/file2
     """
     with open(tgz_path, "wb") as tgz_handle:
-        tgz = gzopen_without_timestamps("name", mode="w", fileobj=tgz_handle)
+        tgz = gzopen_without_timestamps("name", fileobj=tgz_handle)
         files, _ = gather_files(folder)
         tgz.add(root_folder_name, arcname=os.path.basename(root_folder_name))
         tgz.close()

--- a/test/unittests/util/files/tar_extract_test.py
+++ b/test/unittests/util/files/tar_extract_test.py
@@ -1,5 +1,3 @@
-# coding=utf-8
-
 import os
 import platform
 import tarfile
@@ -7,8 +5,9 @@ import unittest
 
 import pytest
 
+from conan.internal.api.uploader import gzopen_without_timestamps
 from conan.test.utils.test_files import temp_folder
-from conan.internal.util.files import tar_extract, gzopen_without_timestamps, save, gather_files, chdir
+from conan.internal.util.files import tar_extract, save, gather_files, chdir
 
 
 class TarExtractTest(unittest.TestCase):
@@ -26,7 +25,7 @@ class TarExtractTest(unittest.TestCase):
             # Create a tar.gz file with the above files
             self.tgz_file = os.path.join(self.tmp_folder, "file.tar.gz")
             with open(self.tgz_file, "wb") as tgz_handle:
-                tgz = gzopen_without_timestamps("name", mode="w", fileobj=tgz_handle)
+                tgz = gzopen_without_timestamps("name", fileobj=tgz_handle)
 
                 files, _ = gather_files(ori_files_dir)
                 for filename, abs_path in files.items():


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Mostly a refactor for encapsulating unzip. Removed unused ``conan config install`` for .gz files, it was not working, so not used (doesn't make sense)

Add more tests for coverage