### PR TITLE
Adding C standard detection

### DIFF
--- a/conan/internal/api/detect/detect_api.py
+++ b/conan/internal/api/detect/detect_api.py
@@ -347,6 +347,54 @@ def detect_cppstd(compiler, compiler_version):
     return cppstd
 
 
+def default_cstd(compiler, compiler_version):
+    """returns the default cstd for the compiler-version. This is not detected, just the default"""
+
+    def _clang_cstd_default(version):
+        if version >= "11":
+            return "gnu17"  # https://releases.llvm.org/11.0.0/tools/clang/docs/ReleaseNotes.html#c-language-changes-in-clang
+        elif version >= "4":  # 3.5 actually
+            return "gnu11"
+        else:
+            return "gnu99"  # It was gnu89 actually
+
+    def _gcc_cstd_default(version):
+        if version >= "15":
+            return "gnu23"
+        elif version >= "11":
+            return "gnu17"
+        elif version >= "5":
+            return "gnu11"
+        else:
+            return "gnu99"  # It was gnu89 actually
+
+    def _visual_cstd_default(version):
+        return None
+
+    def _apple_clang_cstd_default(version):
+        return None
+
+    def _intel_cstd_default(version):
+        return None
+
+    def _mcst_lcc_cstd_default(version):
+        return None
+
+    default = {
+        "gcc": _gcc_cstd_default(compiler_version),
+        "clang": _clang_cstd_default(compiler_version),
+        "apple-clang": _apple_clang_cstd_default(compiler_version),
+        "intel-cc": _intel_cstd_default(compiler_version),
+        "msvc": _visual_cstd_default(compiler_version),
+        "mcst-lcc": _mcst_lcc_cstd_default(compiler_version),
+    }.get(str(compiler), None)
+    return default
+
+
+def detect_cstd(compiler, compiler_version):
+    return default_cstd(compiler, compiler_version)
+
+
 def detect_default_compiler():
     """
         find the default compiler on the build machine

--- a/conan/internal/api/detect/detect_api.py
+++ b/conan/internal/api/detect/detect_api.py
@@ -359,12 +359,12 @@ def default_cstd(compiler, compiler_version):
             return "gnu99"  # It was gnu89 actually
 
     def _gcc_cstd_default(version):
-        if version >= "15":
+        if version >= "15":  # https://www.gnu.org/software/gcc/gcc-15/changes.html#c
             return "gnu23"
-        elif version >= "11":
-            return "gnu17"
+        elif version >= "8":
+            return "gnu17"  # https://www.gnu.org/software/gcc/gcc-8/changes.html#c
         elif version >= "5":
-            return "gnu11"
+            return "gnu11"  # https://www.gnu.org/software/gcc/gcc-5/changes.html#c
         else:
             return "gnu99"  # It was gnu89 actually
 

--- a/conan/internal/api/detect/detect_api.py
+++ b/conan/internal/api/detect/detect_api.py
@@ -391,10 +391,6 @@ def default_cstd(compiler, compiler_version):
     return default
 
 
-def detect_cstd(compiler, compiler_version):
-    return default_cstd(compiler, compiler_version)
-
-
 def detect_default_compiler():
     """
         find the default compiler on the build machine

--- a/conan/internal/api/detect/detect_api.py
+++ b/conan/internal/api/detect/detect_api.py
@@ -372,7 +372,12 @@ def default_cstd(compiler, compiler_version):
         return None
 
     def _apple_clang_cstd_default(version):
-        return None
+        # Based on which LLVM/Clang versions these are based on
+        if version >= "12":
+            return "gnu17"
+        if version >= "10":
+            return "gnu11"
+        return "gnu99"
 
     def _intel_cstd_default(version):
         return None

--- a/conan/internal/api/profile/detect.py
+++ b/conan/internal/api/profile/detect.py
@@ -1,6 +1,6 @@
 from conan.api.output import ConanOutput
 from conan.internal.api.detect.detect_api import detect_os, detect_arch, default_msvc_runtime, \
-    detect_libcxx, detect_cppstd, detect_default_compiler, default_compiler_version, detect_cstd
+    detect_libcxx, detect_cppstd, detect_default_compiler, default_compiler_version
 
 
 def detect_defaults_settings():

--- a/conan/internal/api/profile/detect.py
+++ b/conan/internal/api/profile/detect.py
@@ -1,6 +1,6 @@
 from conan.api.output import ConanOutput
 from conan.internal.api.detect.detect_api import detect_os, detect_arch, default_msvc_runtime, \
-    detect_libcxx, detect_cppstd, detect_default_compiler, default_compiler_version
+    detect_libcxx, detect_cppstd, detect_default_compiler, default_compiler_version, detect_cstd
 
 
 def detect_defaults_settings():
@@ -34,5 +34,8 @@ def detect_defaults_settings():
     cppstd = detect_cppstd(compiler, version)
     if cppstd:
         result.append(("compiler.cppstd", cppstd))
+    cstd = detect_cstd(compiler, version)
+    if cstd:
+        result.append(("compiler.cstd", cstd))
     result.append(("build_type", "Release"))
     return result

--- a/conan/internal/api/profile/detect.py
+++ b/conan/internal/api/profile/detect.py
@@ -34,8 +34,5 @@ def detect_defaults_settings():
     cppstd = detect_cppstd(compiler, version)
     if cppstd:
         result.append(("compiler.cppstd", cppstd))
-    cstd = detect_cstd(compiler, version)
-    if cstd:
-        result.append(("compiler.cstd", cstd))
     result.append(("build_type", "Release"))
     return result

--- a/test/unittests/client/build/c_std_flags_test.py
+++ b/test/unittests/client/build/c_std_flags_test.py
@@ -1,0 +1,170 @@
+import unittest
+
+from conan.internal.api.detect.detect_api import default_cstd
+from conan.tools.build.flags import cstd_flag
+from conan.internal.model.version import Version
+from conan.test.utils.mocks import MockSettings, ConanFileMock
+
+
+def _make_cstd_flag(compiler, compiler_version, cstd=None):
+    conanfile = ConanFileMock()
+    conanfile.settings = MockSettings({"compiler": compiler,
+                                       "compiler.version": compiler_version,
+                                       "compiler.cstd": cstd})
+    return cstd_flag(conanfile)
+
+
+def _make_cstd_default(compiler, compiler_version):
+    return default_cstd(compiler, Version(compiler_version))
+
+
+class CompilerFlagsTest(unittest.TestCase):
+
+    def test_gcc_cstd_flags(self):
+        self.assertEqual(_make_cstd_flag("gcc", "4.2", "99"), "-std=c99")
+        self.assertEqual(_make_cstd_flag("gcc", "4.2", "gnu99"), "-std=gnu99")
+        self.assertEqual(_make_cstd_flag("gcc", "4.2", "11"), "-std=c11")
+        # self.assertEqual(_make_cstd_flag("gcc", "4.2", "11"), None)
+
+        self.assertEqual(_make_cstd_flag("gcc", "4.3", "11"), "-std=c11")
+        # self.assertEqual(_make_cstd_flag("gcc", "4.3", "11"), None)
+
+        self.assertEqual(_make_cstd_flag("gcc", "4.6", "11"), "-std=c11")
+        self.assertEqual(_make_cstd_flag("gcc", "4.6", "gnu11"), "-std=gnu11")
+        # self.assertEqual(_make_cstd_flag("gcc", "4.6", "11"), "-std=c1x")
+        # self.assertEqual(_make_cstd_flag("gcc", "4.6", "gnu11"), "-std=gnu1x")
+
+        self.assertEqual(_make_cstd_flag("gcc", "4.7", "11"), "-std=c11")
+        self.assertEqual(_make_cstd_flag("gcc", "4.7", "gnu11"), "-std=gnu11")
+
+        self.assertEqual(_make_cstd_flag("gcc", "4.8", "11"), "-std=c11")
+        self.assertEqual(_make_cstd_flag("gcc", "4.8", "gnu11"), "-std=gnu11")
+        self.assertEqual(_make_cstd_flag("gcc", "4.8", "17"), "-std=c17")
+        # self.assertEqual(_make_cstd_flag("gcc", "4.8", "17"), None)
+
+        self.assertEqual(_make_cstd_flag("gcc", "4.9", "11"), "-std=c11")
+        self.assertEqual(_make_cstd_flag("gcc", "4.9", "gnu11"), "-std=gnu11")
+        self.assertEqual(_make_cstd_flag("gcc", "4.9", "17"), "-std=c17")
+        # self.assertEqual(_make_cstd_flag("gcc", "4.9", "17"), None)
+
+        self.assertEqual(_make_cstd_flag("gcc", "5", "11"), "-std=c11")
+        self.assertEqual(_make_cstd_flag("gcc", "5", "gnu11"), "-std=gnu11")
+        self.assertEqual(_make_cstd_flag("gcc", "5", "17"), "-std=c17")
+        # self.assertEqual(_make_cstd_flag("gcc", "5", "17"), None)
+
+        self.assertEqual(_make_cstd_flag("gcc", "5.1", "11"), "-std=c11")
+        self.assertEqual(_make_cstd_flag("gcc", "5.1", "gnu11"), "-std=gnu11")
+        self.assertEqual(_make_cstd_flag("gcc", "5.1", "17"), "-std=c17")
+        # self.assertEqual(_make_cstd_flag("gcc", "5.1", "17"), None)
+
+        self.assertEqual(_make_cstd_flag("gcc", "7", "11"), "-std=c11")
+        self.assertEqual(_make_cstd_flag("gcc", "7", "gnu11"), "-std=gnu11")
+        self.assertEqual(_make_cstd_flag("gcc", "7", "17"), "-std=c17")
+        # self.assertEqual(_make_cstd_flag("gcc", "7", "17"), None)
+
+        self.assertEqual(_make_cstd_flag("gcc", "8", "11"), "-std=c11")
+        self.assertEqual(_make_cstd_flag("gcc", "8", "gnu11"), "-std=gnu11")
+        self.assertEqual(_make_cstd_flag("gcc", "8", "17"), "-std=c17")
+        self.assertEqual(_make_cstd_flag("gcc", "8", "gnu17"), "-std=gnu17")
+        self.assertEqual(_make_cstd_flag("gcc", "8", "23"), "-std=c23")
+        # self.assertEqual(_make_cstd_flag("gcc", "8", "23"), None)
+
+        self.assertEqual(_make_cstd_flag("gcc", "9", "11"), "-std=c11")
+        self.assertEqual(_make_cstd_flag("gcc", "9", "gnu11"), "-std=gnu11")
+        self.assertEqual(_make_cstd_flag("gcc", "9", "17"), "-std=c17")
+        self.assertEqual(_make_cstd_flag("gcc", "9", "gnu17"), "-std=gnu17")
+        self.assertEqual(_make_cstd_flag("gcc", "9", "23"), "-std=c23")
+        self.assertEqual(_make_cstd_flag("gcc", "9", "gnu23"), "-std=gnu23")
+
+        self.assertEqual(_make_cstd_flag("gcc", "11", "11"), "-std=c11")
+        self.assertEqual(_make_cstd_flag("gcc", "11", "gnu11"), "-std=gnu11")
+        self.assertEqual(_make_cstd_flag("gcc", "11", "17"), "-std=c17")
+        self.assertEqual(_make_cstd_flag("gcc", "11", "gnu17"), "-std=gnu17")
+        self.assertEqual(_make_cstd_flag("gcc", "11", "23"), "-std=c23")
+        self.assertEqual(_make_cstd_flag("gcc", "11", "gnu23"), "-std=gnu23")
+
+    def test_gcc_cstd_defaults(self):
+        self.assertEqual(_make_cstd_default("gcc", "4"), "gnu99")
+        self.assertEqual(_make_cstd_default("gcc", "5"), "gnu11")
+        self.assertEqual(_make_cstd_default("gcc", "6"), "gnu11")
+        self.assertEqual(_make_cstd_default("gcc", "6.1"), "gnu11")
+        self.assertEqual(_make_cstd_default("gcc", "7.3"), "gnu11")
+        self.assertEqual(_make_cstd_default("gcc", "8.1"), "gnu17")
+        self.assertEqual(_make_cstd_default("gcc", "11"), "gnu17")
+        self.assertEqual(_make_cstd_default("gcc", "11.1"), "gnu17")
+        self.assertEqual(_make_cstd_default("gcc", "15.1"), "gnu23")
+
+    def test_clang_cppstd_flags(self):
+        self.assertEqual(_make_cstd_flag("clang", "3.0", "11"), '-std=c11')
+        self.assertEqual(_make_cstd_flag("clang", "3.0", "17"), '-std=c17')
+        # self.assertEqual(_make_cstd_flag("clang", "3.0", "17"), None)
+
+        self.assertEqual(_make_cstd_flag("clang", "3.1", "11"), '-std=c11')
+        self.assertEqual(_make_cstd_flag("clang", "3.1", "gnu11"), '-std=gnu11')
+        self.assertEqual(_make_cstd_flag("clang", "3.1", "17"), '-std=c17')
+        # self.assertEqual(_make_cstd_flag("clang", "3.1", "17"), None)
+
+        self.assertEqual(_make_cstd_flag("clang", "3.4", "11"), '-std=c11')
+        self.assertEqual(_make_cstd_flag("clang", "3.4", "gnu11"), '-std=gnu11')
+        # self.assertEqual(_make_cstd_flag("clang", "3.4", "17"), None)
+        self.assertEqual(_make_cstd_flag("clang", "3.4", "17"), '-std=c17')
+
+        self.assertEqual(_make_cstd_flag("clang", "3.5", "11"), '-std=c11')
+        self.assertEqual(_make_cstd_flag("clang", "3.5", "gnu11"), '-std=gnu11')
+        self.assertEqual(_make_cstd_flag("clang", "3.5", "17"), '-std=c17')
+        # self.assertEqual(_make_cstd_flag("clang", "3.5", "17"), None)
+
+        self.assertEqual(_make_cstd_flag("clang", "5", "11"), '-std=c11')
+        self.assertEqual(_make_cstd_flag("clang", "5", "gnu11"), '-std=gnu11')
+        self.assertEqual(_make_cstd_flag("clang", "5", "17"), '-std=c17')
+        # self.assertEqual(_make_cstd_flag("clang", "5", "17"), None)
+
+        for version in ["6", "7", "8"]:
+            self.assertEqual(_make_cstd_flag("clang", version, "11"), '-std=c11')
+            self.assertEqual(_make_cstd_flag("clang", version, "17"), '-std=c17')
+            self.assertEqual(_make_cstd_flag("clang", version, "gnu11"), '-std=gnu11')
+            self.assertEqual(_make_cstd_flag("clang", version, "gnu17"), '-std=gnu17')
+            self.assertEqual(_make_cstd_flag("clang", version, "23"), '-std=c23')
+            # self.assertEqual(_make_cstd_flag("clang", version, "23"), None)
+
+        self.assertEqual(_make_cstd_flag("clang", "9", "11"), '-std=c11')
+        self.assertEqual(_make_cstd_flag("clang", "9", "17"), '-std=c17')
+        self.assertEqual(_make_cstd_flag("clang", "9", "gnu11"), '-std=gnu11')
+        self.assertEqual(_make_cstd_flag("clang", "9", "gnu17"), '-std=gnu17')
+        self.assertEqual(_make_cstd_flag("clang", "9", "23"), '-std=c23')
+        self.assertEqual(_make_cstd_flag("clang", "9", "gnu23"), '-std=gnu23')
+        # self.assertEqual(_make_cstd_flag("clang", "9", "23"), '-std=c2x')
+        # self.assertEqual(_make_cstd_flag("clang", "9", "gnu23"), '-std=gnu2x')
+
+        self.assertEqual(_make_cstd_flag("clang", "18", "11"), '-std=c11')
+        self.assertEqual(_make_cstd_flag("clang", "18", "17"), '-std=c17')
+        self.assertEqual(_make_cstd_flag("clang", "18", "gnu11"), '-std=gnu11')
+        self.assertEqual(_make_cstd_flag("clang", "18", "gnu17"), '-std=gnu17')
+        self.assertEqual(_make_cstd_flag("clang", "18", "23"), '-std=c23')
+        self.assertEqual(_make_cstd_flag("clang", "18", "gnu23"), '-std=gnu23')
+
+
+    def test_clang_cppstd_defaults(self):
+        self.assertEqual(_make_cstd_default("clang", "2"), "gnu99")
+        self.assertEqual(_make_cstd_default("clang", "2.1"), "gnu99")
+        self.assertEqual(_make_cstd_default("clang", "3.0"), "gnu99")
+        self.assertEqual(_make_cstd_default("clang", "3.1"), "gnu99")
+        self.assertEqual(_make_cstd_default("clang", "3.4"), "gnu99")
+        self.assertEqual(_make_cstd_default("clang", "3.5"), "gnu99")
+        self.assertEqual(_make_cstd_default("clang", "5"), "gnu11")
+        self.assertEqual(_make_cstd_default("clang", "5.1"), "gnu11")
+        self.assertEqual(_make_cstd_default("clang", "6"), "gnu11")
+        self.assertEqual(_make_cstd_default("clang", "7"), "gnu11")
+        self.assertEqual(_make_cstd_default("clang", "8"), "gnu11")
+        self.assertEqual(_make_cstd_default("clang", "9"), "gnu11")
+        self.assertEqual(_make_cstd_default("clang", "10"), "gnu11")
+        self.assertEqual(_make_cstd_default("clang", "11"), "gnu17")
+        self.assertEqual(_make_cstd_default("clang", "12"), "gnu17")
+        self.assertEqual(_make_cstd_default("clang", "13"), "gnu17")
+        self.assertEqual(_make_cstd_default("clang", "14"), "gnu17")
+        self.assertEqual(_make_cstd_default("clang", "15"), "gnu17")
+        self.assertEqual(_make_cstd_default("clang", "16"), "gnu17")
+        self.assertEqual(_make_cstd_default("clang", "17"), "gnu17")
+        self.assertEqual(_make_cstd_default("clang", "18"), "gnu17")
+        self.assertEqual(_make_cstd_default("clang", "19"), "gnu17")
+        self.assertEqual(_make_cstd_default("clang", "20"), "gnu17")

--- a/test/unittests/client/build/c_std_flags_test.py
+++ b/test/unittests/client/build/c_std_flags_test.py
@@ -18,153 +18,48 @@ def _make_cstd_default(compiler, compiler_version):
     return default_cstd(compiler, Version(compiler_version))
 
 
-class CompilerFlagsTest(unittest.TestCase):
+def test_gcc_cstd_defaults():
+    assert _make_cstd_default("gcc", "4")== "gnu99"
+    assert _make_cstd_default("gcc", "5")== "gnu11"
+    assert _make_cstd_default("gcc", "6")== "gnu11"
+    assert _make_cstd_default("gcc", "6.1")== "gnu11"
+    assert _make_cstd_default("gcc", "7.3")== "gnu11"
+    assert _make_cstd_default("gcc", "8.1")== "gnu17"
+    assert _make_cstd_default("gcc", "11")== "gnu17"
+    assert _make_cstd_default("gcc", "11.1")== "gnu17"
+    assert _make_cstd_default("gcc", "15.1")== "gnu23"
 
-    def test_gcc_cstd_flags(self):
-        self.assertEqual(_make_cstd_flag("gcc", "4.2", "99"), "-std=c99")
-        self.assertEqual(_make_cstd_flag("gcc", "4.2", "gnu99"), "-std=gnu99")
-        self.assertEqual(_make_cstd_flag("gcc", "4.2", "11"), "-std=c11")
-        # self.assertEqual(_make_cstd_flag("gcc", "4.2", "11"), None)
-
-        self.assertEqual(_make_cstd_flag("gcc", "4.3", "11"), "-std=c11")
-        # self.assertEqual(_make_cstd_flag("gcc", "4.3", "11"), None)
-
-        self.assertEqual(_make_cstd_flag("gcc", "4.6", "11"), "-std=c11")
-        self.assertEqual(_make_cstd_flag("gcc", "4.6", "gnu11"), "-std=gnu11")
-        # self.assertEqual(_make_cstd_flag("gcc", "4.6", "11"), "-std=c1x")
-        # self.assertEqual(_make_cstd_flag("gcc", "4.6", "gnu11"), "-std=gnu1x")
-
-        self.assertEqual(_make_cstd_flag("gcc", "4.7", "11"), "-std=c11")
-        self.assertEqual(_make_cstd_flag("gcc", "4.7", "gnu11"), "-std=gnu11")
-
-        self.assertEqual(_make_cstd_flag("gcc", "4.8", "11"), "-std=c11")
-        self.assertEqual(_make_cstd_flag("gcc", "4.8", "gnu11"), "-std=gnu11")
-        self.assertEqual(_make_cstd_flag("gcc", "4.8", "17"), "-std=c17")
-        # self.assertEqual(_make_cstd_flag("gcc", "4.8", "17"), None)
-
-        self.assertEqual(_make_cstd_flag("gcc", "4.9", "11"), "-std=c11")
-        self.assertEqual(_make_cstd_flag("gcc", "4.9", "gnu11"), "-std=gnu11")
-        self.assertEqual(_make_cstd_flag("gcc", "4.9", "17"), "-std=c17")
-        # self.assertEqual(_make_cstd_flag("gcc", "4.9", "17"), None)
-
-        self.assertEqual(_make_cstd_flag("gcc", "5", "11"), "-std=c11")
-        self.assertEqual(_make_cstd_flag("gcc", "5", "gnu11"), "-std=gnu11")
-        self.assertEqual(_make_cstd_flag("gcc", "5", "17"), "-std=c17")
-        # self.assertEqual(_make_cstd_flag("gcc", "5", "17"), None)
-
-        self.assertEqual(_make_cstd_flag("gcc", "5.1", "11"), "-std=c11")
-        self.assertEqual(_make_cstd_flag("gcc", "5.1", "gnu11"), "-std=gnu11")
-        self.assertEqual(_make_cstd_flag("gcc", "5.1", "17"), "-std=c17")
-        # self.assertEqual(_make_cstd_flag("gcc", "5.1", "17"), None)
-
-        self.assertEqual(_make_cstd_flag("gcc", "7", "11"), "-std=c11")
-        self.assertEqual(_make_cstd_flag("gcc", "7", "gnu11"), "-std=gnu11")
-        self.assertEqual(_make_cstd_flag("gcc", "7", "17"), "-std=c17")
-        # self.assertEqual(_make_cstd_flag("gcc", "7", "17"), None)
-
-        self.assertEqual(_make_cstd_flag("gcc", "8", "11"), "-std=c11")
-        self.assertEqual(_make_cstd_flag("gcc", "8", "gnu11"), "-std=gnu11")
-        self.assertEqual(_make_cstd_flag("gcc", "8", "17"), "-std=c17")
-        self.assertEqual(_make_cstd_flag("gcc", "8", "gnu17"), "-std=gnu17")
-        self.assertEqual(_make_cstd_flag("gcc", "8", "23"), "-std=c23")
-        # self.assertEqual(_make_cstd_flag("gcc", "8", "23"), None)
-
-        self.assertEqual(_make_cstd_flag("gcc", "9", "11"), "-std=c11")
-        self.assertEqual(_make_cstd_flag("gcc", "9", "gnu11"), "-std=gnu11")
-        self.assertEqual(_make_cstd_flag("gcc", "9", "17"), "-std=c17")
-        self.assertEqual(_make_cstd_flag("gcc", "9", "gnu17"), "-std=gnu17")
-        self.assertEqual(_make_cstd_flag("gcc", "9", "23"), "-std=c23")
-        self.assertEqual(_make_cstd_flag("gcc", "9", "gnu23"), "-std=gnu23")
-
-        self.assertEqual(_make_cstd_flag("gcc", "11", "11"), "-std=c11")
-        self.assertEqual(_make_cstd_flag("gcc", "11", "gnu11"), "-std=gnu11")
-        self.assertEqual(_make_cstd_flag("gcc", "11", "17"), "-std=c17")
-        self.assertEqual(_make_cstd_flag("gcc", "11", "gnu17"), "-std=gnu17")
-        self.assertEqual(_make_cstd_flag("gcc", "11", "23"), "-std=c23")
-        self.assertEqual(_make_cstd_flag("gcc", "11", "gnu23"), "-std=gnu23")
-
-    def test_gcc_cstd_defaults(self):
-        self.assertEqual(_make_cstd_default("gcc", "4"), "gnu99")
-        self.assertEqual(_make_cstd_default("gcc", "5"), "gnu11")
-        self.assertEqual(_make_cstd_default("gcc", "6"), "gnu11")
-        self.assertEqual(_make_cstd_default("gcc", "6.1"), "gnu11")
-        self.assertEqual(_make_cstd_default("gcc", "7.3"), "gnu11")
-        self.assertEqual(_make_cstd_default("gcc", "8.1"), "gnu17")
-        self.assertEqual(_make_cstd_default("gcc", "11"), "gnu17")
-        self.assertEqual(_make_cstd_default("gcc", "11.1"), "gnu17")
-        self.assertEqual(_make_cstd_default("gcc", "15.1"), "gnu23")
-
-    def test_clang_cppstd_flags(self):
-        self.assertEqual(_make_cstd_flag("clang", "3.0", "11"), '-std=c11')
-        self.assertEqual(_make_cstd_flag("clang", "3.0", "17"), '-std=c17')
-        # self.assertEqual(_make_cstd_flag("clang", "3.0", "17"), None)
-
-        self.assertEqual(_make_cstd_flag("clang", "3.1", "11"), '-std=c11')
-        self.assertEqual(_make_cstd_flag("clang", "3.1", "gnu11"), '-std=gnu11')
-        self.assertEqual(_make_cstd_flag("clang", "3.1", "17"), '-std=c17')
-        # self.assertEqual(_make_cstd_flag("clang", "3.1", "17"), None)
-
-        self.assertEqual(_make_cstd_flag("clang", "3.4", "11"), '-std=c11')
-        self.assertEqual(_make_cstd_flag("clang", "3.4", "gnu11"), '-std=gnu11')
-        # self.assertEqual(_make_cstd_flag("clang", "3.4", "17"), None)
-        self.assertEqual(_make_cstd_flag("clang", "3.4", "17"), '-std=c17')
-
-        self.assertEqual(_make_cstd_flag("clang", "3.5", "11"), '-std=c11')
-        self.assertEqual(_make_cstd_flag("clang", "3.5", "gnu11"), '-std=gnu11')
-        self.assertEqual(_make_cstd_flag("clang", "3.5", "17"), '-std=c17')
-        # self.assertEqual(_make_cstd_flag("clang", "3.5", "17"), None)
-
-        self.assertEqual(_make_cstd_flag("clang", "5", "11"), '-std=c11')
-        self.assertEqual(_make_cstd_flag("clang", "5", "gnu11"), '-std=gnu11')
-        self.assertEqual(_make_cstd_flag("clang", "5", "17"), '-std=c17')
-        # self.assertEqual(_make_cstd_flag("clang", "5", "17"), None)
-
-        for version in ["6", "7", "8"]:
-            self.assertEqual(_make_cstd_flag("clang", version, "11"), '-std=c11')
-            self.assertEqual(_make_cstd_flag("clang", version, "17"), '-std=c17')
-            self.assertEqual(_make_cstd_flag("clang", version, "gnu11"), '-std=gnu11')
-            self.assertEqual(_make_cstd_flag("clang", version, "gnu17"), '-std=gnu17')
-            self.assertEqual(_make_cstd_flag("clang", version, "23"), '-std=c23')
-            # self.assertEqual(_make_cstd_flag("clang", version, "23"), None)
-
-        self.assertEqual(_make_cstd_flag("clang", "9", "11"), '-std=c11')
-        self.assertEqual(_make_cstd_flag("clang", "9", "17"), '-std=c17')
-        self.assertEqual(_make_cstd_flag("clang", "9", "gnu11"), '-std=gnu11')
-        self.assertEqual(_make_cstd_flag("clang", "9", "gnu17"), '-std=gnu17')
-        self.assertEqual(_make_cstd_flag("clang", "9", "23"), '-std=c23')
-        self.assertEqual(_make_cstd_flag("clang", "9", "gnu23"), '-std=gnu23')
-        # self.assertEqual(_make_cstd_flag("clang", "9", "23"), '-std=c2x')
-        # self.assertEqual(_make_cstd_flag("clang", "9", "gnu23"), '-std=gnu2x')
-
-        self.assertEqual(_make_cstd_flag("clang", "18", "11"), '-std=c11')
-        self.assertEqual(_make_cstd_flag("clang", "18", "17"), '-std=c17')
-        self.assertEqual(_make_cstd_flag("clang", "18", "gnu11"), '-std=gnu11')
-        self.assertEqual(_make_cstd_flag("clang", "18", "gnu17"), '-std=gnu17')
-        self.assertEqual(_make_cstd_flag("clang", "18", "23"), '-std=c23')
-        self.assertEqual(_make_cstd_flag("clang", "18", "gnu23"), '-std=gnu23')
+def test_clang_cstd_defaults():
+    assert _make_cstd_default("clang", "2")== "gnu99"
+    assert _make_cstd_default("clang", "2.1")== "gnu99"
+    assert _make_cstd_default("clang", "3.0")== "gnu99"
+    assert _make_cstd_default("clang", "3.1")== "gnu99"
+    assert _make_cstd_default("clang", "3.4")== "gnu99"
+    assert _make_cstd_default("clang", "3.5")== "gnu99"
+    assert _make_cstd_default("clang", "5")== "gnu11"
+    assert _make_cstd_default("clang", "5.1")== "gnu11"
+    assert _make_cstd_default("clang", "6")== "gnu11"
+    assert _make_cstd_default("clang", "7")== "gnu11"
+    assert _make_cstd_default("clang", "8")== "gnu11"
+    assert _make_cstd_default("clang", "9")== "gnu11"
+    assert _make_cstd_default("clang", "10")== "gnu11"
+    assert _make_cstd_default("clang", "11")== "gnu17"
+    assert _make_cstd_default("clang", "12")== "gnu17"
+    assert _make_cstd_default("clang", "13")== "gnu17"
+    assert _make_cstd_default("clang", "14")== "gnu17"
+    assert _make_cstd_default("clang", "15")== "gnu17"
+    assert _make_cstd_default("clang", "16")== "gnu17"
+    assert _make_cstd_default("clang", "17")== "gnu17"
+    assert _make_cstd_default("clang", "18")== "gnu17"
+    assert _make_cstd_default("clang", "19")== "gnu17"
+    assert _make_cstd_default("clang", "20"), "gnu17"
 
 
-    def test_clang_cppstd_defaults(self):
-        self.assertEqual(_make_cstd_default("clang", "2"), "gnu99")
-        self.assertEqual(_make_cstd_default("clang", "2.1"), "gnu99")
-        self.assertEqual(_make_cstd_default("clang", "3.0"), "gnu99")
-        self.assertEqual(_make_cstd_default("clang", "3.1"), "gnu99")
-        self.assertEqual(_make_cstd_default("clang", "3.4"), "gnu99")
-        self.assertEqual(_make_cstd_default("clang", "3.5"), "gnu99")
-        self.assertEqual(_make_cstd_default("clang", "5"), "gnu11")
-        self.assertEqual(_make_cstd_default("clang", "5.1"), "gnu11")
-        self.assertEqual(_make_cstd_default("clang", "6"), "gnu11")
-        self.assertEqual(_make_cstd_default("clang", "7"), "gnu11")
-        self.assertEqual(_make_cstd_default("clang", "8"), "gnu11")
-        self.assertEqual(_make_cstd_default("clang", "9"), "gnu11")
-        self.assertEqual(_make_cstd_default("clang", "10"), "gnu11")
-        self.assertEqual(_make_cstd_default("clang", "11"), "gnu17")
-        self.assertEqual(_make_cstd_default("clang", "12"), "gnu17")
-        self.assertEqual(_make_cstd_default("clang", "13"), "gnu17")
-        self.assertEqual(_make_cstd_default("clang", "14"), "gnu17")
-        self.assertEqual(_make_cstd_default("clang", "15"), "gnu17")
-        self.assertEqual(_make_cstd_default("clang", "16"), "gnu17")
-        self.assertEqual(_make_cstd_default("clang", "17"), "gnu17")
-        self.assertEqual(_make_cstd_default("clang", "18"), "gnu17")
-        self.assertEqual(_make_cstd_default("clang", "19"), "gnu17")
-        self.assertEqual(_make_cstd_default("clang", "20"), "gnu17")
+def test_apple_clang_cppstd_defaults():
+    assert _make_cstd_default("apple-clang", "9") == "gnu99"
+    assert _make_cstd_default("apple-clang", "10") == "gnu11"
+    assert _make_cstd_default("apple-clang", "11") == "gnu11"
+    assert _make_cstd_default("apple-clang", "12") == "gnu17"
+    assert _make_cstd_default("apple-clang", "13") == "gnu17"
+    assert _make_cstd_default("apple-clang", "14") == "gnu17"
+    assert _make_cstd_default("apple-clang", "15") == "gnu17"


### PR DESCRIPTION
Changelog: Feature: Auto detection of C standard.
Docs: https://github.com/conan-io/docs/pull/4097

- [x] Close https://github.com/conan-io/conan/issues/18281
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
