### PR TITLE
Conan takes default build profile name from the environment variable

### DIFF
--- a/conan/api/subapi/profiles.py
+++ b/conan/api/subapi/profiles.py
@@ -42,8 +42,11 @@ class ProfilesAPI:
         :return: the path to the default "build" profile, either in the cache or as
             defined by the user in configuration
         """
-        global_conf = self._conan_api.config.global_conf
-        default_profile = global_conf.get("core:default_build_profile", default=DEFAULT_PROFILE_NAME)
+
+        default_profile = os.environ.get("CONAN_DEFAULT_BUILD_PROFILE")
+        if default_profile is None:
+            global_conf = self._conan_api.config.global_conf
+            default_profile = global_conf.get("core:default_build_profile", default=DEFAULT_PROFILE_NAME)
         default_profile = os.path.join(self._home_paths.profiles_path, default_profile)
         if not os.path.exists(default_profile):
             msg = ("The default build profile '{}' doesn't exist.\n"


### PR DESCRIPTION
Changelog: Feature : Conan takes default build profile name from the environment variable CONAN_DEFAULT_BUILD_PROFILE at first instead hardcoded "default"

