### PR TITLE
Add clearer message when missing some keys in graph file

### DIFF
--- a/conan/api/model/list.py
+++ b/conan/api/model/list.py
@@ -94,6 +94,10 @@ class MultiPackagesList:
             return mpkglist
         except JSONDecodeError as e:
             raise ConanException(f"Graph file invalid JSON: {graphfile}\n{e}")
+        except KeyError as e:
+            raise ConanException(f'Graph file {graphfile} is missing the required "{e}" key in its contents.\n'
+                                 "Note that the graph file should not be filtered "
+                                 "if you expect to use it with the list command.")
         except ConanException as e:
             raise e
         except Exception as e:

--- a/test/integration/command/list/test_combined_pkglist_flows.py
+++ b/test/integration/command/list/test_combined_pkglist_flows.py
@@ -437,3 +437,14 @@ class TestListGraphContext:
             assert content["default"][ref]["revisions"]
         for ref in not_refs:
             assert content["default"].get(ref) is None
+
+    def test_graph_list(self):
+        tc = TestClient(light=True)
+        tc.save({"conanfile.py": GenConanfile("lib", "1.0")})
+        tc.run("export .")
+
+        tc.run("graph info --requires=lib/1.0 -f json --build=never --no-remote --filter=context", redirect_stdout="graph_context.json")
+
+        tc.run("list --graph=graph_context.json --graph-context=build-only --format=json",
+               assert_error=True)
+        assert "Note that the graph file should not be filtered" in tc.out

--- a/test/integration/command/list/test_combined_pkglist_flows.py
+++ b/test/integration/command/list/test_combined_pkglist_flows.py
@@ -441,9 +441,8 @@ class TestListGraphContext:
     def test_graph_list(self):
         tc = TestClient(light=True)
         tc.save({"conanfile.py": GenConanfile("lib", "1.0")})
-        tc.run("export .")
 
-        tc.run("graph info --requires=lib/1.0 -f json --build=never --no-remote --filter=context", redirect_stdout="graph_context.json")
+        tc.run("graph info . -f json --build=never --no-remote --filter=context", redirect_stdout="graph_context.json")
 
         tc.run("list --graph=graph_context.json --graph-context=build-only --format=json",
                assert_error=True)


### PR DESCRIPTION
Changelog: Fix: Better error message in `conan list --graph=file.json` when using filtered graph.
Docs: Omit

Closes https://github.com/conan-io/conan/issues/18302