### PR TITLE
[fix] tools.files.copy should exclude symlinks for folders

### DIFF
--- a/conan/tools/files/copy_pattern.py
+++ b/conan/tools/files/copy_pattern.py
@@ -106,10 +106,12 @@ def _filter_files(src, pattern, excludes, ignore_case, excluded_folder):
     for exclude in excludes:
         if ignore_case:
             files_to_copy = [f for f in files_to_copy if not fnmatch.fnmatch(f.lower(), exclude)]
-            files_symlinked_to_folders = [f for f in files_symlinked_to_folders if not fnmatch.fnmatch(f.lower(), exclude)]
+            files_symlinked_to_folders =\
+                [f for f in files_symlinked_to_folders if not fnmatch.fnmatch(f.lower(), exclude)]
         else:
             files_to_copy = [f for f in files_to_copy if not fnmatch.fnmatchcase(f, exclude)]
-            files_symlinked_to_folders = [f for f in files_symlinked_to_folders if not fnmatch.fnmatchcase(f, exclude)]
+            files_symlinked_to_folders =\
+                [f for f in files_symlinked_to_folders if not fnmatch.fnmatchcase(f, exclude)]
 
     return files_to_copy, files_symlinked_to_folders
 

--- a/conan/tools/files/copy_pattern.py
+++ b/conan/tools/files/copy_pattern.py
@@ -106,8 +106,10 @@ def _filter_files(src, pattern, excludes, ignore_case, excluded_folder):
     for exclude in excludes:
         if ignore_case:
             files_to_copy = [f for f in files_to_copy if not fnmatch.fnmatch(f.lower(), exclude)]
+            files_symlinked_to_folders = [f for f in files_symlinked_to_folders if not fnmatch.fnmatch(f.lower(), exclude)]
         else:
             files_to_copy = [f for f in files_to_copy if not fnmatch.fnmatchcase(f, exclude)]
+            files_symlinked_to_folders = [f for f in files_symlinked_to_folders if not fnmatch.fnmatchcase(f, exclude)]
 
     return files_to_copy, files_symlinked_to_folders
 

--- a/test/unittests/tools/files/test_tool_copy.py
+++ b/test/unittests/tools/files/test_tool_copy.py
@@ -170,6 +170,17 @@ class ToolCopyTest(unittest.TestCase):
         copy(None, "*.txt", folder1, folder2, excludes=("*Test*.txt", "*Impl*"))
         self.assertEqual(['MyLib.txt'], os.listdir(folder2))
 
+        folder1 = temp_folder()
+        src_dir = os.path.join(folder1, "src_dir")
+        dst_dir = os.path.join(folder1, "dst_dir")
+        os.makedirs(src_dir)
+        os.makedirs(dst_dir)
+        save(os.path.join(src_dir, "file"), "nothing")
+        save(os.path.join(dst_dir, "file"), "nothing")
+        copy(None, "*_dir*", folder1, folder2, excludes=["dst_dir", ])
+        self.assertTrue(os.path.exists(os.path.join(folder2, "src_dir")))
+        self.assertFalse(os.path.exists(os.path.join(folder2, "dst_dir")))
+
     def test_excludes_hidden_files(self):
         folder1 = temp_folder()
         save_files(folder1, {
@@ -218,12 +229,12 @@ class ToolCopyTest(unittest.TestCase):
         save(os.path.join(src_dir, "file"), "nothing")
         os.symlink(src_dir, os.path.join(root_folder, "link_dir"))
 
-        copied = copy(None, "*_dir*", root_folder, target_folder, excludes=["symlink_dir",])
+        copied = copy(None, "*_dir*", root_folder, target_folder, excludes=["link_dir",])
 
         assert os.path.exists(target_folder) and os.path.isdir(target_folder)
         assert os.path.exists(os.path.join(target_folder, "src_dir", "file"))
         assert not os.path.exists(os.path.join(target_folder, "link_dir"))
-        assert sorted(copied) == [os.path.join(target_folder, "link_dir"), os.path.join(target_folder, "src_dir", "file")]
+        assert sorted(copied) == [os.path.join(target_folder, "src_dir", "file"),]
 
     @pytest.mark.skipif(platform.system() == "Windows", reason="Requires Symlinks")
     def test_excludes_symlink_file(self):

--- a/test/unittests/tools/files/test_tool_copy.py
+++ b/test/unittests/tools/files/test_tool_copy.py
@@ -208,6 +208,23 @@ class ToolCopyTest(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(folder2, "UPPER.txt")))
         self.assertTrue(os.path.exists(os.path.join(folder2, "lower.txt")))
 
+    @pytest.mark.skipif(platform.system() == "Windows", reason="Requires Symlinks")
+    def test_excludes_symlink(self):
+        # https://github.com/conan-io/conan/issues/18296
+        root_folder = temp_folder(path_with_spaces=False)
+        target_folder = os.path.join(root_folder, "target_folder")
+        src_dir = os.path.join(root_folder, "src_dir")
+        os.makedirs(src_dir)
+        save(os.path.join(src_dir, "file"), "nothing")
+        os.symlink(src_dir, os.path.join(root_folder, "link_dir"))
+
+        copied = copy(None, "*_dir*", root_folder, target_folder, excludes=["symlink_dir",])
+
+        assert os.path.exists(target_folder) and os.path.isdir(target_folder)
+        assert os.path.exists(os.path.join(target_folder, "src_dir", "file"))
+        assert not os.path.exists(os.path.join(target_folder, "link_dir"))
+        assert sorted(copied) == [os.path.join(target_folder, "link_dir"), os.path.join(target_folder, "src_dir", "file")]
+
     def test_multifolder(self):
         src_folder1 = temp_folder()
         src_folder2 = temp_folder()

--- a/test/unittests/tools/files/test_tool_copy.py
+++ b/test/unittests/tools/files/test_tool_copy.py
@@ -209,7 +209,7 @@ class ToolCopyTest(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(folder2, "lower.txt")))
 
     @pytest.mark.skipif(platform.system() == "Windows", reason="Requires Symlinks")
-    def test_excludes_symlink(self):
+    def test_excludes_symlink_folder(self):
         # https://github.com/conan-io/conan/issues/18296
         root_folder = temp_folder(path_with_spaces=False)
         target_folder = os.path.join(root_folder, "target_folder")
@@ -224,6 +224,21 @@ class ToolCopyTest(unittest.TestCase):
         assert os.path.exists(os.path.join(target_folder, "src_dir", "file"))
         assert not os.path.exists(os.path.join(target_folder, "link_dir"))
         assert sorted(copied) == [os.path.join(target_folder, "link_dir"), os.path.join(target_folder, "src_dir", "file")]
+
+    @pytest.mark.skipif(platform.system() == "Windows", reason="Requires Symlinks")
+    def test_excludes_symlink_file(self):
+        # https://github.com/conan-io/conan/issues/18296
+        root_folder = temp_folder(path_with_spaces=False)
+        target_folder = os.path.join(root_folder, "target_folder")
+        save(os.path.join(root_folder, "src_file"), "nothing")
+        os.symlink(os.path.join(root_folder, "src_file"), os.path.join(root_folder, "link_file"))
+
+        copied = copy(None, "*_file", root_folder, target_folder, excludes=["link_file", ])
+
+        assert os.path.exists(target_folder) and os.path.isdir(target_folder)
+        assert os.path.exists(os.path.join(target_folder, "src_file"))
+        assert not os.path.exists(os.path.join(target_folder, "link_file"))
+        assert copied == [os.path.join(target_folder, "src_file"),]
 
     def test_multifolder(self):
         src_folder1 = temp_folder()


### PR DESCRIPTION
Greetings!

This PR is associated with #18296, following the expected behavior as done for regular folders:

When the `excludes` parameter in `conan.tools.files.copy()` matches a folder or file, it should not be copied to the destination folder. This rule is working already for symlinks, but when they are files. The same is working for regular folders, but only failing when a folder is a symlink.

fixes #18296

Changelog: Fix: `copy()` now is capable of excluding symlinks to folders.
Docs: Omit

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
