### PR TITLE
Refactor cache save to create a list of files to compress and reuse existing function

### DIFF
--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -173,6 +173,7 @@ class CacheAPI:
         save(pkglist_path, serialized)
         tar_files["pkglist.json"] = pkglist_path
         compress_files(tar_files, os.path.basename(tgz_path), os.path.dirname(tgz_path), compresslevel, recursive=True)
+        remove(pkglist_path)
 
     def restore(self, path):
         if not os.path.isfile(path):

--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -2,11 +2,10 @@ import json
 import os
 import shutil
 import tarfile
-from io import BytesIO
 
 from conan.api.model import PackagesList
 from conan.api.output import ConanOutput
-from conan.internal.api.uploader import gzopen_without_timestamps
+from conan.internal.api.uploader import compress_files
 from conan.internal.cache.cache import PkgCache
 from conan.internal.cache.conan_reference_layout import EXPORT_SRC_FOLDER, EXPORT_FOLDER, SRC_FOLDER, \
     METADATA, DOWNLOAD_EXPORT_FOLDER
@@ -131,50 +130,48 @@ class CacheAPI:
         cache_folder = cache.store  # Note, this is not the home, but the actual package cache
         out = ConanOutput()
         mkdir(os.path.dirname(tgz_path))
-        name = os.path.basename(tgz_path)
         compresslevel = global_conf.get("core.gzip:compresslevel", check_type=int)
-        with open(tgz_path, "wb") as tgz_handle:
-            tgz = gzopen_without_timestamps(name, fileobj=tgz_handle,
-                                            compresslevel=compresslevel)
-            for ref, ref_bundle in package_list.refs().items():
-                ref_layout = cache.recipe_layout(ref)
-                recipe_folder = os.path.relpath(ref_layout.base_folder, cache_folder)
-                recipe_folder = recipe_folder.replace("\\", "/")  # make win paths portable
-                ref_bundle["recipe_folder"] = recipe_folder
-                out.info(f"Saving {ref}: {recipe_folder}")
-                # Package only selected folders, not DOWNLOAD one
-                for f in (EXPORT_FOLDER, EXPORT_SRC_FOLDER, SRC_FOLDER):
-                    if f == SRC_FOLDER and no_source:
-                        continue
-                    path = os.path.join(cache_folder, recipe_folder, f)
-                    if os.path.exists(path):
-                        tgz.add(path, f"{recipe_folder}/{f}", recursive=True)
-                path = os.path.join(cache_folder, recipe_folder, DOWNLOAD_EXPORT_FOLDER, METADATA)
-                if os.path.exists(path):
-                    tgz.add(path, f"{recipe_folder}/{DOWNLOAD_EXPORT_FOLDER}/{METADATA}",
-                            recursive=True)
+        tar_files: dict[str,str] = {} # {path_in_tar: abs_path}
 
-                for pref, pref_bundle in package_list.prefs(ref, ref_bundle).items():
-                    pref_layout = cache.pkg_layout(pref)
-                    pkg_folder = pref_layout.package()
-                    folder = os.path.relpath(pkg_folder, cache_folder)
-                    folder = folder.replace("\\", "/")  # make win paths portable
-                    pref_bundle["package_folder"] = folder
-                    out.info(f"Saving {pref}: {folder}")
-                    tgz.add(os.path.join(cache_folder, folder), folder, recursive=True)
-                    if os.path.exists(pref_layout.metadata()):
-                        metadata_folder = os.path.relpath(pref_layout.metadata(), cache_folder)
-                        metadata_folder = metadata_folder.replace("\\", "/")  # make paths portable
-                        pref_bundle["metadata_folder"] = metadata_folder
-                        out.info(f"Saving {pref} metadata: {metadata_folder}")
-                        tgz.add(os.path.join(cache_folder, metadata_folder), metadata_folder,
-                                recursive=True)
-            serialized = json.dumps(package_list.serialize(), indent=2)
-            info = tarfile.TarInfo(name="pkglist.json")
-            data = serialized.encode('utf-8')
-            info.size = len(data)
-            tgz.addfile(tarinfo=info, fileobj=BytesIO(data))
-            tgz.close()
+        for ref, ref_bundle in package_list.refs().items():
+            ref_layout = cache.recipe_layout(ref)
+            recipe_folder = os.path.relpath(ref_layout.base_folder, cache_folder)
+            recipe_folder = recipe_folder.replace("\\", "/")  # make win paths portable
+            ref_bundle["recipe_folder"] = recipe_folder
+            out.info(f"Saving {ref}: {recipe_folder}")
+            # Package only selected folders, not DOWNLOAD one
+            for f in (EXPORT_FOLDER, EXPORT_SRC_FOLDER, SRC_FOLDER):
+                if f == SRC_FOLDER and no_source:
+                    continue
+                path = os.path.join(cache_folder, recipe_folder, f)
+                if os.path.exists(path):
+                    tar_files.update({f"{recipe_folder}/{f}": path})
+            path = os.path.join(cache_folder, recipe_folder, DOWNLOAD_EXPORT_FOLDER, METADATA)
+            if os.path.exists(path):
+                tar_files.update({f"{recipe_folder}/{DOWNLOAD_EXPORT_FOLDER}/{METADATA}": path})
+
+            for pref, pref_bundle in package_list.prefs(ref, ref_bundle).items():
+                pref_layout = cache.pkg_layout(pref)
+                pkg_folder = pref_layout.package()
+                folder = os.path.relpath(pkg_folder, cache_folder)
+                folder = folder.replace("\\", "/")  # make win paths portable
+                pref_bundle["package_folder"] = folder
+                out.info(f"Saving {pref}: {folder}")
+                tar_files.update({folder: os.path.join(cache_folder, folder)})
+
+                if os.path.exists(pref_layout.metadata()):
+                    metadata_folder = os.path.relpath(pref_layout.metadata(), cache_folder)
+                    metadata_folder = metadata_folder.replace("\\", "/")  # make paths portable
+                    pref_bundle["metadata_folder"] = metadata_folder
+                    out.info(f"Saving {pref} metadata: {metadata_folder}")
+                    tar_files.update({metadata_folder: os.path.join(cache_folder, metadata_folder)})
+
+        serialized = json.dumps(package_list.serialize(), indent=2)
+        pkglist_path = os.path.join(cache_folder, "pkglist.json")
+        with open(pkglist_path, "w") as file_handler:
+            file_handler.write(serialized)
+        tar_files.update({"pkglist.json": pkglist_path})
+        compress_files(tar_files, os.path.basename(tgz_path), os.path.dirname(tgz_path), compresslevel, recursive=True)
 
     def restore(self, path):
         if not os.path.isfile(path):

--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -171,7 +171,7 @@ class CacheAPI:
         serialized = json.dumps(package_list.serialize(), indent=2)
         pkglist_path = os.path.join(tempfile.gettempdir(), "pkglist.json")
         save(pkglist_path, serialized)
-        tar_files.update({"pkglist.json": pkglist_path})
+        tar_files["pkglist.json"] = pkglist_path
         compress_files(tar_files, os.path.basename(tgz_path), os.path.dirname(tgz_path), compresslevel, recursive=True)
 
     def restore(self, path):

--- a/conan/internal/api/uploader.py
+++ b/conan/internal/api/uploader.py
@@ -276,7 +276,7 @@ def compress_files(files, name, dest_dir, compresslevel=None, ref=None, recursiv
     # FIXME, better write to disk sequentially and not keep tgz contents in memory
     tgz_path = os.path.join(dest_dir, name)
     if ref:
-        ConanOutput(scope=str(ref)).info(f"Compressing {name}")
+        ConanOutput(scope=str(ref) if ref else None).info(f"Compressing {name}")
     with set_dirty_context_manager(tgz_path), open(tgz_path, "wb") as tgz_handle:
         tgz = gzopen_without_timestamps(name, fileobj=tgz_handle, compresslevel=compresslevel)
         for filename, abs_path in sorted(files.items()):

--- a/conan/internal/api/uploader.py
+++ b/conan/internal/api/uploader.py
@@ -271,7 +271,7 @@ def gzopen_without_timestamps(name, fileobj, compresslevel=None):
     return t
 
 
-def compress_files(files, name, dest_dir, compresslevel=None, ref=None):
+def compress_files(files, name, dest_dir, compresslevel=None, ref=None, recursive=False):
     t1 = time.time()
     # FIXME, better write to disk sequentially and not keep tgz contents in memory
     tgz_path = os.path.join(dest_dir, name)
@@ -279,8 +279,8 @@ def compress_files(files, name, dest_dir, compresslevel=None, ref=None):
     with set_dirty_context_manager(tgz_path), open(tgz_path, "wb") as tgz_handle:
         tgz = gzopen_without_timestamps(name, fileobj=tgz_handle, compresslevel=compresslevel)
         for filename, abs_path in sorted(files.items()):
-            # recursive is False in case it is a symlink to a folder
-            tgz.add(abs_path, filename, recursive=False)
+            # recursive is False by default in case it is a symlink to a folder
+            tgz.add(abs_path, filename, recursive=recursive)
         tgz.close()
 
     duration = time.time() - t1

--- a/conan/internal/api/uploader.py
+++ b/conan/internal/api/uploader.py
@@ -275,7 +275,8 @@ def compress_files(files, name, dest_dir, compresslevel=None, ref=None, recursiv
     t1 = time.time()
     # FIXME, better write to disk sequentially and not keep tgz contents in memory
     tgz_path = os.path.join(dest_dir, name)
-    ConanOutput(scope=str(ref)).info(f"Compressing {name}")
+    if ref:
+        ConanOutput(scope=str(ref)).info(f"Compressing {name}")
     with set_dirty_context_manager(tgz_path), open(tgz_path, "wb") as tgz_handle:
         tgz = gzopen_without_timestamps(name, fileobj=tgz_handle, compresslevel=compresslevel)
         for filename, abs_path in sorted(files.items()):

--- a/test/integration/conanfile/test_finalize_method.py
+++ b/test/integration/conanfile/test_finalize_method.py
@@ -1,5 +1,6 @@
 import json
 import os
+from pathlib import Path
 import textwrap
 
 import pytest
@@ -127,8 +128,12 @@ class TestBasicLocalFlows:
     def test_save_restore_cache(self, client):
         # Not created in the cache, just exported, nothing breaks because there is not even a package there
         client.run("cache save *:*")
+        # Check pkglist.json has not been created inside conan cache folder
+        assert not any(Path(client.cache_folder).rglob("pgklist.json"))
         client.run("remove * -c")
         client.run("cache restore conan_cache_save.tgz")
+        # Check the extracted pkglist does not persist in the cache after restore
+        assert not any(Path(client.cache_folder).rglob("pgklist.json"))
 
         # Now create the package and then save/restore
         client.run("create dep")


### PR DESCRIPTION
Changelog: omit
Docs: omit

As suggested in https://github.com/conan-io/conan/pull/18314#discussion_r2092888926

This PR will simplify https://github.com/conan-io/conan/pull/18314 by modifying the compression functionality on cache save command.
Intead of creating a tar object and adding files one by one (very coupled interface with tarfile module), create a list of files which will be passed to a already existing method in conan `compress_files`. 

This method may be moved to another module in a future PR.