### PR TITLE
[PkgConfigDeps][BazelDeps] Avoid duplicate component requirements

### DIFF
--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -202,7 +202,8 @@ class _PCFilesDeps:
             else:  # For instance, dep == "hello/1.0" and req == "hello::cmp1" -> hello == hello
                 req_conanfile = self._dep
             comp_name = self._get_name(req_conanfile, pkg_ref_name, comp_ref_name)
-            ret.append(comp_name)
+            if comp_name not in ret:
+                ret.append(comp_name)
         return ret
 
     def items(self):
@@ -261,7 +262,7 @@ class _PCFilesDeps:
         if pkg_name not in pc_files:
             cpp_info = self._dep.cpp_info
             # At first, let's check if we have defined some global requires, e.g., "other::cmp1"
-            # Note: If DEP has components,, they'll be the requirements == pc_files.keys()
+            # Note: If DEP has components, they'll be the requirements == pc_files.keys()
             requires = list(pc_files.keys()) or self._get_component_requirement_names(cpp_info)
             # If we have found some component requirements it would be enough
             if not requires:

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -498,7 +498,7 @@ class _InfoGenerator:
         self._is_build_require = require.build
         self._transitive_reqs = get_transitive_requires(self._conanfile, dep)
 
-    def _get_cpp_info_requires_names(self, cpp_info):
+    def _get_component_requirement_names(self, cpp_info):
         """
         Get all the valid names from the requirements ones given a CppInfo object.
 
@@ -534,7 +534,9 @@ class _InfoGenerator:
             else:  # For instance, dep == "hello/1.0" and req == "hello::cmp1" -> hello == hello
                 req_conanfile = self._dep
             comp_name = _get_component_name(req_conanfile, comp_ref_name)
-            ret.append(f"{prefix}{comp_name}")
+            dep_name = f"{prefix}{comp_name}"
+            if dep_name not in ret:
+                ret.append(dep_name)
         return ret
 
     @property
@@ -551,7 +553,7 @@ class _InfoGenerator:
         # Loop through all the package's components
         for comp_ref_name, cpp_info in self._dep.cpp_info.get_sorted_components().items():
             # At first, let's check if we have defined some components requires, e.g., "dep::cmp1"
-            comp_requires_names = self._get_cpp_info_requires_names(cpp_info)
+            comp_requires_names = self._get_component_requirement_names(cpp_info)
             comp_name = _get_component_name(self._dep, comp_ref_name)
             # Save each component information
             components_info.append(_BazelTargetInfo(None, comp_name, comp_ref_name,
@@ -568,7 +570,7 @@ class _InfoGenerator:
         repository_name = _get_repository_name(self._dep, is_build_require=self._is_build_require)
         pkg_name = _get_target_name(self._dep)
         # At first, let's check if we have defined some global requires, e.g., "other::cmp1"
-        requires = self._get_cpp_info_requires_names(self._dep.cpp_info)
+        requires = self._get_component_requirement_names(self._dep.cpp_info)
         # If we have found some component requires it would be enough
         if not requires:
             # If no requires were found, let's try to get all the direct dependencies,

--- a/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -1202,3 +1202,29 @@ def test_pkg_config_deps_set_property():
     assert 'Name: new_other_comp' in other_mycomp1
     assert other.split("\n")[0] == other_mycomp1.split("\n")[0]
 
+
+def test_pkg_with_duplicated_component_requires():
+    """
+    Testing that even having duplicated component requires, the PC does not include them.
+    Issue: https://github.com/conan-io/conan/issues/18283
+    """
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+
+        class PkgConfigConan(ConanFile):
+            def package_info(self):
+                self.cpp_info.components["mycomponent"].libs = []
+                self.cpp_info.components["myfirstcomp"].requires.append("mycomponent")
+                # Duplicate one
+                self.cpp_info.components["myfirstcomp"].requires.append("mycomponent")
+
+        """)
+    client.save({"conanfile.py": conanfile}, clean_first=True)
+    client.run("create . --name=mylib --version=0.1")
+    client.save({"conanfile.py": GenConanfile("pkg", "0.1").with_require("mylib/0.1")},
+                clean_first=True)
+    client.run("install . -g PkgConfigDeps")
+    pc_content = client.load("mylib-myfirstcomp.pc")
+    assert "Requires: mylib-mycomponent" == get_requires_from_content(pc_content)
+


### PR DESCRIPTION
Changelog: Fix: Avoid duplicate component requirement names in `PkgConfigDeps` and `BazelDeps`.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/18283
