### PR TITLE
[fix] Change wording on unzip tool when uncompressing file

### DIFF
--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -366,7 +366,7 @@ def unzip(conanfile, filename, destination=".", keep_permissions=False, pattern=
 
     output = conanfile.output
     extract_filter = conanfile.conf.get("tools.files.unzip:filter") or extract_filter
-    output.info(f"Unzipping {filename} to {destination}")
+    output.info(f"Uncompressing {filename} to {destination}")
     if (filename.endswith(".tar.gz") or filename.endswith(".tgz") or
             filename.endswith(".tbz2") or filename.endswith(".tar.bz2") or
             filename.endswith(".tar")):

--- a/test/unittests/tools/files/test_zipping.py
+++ b/test/unittests/tools/files/test_zipping.py
@@ -99,17 +99,6 @@ def create_example_tar(root_file=True, subfolder=False):
 
 
 def test_untargz():
-    archive = create_example_tar(subfolder=True)
-    conanfile = ConanFileMock({})
-
-    # Unzip and check permissions are kept
-    dest_dir = temp_folder()
-    unzip(conanfile, archive, dest_dir)
-    assert exists(join(dest_dir, "foo.txt"))
-    assert exists(join(dest_dir, "src", "bar.txt"))
-
-
-def test_untargz_output():
     import io
     from unittest.mock import patch
 
@@ -117,11 +106,13 @@ def test_untargz_output():
     conanfile = ConanFileMock({})
 
     with patch('sys.stderr', new_callable=io.StringIO) as mock_stderr:
+        # Unzip and check permissions are kept
         dest_dir = temp_folder()
         unzip(conanfile, archive, dest_dir)
+        assert exists(join(dest_dir, "foo.txt"))
+        assert exists(join(dest_dir, "src", "bar.txt"))
 
         stderr_output = mock_stderr.getvalue()
-        print(stderr_output)  # Optional: debug output
         assert f"Uncompressing {archive} to {dest_dir}" in stderr_output
 
 

--- a/test/unittests/tools/files/test_zipping.py
+++ b/test/unittests/tools/files/test_zipping.py
@@ -109,6 +109,22 @@ def test_untargz():
     assert exists(join(dest_dir, "src", "bar.txt"))
 
 
+def test_untargz_output():
+    import io
+    from unittest.mock import patch
+
+    archive = create_example_tar(subfolder=True)
+    conanfile = ConanFileMock({})
+
+    with patch('sys.stderr', new_callable=io.StringIO) as mock_stderr:
+        dest_dir = temp_folder()
+        unzip(conanfile, archive, dest_dir)
+
+        stderr_output = mock_stderr.getvalue()
+        print(stderr_output)  # Optional: debug output
+        assert f"Uncompressing {archive} to {dest_dir}" in stderr_output
+
+
 def test_untargz_with_pattern():
     archive = create_example_tar(subfolder=True)
     conanfile = ConanFileMock({})


### PR DESCRIPTION
Changelog: Fix: Change wording on unzip tool when uncompressing file.
Docs: omit

Close https://github.com/conan-io/conan/pull/18323

- [x] Refer to the issue that supports this Pull Request: closes #18323
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
