### PR TITLE
Add support for extra configure arguments

### DIFF
--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -101,6 +101,7 @@ BUILT_IN_CONFS = {
     "tools.gnu:pkg_config": "Path to pkg-config executable used by PkgConfig build helper",
     "tools.gnu:build_triplet": "Custom build triplet to pass to Autotools scripts",
     "tools.gnu:host_triplet": "Custom host triplet to pass to Autotools scripts",
+    "tools.gnu:extra_configure_args": "List of extra arguments to pass to configure when using AutotoolsToolchain and GnuToolchain",
     "tools.google.bazel:configs": "List of Bazel configurations to be used as 'bazel build --config=config1 ...'",
     "tools.google.bazel:bazelrc_path": "List of paths to bazelrc files to be used as 'bazel --bazelrc=rcpath1 ... build'",
     "tools.meson.mesontoolchain:backend": "Any Meson backend: ninja, vs, vs2010, vs2012, vs2013, vs2015, vs2017, vs2019, xcode",

--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -101,7 +101,7 @@ BUILT_IN_CONFS = {
     "tools.gnu:pkg_config": "Path to pkg-config executable used by PkgConfig build helper",
     "tools.gnu:build_triplet": "Custom build triplet to pass to Autotools scripts",
     "tools.gnu:host_triplet": "Custom host triplet to pass to Autotools scripts",
-    "tools.gnu:configure_args": "List of extra arguments to pass to configure when using AutotoolsToolchain and GnuToolchain",
+    "tools.gnu:extra_configure_args": "List of extra arguments to pass to configure when using AutotoolsToolchain and GnuToolchain",
     "tools.google.bazel:configs": "List of Bazel configurations to be used as 'bazel build --config=config1 ...'",
     "tools.google.bazel:bazelrc_path": "List of paths to bazelrc files to be used as 'bazel --bazelrc=rcpath1 ... build'",
     "tools.meson.mesontoolchain:backend": "Any Meson backend: ninja, vs, vs2010, vs2012, vs2013, vs2015, vs2017, vs2019, xcode",

--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -101,7 +101,7 @@ BUILT_IN_CONFS = {
     "tools.gnu:pkg_config": "Path to pkg-config executable used by PkgConfig build helper",
     "tools.gnu:build_triplet": "Custom build triplet to pass to Autotools scripts",
     "tools.gnu:host_triplet": "Custom host triplet to pass to Autotools scripts",
-    "tools.gnu:extra_configure_args": "List of extra arguments to pass to configure when using AutotoolsToolchain and GnuToolchain",
+    "tools.gnu:configure_args": "List of extra arguments to pass to configure when using AutotoolsToolchain and GnuToolchain",
     "tools.google.bazel:configs": "List of Bazel configurations to be used as 'bazel build --config=config1 ...'",
     "tools.google.bazel:bazelrc_path": "List of paths to bazelrc files to be used as 'bazel --bazelrc=rcpath1 ... build'",
     "tools.meson.mesontoolchain:backend": "Any Meson backend: ninja, vs, vs2010, vs2012, vs2013, vs2015, vs2017, vs2019, xcode",

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -83,7 +83,7 @@ class AutotoolsToolchain:
         sysroot = self._conanfile.conf.get("tools.build:sysroot")
         sysroot = sysroot.replace("\\", "/") if sysroot is not None else None
         self.sysroot_flag = "--sysroot {}".format(sysroot) if sysroot else None
-        extra_configure_args = self._conanfile.conf.get("tools.gnu:extra_configure_args",
+        extra_configure_args = self._conanfile.conf.get("tools.gnu:configure_args",
                                                         check_type=list,
                                                         default=[])
 

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -83,7 +83,9 @@ class AutotoolsToolchain:
         sysroot = self._conanfile.conf.get("tools.build:sysroot")
         sysroot = sysroot.replace("\\", "/") if sysroot is not None else None
         self.sysroot_flag = "--sysroot {}".format(sysroot) if sysroot else None
-        extra_configure_args = self._conanfile.conf.get("tools.gnu:extra_configure_args", default=[])
+        extra_configure_args = self._conanfile.conf.get("tools.gnu:extra_configure_args",
+                                                        check_type=list,
+                                                        default=[])
 
         self.configure_args = (self._default_configure_shared_flags() +
                                self._default_configure_install_flags() +

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -83,10 +83,12 @@ class AutotoolsToolchain:
         sysroot = self._conanfile.conf.get("tools.build:sysroot")
         sysroot = sysroot.replace("\\", "/") if sysroot is not None else None
         self.sysroot_flag = "--sysroot {}".format(sysroot) if sysroot else None
+        extra_configure_args = self._conanfile.conf.get("tools.gnu:extra_configure_args", default=[])
 
         self.configure_args = (self._default_configure_shared_flags() +
                                self._default_configure_install_flags() +
-                               self._get_triplets())
+                               self._get_triplets() +
+                               extra_configure_args)
         self.autoreconf_args = self._default_autoreconf_flags()
         self.make_args = []
         # Apple stuff

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -83,7 +83,7 @@ class AutotoolsToolchain:
         sysroot = self._conanfile.conf.get("tools.build:sysroot")
         sysroot = sysroot.replace("\\", "/") if sysroot is not None else None
         self.sysroot_flag = "--sysroot {}".format(sysroot) if sysroot else None
-        extra_configure_args = self._conanfile.conf.get("tools.gnu:configure_args",
+        extra_configure_args = self._conanfile.conf.get("tools.gnu:extra_configure_args",
                                                         check_type=list,
                                                         default=[])
 

--- a/conan/tools/gnu/gnutoolchain.py
+++ b/conan/tools/gnu/gnutoolchain.py
@@ -62,7 +62,9 @@ class GnuToolchain:
         self.fpic = self._conanfile.options.get_safe("fPIC")
         self.msvc_runtime_flag = self._get_msvc_runtime_flag()
         self.msvc_extra_flags = self._msvc_extra_flags()
-        extra_configure_args = self._conanfile.conf.get("tools.gnu:extra_configure_args", default=[])
+        extra_configure_args = self._conanfile.conf.get("tools.gnu:extra_configure_args",
+                                                        check_type=list,
+                                                        default=[])
         extra_configure_args = {it: None for it in extra_configure_args}
 
         # Host/Build triplets

--- a/conan/tools/gnu/gnutoolchain.py
+++ b/conan/tools/gnu/gnutoolchain.py
@@ -62,7 +62,7 @@ class GnuToolchain:
         self.fpic = self._conanfile.options.get_safe("fPIC")
         self.msvc_runtime_flag = self._get_msvc_runtime_flag()
         self.msvc_extra_flags = self._msvc_extra_flags()
-        extra_configure_args = self._conanfile.conf.get("tools.gnu:extra_configure_args",
+        extra_configure_args = self._conanfile.conf.get("tools.gnu:configure_args",
                                                         check_type=list,
                                                         default=[])
         extra_configure_args = {it: None for it in extra_configure_args}

--- a/conan/tools/gnu/gnutoolchain.py
+++ b/conan/tools/gnu/gnutoolchain.py
@@ -62,7 +62,7 @@ class GnuToolchain:
         self.fpic = self._conanfile.options.get_safe("fPIC")
         self.msvc_runtime_flag = self._get_msvc_runtime_flag()
         self.msvc_extra_flags = self._msvc_extra_flags()
-        extra_configure_args = self._conanfile.conf.get("tools.gnu:configure_args",
+        extra_configure_args = self._conanfile.conf.get("tools.gnu:extra_configure_args",
                                                         check_type=list,
                                                         default=[])
         extra_configure_args = {it: None for it in extra_configure_args}

--- a/conan/tools/gnu/gnutoolchain.py
+++ b/conan/tools/gnu/gnutoolchain.py
@@ -62,6 +62,8 @@ class GnuToolchain:
         self.fpic = self._conanfile.options.get_safe("fPIC")
         self.msvc_runtime_flag = self._get_msvc_runtime_flag()
         self.msvc_extra_flags = self._msvc_extra_flags()
+        extra_configure_args = self._conanfile.conf.get("tools.gnu:extra_configure_args", default=[])
+        extra_configure_args = {it: None for it in extra_configure_args}
 
         # Host/Build triplets
         self.triplets_info = {
@@ -92,6 +94,7 @@ class GnuToolchain:
         self.configure_args.update(self._get_default_configure_shared_flags())
         self.configure_args.update(self._get_default_configure_install_flags())
         self.configure_args.update(self._get_default_triplets())
+        self.configure_args.update(extra_configure_args)
         # Apple stuff
         is_cross_building_osx = (self._is_cross_building
                                  and conanfile.settings_build.get_safe('os') == "Macos"

--- a/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -608,7 +608,9 @@ def test_conf_compiler_executable():
 
 
 def test_autotools_toolchain_conf_extra_configure_args():
-    """Validate that tools.gnu:extra_configure_args are passed to configure command only
+    """Validate that tools.gnu:extra_configure_args are passed to configure command only.
+
+       The configure args should be passed as list only.
     """
     f = temp_folder()
     os.chdir(f)
@@ -623,3 +625,9 @@ def test_autotools_toolchain_conf_extra_configure_args():
     assert "--foo --bar" in obj["configure_args"]
     # make sure it does not forward to make
     assert "--foo" not in obj["make_args"]
+
+    conanfile.conf.define("tools.gnu:extra_configure_args", "--foo --bar")
+    with pytest.raises(ConanException) as expected:
+        AutotoolsToolchain(conanfile)
+    assert "[conf] tools.gnu:extra_configure_args must be a list-like object. "\
+           "The value '--foo --bar' introduced is a str object" in str(expected)

--- a/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -607,8 +607,8 @@ def test_conf_compiler_executable():
     assert "/c/my/path/myg++" == env["CXX"]
 
 
-def test_autotools_toolchain_conf_configure_args():
-    """Validate that tools.gnu:configure_args are passed to configure command only.
+def test_autotools_toolchain_conf_extra_configure_args():
+    """Validate that tools.gnu:extra_configure_args are passed to configure command only.
 
        The configure args should be passed as list only.
     """
@@ -617,7 +617,7 @@ def test_autotools_toolchain_conf_configure_args():
     conanfile = ConanFileMock()
     conanfile.settings = MockSettings({"os": "Linux", "arch": "x86_64"})
     conanfile.conf = Conf()
-    conanfile.conf.define("tools.gnu:configure_args", ["--foo", "--bar"])
+    conanfile.conf.define("tools.gnu:extra_configure_args", ["--foo", "--bar"])
 
     be = AutotoolsToolchain(conanfile)
     be.generate_args()
@@ -626,8 +626,8 @@ def test_autotools_toolchain_conf_configure_args():
     # make sure it does not forward to make
     assert "--foo" not in obj["make_args"]
 
-    conanfile.conf.define("tools.gnu:configure_args", "--foo --bar")
+    conanfile.conf.define("tools.gnu:extra_configure_args", "--foo --bar")
     with pytest.raises(ConanException) as expected:
         AutotoolsToolchain(conanfile)
-    assert "[conf] tools.gnu:configure_args must be a list-like object. "\
+    assert "[conf] tools.gnu:extra_configure_args must be a list-like object. "\
            "The value '--foo --bar' introduced is a str object" in str(expected)

--- a/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -607,8 +607,8 @@ def test_conf_compiler_executable():
     assert "/c/my/path/myg++" == env["CXX"]
 
 
-def test_autotools_toolchain_conf_extra_configure_args():
-    """Validate that tools.gnu:extra_configure_args are passed to configure command only.
+def test_autotools_toolchain_conf_configure_args():
+    """Validate that tools.gnu:configure_args are passed to configure command only.
 
        The configure args should be passed as list only.
     """
@@ -617,7 +617,7 @@ def test_autotools_toolchain_conf_extra_configure_args():
     conanfile = ConanFileMock()
     conanfile.settings = MockSettings({"os": "Linux", "arch": "x86_64"})
     conanfile.conf = Conf()
-    conanfile.conf.define("tools.gnu:extra_configure_args", ["--foo", "--bar"])
+    conanfile.conf.define("tools.gnu:configure_args", ["--foo", "--bar"])
 
     be = AutotoolsToolchain(conanfile)
     be.generate_args()
@@ -626,8 +626,8 @@ def test_autotools_toolchain_conf_extra_configure_args():
     # make sure it does not forward to make
     assert "--foo" not in obj["make_args"]
 
-    conanfile.conf.define("tools.gnu:extra_configure_args", "--foo --bar")
+    conanfile.conf.define("tools.gnu:configure_args", "--foo --bar")
     with pytest.raises(ConanException) as expected:
         AutotoolsToolchain(conanfile)
-    assert "[conf] tools.gnu:extra_configure_args must be a list-like object. "\
+    assert "[conf] tools.gnu:configure_args must be a list-like object. "\
            "The value '--foo --bar' introduced is a str object" in str(expected)

--- a/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -625,9 +625,3 @@ def test_autotools_toolchain_conf_extra_configure_args():
     assert "--foo --bar" in obj["configure_args"]
     # make sure it does not forward to make
     assert "--foo" not in obj["make_args"]
-
-    conanfile.conf.define("tools.gnu:extra_configure_args", "--foo --bar")
-    with pytest.raises(ConanException) as expected:
-        AutotoolsToolchain(conanfile)
-    assert "[conf] tools.gnu:extra_configure_args must be a list-like object. "\
-           "The value '--foo --bar' introduced is a str object" in str(expected)

--- a/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -605,3 +605,21 @@ def test_conf_compiler_executable():
     be = AutotoolsToolchain(conanfile)
     env = be.vars()
     assert "/c/my/path/myg++" == env["CXX"]
+
+
+def test_autotools_toolchain_conf_extra_configure_args():
+    """Validate that tools.gnu:extra_configure_args are passed to configure command only
+    """
+    f = temp_folder()
+    os.chdir(f)
+    conanfile = ConanFileMock()
+    conanfile.settings = MockSettings({"os": "Linux", "arch": "x86_64"})
+    conanfile.conf = Conf()
+    conanfile.conf.define("tools.gnu:extra_configure_args", ["--foo", "--bar"])
+
+    be = AutotoolsToolchain(conanfile)
+    be.generate_args()
+    obj = load_toolchain_args()
+    assert "--foo --bar" in obj["configure_args"]
+    # make sure it does not forward to make
+    assert "--foo" not in obj["make_args"]

--- a/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -625,9 +625,3 @@ def test_autotools_toolchain_conf_configure_args():
     assert "--foo --bar" in obj["configure_args"]
     # make sure it does not forward to make
     assert "--foo" not in obj["make_args"]
-
-    conanfile.conf.define("tools.gnu:configure_args", "--foo --bar")
-    with pytest.raises(ConanException) as expected:
-        AutotoolsToolchain(conanfile)
-    assert "[conf] tools.gnu:configure_args must be a list-like object. "\
-           "The value '--foo --bar' introduced is a str object" in str(expected)

--- a/test/unittests/tools/gnu/test_gnutoolchain.py
+++ b/test/unittests/tools/gnu/test_gnutoolchain.py
@@ -240,6 +240,7 @@ def test_crossbuild_to_android(build_env_mock):
 def test_gnu_toolchain_conf_extra_configure_args():
     """ Validate that tools.gnu:extra_configure_args are passed to the configure_args when
         building with GnuToolchain.
+        The configure args should be passed as a list-like object.
     """
     conanfile = ConanFileMock()
     conanfile.settings = MockSettings({"os": "Linux", "arch": "x86_64"})
@@ -249,3 +250,9 @@ def test_gnu_toolchain_conf_extra_configure_args():
     tc = GnuToolchain(conanfile)
     assert tc.configure_args["--foo"] is None
     assert tc.configure_args["--bar"] is None
+
+    conanfile.conf.define("tools.gnu:extra_configure_args", "--foo --bar")
+    with pytest.raises(ConanException) as expected:
+        GnuToolchain(conanfile)
+    assert "[conf] tools.gnu:extra_configure_args must be a list-like object. " \
+           "The value '--foo --bar' introduced is a str object" in str(expected)

--- a/test/unittests/tools/gnu/test_gnutoolchain.py
+++ b/test/unittests/tools/gnu/test_gnutoolchain.py
@@ -250,9 +250,3 @@ def test_gnu_toolchain_conf_extra_configure_args():
     tc = GnuToolchain(conanfile)
     assert tc.configure_args["--foo"] is None
     assert tc.configure_args["--bar"] is None
-
-    conanfile.conf.define("tools.gnu:extra_configure_args", "--foo --bar")
-    with pytest.raises(ConanException) as expected:
-        GnuToolchain(conanfile)
-    assert "[conf] tools.gnu:extra_configure_args must be a list-like object. " \
-           "The value '--foo --bar' introduced is a str object" in str(expected)

--- a/test/unittests/tools/gnu/test_gnutoolchain.py
+++ b/test/unittests/tools/gnu/test_gnutoolchain.py
@@ -237,22 +237,22 @@ def test_crossbuild_to_android(build_env_mock):
     assert env_vars["STRIP"] == os.path.join(ndk_bin, "llvm-strip")  # does not exist but appears
 
 
-def test_gnu_toolchain_conf_configure_args():
-    """ Validate that tools.gnu:configure_args are passed to the configure_args when
+def test_gnu_toolchain_conf_extra_configure_args():
+    """ Validate that tools.gnu:extra_configure_args are passed to the configure_args when
         building with GnuToolchain.
         The configure args should be passed as a list-like object.
     """
     conanfile = ConanFileMock()
     conanfile.settings = MockSettings({"os": "Linux", "arch": "x86_64"})
     conanfile.conf = Conf()
-    conanfile.conf.define("tools.gnu:configure_args", ["--foo", "--bar"])
+    conanfile.conf.define("tools.gnu:extra_configure_args", ["--foo", "--bar"])
 
     tc = GnuToolchain(conanfile)
     assert tc.configure_args["--foo"] is None
     assert tc.configure_args["--bar"] is None
 
-    conanfile.conf.define("tools.gnu:configure_args", "--foo --bar")
+    conanfile.conf.define("tools.gnu:extra_configure_args", "--foo --bar")
     with pytest.raises(ConanException) as expected:
         GnuToolchain(conanfile)
-    assert "[conf] tools.gnu:configure_args must be a list-like object. " \
+    assert "[conf] tools.gnu:extra_configure_args must be a list-like object. " \
            "The value '--foo --bar' introduced is a str object" in str(expected)

--- a/test/unittests/tools/gnu/test_gnutoolchain.py
+++ b/test/unittests/tools/gnu/test_gnutoolchain.py
@@ -237,22 +237,22 @@ def test_crossbuild_to_android(build_env_mock):
     assert env_vars["STRIP"] == os.path.join(ndk_bin, "llvm-strip")  # does not exist but appears
 
 
-def test_gnu_toolchain_conf_extra_configure_args():
-    """ Validate that tools.gnu:extra_configure_args are passed to the configure_args when
+def test_gnu_toolchain_conf_configure_args():
+    """ Validate that tools.gnu:configure_args are passed to the configure_args when
         building with GnuToolchain.
         The configure args should be passed as a list-like object.
     """
     conanfile = ConanFileMock()
     conanfile.settings = MockSettings({"os": "Linux", "arch": "x86_64"})
     conanfile.conf = Conf()
-    conanfile.conf.define("tools.gnu:extra_configure_args", ["--foo", "--bar"])
+    conanfile.conf.define("tools.gnu:configure_args", ["--foo", "--bar"])
 
     tc = GnuToolchain(conanfile)
     assert tc.configure_args["--foo"] is None
     assert tc.configure_args["--bar"] is None
 
-    conanfile.conf.define("tools.gnu:extra_configure_args", "--foo --bar")
+    conanfile.conf.define("tools.gnu:configure_args", "--foo --bar")
     with pytest.raises(ConanException) as expected:
         GnuToolchain(conanfile)
-    assert "[conf] tools.gnu:extra_configure_args must be a list-like object. " \
+    assert "[conf] tools.gnu:configure_args must be a list-like object. " \
            "The value '--foo --bar' introduced is a str object" in str(expected)

--- a/test/unittests/tools/gnu/test_gnutoolchain.py
+++ b/test/unittests/tools/gnu/test_gnutoolchain.py
@@ -250,9 +250,3 @@ def test_gnu_toolchain_conf_configure_args():
     tc = GnuToolchain(conanfile)
     assert tc.configure_args["--foo"] is None
     assert tc.configure_args["--bar"] is None
-
-    conanfile.conf.define("tools.gnu:configure_args", "--foo --bar")
-    with pytest.raises(ConanException) as expected:
-        GnuToolchain(conanfile)
-    assert "[conf] tools.gnu:configure_args must be a list-like object. " \
-           "The value '--foo --bar' introduced is a str object" in str(expected)

--- a/test/unittests/tools/gnu/test_gnutoolchain.py
+++ b/test/unittests/tools/gnu/test_gnutoolchain.py
@@ -235,3 +235,17 @@ def test_crossbuild_to_android(build_env_mock):
     assert gnutc.triplets_info["host"]["triplet"] == "aarch64-linux-android"
     assert env_vars["LD"] == os.path.join(ndk_bin, "ld")  # exists
     assert env_vars["STRIP"] == os.path.join(ndk_bin, "llvm-strip")  # does not exist but appears
+
+
+def test_gnu_toolchain_conf_extra_configure_args():
+    """ Validate that tools.gnu:extra_configure_args are passed to the configure_args when
+        building with GnuToolchain.
+    """
+    conanfile = ConanFileMock()
+    conanfile.settings = MockSettings({"os": "Linux", "arch": "x86_64"})
+    conanfile.conf = Conf()
+    conanfile.conf.define("tools.gnu:extra_configure_args", ["--foo", "--bar"])
+
+    tc = GnuToolchain(conanfile)
+    assert tc.configure_args["--foo"] is None
+    assert tc.configure_args["--bar"] is None


### PR DESCRIPTION
Changelog: Feature: Add `tools.gnu:configure_args` conf to GnuToolchain and Autotoolchain generator to allow extra arguments to be added to the configure command.

Docs: https://github.com/conan-io/docs/pull/4100

close #18256

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
