### PR TITLE
[workspace] Removed `home_folder` mechanism

### DIFF
--- a/conan/api/conan_api.py
+++ b/conan/api/conan_api.py
@@ -45,8 +45,7 @@ class ConanAPI:
             raise ConanException("cache_folder has to be an absolute path")
 
         init_colorama(sys.stderr)
-        self.workspace = WorkspaceAPI(self)
-        self.cache_folder = self.workspace.home_folder() or cache_folder or get_conan_user_home()
+        self.cache_folder = cache_folder or get_conan_user_home()
         self.home_folder = self.cache_folder  # Lets call it home, deprecate "cache"
         self.migrate()
 
@@ -71,6 +70,8 @@ class ConanAPI:
         self.lockfile = LockfileAPI(self)
         self.local = LocalAPI(self)
         self.audit = AuditAPI(self)
+        # Now, lazy loading of editables
+        self.workspace = WorkspaceAPI(self)
 
         _check_conan_version(self)
 

--- a/conan/api/subapi/workspace.py
+++ b/conan/api/subapi/workspace.py
@@ -87,17 +87,6 @@ class WorkspaceAPI:
         self._check_ws()
         return self._ws.name()
 
-    def home_folder(self):
-        """
-        @return: The custom defined Conan home/cache folder if defined, else None
-        """
-        if not self._folder:
-            return
-        folder = self._ws.home_folder()
-        if folder is None or os.path.isabs(folder):
-            return folder
-        return os.path.normpath(os.path.join(self._folder, folder))
-
     def folder(self):
         """
         @return: the current workspace folder where the conanws.yml or conanws.py is located

--- a/conan/internal/model/workspace.py
+++ b/conan/internal/model/workspace.py
@@ -36,9 +36,6 @@ class Workspace:
             raise ConanException("Invalid yml format at {}: {}".format(WORKSPACE_YML, e))
         return data or {}
 
-    def home_folder(self):
-        return self.conan_data.get("home_folder")
-
     def add(self, ref, path, output_folder, product=False):
         assert os.path.isfile(path)
         path = self._conan_rel_path(os.path.dirname(path))

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -15,30 +15,7 @@ from conan.internal.util.files import save, save_files
 WorkspaceAPI.TEST_ENABLED = "will_break_next"
 
 
-class TestHomeRoot:
-    def test_workspace_home_yml(self):
-        folder = temp_folder()
-        cwd = os.path.join(folder, "sub1", "sub2")
-        save(os.path.join(folder, f"conanws.yml"), "home_folder: myhome")
-        c = TestClient(current_folder=cwd, light=True)
-        c.run("config home")
-        assert os.path.join(folder, "myhome") in c.stdout
-
-    def test_workspace_home_user_py(self):
-        folder = temp_folder()
-        cwd = os.path.join(folder, "sub1", "sub2")
-        conanwspy = textwrap.dedent("""
-            from conan import Workspace
-
-            class MyWs(Workspace):
-                def home_folder(self):
-                    return "new" + self.conan_data["home_folder"]
-            """)
-        save(os.path.join(folder, f"conanws.py"), conanwspy)
-        save(os.path.join(folder, "conanws.yml"), "home_folder: myhome")
-        c = TestClient(current_folder=cwd, light=True)
-        c.run("config home")
-        assert os.path.join(folder, "newmyhome") in c.stdout
+class TestWorkspaceRoot:
 
     def test_workspace_root(self):
         c = TestClient(light=True)
@@ -576,7 +553,7 @@ def test_workspace_with_local_recipes_index():
                                 "zlib/all/conandata.yml": ""})
 
     c = TestClient(light=True)
-    c.save({"conanws.yml": 'home_folder: "deps"'})
+    c.save({".conanrc": 'conan_home=deps\n'})
     c.run(f'remote add local "{c3i_folder}"')
 
     c.run("list zlib/1.2.11#* -r=local")


### PR DESCRIPTION
Changelog: Feature: Removed the `home_folder` definition mechanism from the `conanws.[yml | py]` file.
Docs: https://github.com/conan-io/docs/pull/4106
