### PR TITLE
feature: Add support for source targets CMakeConfigDeps generator

### DIFF
--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -13,7 +13,7 @@ from conan.internal.util.files import load, save
 _DIRS_VAR_NAMES = ["_includedirs", "_srcdirs", "_libdirs", "_resdirs", "_bindirs", "_builddirs",
                    "_frameworkdirs", "_objects"]
 _FIELD_VAR_NAMES = ["_system_libs", "_package_framework", "_frameworks", "_libs", "_defines",
-                    "_cflags", "_cxxflags", "_sharedlinkflags", "_exelinkflags"]
+                    "_cflags", "_cxxflags", "_sharedlinkflags", "_exelinkflags", "_sources"]
 _ALL_NAMES = _DIRS_VAR_NAMES + _FIELD_VAR_NAMES
 
 
@@ -81,6 +81,7 @@ class _Component:
         self._sharedlinkflags = None  # linker flags
         self._exelinkflags = None  # linker flags
         self._objects = None  # linker flags
+        self._sources = None  # source files
         self._exe = None  # application executable, only 1 allowed, following CPS
         self._languages = None
 
@@ -120,6 +121,7 @@ class _Component:
             "sharedlinkflags": self._sharedlinkflags,
             "exelinkflags": self._exelinkflags,
             "objects": self._objects,
+            "sources": self._sources,
             "sysroot": self._sysroot,
             "requires": self._requires,
             "properties": self._properties,
@@ -379,6 +381,16 @@ class _Component:
     @objects.setter
     def objects(self, value):
         self._objects = value
+
+    @property
+    def sources(self):
+        if self._sources is None:
+            self._sources = []
+        return self._sources
+
+    @sources.setter
+    def sources(self, value):
+        self._sources = value
 
     @property
     def sysroot(self):

--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -272,24 +272,20 @@ class TargetConfigurationTemplate2:
         return exes
 
     def _get_sources(self, cpp_info, pkg_name, pkg_folder, pkg_folder_var):
-        sources = {}
+        def _fill_sources(info, comp_name=None):
+            if info.sources:
+                target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile,
+                                                           comp_name=comp_name, check_type=list)
+                target = target_name or f"{pkg_name}::{name}"
+                sources[target].extend([self._path(source, pkg_folder, pkg_folder_var)
+                                        for source in info.sources])
 
+        sources = {}
         if cpp_info.has_components:
             for name, comp in cpp_info.components.items():
-                if comp.sources:
-                    target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile,
-                                                               name)
-                    target = target_name or f"{pkg_name}::{name}"
-                    sources[target] = []
-                    for source in comp.sources:
-                        sources[target].append(self._path(source, pkg_folder, pkg_folder_var))
+                _fill_sources(comp, comp_name=name)
         else:
-            if cpp_info.sources:
-                target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile)
-                target = target_name or f"{pkg_name}::{pkg_name}"
-                sources[target] = []
-                for source in cpp_info.sources:
-                    sources[target].append(self._path(source, pkg_folder, pkg_folder_var))
+            _fill_sources(cpp_info)
         return sources
 
     def _get_dependencies(self):

--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -283,7 +283,6 @@ class TargetConfigurationTemplate2:
                     sources[target] = []
                     for source in comp.sources:
                         sources[target].append(self._path(source, pkg_folder, pkg_folder_var))
-                    sources[target] = ";".join(sources[target])
         else:
             if cpp_info.sources:
                 target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile)
@@ -291,7 +290,6 @@ class TargetConfigurationTemplate2:
                 sources[target] = []
                 for source in cpp_info.sources:
                     sources[target].append(self._path(source, pkg_folder, pkg_folder_var))
-                sources[target] = ";".join(sources[target])
         return sources
 
     def _get_dependencies(self):
@@ -487,7 +485,7 @@ class TargetConfigurationTemplate2:
         {% for target, srcs in sources.items() %}
         #################### {{target}} ####################
         set_property(TARGET {{target}} APPEND PROPERTY INTERFACE_SOURCES
-                     {{config_wrapper(config, srcs)}})
+                     {{config_wrapper(config, srcs | join(';') )}})
         {% endfor %}
         {% endif %}
         """)

--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -275,14 +275,15 @@ class TargetConfigurationTemplate2:
         sources = {}
 
         if cpp_info.has_components:
-            # FIXME: NOT IMPLEMENTED
             for name, comp in cpp_info.components.items():
-                if comp.exe or comp.type is PackageType.APP:
+                if comp.sources:
                     target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile,
                                                                name)
                     target = target_name or f"{pkg_name}::{name}"
-                    exe_location = self._path(comp.location, pkg_folder, pkg_folder_var)
-                    sources[target] = exe_location
+                    sources[target] = []
+                    for source in comp.sources:
+                        sources[target].append(self._path(source, pkg_folder, pkg_folder_var))
+                    sources[target] = ";".join(sources[target])
         else:
             if cpp_info.sources:
                 target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile)

--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -113,7 +113,6 @@ class TargetConfigurationTemplate2:
             libs = self._get_libs(cpp_info, pkg_name, pkg_folder, pkg_folder_var)
             self._add_root_lib_target(libs, pkg_name, cpp_info)
         exes = self._get_exes(cpp_info, pkg_name, pkg_folder, pkg_folder_var)
-        sources = self._get_sources(cpp_info, pkg_name, pkg_folder, pkg_folder_var)
 
         prefixes = self._cmakedeps.get_property("cmake_additional_variables_prefixes",
                                                 self._conanfile, check_type=list) or []
@@ -139,7 +138,6 @@ class TargetConfigurationTemplate2:
                 "pkg_folder_var": pkg_folder_var,
                 "config": config,
                 "exes": exes,
-                "sources": sources,
                 "libs": libs,
                 "context": self._conanfile.context,
                 # Extra global variables
@@ -182,7 +180,7 @@ class TargetConfigurationTemplate2:
         # FIXME: Filter by lib traits!!!!!
         if not self._require.headers:  # If not depending on headers, paths and
             includedirs = defines = None
-        system_libs = " ".join(info.system_libs)
+        sources = [self._path(source, pkg_folder, pkg_folder_var) for source in info.sources]
         target = {"type": "INTERFACE",
                   "includedirs": includedirs,
                   "defines": defines,
@@ -191,7 +189,8 @@ class TargetConfigurationTemplate2:
                   "cflags": " ".join(info.cflags),
                   "sharedlinkflags": " ".join(info.sharedlinkflags),
                   "exelinkflags": " ".join(info.exelinkflags),
-                  "system_libs": system_libs
+                  "system_libs": " ".join(info.system_libs),
+                  "sources": " ".join(sources)
         }
         # System frameworks (only Apple OS)
         if info.frameworks:
@@ -270,27 +269,6 @@ class TargetConfigurationTemplate2:
                 exes[target] = exe_location
 
         return exes
-
-    def _get_sources(self, cpp_info, pkg_name, pkg_folder, pkg_folder_var):
-        sources = {}
-
-        if cpp_info.has_components:
-            for name, comp in cpp_info.components.items():
-                if comp.sources:
-                    target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile,
-                                                               name)
-                    target = target_name or f"{pkg_name}::{name}"
-                    sources[target] = []
-                    for source in comp.sources:
-                        sources[target].append(self._path(source, pkg_folder, pkg_folder_var))
-        else:
-            if cpp_info.sources:
-                target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile)
-                target = target_name or f"{pkg_name}::{pkg_name}"
-                sources[target] = []
-                for source in cpp_info.sources:
-                    sources[target].append(self._path(source, pkg_folder, pkg_folder_var))
-        return sources
 
     def _get_dependencies(self):
         """ transitive dependencies Filenames for find_dependency()
@@ -440,6 +418,11 @@ class TargetConfigurationTemplate2:
                          $<$<COMPILE_LANGUAGE:C>:-F{{lib_info["package_framework"]["frameworkdir"]}}>)
         endif()
         {% endif %}
+
+        {% if lib_info.get("sources") %}
+        set_property(TARGET {{lib}} APPEND PROPERTY INTERFACE_SOURCES
+                     {{config_wrapper(config, lib_info["sources"] )}})
+        {% endif %}
         {% endfor %}
 
         ################# Global variables for try compile and legacy ##############
@@ -479,13 +462,4 @@ class TargetConfigurationTemplate2:
         set_target_properties({{exe}} PROPERTIES IMPORTED_LOCATION_{{config}} "{{location}}")
         set_property(TARGET {{exe}} PROPERTY CONAN_CONTEXT "{{context}}")
         {% endfor %}
-
-        {% if sources %}
-        ################# Sources information ##############
-        {% for target, srcs in sources.items() %}
-        #################### {{target}} ####################
-        set_property(TARGET {{target}} APPEND PROPERTY INTERFACE_SOURCES
-                     {{config_wrapper(config, srcs | join(';') )}})
-        {% endfor %}
-        {% endif %}
         """)

--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -113,6 +113,7 @@ class TargetConfigurationTemplate2:
             libs = self._get_libs(cpp_info, pkg_name, pkg_folder, pkg_folder_var)
             self._add_root_lib_target(libs, pkg_name, cpp_info)
         exes = self._get_exes(cpp_info, pkg_name, pkg_folder, pkg_folder_var)
+        sources = self._get_sources(cpp_info, pkg_name, pkg_folder, pkg_folder_var)
 
         prefixes = self._cmakedeps.get_property("cmake_additional_variables_prefixes",
                                                 self._conanfile, check_type=list) or []
@@ -138,6 +139,7 @@ class TargetConfigurationTemplate2:
                 "pkg_folder_var": pkg_folder_var,
                 "config": config,
                 "exes": exes,
+                "sources": sources,
                 "libs": libs,
                 "context": self._conanfile.context,
                 # Extra global variables
@@ -268,6 +270,28 @@ class TargetConfigurationTemplate2:
                 exes[target] = exe_location
 
         return exes
+
+    def _get_sources(self, cpp_info, pkg_name, pkg_folder, pkg_folder_var):
+        sources = {}
+
+        if cpp_info.has_components:
+            # FIXME: NOT IMPLEMENTED
+            for name, comp in cpp_info.components.items():
+                if comp.exe or comp.type is PackageType.APP:
+                    target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile,
+                                                               name)
+                    target = target_name or f"{pkg_name}::{name}"
+                    exe_location = self._path(comp.location, pkg_folder, pkg_folder_var)
+                    sources[target] = exe_location
+        else:
+            if cpp_info.sources:
+                target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile)
+                target = target_name or f"{pkg_name}::{pkg_name}"
+                sources[target] = []
+                for source in cpp_info.sources:
+                    sources[target].append(self._path(source, pkg_folder, pkg_folder_var))
+                sources[target] = ";".join(sources[target])
+        return sources
 
     def _get_dependencies(self):
         """ transitive dependencies Filenames for find_dependency()
@@ -456,4 +480,13 @@ class TargetConfigurationTemplate2:
         set_target_properties({{exe}} PROPERTIES IMPORTED_LOCATION_{{config}} "{{location}}")
         set_property(TARGET {{exe}} PROPERTY CONAN_CONTEXT "{{context}}")
         {% endfor %}
+
+         {% if sources %}
+        ################# Sources information ##############
+        {% for target, srcs in sources.items() %}
+        #################### {{target}} ####################
+        set_property(TARGET {{target}} APPEND PROPERTY INTERFACE_SOURCES
+                     {{config_wrapper(config, srcs)}})
+        {% endfor %}
+        {% endif %}
         """)

--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -482,7 +482,7 @@ class TargetConfigurationTemplate2:
         set_property(TARGET {{exe}} PROPERTY CONAN_CONTEXT "{{context}}")
         {% endfor %}
 
-         {% if sources %}
+        {% if sources %}
         ################# Sources information ##############
         {% for target, srcs in sources.items() %}
         #################### {{target}} ####################

--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -272,20 +272,24 @@ class TargetConfigurationTemplate2:
         return exes
 
     def _get_sources(self, cpp_info, pkg_name, pkg_folder, pkg_folder_var):
-        def _fill_sources(info, comp_name=None):
-            if info.sources:
-                target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile,
-                                                           comp_name=comp_name, check_type=list)
-                target = target_name or f"{pkg_name}::{name}"
-                sources[target].extend([self._path(source, pkg_folder, pkg_folder_var)
-                                        for source in info.sources])
-
         sources = {}
+
         if cpp_info.has_components:
             for name, comp in cpp_info.components.items():
-                _fill_sources(comp, comp_name=name)
+                if comp.sources:
+                    target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile,
+                                                               name)
+                    target = target_name or f"{pkg_name}::{name}"
+                    sources[target] = []
+                    for source in comp.sources:
+                        sources[target].append(self._path(source, pkg_folder, pkg_folder_var))
         else:
-            _fill_sources(cpp_info)
+            if cpp_info.sources:
+                target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile)
+                target = target_name or f"{pkg_name}::{pkg_name}"
+                sources[target] = []
+                for source in cpp_info.sources:
+                    sources[target].append(self._path(source, pkg_folder, pkg_folder_var))
         return sources
 
     def _get_dependencies(self):

--- a/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_sources.py
+++ b/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_sources.py
@@ -1,0 +1,91 @@
+import os
+import platform
+import textwrap
+
+import pytest
+
+from conan.tools.files import replace_in_file
+from conan.test.utils.mocks import ConanFileMock
+
+from conan.test.utils.tools import TestClient
+
+new_value = "will_break_next"
+
+
+@pytest.mark.skipif(platform.system() != "Linux", reason="No OS specific test")
+@pytest.mark.tool("cmake")
+def test_cpp_info_sources():
+    c = TestClient()
+    c.run("new cmake_lib -d name=hello -d version=1.0")
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.files import copy
+
+        class HelloConan(ConanFile):
+            name = "hello"
+            version = "1.0"
+            exports_sources = "src/*", "include/*"
+            package_type = "header-library"
+
+            def package(self):
+                copy(self, "*.h", self.source_folder, self.package_folder)
+                copy(self, "*.cpp", self.source_folder, self.package_folder)
+
+            def package_info(self):
+                self.cpp_info.sources = ["include/hello.h", "src/hello.cpp"]
+    """)
+    c.save({"conanfile.py": conanfile})
+    # Check that the hello library builds in test_package
+    c.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
+    # Check content of the generated files
+    c.run(f"install --requires=hello/1.0 -g=CMakeConfigDeps "
+          f"-c tools.cmake.cmakedeps:new={new_value}")
+    cmake = c.load("hello-Targets-release.cmake")
+    assert "add_library(hello::hello INTERFACE IMPORTED)" in cmake
+    assert "set_property(TARGET hello::hello APPEND PROPERTY INTERFACE_SOURCES\n"\
+           "             $<$<CONFIG:RELEASE>:${hello_PACKAGE_FOLDER_RELEASE}/include/hello.h;" \
+           "${hello_PACKAGE_FOLDER_RELEASE}/src/hello.cpp>)" in cmake
+
+
+@pytest.mark.skipif(platform.system() != "Linux", reason="No OS specific test")
+@pytest.mark.tool("cmake")
+def test_cpp_info_component_sources():
+    c = TestClient()
+    c.run("new cmake_lib -d name=hello -d version=1.0")
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.files import copy
+
+        class HelloConan(ConanFile):
+            name = "hello"
+            version = "1.0"
+            exports_sources = "src/*", "include/*"
+            package_type = "header-library"
+
+            def package(self):
+                copy(self, "*.h", self.source_folder, self.package_folder)
+                copy(self, "*.cpp", self.source_folder, self.package_folder)
+
+            def package_info(self):
+                self.cpp_info.components["my_comp"].sources = ["include/hello.h", "src/hello.cpp"]
+    """)
+    c.save({
+        "conanfile.py": conanfile
+    })
+
+    # Make test_package link with component's target
+    test_package_cmakelists_path = os.path.join(c.current_folder, "test_package", "CMakeLists.txt")
+    replace_in_file(ConanFileMock(), test_package_cmakelists_path, "hello::hello", "hello::my_comp")
+    test_package_cmakelists_content = c.load(test_package_cmakelists_path)
+    assert "target_link_libraries(example hello::my_comp)" in test_package_cmakelists_content
+    # Check that the hello library builds in test_package
+    c.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
+    # Check the content of the generated files
+    c.run(f"install --requires=hello/1.0 -g=CMakeConfigDeps "
+          f"-c tools.cmake.cmakedeps:new={new_value}")
+    cmake = c.load("hello-Targets-release.cmake")
+    assert "add_library(hello::hello INTERFACE IMPORTED)" in cmake
+    assert "add_library(hello::my_comp INTERFACE IMPORTED)" in cmake
+    assert "set_property(TARGET hello::my_comp APPEND PROPERTY INTERFACE_SOURCES\n"\
+           "             $<$<CONFIG:RELEASE>:${hello_PACKAGE_FOLDER_RELEASE}/include/hello.h;" \
+           "${hello_PACKAGE_FOLDER_RELEASE}/src/hello.cpp>)" in cmake

--- a/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_sources.py
+++ b/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_sources.py
@@ -32,7 +32,7 @@ def test_cpp_info_sources():
                 copy(self, "*.cpp", self.source_folder, self.package_folder)
 
             def package_info(self):
-                self.cpp_info.sources = ["include/hello.h", "src/hello.cpp"]
+                self.cpp_info.sources = ["src/hello.cpp"]
     """)
     c.save({"conanfile.py": conanfile})
     # Check that the hello library builds in test_package
@@ -43,8 +43,7 @@ def test_cpp_info_sources():
     cmake = c.load("hello-Targets-release.cmake")
     assert "add_library(hello::hello INTERFACE IMPORTED)" in cmake
     assert "set_property(TARGET hello::hello APPEND PROPERTY INTERFACE_SOURCES\n"\
-           "             $<$<CONFIG:RELEASE>:${hello_PACKAGE_FOLDER_RELEASE}/include/hello.h;" \
-           "${hello_PACKAGE_FOLDER_RELEASE}/src/hello.cpp>)" in cmake
+           "             $<$<CONFIG:RELEASE>:${hello_PACKAGE_FOLDER_RELEASE}/src/hello.cpp>)" in cmake
 
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="No OS specific test")
@@ -67,7 +66,7 @@ def test_cpp_info_component_sources():
                 copy(self, "*.cpp", self.source_folder, self.package_folder)
 
             def package_info(self):
-                self.cpp_info.components["my_comp"].sources = ["include/hello.h", "src/hello.cpp"]
+                self.cpp_info.components["my_comp"].sources = ["src/hello.cpp"]
     """)
     c.save({
         "conanfile.py": conanfile
@@ -87,5 +86,4 @@ def test_cpp_info_component_sources():
     assert "add_library(hello::hello INTERFACE IMPORTED)" in cmake
     assert "add_library(hello::my_comp INTERFACE IMPORTED)" in cmake
     assert "set_property(TARGET hello::my_comp APPEND PROPERTY INTERFACE_SOURCES\n"\
-           "             $<$<CONFIG:RELEASE>:${hello_PACKAGE_FOLDER_RELEASE}/include/hello.h;" \
-           "${hello_PACKAGE_FOLDER_RELEASE}/src/hello.cpp>)" in cmake
+           "             $<$<CONFIG:RELEASE>:${hello_PACKAGE_FOLDER_RELEASE}/src/hello.cpp>)" in cmake

--- a/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_sources.py
+++ b/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_sources.py
@@ -66,10 +66,11 @@ def test_cpp_info_component_sources():
                 copy(self, "*.cpp", self.source_folder, self.package_folder)
 
             def package_info(self):
-                self.cpp_info.components["my_comp"].sources = ["src/hello.cpp"]
+                self.cpp_info.components["my_comp"].sources = ["src/hello.cpp", "src/other.cpp"]
     """)
     c.save({
-        "conanfile.py": conanfile
+        "conanfile.py": conanfile,
+        "src/other.cpp": "",
     })
 
     # Make test_package link with component's target
@@ -86,4 +87,5 @@ def test_cpp_info_component_sources():
     assert "add_library(hello::hello INTERFACE IMPORTED)" in cmake
     assert "add_library(hello::my_comp INTERFACE IMPORTED)" in cmake
     assert "set_property(TARGET hello::my_comp APPEND PROPERTY INTERFACE_SOURCES\n"\
-           "             $<$<CONFIG:RELEASE>:${hello_PACKAGE_FOLDER_RELEASE}/src/hello.cpp>)" in cmake
+           "             $<$<CONFIG:RELEASE>:${hello_PACKAGE_FOLDER_RELEASE}/src/hello.cpp"\
+           ";${hello_PACKAGE_FOLDER_RELEASE}/src/other.cpp>)" in cmake

--- a/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_sources.py
+++ b/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_sources.py
@@ -88,4 +88,4 @@ def test_cpp_info_component_sources():
     assert "add_library(hello::my_comp INTERFACE IMPORTED)" in cmake
     assert "set_property(TARGET hello::my_comp APPEND PROPERTY INTERFACE_SOURCES\n"\
            "             $<$<CONFIG:RELEASE>:${hello_PACKAGE_FOLDER_RELEASE}/src/hello.cpp"\
-           ";${hello_PACKAGE_FOLDER_RELEASE}/src/other.cpp>)" in cmake
+           " ${hello_PACKAGE_FOLDER_RELEASE}/src/other.cpp>)" in cmake

--- a/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
@@ -1,10 +1,13 @@
+import os
 import re
 import textwrap
 
 import pytest
+from conan.test.utils.mocks import ConanFileMock
 
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
+from conan.tools.files import replace_in_file
 
 new_value = "will_break_next"
 
@@ -269,6 +272,75 @@ def test_cpp_info_sources():
     assert "add_library(hello::hello INTERFACE IMPORTED)" in cmake
     assert "set_property(TARGET hello::hello APPEND PROPERTY INTERFACE_SOURCES\n"\
            "             $<$<CONFIG:RELEASE>:${hello_PACKAGE_FOLDER_RELEASE}/include/hello.h;${hello_PACKAGE_FOLDER_RELEASE}/src/hello.cpp>)" in cmake
+
+
+def test_cpp_info_sources_with_component():
+    c = TestClient()
+    c.run("new cmake_lib -d name=hello -d version=1.0")
+
+    cmakelists = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.15)
+        project(hello CXX)
+
+        add_library(hello INTERFACE)
+        target_include_directories(hello INTERFACE include)
+        set_target_properties(hello PROPERTIES PUBLIC_HEADER "include/hello.h")
+        target_sources(hello INTERFACE
+                       "include/hello.h"
+                       "src/hello.cpp")
+
+        install(TARGETS hello)
+        install(FILES src/hello.cpp DESTINATION src)
+    """)
+    conanfile = textwrap.dedent("""
+        import os
+        from conan.tools.cmake import CMake, CMakeToolchain
+        from conan.tools.files import copy
+        from conan import ConanFile
+
+        class HelloConan(ConanFile):
+            name = "hello"
+            version = "1.0"
+            settings = "os", "arch", "compiler", "build_type"
+            exports_sources = "CMakeLists.txt", "src/*", "include/*"
+
+            def generate(self):
+                tc = CMakeToolchain(self)
+                tc.generate()
+
+            def package(self):
+                cmake = CMake(self)
+                cmake.install()
+
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+
+            def package_info(self):
+                self.cpp_info.components["my_comp"].sources = ["include/hello.h", "src/hello.cpp"]
+    """)
+    c.save({
+        "CMakeLists.txt": cmakelists,
+        "conanfile.py": conanfile
+    })
+
+    # Make test_package link with component's target
+    test_package_cmakelists_path = os.path.join(c.current_folder, "test_package", "CMakeLists.txt")
+    replace_in_file(ConanFileMock(), test_package_cmakelists_path, "hello::hello", "hello::my_comp")
+    test_package_cmakelists_content = c.load(test_package_cmakelists_path)
+    assert "target_link_libraries(example hello::my_comp)" in test_package_cmakelists_content
+
+    c.run(f"create . -s compiler.version=193 -c tools.cmake.cmakedeps:new={new_value}")
+    print(c.out)
+    c.run(f"install --requires=hello/1.0 -g=CMakeConfigDeps -s=compiler.version=193 "
+          f"-c tools.cmake.cmakedeps:new={new_value}")
+    cmake = c.load("hello-Targets-release.cmake")
+    print(cmake)
+    assert "add_library(hello::hello INTERFACE IMPORTED)" in cmake
+    assert "add_library(hello::my_comp INTERFACE IMPORTED)" in cmake
+    assert "set_property(TARGET hello::my_comp APPEND PROPERTY INTERFACE_SOURCES\n"\
+           "             $<$<CONFIG:RELEASE>:${hello_PACKAGE_FOLDER_RELEASE}/include/hello.h;${hello_PACKAGE_FOLDER_RELEASE}/src/hello.cpp>)" in cmake
+
 
 def test_system_wrappers():
     c = TestClient()

--- a/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
@@ -1,14 +1,10 @@
-import os
 import re
 import textwrap
-import platform
 
 import pytest
-from conan.test.utils.mocks import ConanFileMock
 
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
-from conan.tools.files import replace_in_file
 
 new_value = "will_break_next"
 
@@ -213,134 +209,6 @@ def test_cmakeconfigdeps_recipe():
     assert "WARN: Using the new CMakeConfigDeps generator" in c.out
     c.run("install app -c tools.cmake.cmakedeps:new=recipe_will_break")
     assert "WARN: Using the new CMakeConfigDeps generator" in c.out
-
-
-@pytest.mark.skipif(platform.system() != "Linux", reason="Only linux")
-def test_cpp_info_sources():
-    c = TestClient()
-    c.run("new cmake_lib -d name=hello -d version=1.0")
-
-    cmakelists = textwrap.dedent("""
-        cmake_minimum_required(VERSION 3.15)
-        project(hello CXX)
-
-        add_library(hello INTERFACE)
-        target_include_directories(hello INTERFACE include)
-        set_target_properties(hello PROPERTIES PUBLIC_HEADER "include/hello.h")
-        target_sources(hello INTERFACE
-                       "include/hello.h"
-                       "src/hello.cpp")
-
-        install(TARGETS hello)
-        install(FILES src/hello.cpp DESTINATION src)
-    """)
-    conanfile = textwrap.dedent("""
-        import os
-        from conan.tools.cmake import CMake, CMakeToolchain
-        from conan.tools.files import copy
-        from conan import ConanFile
-
-        class HelloConan(ConanFile):
-            name = "hello"
-            version = "1.0"
-            settings = "os", "arch", "compiler", "build_type"
-            exports_sources = "CMakeLists.txt", "src/*", "include/*"
-
-            def generate(self):
-                tc = CMakeToolchain(self)
-                tc.generate()
-
-            def package(self):
-                cmake = CMake(self)
-                cmake.install()
-
-            def build(self):
-                cmake = CMake(self)
-                cmake.configure()
-
-            def package_info(self):
-                self.cpp_info.sources = ["include/hello.h", "src/hello.cpp"]
-    """)
-    c.save({
-        "CMakeLists.txt": cmakelists,
-        "conanfile.py": conanfile
-    })
-    c.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
-    c.run(f"install --requires=hello/1.0 -g=CMakeConfigDeps "
-          f"-c tools.cmake.cmakedeps:new={new_value}")
-    cmake = c.load("hello-Targets-release.cmake")
-    assert "add_library(hello::hello INTERFACE IMPORTED)" in cmake
-    assert "set_property(TARGET hello::hello APPEND PROPERTY INTERFACE_SOURCES\n"\
-           "             $<$<CONFIG:RELEASE>:${hello_PACKAGE_FOLDER_RELEASE}/include/hello.h;" \
-           "${hello_PACKAGE_FOLDER_RELEASE}/src/hello.cpp>)" in cmake
-
-
-@pytest.mark.skipif(platform.system() != "Linux", reason="Only linux")
-def test_cpp_info_sources_with_component():
-    c = TestClient()
-    c.run("new cmake_lib -d name=hello -d version=1.0")
-
-    cmakelists = textwrap.dedent("""
-        cmake_minimum_required(VERSION 3.15)
-        project(hello CXX)
-
-        add_library(hello INTERFACE)
-        target_include_directories(hello INTERFACE include)
-        set_target_properties(hello PROPERTIES PUBLIC_HEADER "include/hello.h")
-        target_sources(hello INTERFACE
-                       "include/hello.h"
-                       "src/hello.cpp")
-
-        install(TARGETS hello)
-        install(FILES src/hello.cpp DESTINATION src)
-    """)
-    conanfile = textwrap.dedent("""
-        import os
-        from conan.tools.cmake import CMake, CMakeToolchain
-        from conan.tools.files import copy
-        from conan import ConanFile
-
-        class HelloConan(ConanFile):
-            name = "hello"
-            version = "1.0"
-            settings = "os", "arch", "compiler", "build_type"
-            exports_sources = "CMakeLists.txt", "src/*", "include/*"
-
-            def generate(self):
-                tc = CMakeToolchain(self)
-                tc.generate()
-
-            def package(self):
-                cmake = CMake(self)
-                cmake.install()
-
-            def build(self):
-                cmake = CMake(self)
-                cmake.configure()
-
-            def package_info(self):
-                self.cpp_info.components["my_comp"].sources = ["include/hello.h", "src/hello.cpp"]
-    """)
-    c.save({
-        "CMakeLists.txt": cmakelists,
-        "conanfile.py": conanfile
-    })
-
-    # Make test_package link with component's target
-    test_package_cmakelists_path = os.path.join(c.current_folder, "test_package", "CMakeLists.txt")
-    replace_in_file(ConanFileMock(), test_package_cmakelists_path, "hello::hello", "hello::my_comp")
-    test_package_cmakelists_content = c.load(test_package_cmakelists_path)
-    assert "target_link_libraries(example hello::my_comp)" in test_package_cmakelists_content
-
-    c.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
-    c.run(f"install --requires=hello/1.0 -g=CMakeConfigDeps "
-          f"-c tools.cmake.cmakedeps:new={new_value}")
-    cmake = c.load("hello-Targets-release.cmake")
-    assert "add_library(hello::hello INTERFACE IMPORTED)" in cmake
-    assert "add_library(hello::my_comp INTERFACE IMPORTED)" in cmake
-    assert "set_property(TARGET hello::my_comp APPEND PROPERTY INTERFACE_SOURCES\n"\
-           "             $<$<CONFIG:RELEASE>:${hello_PACKAGE_FOLDER_RELEASE}/include/hello.h;" \
-           "${hello_PACKAGE_FOLDER_RELEASE}/src/hello.cpp>)" in cmake
 
 
 def test_system_wrappers():

--- a/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
@@ -263,9 +263,9 @@ def test_cpp_info_sources():
         "CMakeLists.txt": cmakelists,
         "conanfile.py": conanfile
     })
-    c.run(f"create . -s compiler.version=193 -c tools.cmake.cmakedeps:new={new_value}")
+    c.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
     print(c.out)
-    c.run(f"install --requires=hello/1.0 -g=CMakeConfigDeps -s=compiler.version=193 "
+    c.run(f"install --requires=hello/1.0 -g=CMakeConfigDeps "
           f"-c tools.cmake.cmakedeps:new={new_value}")
     cmake = c.load("hello-Targets-release.cmake")
     print(cmake)
@@ -330,9 +330,9 @@ def test_cpp_info_sources_with_component():
     test_package_cmakelists_content = c.load(test_package_cmakelists_path)
     assert "target_link_libraries(example hello::my_comp)" in test_package_cmakelists_content
 
-    c.run(f"create . -s compiler.version=193 -c tools.cmake.cmakedeps:new={new_value}")
+    c.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
     print(c.out)
-    c.run(f"install --requires=hello/1.0 -g=CMakeConfigDeps -s=compiler.version=193 "
+    c.run(f"install --requires=hello/1.0 -g=CMakeConfigDeps "
           f"-c tools.cmake.cmakedeps:new={new_value}")
     cmake = c.load("hello-Targets-release.cmake")
     print(cmake)

--- a/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
@@ -211,6 +211,65 @@ def test_cmakeconfigdeps_recipe():
     assert "WARN: Using the new CMakeConfigDeps generator" in c.out
 
 
+def test_cpp_info_sources():
+    c = TestClient()
+    c.run("new cmake_lib -d name=hello -d version=1.0")
+
+    cmakelists = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.15)
+        project(hello CXX)
+
+        add_library(hello INTERFACE)
+        target_include_directories(hello INTERFACE include)
+        set_target_properties(hello PROPERTIES PUBLIC_HEADER "include/hello.h")
+        target_sources(hello INTERFACE
+                       "include/hello.h"
+                       "src/hello.cpp")
+
+        install(TARGETS hello)
+        install(FILES src/hello.cpp DESTINATION src)
+    """)
+    conanfile = textwrap.dedent("""
+        import os
+        from conan.tools.cmake import CMake, CMakeToolchain
+        from conan.tools.files import copy
+        from conan import ConanFile
+
+        class HelloConan(ConanFile):
+            name = "hello"
+            version = "1.0"
+            settings = "os", "arch", "compiler", "build_type"
+            exports_sources = "CMakeLists.txt", "src/*", "include/*"
+
+            def generate(self):
+                tc = CMakeToolchain(self)
+                tc.generate()
+
+            def package(self):
+                cmake = CMake(self)
+                cmake.install()
+
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+
+            def package_info(self):
+                self.cpp_info.sources = ["include/hello.h", "src/hello.cpp"]
+    """)
+    c.save({
+        "CMakeLists.txt": cmakelists,
+        "conanfile.py": conanfile
+    })
+    c.run(f"create . -s compiler.version=193 -c tools.cmake.cmakedeps:new={new_value}")
+    print(c.out)
+    c.run(f"install --requires=hello/1.0 -g=CMakeConfigDeps -s=compiler.version=193 "
+          f"-c tools.cmake.cmakedeps:new={new_value}")
+    cmake = c.load("hello-Targets-release.cmake")
+    print(cmake)
+    assert "add_library(hello::hello INTERFACE IMPORTED)" in cmake
+    assert "set_property(TARGET hello::hello APPEND PROPERTY INTERFACE_SOURCES\n"\
+           "             $<$<CONFIG:RELEASE>:${hello_PACKAGE_FOLDER_RELEASE}/include/hello.h;${hello_PACKAGE_FOLDER_RELEASE}/src/hello.cpp>)" in cmake
+
 def test_system_wrappers():
     c = TestClient()
     conanfile = textwrap.dedent("""

--- a/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
@@ -1,6 +1,7 @@
 import os
 import re
 import textwrap
+import platform
 
 import pytest
 from conan.test.utils.mocks import ConanFileMock
@@ -214,6 +215,7 @@ def test_cmakeconfigdeps_recipe():
     assert "WARN: Using the new CMakeConfigDeps generator" in c.out
 
 
+@pytest.mark.skipif(platform.system() != "Linux", reason="Only linux")
 def test_cpp_info_sources():
     c = TestClient()
     c.run("new cmake_lib -d name=hello -d version=1.0")
@@ -264,16 +266,16 @@ def test_cpp_info_sources():
         "conanfile.py": conanfile
     })
     c.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
-    print(c.out)
     c.run(f"install --requires=hello/1.0 -g=CMakeConfigDeps "
           f"-c tools.cmake.cmakedeps:new={new_value}")
     cmake = c.load("hello-Targets-release.cmake")
-    print(cmake)
     assert "add_library(hello::hello INTERFACE IMPORTED)" in cmake
     assert "set_property(TARGET hello::hello APPEND PROPERTY INTERFACE_SOURCES\n"\
-           "             $<$<CONFIG:RELEASE>:${hello_PACKAGE_FOLDER_RELEASE}/include/hello.h;${hello_PACKAGE_FOLDER_RELEASE}/src/hello.cpp>)" in cmake
+           "             $<$<CONFIG:RELEASE>:${hello_PACKAGE_FOLDER_RELEASE}/include/hello.h;" \
+           "${hello_PACKAGE_FOLDER_RELEASE}/src/hello.cpp>)" in cmake
 
 
+@pytest.mark.skipif(platform.system() != "Linux", reason="Only linux")
 def test_cpp_info_sources_with_component():
     c = TestClient()
     c.run("new cmake_lib -d name=hello -d version=1.0")
@@ -331,15 +333,14 @@ def test_cpp_info_sources_with_component():
     assert "target_link_libraries(example hello::my_comp)" in test_package_cmakelists_content
 
     c.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
-    print(c.out)
     c.run(f"install --requires=hello/1.0 -g=CMakeConfigDeps "
           f"-c tools.cmake.cmakedeps:new={new_value}")
     cmake = c.load("hello-Targets-release.cmake")
-    print(cmake)
     assert "add_library(hello::hello INTERFACE IMPORTED)" in cmake
     assert "add_library(hello::my_comp INTERFACE IMPORTED)" in cmake
     assert "set_property(TARGET hello::my_comp APPEND PROPERTY INTERFACE_SOURCES\n"\
-           "             $<$<CONFIG:RELEASE>:${hello_PACKAGE_FOLDER_RELEASE}/include/hello.h;${hello_PACKAGE_FOLDER_RELEASE}/src/hello.cpp>)" in cmake
+           "             $<$<CONFIG:RELEASE>:${hello_PACKAGE_FOLDER_RELEASE}/include/hello.h;" \
+           "${hello_PACKAGE_FOLDER_RELEASE}/src/hello.cpp>)" in cmake
 
 
 def test_system_wrappers():

--- a/test/unittests/model/build_info/test_deduce_locations.py
+++ b/test/unittests/model/build_info/test_deduce_locations.py
@@ -288,3 +288,14 @@ def test_several_libs_and_exact_match(lib_name, libs, conanfile):
     result = cppinfo.deduce_full_cpp_info(conanfile)
     assert result.location == f"{folder}/libdir/{lib_name}.lib"
     assert result.type == "static-library"
+
+
+def test_sources(conanfile):
+    folder = temp_folder()
+    save(os.path.join(folder, "src", "mylib.cpp"), "")
+    cppinfo = CppInfo()
+    cppinfo.sources = ["src/mylib.cpp"]
+    cppinfo.set_relative_base_folder(folder)
+    result = cppinfo.deduce_full_cpp_info(conanfile)
+    assert result.location is None
+    assert result.type == "header-library"


### PR DESCRIPTION
Changelog: Feature: Implement ``cpp_info.sources`` to support source targets.
Changelog: Feature: Add support for source targets in CMakeConfigDeps generator.
Docs: https://github.com/conan-io/docs/pull/4128
Closes: #10413
