### PR TITLE
[workspace] Renamed 'editables' to 'packages'

### DIFF
--- a/conan/api/subapi/workspace.py
+++ b/conan/api/subapi/workspace.py
@@ -103,7 +103,7 @@ class WorkspaceAPI:
         """
         if not self._folder:
             return
-        editables = self._ws.editables()
+        editables = self._ws.packages()
         editables = {RecipeReference.loads(r): v.copy() for r, v in editables.items()}
         for v in editables.values():
             path = os.path.normpath(os.path.join(self._folder, v["path"], "conanfile.py"))
@@ -231,10 +231,10 @@ class WorkspaceAPI:
         return {"name": self.name,
                 "folder": self._folder,
                 "products": self.products,
-                "editables": self._ws.editables()}
+                "packages": self._ws.packages()}
 
     def editable_from_path(self, path):
-        editables = self._ws.editables()
+        editables = self._ws.packages()
         for ref, info in editables.items():
             if info["path"].replace("\\", "/") == path:
                 return RecipeReference.loads(ref)

--- a/conan/internal/api/new/workspace.py
+++ b/conan/internal/api/new/workspace.py
@@ -4,7 +4,7 @@ from conan.internal.api.new.cmake_lib import cmake_lib_files
 
 
 conanws_yml = """\
-editables:
+packages:
   liba/0.1:
     path: liba
   libb/0.1:

--- a/conan/internal/model/workspace.py
+++ b/conan/internal/model/workspace.py
@@ -44,7 +44,7 @@ class Workspace:
         editable = {"path": path}
         if output_folder:
             editable["output_folder"] = self._conan_rel_path(output_folder)
-        self.conan_data.setdefault("editables", {})[str(ref)] = editable
+        self.conan_data.setdefault("packages", {})[str(ref)] = editable
         if product:
             self.conan_data.setdefault("products", []).append(path)
         save(os.path.join(self.folder, WORKSPACE_YML), yaml.dump(self.conan_data))
@@ -52,13 +52,13 @@ class Workspace:
     def remove(self, path):
         found_ref = None
         path = self._conan_rel_path(path)
-        for ref, info in self.conan_data.get("editables", {}).items():
+        for ref, info in self.conan_data.get("packages", {}).items():
             if info["path"].replace("\\", "/") == path:
                 found_ref = ref
                 break
         if not found_ref:
             raise ConanException(f"No editable package to remove from this path: {path}")
-        self.conan_data["editables"].pop(found_ref)
+        self.conan_data["packages"].pop(found_ref)
         if path in self.conan_data.get("products", []):
             self.conan_data["products"].remove(path)
         save(os.path.join(self.folder, WORKSPACE_YML), yaml.dump(self.conan_data))
@@ -66,7 +66,7 @@ class Workspace:
 
     def clean(self):
         self.output.info("Default workspace clean: Removing the output-folder of each editable")
-        for ref, info in self.conan_data.get("editables", {}).items():
+        for ref, info in self.conan_data.get("packages", {}).items():
             if not info.get("output_folder"):
                 self.output.info(f"Editable {ref} doesn't have an output_folder defined")
                 continue
@@ -85,8 +85,8 @@ class Workspace:
         path = os.path.relpath(path, self.folder)
         return path.replace("\\", "/")  # Normalize to unix path
 
-    def editables(self):
-        return self.conan_data.get("editables", {})
+    def packages(self):
+        return self.conan_data.get("packages", {})
 
     def products(self):
         return self.conan_data.get("products", [])

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -136,7 +136,7 @@ class TestAddRemove:
                 from conan import Workspace
 
                 class MyWorkspace(Workspace):
-                    def editables(self):
+                    def packages(self):
                         result = {}
                         for f in os.listdir(self.folder):
                             if os.path.isdir(os.path.join(self.folder, f)):
@@ -153,7 +153,7 @@ class TestAddRemove:
                 from conan import Workspace
 
                 class MyWorkspace(Workspace):
-                    def editables(self):
+                    def packages(self):
                         result = {}
                         for f in os.listdir(self.folder):
                             if os.path.isdir(os.path.join(self.folder, f)):
@@ -168,12 +168,12 @@ class TestAddRemove:
                 "dep1/version.txt": "2.1"})
         c.run("workspace info --format=json")
         info = json.loads(c.stdout)
-        assert info["editables"] == {"pkg/2.1": {"path": "dep1"}}
+        assert info["packages"] == {"pkg/2.1": {"path": "dep1"}}
         c.save({"dep1/name.txt": "other",
                 "dep1/version.txt": "14.5"})
         c.run("workspace info --format=json")
         info = json.loads(c.stdout)
-        assert info["editables"] == {"other/14.5": {"path": "dep1"}}
+        assert info["packages"] == {"other/14.5": {"path": "dep1"}}
         c.run("install --requires=other/14.5")
         # Doesn't fail
         assert "other/14.5 - Editable" in c.out
@@ -201,7 +201,7 @@ class TestAddRemove:
             from conan import Workspace
 
             class MyWorkspace(Workspace):
-                def editables(self):
+                def packages(self):
                     conanfile = self.load_conanfile("dep1")
                     return {f"{conanfile.name}/{conanfile.version}": {"path": "dep1"}}
             """)
@@ -210,7 +210,7 @@ class TestAddRemove:
                 "dep1/conanfile.py": conanfile})
         c.run("workspace info --format=json")
         info = json.loads(c.stdout)
-        assert info["editables"] == {"pkg/2.1": {"path": "dep1"}}
+        assert info["packages"] == {"pkg/2.1": {"path": "dep1"}}
         c.run("install --requires=pkg/2.1")
         # it will not fail
 
@@ -627,7 +627,7 @@ def test_relative_paths():
         expected = textwrap.dedent("""\
             products
               ../app1
-            editables
+            packages
               app1/0.1
                 path: ../app1
               liba/0.1
@@ -644,7 +644,7 @@ def test_relative_paths():
         expected = textwrap.dedent("""\
             products
               ../other/app2
-            editables
+            packages
               app2/0.1
                 path: ../other/app2
               libb/0.1


### PR DESCRIPTION
Changelog: Feature: Renamed 'editables' to 'packages'.
Docs: https://github.com/conan-io/docs/pull/4106
Closes: https://github.com/conan-io/conan/issues/18269
