### PR TITLE
Fix _parse_error_threshold crash when some package was not found in the catalog.

### DIFF
--- a/conan/cli/commands/audit.py
+++ b/conan/cli/commands/audit.py
@@ -31,6 +31,8 @@ def _parse_error_threshold(result: dict, error_level: float) -> None:
     """
     if "conan_error" not in result:
         for ref in result["data"]:
+            if "vulnerabilities" not in result["data"][ref]:
+                continue
             for edge in result["data"][ref]["vulnerabilities"]["edges"]:
                 preferred_base_score = float(edge["node"]["cvss"].get("preferredBaseScore", 0.0))
                 if preferred_base_score >= error_level:


### PR DESCRIPTION
Changelog: BugFix: Fix ``conan audit`` producing `_parse_error_threshold` crash when some package was not found in the catalog.
Docs: Omit

This was crashing

![image](https://github.com/user-attachments/assets/889ec994-b9e6-4948-8db0-1340db325c5f)

because of this entry:

```
'dav1d/1.4.3': {'error': {'details': "Package 'dav1d/1.4.3' not scanned: Not found."}}
```

to reproduce audit any dependency graph that has one dependency like this resulting in not found.
