### PR TITLE
fixing CmakeConfigDeps link flags

### DIFF
--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -345,13 +345,13 @@ class TargetConfigurationTemplate2:
         {% if lib_info.get("sharedlinkflags") %}
         {% set linkflags = config_wrapper(config, lib_info["sharedlinkflags"]) %}
         set_property(TARGET {{lib}} APPEND PROPERTY INTERFACE_LINK_OPTIONS
-                     "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:{{linkflags}}>"
-                     "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>:{{linkflags}}>")
+                     $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:{{linkflags}}>
+                     $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>:{{linkflags}}>)
         {% endif %}
         {% if lib_info.get("exelinkflags") %}
         {% set exeflags = config_wrapper(config, lib_info["exelinkflags"]) %}
         set_property(TARGET {{lib}} APPEND PROPERTY INTERFACE_LINK_OPTIONS
-                     "$<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:{{exeflags}}>")
+                     $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:{{exeflags}}>)
         {% endif %}
 
         {% if lib_info.get("link_languages") %}

--- a/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new.py
+++ b/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new.py
@@ -842,8 +842,8 @@ class TestHeaders:
                         self.cpp_info.system_libs = ["m", "dl"]
                         # Just to verify CMake don't break
                     if self.settings.compiler == "gcc":
-                        self.cpp_info.sharedlinkflags = ["-z now", "-z relro"]
-                        self.cpp_info.exelinkflags = ["-z now", "-z relro"]
+                        self.cpp_info.sharedlinkflags = ["-z lazy", "-s"]
+                        self.cpp_info.exelinkflags = ["-z lazy", "-s"]
              """)
         engine_h = textwrap.dedent("""
             #pragma once


### PR DESCRIPTION
Changelog: Bugfix: Fix CMakeConfigDeps link flags.
Docs: Omit

Close https://github.com/conan-io/conan/issues/18365
