### PR TITLE
Always stringify ConanOutput scope

### DIFF
--- a/.github/actions/test-coverage/action.yml
+++ b/.github/actions/test-coverage/action.yml
@@ -30,7 +30,7 @@ runs:
         if: ${{ inputs.tests }}
         shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
         run: |
-          pytest ${{ inputs.tests }} -rf --durations=${{ inputs.duration }} -n ${{ inputs.workers }} ${{ github.ref == 'refs/heads/develop2' && '--cov=conan --cov=conans --cov=test --cov-report=' || '' }}
+          pytest ${{ inputs.tests }} -rsf --durations=${{ inputs.duration }} -n ${{ inputs.workers }} ${{ github.ref == 'refs/heads/develop2' && '--cov=conan --cov=conans --cov=test --cov-report=' || '' }}
 
       - name: Rename coverage file
         if: github.ref == 'refs/heads/develop2'

--- a/.github/actions/test-coverage/action.yml
+++ b/.github/actions/test-coverage/action.yml
@@ -30,7 +30,7 @@ runs:
         if: ${{ inputs.tests }}
         shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
         run: |
-          pytest ${{ inputs.tests }} -rsf --durations=${{ inputs.duration }} -n ${{ inputs.workers }} ${{ github.ref == 'refs/heads/develop2' && '--cov=conan --cov=conans --cov=test --cov-report=' || '' }}
+          pytest ${{ inputs.tests }} -rf --durations=${{ inputs.duration }} -n ${{ inputs.workers }} ${{ github.ref == 'refs/heads/develop2' && '--cov=conan --cov=conans --cov=test --cov-report=' || '' }}
 
       - name: Rename coverage file
         if: github.ref == 'refs/heads/develop2'

--- a/conan/api/output.py
+++ b/conan/api/output.py
@@ -93,7 +93,7 @@ class ConanOutput:
 
     def __init__(self, scope=""):
         self.stream = sys.stderr
-        self._scope = scope
+        self._scope = str(scope)
         # FIXME:  This is needed because in testing we are redirecting the sys.stderr to a buffer
         #         stream to capture it, so colorama is not there to strip the color bytes
         self._color = _color_enabled(self.stream)
@@ -188,7 +188,7 @@ class ConanOutput:
             if self._color:
                 ret = "{}{}{}:{} ".format(fg or '', bg or '', self.scope, Style.RESET_ALL)
             else:
-                ret = "{}: ".format(str(self._scope))
+                ret = "{}: ".format(self._scope)
 
         if self._color:
             ret += "{}{}{}{}".format(fg or '', bg or '', msg, Style.RESET_ALL)

--- a/conan/api/output.py
+++ b/conan/api/output.py
@@ -188,7 +188,7 @@ class ConanOutput:
             if self._color:
                 ret = "{}{}{}:{} ".format(fg or '', bg or '', self.scope, Style.RESET_ALL)
             else:
-                ret = "{}: ".format(self._scope)
+                ret = "{}: ".format(str(self._scope))
 
         if self._color:
             ret += "{}{}{}{}".format(fg or '', bg or '', msg, Style.RESET_ALL)


### PR DESCRIPTION
Changelog: Fix: Always stringify `ConanOutput` `scope` param
Docs: Omit

So that users don't need to pass it, as we send to to str.format either way