### PR TITLE
Fix PyInstaller --exclude-module

### DIFF
--- a/pyinstaller.py
+++ b/pyinstaller.py
@@ -128,7 +128,7 @@ def pyinstall(source_folder, onefile=False):
     hidden_imports.append("pathlib")
     # inclusion of full conan package (with exclusion of irrelevant modules)
     command_args.append("--collect-submodules=conan")
-    command_args.append("--exclude-module=conan.test")
+    command_args.append("--exclude-module=conan.test.*")
 
     command_args.extend(f"--hidden-import={name}" for name in hidden_imports)
 


### PR DESCRIPTION
Changelog: Fix: Fix PyInstaller `--exclude-module` adding wildcard for `conan.test`.
Docs: Omit

To make these errors disapear when building the executables:

```
3471 ERROR: Hidden import 'conan.test.utils.env' not found
3471 INFO: Analyzing hidden import 'conan.test.utils.file_server'
3471 ERROR: Hidden import 'conan.test.utils.file_server' not found
3471 INFO: Analyzing hidden import 'conan.test.utils.mocks'
3471 ERROR: Hidden import 'conan.test.utils.mocks' not found
3471 INFO: Analyzing hidden import 'conan.test.utils.profiles'
3471 ERROR: Hidden import 'conan.test.utils.profiles' not found
3471 INFO: Analyzing hidden import 'conan.test.utils.scm'
3471 ERROR: Hidden import 'conan.test.utils.scm' not found
3471 INFO: Analyzing hidden import 'conan.test.utils.server_launcher'
3471 ERROR: Hidden import 'conan.test.utils.server_launcher' not found
3471 INFO: Analyzing hidden import 'conan.test.utils.test_files'
3471 ERROR: Hidden import 'conan.test.utils.test_files' not found
3471 INFO: Analyzing hidden import 'conan.test.utils.tools'
3471 ERROR: Hidden import 'conan.test.utils.tools' not found
```