### PR TITLE
Add open functionality to TestClient

### DIFF
--- a/conan/test/utils/tools.py
+++ b/conan/test/utils/tools.py
@@ -453,7 +453,7 @@ class TestClient:
             return None
 
     def open(self, filename):
-        """ Opens a file in the current folder """
+        # CI is set in our GitHub Actions, so we don't open files there
         if not os.environ.get("CI", False):
             current_path = os.path.join(self.current_folder, filename)
             if platform.system() == "Windows":

--- a/conan/test/utils/tools.py
+++ b/conan/test/utils/tools.py
@@ -11,6 +11,7 @@ import textwrap
 import traceback
 import uuid
 import zipfile
+import subprocess
 from contextlib import contextmanager
 from inspect import getframeinfo, stack
 from urllib.parse import urlsplit, urlunsplit
@@ -450,6 +451,20 @@ class TestClient:
             return load(os.path.join(self.cache_folder, filename))
         except IOError:
             return None
+
+    def open(self, filename):
+        """ Opens a file in the current folder """
+        if not os.environ.get("CI", False):
+            current_path = os.path.join(self.current_folder, filename)
+            if platform.system() == "Windows":
+                os.startfile(os.path.normpath(current_path))
+            elif platform.system() == "Darwin":
+                subprocess.call(["open", current_path])
+            else:
+                subprocess.call(["xdg-open", current_path])
+
+    def open_home(self, filename):
+        return self.open(os.path.join(self.cache_folder, filename))
 
     @property
     def cache(self):

--- a/conan/test/utils/tools.py
+++ b/conan/test/utils/tools.py
@@ -453,15 +453,17 @@ class TestClient:
             return None
 
     def open(self, filename):
-        # CI is set in our GitHub Actions, so we don't open files there
-        if not os.environ.get("CI", False):
-            current_path = os.path.join(self.current_folder, filename)
-            if platform.system() == "Windows":
-                os.startfile(os.path.normpath(current_path))
-            elif platform.system() == "Darwin":
-                subprocess.call(["open", current_path])
-            else:
-                subprocess.call(["xdg-open", current_path])
+        # CI is set by default by GitHub Actions
+        if os.environ.get("CI", False):
+            assert False, "TestClient::open should not be used in CI"
+
+        current_path = os.path.join(self.current_folder, filename)
+        if platform.system() == "Windows":
+            os.startfile(os.path.normpath(current_path))
+        elif platform.system() == "Darwin":
+            subprocess.call(["open", current_path])
+        else:
+            subprocess.call(["xdg-open", current_path])
 
     def open_home(self, filename):
         return self.open(os.path.join(self.cache_folder, filename))


### PR DESCRIPTION
Changelog: Feature: Add `open` to `TestClient` to open files locally.
Docs: Omit

Tested on Macos, Windows and Ubuntu, but I can't add a test for it for obvious reasons. Maybe one that shows that this is a noop in the CI? But even that might be overkill