### PR TITLE
do not call generators for editables not being built

### DIFF
--- a/conan/internal/graph/installer.py
+++ b/conan/internal/graph/installer.py
@@ -355,12 +355,12 @@ class BinaryInstaller:
         base_path = os.path.dirname(conanfile_path)
 
         conanfile.folders.set_base_folders(base_path, output_folder)
-        output = conanfile.output
-        output.info("Rewriting files of editable package "
-                    "'{}' at '{}'".format(conanfile.name, conanfile.generators_folder))
-        write_generators(conanfile, self._hook_manager, self._home_folder)
 
         if node.binary == BINARY_EDITABLE_BUILD:
+            output = conanfile.output
+            output.info("Rewriting files of editable package "
+                        "'{}' at '{}'".format(conanfile.name, conanfile.generators_folder))
+            write_generators(conanfile, self._hook_manager, self._home_folder)
             run_build_method(conanfile, self._hook_manager)
 
         rooted_base_path = base_path if conanfile.folders.root is None else \

--- a/test/integration/editable/test_editable_layout.py
+++ b/test/integration/editable/test_editable_layout.py
@@ -40,7 +40,7 @@ def test_editable_folders_root():
             "conanfile.py": app})
 
     c.run("editable add libs/pkg")
-    c.run("install .")
+    c.run("install . --build=editable")
     libdir = os.path.join(c.current_folder, "libs", "mybuild", "mylibdir")
     assert f"conanfile.py: PKG LIBDIR {libdir}" in c.out
     assert f"pkg/0.1: PKG package_folder {c.current_folder}" in c.out
@@ -82,7 +82,7 @@ def test_editable_folders_sibiling_root():
             "app/conanfile.py": app})
 
     c.run("editable add pkg")
-    c.run("install app")
+    c.run("install app --build=editable")
     libdir = os.path.join(c.current_folder, "mybuild", "mylibdir")
     assert f"conanfile.py: PKG LIBDIR {libdir}" in c.out
     assert f"pkg/0.1: PKG source_folder {c.current_folder}" in c.out
@@ -145,6 +145,6 @@ def test_install_editable_build_folder_vars():
             "profile": profile})
     c.run("editable add lib")
     c.run("build lib -pr=profile")
-    c.run("install app -pr=profile")
+    c.run("install app -pr=profile --build=editable")
     path = os.path.join(c.current_folder, "lib", "build", "windows-x86_64", "Release", "generators")
     assert f"lib/0.1: Writing generators to {path}" in c.out

--- a/test/integration/test_package_vendor.py
+++ b/test/integration/test_package_vendor.py
@@ -109,7 +109,7 @@ def test_package_vendor_editable():
             })
     c.run("create pkga")
     c.run("editable add pkgb")
-    c.run("install app -s os=Linux")
+    c.run("install app -s os=Linux --build=editable")
     assert "pkga" in c.out
     # The environment file of "app" doesn't have any visibility of the "pkga" paths
     envfile_app = c.load("app/conanrunenv.sh")

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -1115,7 +1115,7 @@ def test_build_folder_vars_editables():
     c.run("editable add dep")
     conf = "tools.cmake.cmake_layout:build_folder_vars='[\"settings.os\", \"settings.build_type\"]'"
     settings = " -s os=FreeBSD -s arch=armv8 -s build_type=Debug"
-    c.run("install app -c={} {}".format(conf, settings))
+    c.run("install app -c={} {} --build=editable".format(conf, settings))
     assert os.path.exists(os.path.join(c.current_folder, "dep", "build", "freebsd-debug"))
 
 


### PR DESCRIPTION
Changelog: BugFix: Do not call generators on editable packages not being built with ``--build=editable``
Docs: https://github.com/conan-io/docs/pull/XXXX

