### PR TITLE
[CMakeConfigDeps] Fixed `find_package` in subforlders

### DIFF
--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -385,7 +385,7 @@ class TargetConfigurationTemplate2:
         {% if link %}
         # set property allows to append, and lib_info[requires] will iterate
         set_property(TARGET {{lib}} APPEND PROPERTY INTERFACE_LINK_LIBRARIES
-                     {{config_wrapper(config, require_target)}})
+                     "{{config_wrapper(config, require_target)}}")
         {% else %}
         if(${CMAKE_VERSION} VERSION_LESS "3.27")
             message(FATAL_ERROR "The 'CMakeToolchain' generator only works with CMake >= 3.27")
@@ -400,13 +400,12 @@ class TargetConfigurationTemplate2:
         {% endif %}
 
         {% if lib_info.get("system_libs") %}
-        target_link_libraries({{lib}} INTERFACE {{lib_info["system_libs"]}})
         set_property(TARGET {{lib}} APPEND PROPERTY INTERFACE_LINK_LIBRARIES
-                     {{config_wrapper(config, lib_info["system_libs"])}})
+                     "{{config_wrapper(config, lib_info["system_libs"])}}")
         {% endif %}
         {% if lib_info.get("frameworks") %}
         set_property(TARGET {{lib}} APPEND PROPERTY INTERFACE_LINK_LIBRARIES
-                     {{config_wrapper(config, lib_info["frameworks"])}})
+                     "{{config_wrapper(config, lib_info["frameworks"])}}")
         {% endif %}
         {% if lib_info.get("package_framework") %}
         set_target_properties({{lib}} PROPERTIES

--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -401,7 +401,7 @@ class TargetConfigurationTemplate2:
 
         {% if lib_info.get("system_libs") %}
         set_property(TARGET {{lib}} APPEND PROPERTY INTERFACE_LINK_LIBRARIES
-                     "{{config_wrapper(config, lib_info["system_libs"])}}")
+                     {{config_wrapper(config, lib_info["system_libs"])}})
         {% endif %}
         {% if lib_info.get("frameworks") %}
         set_property(TARGET {{lib}} APPEND PROPERTY INTERFACE_LINK_LIBRARIES

--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -385,7 +385,7 @@ class TargetConfigurationTemplate2:
         {% if link %}
         # set property allows to append, and lib_info[requires] will iterate
         set_property(TARGET {{lib}} APPEND PROPERTY INTERFACE_LINK_LIBRARIES
-                     "{{config_wrapper(config, require_target)}}")
+                     {{config_wrapper(config, require_target)}})
         {% else %}
         if(${CMAKE_VERSION} VERSION_LESS "3.27")
             message(FATAL_ERROR "The 'CMakeToolchain' generator only works with CMake >= 3.27")
@@ -401,10 +401,12 @@ class TargetConfigurationTemplate2:
 
         {% if lib_info.get("system_libs") %}
         target_link_libraries({{lib}} INTERFACE {{lib_info["system_libs"]}})
+        set_property(TARGET {{lib}} APPEND PROPERTY INTERFACE_LINK_LIBRARIES
+                     {{config_wrapper(config, lib_info["system_libs"])}})
         {% endif %}
         {% if lib_info.get("frameworks") %}
         set_property(TARGET {{lib}} APPEND PROPERTY INTERFACE_LINK_LIBRARIES
-                     "{{config_wrapper(config, lib_info["frameworks"])}}")
+                     {{config_wrapper(config, lib_info["frameworks"])}})
         {% endif %}
         {% if lib_info.get("package_framework") %}
         set_target_properties({{lib}} PROPERTIES

--- a/conan/tools/cmake/cmakedeps2/targets.py
+++ b/conan/tools/cmake/cmakedeps2/targets.py
@@ -32,6 +32,7 @@ class TargetsTemplate2:
     @property
     def _template(self):
         return textwrap.dedent("""\
+            include_guard()
             message(STATUS "Conan: Configuring Targets for {{ ref }}")
 
             # Load information for each installed configuration.

--- a/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new.py
+++ b/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new.py
@@ -1518,8 +1518,19 @@ class TestCppInfoChecks:
 
 
 
-def test_libs(matrix_client):
-    c = matrix_client
+def test_multiple_find_package_subfolder():
+    c = TestClient()
+    conanfile = textwrap.dedent("""
+    from conan import ConanFile
+    class TestPackage(ConanFile):
+        name = "matrix"
+        version = "1.0"
+        def package_info(self):
+            self.cpp_info.system_libs = ["mysystemlib"]
+        """)
+    c.save({"conanfile.py": conanfile})
+    c.run("create .")
+
     cmake = textwrap.dedent("""
         cmake_minimum_required(VERSION 3.15)
         project(app NONE)
@@ -1528,6 +1539,7 @@ def test_libs(matrix_client):
         add_subdirectory(subdir)
         """)
     subcmake = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.15)
         project(subdir NONE)
 
         find_package(matrix CONFIG REQUIRED)
@@ -1545,9 +1557,9 @@ def test_libs(matrix_client):
         """)
     c.save({"conanfile.py": conanfile,
             "CMakeLists.txt": cmake,
-            "subdir/CMakeLists.txt": subcmake})
+            "subdir/CMakeLists.txt": subcmake}, clean_first=True)
 
     c.run(f"build . -c tools.cmake.cmakedeps:new={new_value}")
     assert "find_package(matrix)" in c.out
     assert "target_link_libraries(... matrix::matrix)" in c.out
-    assert "Conan: Target declared imported STATIC library 'matrix::matrix'" in c.out
+    assert "Conan: Target declared imported INTERFACE library 'matrix::matrix'" in c.out

--- a/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new.py
+++ b/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new.py
@@ -1515,3 +1515,39 @@ class TestCppInfoChecks:
         args = f"-g CMakeDeps -c tools.cmake.cmakedeps:new={new_value}"
         c.run(f"install --requires=dep/0.1 {args}", assert_error=True)
         assert "dep/0.1 cpp_info incorrect .type shared-library for .exe myexe" in c.out
+
+
+
+def test_libs(matrix_client):
+    c = matrix_client
+    cmake = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.15)
+        project(app NONE)
+
+        find_package(matrix CONFIG REQUIRED)
+        add_subdirectory(subdir)
+        """)
+    subcmake = textwrap.dedent("""
+        project(subdir NONE)
+
+        find_package(matrix CONFIG REQUIRED)
+        """)
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.cmake import CMake
+        class Pkg(ConanFile):
+            requires = "matrix/1.0"
+            generators = "CMakeToolchain", "CMakeDeps"
+            settings = "os", "compiler", "build_type", "arch"
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+        """)
+    c.save({"conanfile.py": conanfile,
+            "CMakeLists.txt": cmake,
+            "subdir/CMakeLists.txt": subcmake})
+
+    c.run(f"build . -c tools.cmake.cmakedeps:new={new_value}")
+    assert "find_package(matrix)" in c.out
+    assert "target_link_libraries(... matrix::matrix)" in c.out
+    assert "Conan: Target declared imported STATIC library 'matrix::matrix'" in c.out

--- a/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
@@ -234,7 +234,8 @@ def test_system_wrappers():
           f"-c tools.cmake.cmakedeps:new={new_value}")
     cmake = c.load("lib-Targets-release.cmake")
     assert "add_library(lib::lib INTERFACE IMPORTED)" in cmake
-    assert "target_link_libraries(lib::lib INTERFACE my_system_cool_lib)" in cmake
+    assert "set_property(TARGET lib::lib APPEND PROPERTY INTERFACE_LINK_LIBRARIES\n" \
+           '             "$<$<CONFIG:RELEASE>:my_system_cool_lib>")' in cmake
 
 
 def test_autolink_pragma():

--- a/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
@@ -235,7 +235,7 @@ def test_system_wrappers():
     cmake = c.load("lib-Targets-release.cmake")
     assert "add_library(lib::lib INTERFACE IMPORTED)" in cmake
     assert "set_property(TARGET lib::lib APPEND PROPERTY INTERFACE_LINK_LIBRARIES\n" \
-           '             "$<$<CONFIG:RELEASE>:my_system_cool_lib>")' in cmake
+           '             $<$<CONFIG:RELEASE>:my_system_cool_lib>)' in cmake
 
 
 def test_autolink_pragma():


### PR DESCRIPTION
Changelog: Bugfix: Fixed `CMakeConfigDeps` behavior with multiple `find_package` in folders and subfolders.
Docs: Omit

Close https://github.com/conan-io/conan/issues/18405
