### PR TITLE
Implement package path template configuration and validation (#18401)

### DIFF
--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -76,7 +76,7 @@ class CacheAPI:
         checker.check(package_list)
 
     def clean(self, package_list, source=True, build=True, download=True, temp=True,
-              backup_sources=False):
+              backup_sources=False, output=False):
         """
         Remove non critical folders from the cache, like source, build and download (.tgz store)
         folders.
@@ -86,6 +86,7 @@ class CacheAPI:
         :param download: boolean, remove the "download (.tgz)" folder if True
         :param temp: boolean, remove the temporary folders
         :param backup_sources: boolean, remove the "source" folder if True
+        :param output: boolean, remove the "package" folder if True (needed when changing package path template)
         :return:
         """
 
@@ -124,6 +125,11 @@ class CacheAPI:
                     cache.remove_build_id(pref)
                 if download:
                     rmdir(pref_layout.download_package())
+                if output:
+                    ConanOutput(pref).info("Removing package folder")
+                    rmdir(pref_layout.package())
+                    # We've removed the package, remove it from the database too
+                    cache.remove_package_layout(pref_layout)
 
     def save(self, package_list, tgz_path, no_source=False):
         global_conf = self.conan_api.config.global_conf

--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -83,6 +83,8 @@ def cache_clean(conan_api: ConanAPI, parser, subparser, *args):
                            help="Clean temporary folders")
     subparser.add_argument("-bs", "--backup-sources", action='store_true', default=False,
                            help="Clean backup sources")
+    subparser.add_argument("-o", "--output", action='store_true', default=False,
+                           help="Clean the output folders (packages) - use when changing package path template")
     subparser.add_argument('-p', '--package-query', action=OnceArgument,
                            help="Remove only the packages matching a specific query, e.g., "
                                 "os=Windows AND (arch=x86 OR compiler=gcc)")
@@ -99,10 +101,10 @@ def cache_clean(conan_api: ConanAPI, parser, subparser, *args):
     else:
         ref_pattern = ListPattern(args.pattern or "*", rrev="*", package_id="*", prev="*")
         package_list = conan_api.list.select(ref_pattern, package_query=args.package_query)
-    if args.build or args.source or args.download or args.temp or args.backup_sources:
+    if args.build or args.source or args.download or args.temp or args.backup_sources or args.output:
         conan_api.cache.clean(package_list, source=args.source, build=args.build,
                               download=args.download, temp=args.temp,
-                              backup_sources=args.backup_sources)
+                              backup_sources=args.backup_sources, output=args.output)
     else:
         conan_api.cache.clean(package_list)
 

--- a/conan/internal/cache/cache.py
+++ b/conan/internal/cache/cache.py
@@ -4,12 +4,13 @@ import re
 import shutil
 import uuid
 from fnmatch import translate
-from typing import List
+from typing import List, Optional
 
 from conan.internal.cache.conan_reference_layout import RecipeLayout, PackageLayout
 # TODO: Random folders are no longer accessible, how to get rid of them asap?
 # TODO: We need the workflow to remove existing references.
 from conan.internal.cache.db.cache_database import CacheDatabase
+from conan.internal.cache.package_path_validator import PackagePathValidator
 from conan.internal.errors import ConanReferenceAlreadyExistsInDB
 from conan.errors import ConanException
 from conan.api.model import PkgReference
@@ -26,6 +27,14 @@ class PkgCache:
         # paths
         self._store_folder = global_conf.get("core.cache:storage_path") or \
                              os.path.join(cache_folder, "p")
+        
+        # Get the package path template if configured
+        self._package_path_template = global_conf.get("core.cache:package_path_template")
+        
+        # Validate path template configuration and warn if changed
+        if self._package_path_template:
+            validator = PackagePathValidator(cache_folder)
+            validator.validate_path_config(self._package_path_template)
 
         try:
             mkdir(self._store_folder)
@@ -77,9 +86,31 @@ class PkgCache:
     def _get_path(ref):
         return ref.name[:5] + PkgCache._short_hash_path(ref.repr_notime())
 
-    @staticmethod
-    def _get_path_pref(pref):
-        return pref.ref.name[:5] + PkgCache._short_hash_path(pref.repr_notime())
+    def _get_path_pref(self, pref):
+        base_path = pref.ref.name[:5] + PkgCache._short_hash_path(pref.repr_notime())
+        
+        # If the package_path_template is defined, use it to structure the path
+        if self._package_path_template:
+            try:
+                # Create path variables
+                pkgname = pref.ref.name
+                version = str(pref.ref.version) if pref.ref.version else ""
+                
+                # Apply template
+                package_folder = self._package_path_template.format(
+                    pkgname=pkgname,
+                    version=version
+                )
+                
+                # Return the formatted path with the subfolder
+                return os.path.join(base_path, package_folder)
+            except (KeyError, ValueError) as e:
+                # If template formatting fails, log warning and fallback to default
+                from conan.api.output import ConanOutput
+                ConanOutput().warning(f"Error applying package_path_template: {e}. Falling back to default path.")
+        
+        # Default behavior - return the base path only
+        return base_path
 
     def create_export_recipe_layout(self, ref: RecipeReference):
         """  This is a temporary layout while exporting a new recipe, because the revision is not

--- a/conan/internal/cache/package_path_validator.py
+++ b/conan/internal/cache/package_path_validator.py
@@ -1,0 +1,71 @@
+import os
+import json
+from conan.api.output import ConanOutput
+
+
+class PackagePathValidator:
+    """
+    Validates package path structure configuration and warns when it changes.
+    This ensures users know they need to clear their cache when changing path structure.
+    """
+    
+    CONFIG_FILE = "package_path_config.json"
+    
+    def __init__(self, cache_folder):
+        self.cache_folder = cache_folder
+        self.config_file_path = os.path.join(cache_folder, self.CONFIG_FILE)
+    
+    def validate_path_config(self, current_template):
+        """
+        Validates if the package path template configuration has changed since last use.
+        If it has changed, warns the user to clear their cache.
+        
+        Args:
+            current_template: The current package path template from configuration
+            
+        Returns:
+            bool: True if configuration is valid to use, False otherwise.
+        """
+        # Check if we have a stored config
+        previous_template = self._get_stored_template()
+        
+        # Store current config for future comparisons
+        self._store_current_template(current_template)
+        
+        # If the template has changed, warn user
+        if previous_template is not None and previous_template != current_template:
+            ConanOutput().warning(
+                f"Package path template configuration has changed from '{previous_template}' to "
+                f"'{current_template}'. This affects where packages are stored in the cache."
+            )
+            ConanOutput().warning(
+                "For the change to take effect properly, you should remove the existing cache by running: "
+                "conan cache clean --output"
+            )
+            return False
+        
+        return True
+    
+    def _get_stored_template(self):
+        """Gets the stored template from the config file"""
+        if not os.path.exists(self.config_file_path):
+            return None
+            
+        try:
+            with open(self.config_file_path, 'r') as f:
+                data = json.load(f)
+            return data.get('template')
+        except (json.JSONDecodeError, IOError):
+            # If any errors, just return None and we'll create a new config
+            return None
+    
+    def _store_current_template(self, template):
+        """Stores the current template in the config file"""
+        try:
+            with open(self.config_file_path, 'w') as f:
+                json.dump({'template': template}, f)
+        except IOError:
+            # If we can't write the file, just log a warning but continue
+            ConanOutput().warning(
+                f"Could not write package path configuration to {self.config_file_path}"
+            )

--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -30,6 +30,7 @@ BUILT_IN_CONFS = {
     "core.download:retry_wait": "Seconds to wait between download attempts from Conan server",
     "core.download:download_cache": "Define path to a file download cache",
     "core.cache:storage_path": "Absolute path where the packages and database are stored",
+    "core.cache:package_path_template": "Optional template for package paths structure. Supports variables: {pkgname}, {version}",
     "core:update_policy": "(Legacy). If equal 'legacy' when multiple remotes, update based on order of remotes, only the timestamp of the first occurrence of each revision counts.",
     # Sources backup
     "core.sources:download_cache": "Folder to store the sources backup",

--- a/docs/examples/features/package_path_template.md
+++ b/docs/examples/features/package_path_template.md
@@ -1,0 +1,58 @@
+# Custom Package Path Template
+
+The Conan package cache contains binary packages in a structure that looks like this by default:
+
+```
+~/.conan2/p/b/<folder>/<files>
+```
+
+Where `<folder>` is a combination of the package name and a hash.
+
+Starting in Conan 2.x, you can define a custom template for package paths using the `core.cache:package_path_template` configuration option. This allows you to create more organized folder structures, for example to include package names in the folder structure.
+
+## Configuration
+
+Set the `core.cache:package_path_template` in your global.conf file as follows:
+
+```
+core.cache:package_path_template = {pkgname}/{version}
+```
+
+You can use the following variables in your template:
+- `{pkgname}`: The name of the package (without version)
+- `{version}`: The version of the package
+
+## Examples
+
+### Add package name subfolder
+
+To create a structure where each package's files are in a subfolder with the package name:
+
+```
+core.cache:package_path_template = {pkgname}
+```
+
+This will create a structure like:
+```
+~/.conan2/p/b/libev554a87e87d87d87/libev/<files>
+```
+
+### Add package name and version
+
+To create a structure with both package name and version:
+
+```
+core.cache:package_path_template = {pkgname}-{version}
+```
+
+This will create a structure like:
+```
+~/.conan2/p/b/libev554a87e87d87d87/libev-1.0/<files>
+```
+
+## Important Notes
+
+1. Changing this configuration will only affect newly built or downloaded packages
+2. You should run `conan cache clean --output` after changing this configuration to avoid having packages with mixed structures
+3. This configuration option is global and cannot be set per-package
+4. Remote packages are still stored in the standard format on the server - the template is applied only in the local cache

--- a/test/integration/configuration/conf/test_package_path_template.py
+++ b/test/integration/configuration/conf/test_package_path_template.py
@@ -1,0 +1,81 @@
+import os
+import textwrap
+import unittest
+
+from conan.test.utils.tools import TestClient
+from conan.test.utils.test_files import temp_folder
+from conan.api.output import ConanOutput
+from conan.internal.util.files import save, load
+
+
+class PackagePathTemplateTest(unittest.TestCase):
+
+    def test_package_path_template(self):
+        """ Test that the package path template works correctly """
+        # Create a test client with our custom template
+        client = TestClient()
+        save(os.path.join(client.cache_folder, "global.conf"),
+             "core.cache:package_path_template = {pkgname}\n")
+
+        # Create a simple package
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            
+            class TestConan(ConanFile):
+                name = "hello"
+                version = "1.0"
+                
+                def package(self):
+                    self.output.info("Packaging...")
+                    save(self, os.path.join(self.package_folder, "hello.txt"), "Hello World!")
+            """)
+        
+        client.save({"conanfile.py": conanfile})
+        client.run("create .")
+        
+        # Verify the package was created with the custom template
+        package_ref = client.created_package_reference("hello/1.0")
+        package_path = client.packlayout(package_ref).package()
+        
+        # Check that the path contains /hello/ as per our template
+        self.assertIn("/hello/", package_path)
+        
+        # Verify the package content is accessible
+        hello_path = os.path.join(package_path, "hello.txt")
+        self.assertTrue(os.path.exists(hello_path))
+        self.assertEqual(load(hello_path), "Hello World!")
+        
+    def test_template_with_version(self):
+        """ Test that the package path template works with version """
+        # Create a test client with custom template including version
+        client = TestClient()
+        save(os.path.join(client.cache_folder, "global.conf"),
+             "core.cache:package_path_template = {pkgname}-{version}\n")
+
+        # Create a simple package
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            
+            class TestConan(ConanFile):
+                name = "hello"
+                version = "2.0"
+                
+                def package(self):
+                    self.output.info("Packaging...")
+                    save(self, os.path.join(self.package_folder, "hello.txt"), "Hello World!")
+            """)
+        
+        client.save({"conanfile.py": conanfile})
+        client.run("create .")
+        
+        # Verify the package was created with the custom template
+        package_ref = client.created_package_reference("hello/2.0")
+        package_path = client.packlayout(package_ref).package()
+        
+        # Check that the path contains /hello-2.0/ as per our template
+        self.assertIn("hello-2.0", package_path)
+        
+        # Verify the package content is accessible
+        hello_path = os.path.join(package_path, "hello.txt")
+        self.assertTrue(os.path.exists(hello_path))
+        self.assertEqual(load(hello_path), "Hello World!")


### PR DESCRIPTION
- Added `core.cache:package_path_template` option to customize package folder structure.
- Introduced `PackagePathValidator` to validate and warn on changes to the path template.
- Updated `CacheAPI.clean` method to support output folder removal.
- Enhanced CLI command for cache cleaning to include output folder option.
- Added tests for package path template functionality.
- Documented usage of custom package path templates.

Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
