### PR TITLE
Allow multi-digit version minors for detected compilers

### DIFF
--- a/conan/internal/api/detect/detect_api.py
+++ b/conan/internal/api/detect/detect_api.py
@@ -488,7 +488,7 @@ def _cc_compiler(compiler_exe="cc"):
         compiler = "clang" if "clang" in out else "gcc"
         # clang and gcc have version after a space, first try to find that to skip extra numbers
         # that might appear in the first line of the output before the version
-        installed_version = re.search(r" ([0-9]+(\.[0-9])+)", out)
+        installed_version = re.search(r" ([0-9]+(\.[0-9]+)+)", out)
         # Try only major but with spaces next
         installed_version = installed_version or re.search(r" ([0-9]+(\.[0-9])?)", out)
         # Fallback to the first number we find optionally followed by other version fields
@@ -515,7 +515,7 @@ def detect_gcc_compiler(compiler_exe="gcc"):
         if ret != 0:
             return None, None, None
         compiler = "gcc"
-        installed_version = re.search(r"([0-9]+(\.[0-9])?)", out).group()
+        installed_version = re.search(r"([0-9]+(\.[0-9]+)?)", out).group()
         if installed_version:
             ConanOutput(scope="detect_api").info("Found %s %s" % (compiler, installed_version))
             return compiler, Version(installed_version), compiler_exe

--- a/conan/internal/api/detect/detect_api.py
+++ b/conan/internal/api/detect/detect_api.py
@@ -493,8 +493,8 @@ def _cc_compiler(compiler_exe="cc"):
         installed_version = installed_version or re.search(r" ([0-9]+(\.[0-9])?)", out)
         # Fallback to the first number we find optionally followed by other version fields
         installed_version = installed_version or re.search(r"([0-9]+(\.[0-9])?)", out)
-        if installed_version and installed_version.group():
-            installed_version = installed_version.group()
+        if installed_version and installed_version.group(1):
+            installed_version = installed_version.group(1)
             ConanOutput(scope="detect_api").info("Found cc=%s-%s" % (compiler, installed_version))
             return compiler, Version(installed_version), compiler_exe
     except (Exception,):  # to disable broad-except

--- a/conan/internal/api/detect/detect_api.py
+++ b/conan/internal/api/detect/detect_api.py
@@ -490,9 +490,9 @@ def _cc_compiler(compiler_exe="cc"):
         # that might appear in the first line of the output before the version
         installed_version = re.search(r" ([0-9]+(\.[0-9]+)+)", out)
         # Try only major but with spaces next
-        installed_version = installed_version or re.search(r" ([0-9]+(\.[0-9])?)", out)
+        installed_version = installed_version or re.search(r" ([0-9]+(\.[0-9]+)?)", out)
         # Fallback to the first number we find optionally followed by other version fields
-        installed_version = installed_version or re.search(r"([0-9]+(\.[0-9])?)", out)
+        installed_version = installed_version or re.search(r"([0-9]+(\.[0-9]+)?)", out)
         if installed_version and installed_version.group(1):
             installed_version = installed_version.group(1)
             ConanOutput(scope="detect_api").info("Found cc=%s-%s" % (compiler, installed_version))

--- a/test/unittests/client/conf/detect/test_gcc_compiler.py
+++ b/test/unittests/client/conf/detect/test_gcc_compiler.py
@@ -1,19 +1,14 @@
-import unittest
 
 import mock
-from parameterized import parameterized
-
+import pytest
 
 from conan.internal.api.detect.detect_api import detect_gcc_compiler
 
-
-class GCCCompilerTestCase(unittest.TestCase):
-
-    @parameterized.expand([("10",), ("4.2",), ('7', )])
-    def test_detect_gcc_10(self, version):
-        with mock.patch("platform.system", return_value="Linux"):
-            with mock.patch("conan.internal.api.detect.detect_api.detect_runner", return_value=(0, version)):
-                compiler, installed_version, compiler_exe = detect_gcc_compiler()
-        self.assertEqual(compiler, 'gcc')
-        self.assertEqual(installed_version, version)
-        self.assertEqual(compiler_exe, 'gcc')
+@pytest.mark.parametrize("version", ["10", "4.2", '7', "8.12"])
+def test_detect_gcc_10(version):
+    with mock.patch("platform.system", return_value="Linux"):
+        with mock.patch("conan.internal.api.detect.detect_api.detect_runner", return_value=(0, version)):
+            compiler, installed_version, compiler_exe = detect_gcc_compiler()
+    assert compiler == 'gcc'
+    assert installed_version == version
+    assert compiler_exe == 'gcc'

--- a/test/unittests/util/detect_test.py
+++ b/test/unittests/util/detect_test.py
@@ -65,6 +65,8 @@ class DetectTest(unittest.TestCase):
 @pytest.mark.parametrize("version_return,expected_version", [
     ["cc.exe (Rev3, Built by MSYS2 project) 14.1.0", "14.1.0"],
     ["g++ (Conan-Build-gcc--binutils-2.42) 14.1.0", "14.1.0"],
+    ["gcc.exe (x86_64-posix-seh-rev0, Built by MinGW-Builds project) 15.1.0", "15.1.0"],
+    ["gcc.exe (x86_64-posix-seh-rev0, Built by MinGW-Builds project) 15.15.0", "15.15.0"],
     ["clang version 18.1.0rc (https://github.com/llvm/llvm-project.git 461274b81d8641eab64d494accddc81d7db8a09e)", "18.1.0"],
     ["cc.exe (Rev3, Built by MSYS2 project) 14.0", "14.0"],
     ["clang version 18 (https://github.com/llvm/llvm-project.git 461274b81d8641eab64d494accddc81d7db8a09e)", "18"],

--- a/test/unittests/util/detect_test.py
+++ b/test/unittests/util/detect_test.py
@@ -67,6 +67,7 @@ class DetectTest(unittest.TestCase):
     ["g++ (Conan-Build-gcc--binutils-2.42) 14.1.0", "14.1.0"],
     ["gcc.exe (x86_64-posix-seh-rev0, Built by MinGW-Builds project) 15.1.0", "15.1.0"],
     ["gcc.exe (x86_64-posix-seh-rev0, Built by MinGW-Builds project) 15.15.0", "15.15.0"],
+    ["gcc (GCC) 4.8.1", "4.8.1"],
     ["clang version 18.1.0rc (https://github.com/llvm/llvm-project.git 461274b81d8641eab64d494accddc81d7db8a09e)", "18.1.0"],
     ["cc.exe (Rev3, Built by MSYS2 project) 14.0", "14.0"],
     ["clang version 18 (https://github.com/llvm/llvm-project.git 461274b81d8641eab64d494accddc81d7db8a09e)", "18"],
@@ -76,6 +77,8 @@ class DetectTest(unittest.TestCase):
 def test_detect_cc_versionings(detect_runner_mock, version_return, expected_version):
     detect_runner_mock.return_value = 0, version_return
     compiler, installed_version, compiler_exe = _cc_compiler()
+    # Using private _value attribute to compare the str that reaches it, so no space issues arise
+    assert installed_version._value == Version(expected_version)._value
     assert installed_version == Version(expected_version)
 
 @pytest.mark.parametrize("function,version_return,expected_version", [


### PR DESCRIPTION
Changelog: Fix: Allow minors greater than 9 in `detect_api`.
Docs: Omit

Closes https://github.com/conan-io/conan/issues/18409