### PR TITLE
Fix verbosity issue on windows using powershell

### DIFF
--- a/conan/tools/microsoft/msbuild.py
+++ b/conan/tools/microsoft/msbuild.py
@@ -14,7 +14,7 @@ def msbuild_verbosity_cmd_line_arg(conanfile):
             "quiet": "Quiet",
             "verbose": "Detailed",
         }.get(verbosity)
-        return f'-verbosity:{verbosity}'
+        return f'/verbosity:{verbosity}'
     return ""
 
 

--- a/test/integration/configuration/conf/test_conf_profile.py
+++ b/test/integration/configuration/conf/test_conf_profile.py
@@ -40,7 +40,7 @@ def test_cmake_no_config(client):
         """)
     client.save({"myprofile": profile})
     client.run("create . --name=pkg --version=0.1 -pr=myprofile")
-    assert "-verbosity" not in client.out
+    assert "/verbosity" not in client.out
 
 
 def test_cmake_config(client):
@@ -57,7 +57,7 @@ def test_cmake_config(client):
         """)
     client.save({"myprofile": profile})
     client.run("create . --name=pkg --version=0.1 -pr=myprofile")
-    assert "-verbosity:Quiet" in client.out
+    assert "/verbosity:Quiet" in client.out
 
 
 def test_cmake_config_error(client):
@@ -91,9 +91,9 @@ def test_cmake_config_package(client):
         """)
     client.save({"myprofile": profile})
     client.run("create . --name=pkg --version=0.1 -pr=myprofile")
-    assert "-verbosity" not in client.out
+    assert "/verbosity" not in client.out
     client.run("create . --name=dep --version=0.1 -pr=myprofile")
-    assert "-verbosity:Quiet" in client.out
+    assert "/verbosity:Quiet" in client.out
 
 
 def test_cmake_config_package_not_scoped(client):
@@ -110,9 +110,9 @@ def test_cmake_config_package_not_scoped(client):
         """)
     client.save({"myprofile": profile})
     client.run("create . --name=pkg --version=0.1 -pr=myprofile")
-    assert "-verbosity:Quiet" in client.out
+    assert "/verbosity:Quiet" in client.out
     client.run("create . --name=dep --version=0.1 -pr=myprofile")
-    assert "-verbosity:Quiet" in client.out
+    assert "/verbosity:Quiet" in client.out
 
 
 def test_config_profile_forbidden(client):
@@ -152,7 +152,7 @@ def test_msbuild_config():
         """)
     client.save({"myprofile": profile})
     client.run("create . --name=pkg --version=0.1 -pr=myprofile")
-    assert "-verbosity:Quiet" in client.out
+    assert "/verbosity:Quiet" in client.out
 
 
 def test_msbuild_compile_options():


### PR DESCRIPTION
Changelog: Bugfix: Fix compilation error on `msvc` when setting `tools.build:verbosity`
Docs: omit

This fix compilation issues when the following config is present:
```
[conf]
tools.env.virtualenv:powershell=powershell.exe
tools.build:verbosity=verbose
tools.compilation:verbosity=verbose
```

Compilation error:
```
Run Build Command(s): "C:/Program Files/Microsoft Visual Studio/2022/Community/MSBuild/Current/Bin/arm64/MSBuild.exe" ALL_BUILD.vcxproj /p:Configuration=Release /p:Platform=ARM64 /p:VisualStudioVersion=17.0 /v:n -verbosity: Detailed
MSBuild version 17.11.2+c078802d4 for .NET Framework
MSBUILD : error MSB1016: Specify the verbosity level.
```
