### PR TITLE
Make older gccs explictily return up to minor, to keep compat with ol…

### DIFF
--- a/conan/internal/api/detect/detect_api.py
+++ b/conan/internal/api/detect/detect_api.py
@@ -628,9 +628,13 @@ def default_compiler_version(compiler, version):
     if compiler == "clang" and major >= 8:
         output.info("clang>=8, using the major as version")
         return major
-    elif compiler == "gcc" and major >= 5:
-        output.info("gcc>=5, using the major as version")
-        return major
+    elif compiler == "gcc":
+        if major >= 5:
+            output.info("gcc>=5, using the major as version")
+            return major
+        else:
+            output.info("gcc<5, using the major.minor as version")
+            return Version(f"{major}.{minor}")
     elif compiler == "apple-clang" and major >= 13:
         output.info("apple-clang>=13, using the major as version")
         return major


### PR DESCRIPTION
Changelog: Fix: Ensure old gcc version are detected up to minor version only.
Docs: Omit

This keeps compat with old Conan behaviour that would only detect major.minor even if major.mino.patch was printed. We now give users a way to detect the full compiler version, but now `default_compiler_version` properly trims it to keep old behaviour

Closes #18409 again