### PR TITLE
fix in autotools win-clang and test for NMake with clang-cl

### DIFF
--- a/conan/tools/build/flags.py
+++ b/conan/tools/build/flags.py
@@ -134,14 +134,15 @@ def build_type_flags(conanfile):
     if not compiler or not build_type:
         return []
 
-    # https://github.com/Kitware/CMake/blob/d7af8a34b67026feaee558433db3a835d6007e06/
-    # Modules/Platform/Windows-MSVC.cmake
     comp_exes = conanfile.conf.get("tools.build:compiler_executables", check_type=dict,
                                    default={})
     clangcl = "clang-cl" in (comp_exes.get("c") or comp_exes.get("cpp", ""))
 
     if compiler == "msvc" or clangcl:
-        if clangcl or (vs_toolset and "clang" in vs_toolset):
+        # https://github.com/Kitware/CMake/blob/d7af8a34b67026feaee558433db3a835d6007e06/
+        # Modules/Platform/Windows-MSVC.cmake
+        # FIXME: This condition seems legacy, as no more "clang" exists in Conan toolsets
+        if vs_toolset and "clang" in vs_toolset:
             flags = {"Debug": ["-gline-tables-only", "-fno-inline", "-O0"],
                      "Release": ["-O2"],
                      "RelWithDebInfo": ["-gline-tables-only", "-O2", "-fno-inline"],

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -174,7 +174,9 @@ class AutotoolsToolchain:
             if self._conanfile.settings.compiler.runtime == "dynamic":
                 runtime_type = self._conanfile.settings.get_safe("compiler.runtime_type")
                 library = "msvcrtd" if runtime_type == "Debug" else "msvcrt"
-                return f"-D_DLL -D_MT -Xclang --dependent-lib={library}"
+                # The -D_DEBUG is important to link with the Debug MSVCP140D.dll
+                debug = "-D_DEBUG " if runtime_type == "Debug" else ""
+                return f"{debug}-D_DLL -D_MT -Xclang --dependent-lib={library}"
             return ""  # By default it already link statically
 
         flag = msvc_runtime_flag(self._conanfile)

--- a/conan/tools/gnu/gnutoolchain.py
+++ b/conan/tools/gnu/gnutoolchain.py
@@ -239,7 +239,8 @@ class GnuToolchain:
             if self._conanfile.settings.compiler.runtime == "dynamic":
                 runtime_type = self._conanfile.settings.get_safe("compiler.runtime_type")
                 library = "msvcrtd" if runtime_type == "Debug" else "msvcrt"
-                return f"-D_DLL -D_MT -Xclang --dependent-lib={library}"
+                debug = "-D_DEBUG " if runtime_type == "Debug" else ""
+                return f"{debug}-D_DLL -D_MT -Xclang --dependent-lib={library}"
             return ""  # By default it already link statically
 
         flag = msvc_runtime_flag(self._conanfile)

--- a/test/functional/toolchains/test_nmake_toolchain.py
+++ b/test/functional/toolchains/test_nmake_toolchain.py
@@ -85,3 +85,78 @@ def test_toolchain_nmake(compiler, version, runtime, cppstd, build_type,
     client.run_command("simple.exe")
     assert "dep/1.0" in client.out
     check_exe_run(client.out, "main", "msvc", version, build_type, "x86_64", cppstd, conf_preprocessors)
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows")
+@pytest.mark.tool("clang", "18")
+def test_toolchain_nmake_clang():
+    compiler = "clang"
+    version = "18"
+    runtime = "dynamic"
+    cppstd = "14"
+    build_type = "Debug"
+    defines = ["TEST_DEFINITION1", "TEST_DEFINITION2=0", "TEST_DEFINITION3=", "TEST_DEFINITION4=TestPpdValue4",
+          "TEST_DEFINITION5=__declspec(dllexport)", "TEST_DEFINITION6=foo bar"]
+    cflags = cxxflags = sharedlinkflags = exelinkflags = []
+    client = TestClient(path_with_spaces=False)
+    settings = {"compiler": compiler,
+                "compiler.version": version,
+                "compiler.cppstd": cppstd,
+                "compiler.runtime": runtime,
+                "build_type": build_type,
+                "compiler.runtime_version": "v144",
+                "arch": "x86_64"}
+
+    serialize_array = lambda arr: "[{}]".format(",".join([f"'{v}'" for v in arr]))
+    conf = {
+        "tools.build:defines": serialize_array(defines) if defines else "",
+        "tools.build:cflags": serialize_array(cflags) if cflags else "",
+        "tools.build:cxxflags": serialize_array(cxxflags) if cxxflags else "",
+        "tools.build:sharedlinkflags": serialize_array(sharedlinkflags) if sharedlinkflags else "",
+        "tools.build:exelinkflags": serialize_array(exelinkflags) if exelinkflags else "",
+        "tools.build:compiler_executables": r'{\"c\": \"clang-cl\", \"cpp\": \"clang-cl\"}',
+        "tools.cmake.cmaketoolchain:generator": "Visual Studio 17",
+    }
+
+    # Build the profile according to the settings provided
+    settings = " ".join('-s %s="%s"' % (k, v) for k, v in settings.items() if v)
+
+    client.run("new cmake_lib -d name=dep -d version=1.0")
+    conf = " ".join(f'-c {k}="{v}"' for k, v in conf.items() if v)
+    client.run(f'create . -tf=\"\" {settings} {conf}')
+
+    # Rearrange defines to macro / value dict
+    conf_preprocessors = {}
+    for define in defines:
+        if "=" in define:
+            key, value = define.split("=", 1)
+            # gen_function_cpp doesn't properly handle empty macros
+            if value:
+                conf_preprocessors[key] = value
+        else:
+            conf_preprocessors[define] = "1"
+
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        class Pkg(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+            requires = "dep/1.0"
+            generators = "NMakeToolchain", "NMakeDeps"
+
+            def build(self):
+                self.run(f"nmake /f makefile")
+            """)
+    makefile = textwrap.dedent("""\
+        all: simple.exe
+
+        simple.exe: simple.cpp
+          $(CPP) simple.cpp -o simple.exe
+        """)
+    client.save({"conanfile.py": conanfile,
+                 "makefile": makefile,
+                 "simple.cpp": gen_function_cpp(name="main", includes=["dep"], calls=["dep"], preprocessor=conf_preprocessors.keys())},
+                clean_first=True)
+    client.run(f"build . {settings} {conf}")
+    client.run_command("simple.exe")
+    assert "dep/1.0" in client.out
+    check_exe_run(client.out, "main", "clang", "19.1", build_type, "x86_64", cppstd, conf_preprocessors)

--- a/test/functional/utils.py
+++ b/test/functional/utils.py
@@ -9,7 +9,6 @@ def check_vs_runtime(artifact, client, vs_version, build_type, architecture="amd
     if not static:
         cmd = ('%s && dumpbin /nologo /dependents "%s"' % (vcvars, normalized_path))
         client.run_command(cmd)
-        print(client.out)
         if subsystem:
             assert "KERNEL32.dll" in client.out
             if subsystem in ("mingw32", "mingw64"):

--- a/test/functional/utils.py
+++ b/test/functional/utils.py
@@ -9,6 +9,7 @@ def check_vs_runtime(artifact, client, vs_version, build_type, architecture="amd
     if not static:
         cmd = ('%s && dumpbin /nologo /dependents "%s"' % (vcvars, normalized_path))
         client.run_command(cmd)
+        print(client.out)
         if subsystem:
             assert "KERNEL32.dll" in client.out
             if subsystem in ("mingw32", "mingw64"):

--- a/test/unittests/client/build/compiler_flags_test.py
+++ b/test/unittests/client/build/compiler_flags_test.py
@@ -127,10 +127,10 @@ class CompilerFlagsTest(unittest.TestCase):
         conanfile.settings = settings
         self.assertEqual(' '.join(build_type_flags(conanfile)), flags)
 
-    @parameterized.expand([("clang", "Debug", "-gline-tables-only -fno-inline -O0"),
-                           ("clang", "Release", "-O2"),
-                           ("clang", "RelWithDebInfo", "-gline-tables-only -O2 -fno-inline"),
-                           ("clang", "MinSizeRel", ""),
+    @parameterized.expand([("clang", "Debug", "-Zi -Ob0 -Od"),
+                           ("clang", "Release", "-O2 -Ob2"),
+                           ("clang", "RelWithDebInfo", "-Zi -O2 -Ob1"),
+                           ("clang", "MinSizeRel", "-O1 -Ob1"),
                            ])
     def test_build_type_flags_clangcl(self, compiler, build_type, flags):
         settings = MockSettings({"compiler": compiler,


### PR DESCRIPTION
Changelog: Fix: Fix AutotoolsToolchain/GnuToolchain with LLVM/Clang in Windows for dynamic runtime in Debug. 
Changelog: Fix: Test ``NMake`` integration with ``clang-cl``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/17491