### PR TITLE
Create folders if they don't exist when using `--out-file`

### DIFF
--- a/conan/cli/command.py
+++ b/conan/cli/command.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 import textwrap
 from contextlib import redirect_stdout
 
@@ -96,6 +97,8 @@ class BaseConanCommand:
                 formatarg, ", ".join(self._help_formatters)))
 
         if out_file:
+            if os.path.dirname(out_file):
+                os.makedirs(os.path.dirname(out_file), exist_ok=True)
             with open(out_file, 'w') as f:
                 with redirect_stdout(f):
                     formatter(info)

--- a/test/integration/command/test_output.py
+++ b/test/integration/command/test_output.py
@@ -1,6 +1,8 @@
 import json
+import os
 
 from conan.test.assets.genconanfile import GenConanfile
+from conan.test.utils.test_files import temp_folder
 from conan.test.utils.tools import TestClient
 from conan.test.utils.env import environment_update
 
@@ -291,3 +293,18 @@ def test_formatter_redirection_to_file():
     graph = json.loads(c.load("graph.json"))
     assert len(graph["graph"]["nodes"]) == 1
     assert not "nodes" in c.stdout
+
+
+def test_redirect_to_file_create_dir():
+    c = TestClient(light=True)
+    c.save({"conanfile.py": GenConanfile("pkg", "0.1")})
+    c.run("config home --out-file=subdir/cmd_out.txt")
+    cmd_out = c.load("subdir/cmd_out.txt")
+    assert f"{c.cache_folder}" in cmd_out
+
+    base = temp_folder()
+    c = TestClient(light=True, current_folder=os.path.join(base, "sub1"))
+    c.save({"conanfile.py": GenConanfile("pkg", "0.1")})
+    c.run("config home --out-file=../subdir/cmd_out.txt")
+    cmd_out = c.load("../subdir/cmd_out.txt")
+    assert f"{c.cache_folder}" in cmd_out


### PR DESCRIPTION
Changelog: Fix: Create folders if they don't exist when using `--out-file`.
Docs: Omit

Closes https://github.com/conan-io/docs/issues/4118