### PR TITLE
[feature] Add generic config for CMake and Meson install strip

### DIFF
--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -86,7 +86,7 @@ BUILT_IN_CONFS = {
     "tools.cmake.cmake_layout:test_folder": "(Experimental) Allow configuring the base folder of the build for test_package",
     "tools.cmake:cmake_program": "Path to CMake executable",
     "tools.cmake.cmakedeps:new": "Use the new CMakeDeps generator",
-    "tools.cmake:install_strip": "(Deprecated) Add --strip to cmake.install(). Use tools.install:strip instead",
+    "tools.cmake:install_strip": "(Deprecated) Add --strip to cmake.install(). Use tools.build.install:strip instead",
     "tools.deployer:symlinks": "Set to False to disable deployers copying symlinks",
     "tools.files.download:retry": "Number of retries in case of failure when downloading",
     "tools.files.download:retry_wait": "Seconds to wait between download attempts",
@@ -136,7 +136,7 @@ BUILT_IN_CONFS = {
     "tools.build:exelinkflags": "List of extra flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:linker_scripts": "List of linker script files to pass to the linker used by different toolchains like CMakeToolchain, AutotoolsToolchain, and MesonToolchain",
     # Toolchain installation
-    "tools.install:strip": "(boolean) Strip the binaries when installing them with CMake and Meson",
+    "tools.build.install:strip": "(boolean) Strip the binaries when installing them with CMake and Meson",
     # Package ID composition
     "tools.info.package_id:confs": "List of existing configuration to be part of the package ID",
 }

--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -136,7 +136,7 @@ BUILT_IN_CONFS = {
     "tools.build:exelinkflags": "List of extra flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:linker_scripts": "List of linker script files to pass to the linker used by different toolchains like CMakeToolchain, AutotoolsToolchain, and MesonToolchain",
     # Toolchain installation
-    "tools.install:strip": "(boolean) Strip the binaries when installing them",
+    "tools.install:strip": "(boolean) Strip the binaries when installing them with CMake and Meson",
     # Package ID composition
     "tools.info.package_id:confs": "List of existing configuration to be part of the package ID",
 }

--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -86,7 +86,7 @@ BUILT_IN_CONFS = {
     "tools.cmake.cmake_layout:test_folder": "(Experimental) Allow configuring the base folder of the build for test_package",
     "tools.cmake:cmake_program": "Path to CMake executable",
     "tools.cmake.cmakedeps:new": "Use the new CMakeDeps generator",
-    "tools.cmake:install_strip": "Add --strip to cmake.install()",
+    "tools.cmake:install_strip": "(Deprecated) Add --strip to cmake.install(). Use tools.install:strip instead",
     "tools.deployer:symlinks": "Set to False to disable deployers copying symlinks",
     "tools.files.download:retry": "Number of retries in case of failure when downloading",
     "tools.files.download:retry_wait": "Seconds to wait between download attempts",
@@ -135,6 +135,8 @@ BUILT_IN_CONFS = {
     "tools.build:sharedlinkflags": "List of extra flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:exelinkflags": "List of extra flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:linker_scripts": "List of linker script files to pass to the linker used by different toolchains like CMakeToolchain, AutotoolsToolchain, and MesonToolchain",
+    # Toolchain installation
+    "tools.install:strip": "(boolean) Strip the binaries when installing them",
     # Package ID composition
     "tools.info.package_id:confs": "List of existing configuration to be part of the package ID",
 }

--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -86,7 +86,7 @@ BUILT_IN_CONFS = {
     "tools.cmake.cmake_layout:test_folder": "(Experimental) Allow configuring the base folder of the build for test_package",
     "tools.cmake:cmake_program": "Path to CMake executable",
     "tools.cmake.cmakedeps:new": "Use the new CMakeDeps generator",
-    "tools.cmake:install_strip": "(Deprecated) Add --strip to cmake.install(). Use tools.build.install:strip instead",
+    "tools.cmake:install_strip": "(Deprecated) Add --strip to cmake.install(). Use tools.build.install_strip instead",
     "tools.deployer:symlinks": "Set to False to disable deployers copying symlinks",
     "tools.files.download:retry": "Number of retries in case of failure when downloading",
     "tools.files.download:retry_wait": "Seconds to wait between download attempts",
@@ -136,7 +136,7 @@ BUILT_IN_CONFS = {
     "tools.build:exelinkflags": "List of extra flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:linker_scripts": "List of linker script files to pass to the linker used by different toolchains like CMakeToolchain, AutotoolsToolchain, and MesonToolchain",
     # Toolchain installation
-    "tools.build.install:strip": "(boolean) Strip the binaries when installing them with CMake and Meson",
+    "tools.build.install_strip": "(boolean) Strip the binaries when installing them with CMake and Meson",
     # Package ID composition
     "tools.info.package_id:confs": "List of existing configuration to be part of the package ID",
 }

--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -86,7 +86,7 @@ BUILT_IN_CONFS = {
     "tools.cmake.cmake_layout:test_folder": "(Experimental) Allow configuring the base folder of the build for test_package",
     "tools.cmake:cmake_program": "Path to CMake executable",
     "tools.cmake.cmakedeps:new": "Use the new CMakeDeps generator",
-    "tools.cmake:install_strip": "(Deprecated) Add --strip to cmake.install(). Use tools.build.install_strip instead",
+    "tools.cmake:install_strip": "(Deprecated) Add --strip to cmake.install(). Use tools.build:install_strip instead",
     "tools.deployer:symlinks": "Set to False to disable deployers copying symlinks",
     "tools.files.download:retry": "Number of retries in case of failure when downloading",
     "tools.files.download:retry_wait": "Seconds to wait between download attempts",
@@ -136,7 +136,7 @@ BUILT_IN_CONFS = {
     "tools.build:exelinkflags": "List of extra flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:linker_scripts": "List of linker script files to pass to the linker used by different toolchains like CMakeToolchain, AutotoolsToolchain, and MesonToolchain",
     # Toolchain installation
-    "tools.build.install_strip": "(boolean) Strip the binaries when installing them with CMake and Meson",
+    "tools.build:install_strip": "(boolean) Strip the binaries when installing them with CMake and Meson",
     # Package ID composition
     "tools.info.package_id:confs": "List of existing configuration to be part of the package ID",
 }

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -215,7 +215,7 @@ class CMake:
                                            "use 'tools.install:strip' instead.")
 
         do_strip = self._conanfile.conf.get("tools.install:strip", check_type=bool)
-        if do_strip:
+        if do_strip or deprecated_install_strip:
             arg_list.append("--strip")
 
         if cli_args:

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -212,9 +212,9 @@ class CMake:
         deprecated_install_strip = self._conanfile.conf.get("tools.cmake:install_strip", check_type=bool)
         if deprecated_install_strip:
             self._conanfile.output.warning("The 'tools.cmake:install_strip' configuration is deprecated, "
-                                           "use 'tools.build.install_strip' instead.", warn_tag="deprecated")
+                                           "use 'tools.build:install_strip' instead.", warn_tag="deprecated")
 
-        do_strip = self._conanfile.conf.get("tools.build.install_strip", check_type=bool)
+        do_strip = self._conanfile.conf.get("tools.build:install_strip", check_type=bool)
         if do_strip or deprecated_install_strip:
             arg_list.append("--strip")
 

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -212,9 +212,9 @@ class CMake:
         deprecated_install_strip = self._conanfile.conf.get("tools.cmake:install_strip", check_type=bool)
         if deprecated_install_strip:
             self._conanfile.output.warning("The 'tools.cmake:install_strip' configuration is deprecated, "
-                                           "use 'tools.install:strip' instead.", warn_tag="deprecated")
+                                           "use 'tools.build.install:strip' instead.", warn_tag="deprecated")
 
-        do_strip = self._conanfile.conf.get("tools.install:strip", check_type=bool)
+        do_strip = self._conanfile.conf.get("tools.build.install:strip", check_type=bool)
         if do_strip or deprecated_install_strip:
             arg_list.append("--strip")
 

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -212,7 +212,7 @@ class CMake:
         deprecated_install_strip = self._conanfile.conf.get("tools.cmake:install_strip", check_type=bool)
         if deprecated_install_strip:
             self._conanfile.output.warning("The 'tools.cmake:install_strip' configuration is deprecated, "
-                                           "use 'tools.install:strip' instead.")
+                                           "use 'tools.install:strip' instead.", warn_tag="deprecated")
 
         do_strip = self._conanfile.conf.get("tools.install:strip", check_type=bool)
         if do_strip or deprecated_install_strip:

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -212,9 +212,9 @@ class CMake:
         deprecated_install_strip = self._conanfile.conf.get("tools.cmake:install_strip", check_type=bool)
         if deprecated_install_strip:
             self._conanfile.output.warning("The 'tools.cmake:install_strip' configuration is deprecated, "
-                                           "use 'tools.build.install:strip' instead.", warn_tag="deprecated")
+                                           "use 'tools.build.install_strip' instead.", warn_tag="deprecated")
 
-        do_strip = self._conanfile.conf.get("tools.build.install:strip", check_type=bool)
+        do_strip = self._conanfile.conf.get("tools.build.install_strip", check_type=bool)
         if do_strip or deprecated_install_strip:
             arg_list.append("--strip")
 

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -209,7 +209,12 @@ class CMake:
             arg_list.extend(["--component", component])
         arg_list.extend(self._compilation_verbosity_arg)
 
-        do_strip = self._conanfile.conf.get("tools.cmake:install_strip", check_type=bool)
+        deprecated_install_strip = self._conanfile.conf.get("tools.cmake:install_strip", check_type=bool)
+        if deprecated_install_strip:
+            self._conanfile.output.warning("The 'tools.cmake:install_strip' configuration is deprecated, "
+                                           "use 'tools.install:strip' instead.")
+
+        do_strip = self._conanfile.conf.get("tools.install:strip", check_type=bool)
         if do_strip:
             arg_list.append("--strip")
 

--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -82,7 +82,7 @@ class Meson(object):
         verbosity = self._install_verbosity
         if verbosity:
             cmd += " " + verbosity
-        if self._conanfile.conf.get("tools.build.install_strip", check_type=bool):
+        if self._conanfile.conf.get("tools.build:install_strip", check_type=bool):
             cmd += " --strip"
         self._conanfile.run(cmd)
 

--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -82,8 +82,8 @@ class Meson(object):
         verbosity = self._install_verbosity
         if verbosity:
             cmd += " " + verbosity
-        if self._install_strip:
-            cmd += " " + self._install_strip
+        if self._conanfile.conf.get("tools.install:strip", check_type=bool):
+            cmd += " --strip"
         self._conanfile.run(cmd)
 
     def test(self):
@@ -113,15 +113,6 @@ class Meson(object):
         # so it's a bit backwards
         verbosity = self._conanfile.conf.get("tools.build:verbosity", choices=("quiet", "verbose"))
         return "--quiet" if verbosity else ""
-
-    @property
-    def _install_strip(self) -> str:
-        """
-        Returns Meson install strip the value based on ``tools.install:strip`` configuration.
-        https://mesonbuild.com/Release-notes-for-0-62-0.html#meson-install-strip
-        """
-        strip = self._conanfile.conf.get("tools.install:strip", check_type=bool)
-        return "--strip" if strip else ""
 
     @property
     def _prefix(self):

--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -82,7 +82,7 @@ class Meson(object):
         verbosity = self._install_verbosity
         if verbosity:
             cmd += " " + verbosity
-        if self._conanfile.conf.get("tools.install:strip", check_type=bool):
+        if self._conanfile.conf.get("tools.build.install:strip", check_type=bool):
             cmd += " --strip"
         self._conanfile.run(cmd)
 

--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -82,7 +82,7 @@ class Meson(object):
         verbosity = self._install_verbosity
         if verbosity:
             cmd += " " + verbosity
-        if self._conanfile.conf.get("tools.build.install:strip", check_type=bool):
+        if self._conanfile.conf.get("tools.build.install_strip", check_type=bool):
             cmd += " --strip"
         self._conanfile.run(cmd)
 

--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -82,6 +82,8 @@ class Meson(object):
         verbosity = self._install_verbosity
         if verbosity:
             cmd += " " + verbosity
+        if self._install_strip:
+            cmd += " " + self._install_strip
         self._conanfile.run(cmd)
 
     def test(self):
@@ -111,6 +113,15 @@ class Meson(object):
         # so it's a bit backwards
         verbosity = self._conanfile.conf.get("tools.build:verbosity", choices=("quiet", "verbose"))
         return "--quiet" if verbosity else ""
+
+    @property
+    def _install_strip(self) -> str:
+        """
+        Returns Meson install strip the value based on ``tools.install:strip`` configuration.
+        https://mesonbuild.com/Release-notes-for-0-62-0.html#meson-install-strip
+        """
+        strip = self._conanfile.conf.get("tools.install:strip", check_type=bool)
+        return "--strip" if strip else ""
 
     @property
     def _prefix(self):

--- a/test/unittests/tools/cmake/test_cmake_install.py
+++ b/test/unittests/tools/cmake/test_cmake_install.py
@@ -42,7 +42,7 @@ def test_run_install_component():
 
 @pytest.mark.parametrize("config, deprecated",
                          [("tools.cmake:install_strip", True),
-                          ("tools.build.install:strip", False),])
+                          ("tools.build.install_strip", False),])
 def test_run_install_strip(config, deprecated):
     """
     Testing that the install/strip rule is called
@@ -75,7 +75,7 @@ def test_run_install_strip(config, deprecated):
 
     if deprecated:
         assert "WARN: deprecated: The 'tools.cmake:install_strip' configuration is deprecated, use"\
-               " 'tools.build.install:strip' instead" in stderr
+               " 'tools.build.install_strip' instead" in stderr
     else:
         assert "tools.cmake:install_strip" not in stderr
     assert "--strip" in conanfile.command

--- a/test/unittests/tools/cmake/test_cmake_install.py
+++ b/test/unittests/tools/cmake/test_cmake_install.py
@@ -39,9 +39,10 @@ def test_run_install_component():
 
     assert "--component foo" in conanfile.command
 
+
 @pytest.mark.parametrize("config, deprecated",
                          [("tools.cmake:install_strip", True),
-                          ("tools.install:strip", False),])
+                          ("tools.build.install:strip", False),])
 def test_run_install_strip(config, deprecated):
     """
     Testing that the install/strip rule is called
@@ -73,8 +74,8 @@ def test_run_install_strip(config, deprecated):
         cmake.install(stdout=stdout, stderr=stderr)
 
     if deprecated:
-        assert "WARN: The 'tools.cmake:install_strip' configuration is deprecated, "\
-                "use 'tools.install:strip' instead." in stderr
+        assert "WARN: deprecated: The 'tools.cmake:install_strip' configuration is deprecated, use"\
+               " 'tools.build.install:strip' instead" in stderr
     else:
         assert "tools.cmake:install_strip" not in stderr
     assert "--strip" in conanfile.command

--- a/test/unittests/tools/cmake/test_cmake_install.py
+++ b/test/unittests/tools/cmake/test_cmake_install.py
@@ -73,12 +73,11 @@ def test_run_install_strip(config, deprecated):
         cmake.install(stdout=stdout, stderr=stderr)
 
     if deprecated:
-        assert "--strip" not in conanfile.command
         assert "WARN: The 'tools.cmake:install_strip' configuration is deprecated, "\
                 "use 'tools.install:strip' instead." in stderr
     else:
-        assert "--strip" in conanfile.command
         assert "tools.cmake:install_strip" not in stderr
+    assert "--strip" in conanfile.command
 
 def test_run_install_cli_args():
     """

--- a/test/unittests/tools/cmake/test_cmake_install.py
+++ b/test/unittests/tools/cmake/test_cmake_install.py
@@ -42,7 +42,7 @@ def test_run_install_component():
 
 @pytest.mark.parametrize("config, deprecated",
                          [("tools.cmake:install_strip", True),
-                          ("tools.build.install_strip", False),])
+                          ("tools.build:install_strip", False),])
 def test_run_install_strip(config, deprecated):
     """
     Testing that the install/strip rule is called
@@ -75,7 +75,7 @@ def test_run_install_strip(config, deprecated):
 
     if deprecated:
         assert "WARN: deprecated: The 'tools.cmake:install_strip' configuration is deprecated, use"\
-               " 'tools.build.install_strip' instead" in stderr
+               " 'tools.build:install_strip' instead" in stderr
     else:
         assert "tools.cmake:install_strip" not in stderr
     assert "--strip" in conanfile.command

--- a/test/unittests/tools/cmake/test_cmake_install.py
+++ b/test/unittests/tools/cmake/test_cmake_install.py
@@ -1,10 +1,14 @@
+import pytest
+
 from conan.internal.default_settings import default_settings_yml
 from conan.tools.cmake import CMake
 from conan.tools.cmake.presets import write_cmake_presets
 from conan.internal.model.conf import Conf
 from conan.internal.model.settings import Settings
-from conan.test.utils.mocks import ConanFileMock
+from conan.test.utils.mocks import ConanFileMock, RedirectedTestOutput
 from conan.test.utils.test_files import temp_folder
+from conan.test.utils.tools import redirect_output
+
 
 
 def test_run_install_component():
@@ -35,8 +39,10 @@ def test_run_install_component():
 
     assert "--component foo" in conanfile.command
 
-
-def test_run_install_strip():
+@pytest.mark.parametrize("config, deprecated",
+                         [("tools.cmake:install_strip", True),
+                          ("tools.install:strip", False),])
+def test_run_install_strip(config, deprecated):
     """
     Testing that the install/strip rule is called
     Issue related: https://github.com/conan-io/conan/issues/14166
@@ -52,7 +58,7 @@ def test_run_install_strip():
     conanfile = ConanFileMock()
 
     conanfile.conf = Conf()
-    conanfile.conf.define("tools.cmake:install_strip", True)
+    conanfile.conf.define(config, True)
 
     conanfile.folders.generators = "."
     conanfile.folders.set_base_generators(temp_folder())
@@ -61,9 +67,18 @@ def test_run_install_strip():
 
     write_cmake_presets(conanfile, "toolchain", "Unix Makefiles", {})
     cmake = CMake(conanfile)
-    cmake.install()
-    assert "--strip" in conanfile.command
+    stdout = RedirectedTestOutput()  # Initialize each command
+    stderr = RedirectedTestOutput()
+    with redirect_output(stderr, stdout):
+        cmake.install(stdout=stdout, stderr=stderr)
 
+    if deprecated:
+        assert "--strip" not in conanfile.command
+        assert "WARN: The 'tools.cmake:install_strip' configuration is deprecated, "\
+                "use 'tools.install:strip' instead." in stderr
+    else:
+        assert "--strip" in conanfile.command
+        assert "tools.cmake:install_strip" not in stderr
 
 def test_run_install_cli_args():
     """

--- a/test/unittests/tools/meson/test_meson.py
+++ b/test/unittests/tools/meson/test_meson.py
@@ -68,11 +68,11 @@ def test_meson_to_cppstd_flag(compiler, compiler_version, cppstd, expected):
 
 
 def test_meson_install_strip():
-    """When the configuration `tools.build.install_strip` is set to True,
+    """When the configuration `tools.build:install_strip` is set to True,
         the Meson install command should include the `--strip` option.
     """
     c = ConfDefinition()
-    c.loads("tools.build.install_strip=True")
+    c.loads("tools.build:install_strip=True")
 
     settings = MockSettings({"build_type": "Release",
                              "compiler": "gcc",

--- a/test/unittests/tools/meson/test_meson.py
+++ b/test/unittests/tools/meson/test_meson.py
@@ -68,11 +68,11 @@ def test_meson_to_cppstd_flag(compiler, compiler_version, cppstd, expected):
 
 
 def test_meson_install_strip():
-    """When the configuration `tools.build.install:strip` is set to True,
+    """When the configuration `tools.build.install_strip` is set to True,
         the Meson install command should include the `--strip` option.
     """
     c = ConfDefinition()
-    c.loads("tools.build.install:strip=True")
+    c.loads("tools.build.install_strip=True")
 
     settings = MockSettings({"build_type": "Release",
                              "compiler": "gcc",

--- a/test/unittests/tools/meson/test_meson.py
+++ b/test/unittests/tools/meson/test_meson.py
@@ -68,11 +68,11 @@ def test_meson_to_cppstd_flag(compiler, compiler_version, cppstd, expected):
 
 
 def test_meson_install_strip():
-    """When the configuration `tools.install:strip` is set to True,
+    """When the configuration `tools.build.install:strip` is set to True,
         the Meson install command should include the `--strip` option.
     """
     c = ConfDefinition()
-    c.loads("tools.install:strip=True")
+    c.loads("tools.build.install:strip=True")
 
     settings = MockSettings({"build_type": "Release",
                              "compiler": "gcc",

--- a/test/unittests/tools/meson/test_meson.py
+++ b/test/unittests/tools/meson/test_meson.py
@@ -5,6 +5,7 @@ import pytest
 from conan.tools.meson import Meson
 from conan.internal.model.conf import ConfDefinition
 from conan.test.utils.mocks import ConanFileMock, MockSettings
+from conan.test.utils.test_files import temp_folder
 from conan.tools.meson.helpers import get_apple_subsystem, to_cstd_flag, to_cppstd_flag
 
 
@@ -64,3 +65,28 @@ def test_meson_to_cstd_flag(cstd, expected):
 ])
 def test_meson_to_cppstd_flag(compiler, compiler_version, cppstd, expected):
     assert to_cppstd_flag(compiler, compiler_version, cppstd) == expected
+
+
+def test_meson_install_strip():
+    """When the configuration `tools.install:strip` is set to True,
+        the Meson install command should include the `--strip` option.
+    """
+    c = ConfDefinition()
+    c.loads("tools.install:strip=True")
+
+    settings = MockSettings({"build_type": "Release",
+                             "compiler": "gcc",
+                             "compiler.version": "7",
+                             "os": "Linux",
+                             "arch": "x86_64"})
+    conanfile = ConanFileMock()
+    conanfile.settings = settings
+    conanfile.conf = c.get_conanfile_conf(None)
+    conanfile.folders.generators = "."
+    conanfile.folders.set_base_generators(temp_folder())
+    conanfile.folders.set_base_package(temp_folder())
+
+    meson = Meson(conanfile)
+    meson.install()
+
+    assert '--strip' in str(conanfile.command)


### PR DESCRIPTION
Hello!

This PR replaces the current config `tools.cmake:install_strip` with the generic `tools.install:strip`, so it can be used by both `CMake` and `Meson`. The `install_strip` is now marked as deprecated and will warn the user with a message.



Changelog: Feature: Replace `tools.cmake:install_strip` by `tools.install:strip`. Affect both CMake and Meson tool helpers.
Docs: https://github.com/conan-io/docs/pull/4121

closes #18308

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
