### PR TITLE
Less verbose text upload

### DIFF
--- a/conan/cli/commands/upload.py
+++ b/conan/cli/commands/upload.py
@@ -23,6 +23,7 @@ def summary_upload_list(results):
                     v.pop("info", None)
                     v.pop("timestamp", None)
                     v.pop("files", None)
+                    v.pop("upload-urls", None)
                     upload_value = v.pop("upload", None)
                     if upload_value is not None:
                         msg = "Uploaded" if upload_value else "Skipped, already in server"

--- a/test/integration/command/upload/upload_test.py
+++ b/test/integration/command/upload/upload_test.py
@@ -571,7 +571,7 @@ def test_upload_json_output():
     }
 
 
-def test_upload_dry_run_json_output():
+def test_upload_dry_run_output():
     c = TestClient(default_server_user=True)
     c.save({"conanfile.py": GenConanfile("liba", "0.1").with_settings("os")
                                                        .with_shared_option(False)})
@@ -606,3 +606,9 @@ def test_upload_dry_run_json_output():
             "checksum": sha1sum(prev["files"]["conanmanifest.txt"])
         }
     }
+
+    # check we don't have anything about the upload-urls in the text formatter
+    c.run("upload * -r=default -c --dry-run")
+    assert "upload-urls" not in c.stdout
+    assert "url:" not in c.stdout
+    assert "checksum:" not in c.stdout


### PR DESCRIPTION
Changelog: Fix: Do not output upload-urls on basic text `conan upload` output.
Docs: Omit

To try to avoid excess of information for a regular conan upload on cli
![image](https://github.com/user-attachments/assets/8318ac8d-18f6-4c49-92e5-11d5ea592d04)

