### PR TITLE
[PkgConfigDeps] Mechanism to skip some `*.pc` files creation

### DIFF
--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -229,7 +229,7 @@ class _PCFilesDeps:
         # First, let's load all the components PC files
         # Loop through all the package's components
         for comp_ref_name, comp_cpp_info in self._dep.cpp_info.get_sorted_components().items():
-            should_skip = self._get_property("pkg_config_skip", self._dep, comp_ref_name, check_type=bool)
+            should_skip = self._get_property("pkg_config_skip", self._dep, comp_ref_name) == "none"
             if should_skip:
                 continue
             # At first, let's check if we have defined some components requires, e.g., "dep::cmp1"
@@ -262,7 +262,7 @@ class _PCFilesDeps:
         # Second, let's load the root package's PC file ONLY
         # if it does not already exist in components one
         # Issue related: https://github.com/conan-io/conan/issues/10341
-        should_skip_main = self._get_property("pkg_config_skip", self._dep, check_type=bool)
+        should_skip_main = self._get_property("pkg_config_name", self._dep) == "none"
         if pkg_name not in pc_files and not should_skip_main:
             cpp_info = self._dep.cpp_info
             # At first, let's check if we have defined some global requires, e.g., "other::cmp1"

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -230,6 +230,9 @@ class _PCFilesDeps:
         # Loop through all the package's components
         for comp_ref_name, comp_cpp_info in self._dep.cpp_info.get_sorted_components().items():
             # At first, let's check if we have defined some components requires, e.g., "dep::cmp1"
+            should_skip = self._get_property("pkg_config_skip", self._dep, comp_ref_name, check_type=bool)
+            if should_skip:
+                continue
             comp_requires = self._get_component_requirement_names(comp_cpp_info)
             comp_name = self._get_name(self._dep, pkg_name, comp_ref_name)
             version = (self._get_property("component_version", self._dep, comp_ref_name) or

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -229,7 +229,7 @@ class _PCFilesDeps:
         # First, let's load all the components PC files
         # Loop through all the package's components
         for comp_ref_name, comp_cpp_info in self._dep.cpp_info.get_sorted_components().items():
-            should_skip = self._get_property("pkg_config_skip", self._dep, comp_ref_name) == "none"
+            should_skip = self._get_property("pkg_config_name", self._dep, comp_ref_name) == "none"
             if should_skip:
                 continue
             # At first, let's check if we have defined some components requires, e.g., "dep::cmp1"

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -235,9 +235,6 @@ class _PCFilesDeps:
                 continue
             # At first, let's check if we have defined some components requires, e.g., "dep::cmp1"
             comp_requires = self._get_component_requirement_names(comp_cpp_info)
-            for req in comp_requires:
-                if not self._get_property("pkg_config_skip", self._dep, req, check_type=bool):
-                    ConanOutput().debug(f"Component {req} is required by {comp_ref_name} but is skipping its .pc file")
             comp_name = self._get_name(self._dep, pkg_name, comp_ref_name)
             version = (self._get_property("component_version", self._dep, comp_ref_name) or
                        self._get_property("system_package_version", self._dep, comp_ref_name) or

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -4,6 +4,7 @@ import textwrap
 
 from jinja2 import Template, StrictUndefined
 
+from conan.api.output import ConanOutput
 from conan.errors import ConanException
 from conan.internal import check_duplicated_generator
 from conan.internal.model.dependencies import get_transitive_requires
@@ -229,11 +230,14 @@ class _PCFilesDeps:
         # First, let's load all the components PC files
         # Loop through all the package's components
         for comp_ref_name, comp_cpp_info in self._dep.cpp_info.get_sorted_components().items():
-            # At first, let's check if we have defined some components requires, e.g., "dep::cmp1"
             should_skip = self._get_property("pkg_config_skip", self._dep, comp_ref_name, check_type=bool)
             if should_skip:
                 continue
+            # At first, let's check if we have defined some components requires, e.g., "dep::cmp1"
             comp_requires = self._get_component_requirement_names(comp_cpp_info)
+            for req in comp_requires:
+                if not self._get_property("pkg_config_skip", self._dep, req, check_type=bool):
+                    ConanOutput().debug(f"Component {req} is required by {comp_ref_name} but is skipping its .pc file")
             comp_name = self._get_name(self._dep, pkg_name, comp_ref_name)
             version = (self._get_property("component_version", self._dep, comp_ref_name) or
                        self._get_property("system_package_version", self._dep, comp_ref_name) or
@@ -262,7 +266,8 @@ class _PCFilesDeps:
         # Second, let's load the root package's PC file ONLY
         # if it does not already exist in components one
         # Issue related: https://github.com/conan-io/conan/issues/10341
-        if pkg_name not in pc_files:
+        should_skip_main = self._get_property("pkg_config_skip", self._dep, check_type=bool)
+        if pkg_name not in pc_files and not should_skip_main:
             cpp_info = self._dep.cpp_info
             # At first, let's check if we have defined some global requires, e.g., "other::cmp1"
             # Note: If DEP has components, they'll be the requirements == pc_files.keys()

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -4,7 +4,6 @@ import textwrap
 
 from jinja2 import Template, StrictUndefined
 
-from conan.api.output import ConanOutput
 from conan.errors import ConanException
 from conan.internal import check_duplicated_generator
 from conan.internal.model.dependencies import get_transitive_requires

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -229,9 +229,6 @@ class _PCFilesDeps:
         # First, let's load all the components PC files
         # Loop through all the package's components
         for comp_ref_name, comp_cpp_info in self._dep.cpp_info.get_sorted_components().items():
-            should_skip = self._get_property("pkg_config_name", self._dep, comp_ref_name) == "none"
-            if should_skip:
-                continue
             # At first, let's check if we have defined some components requires, e.g., "dep::cmp1"
             comp_requires = self._get_component_requirement_names(comp_cpp_info)
             comp_name = self._get_name(self._dep, pkg_name, comp_ref_name)

--- a/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -1278,4 +1278,5 @@ def test_pkg_skip_component():
     b_cmp1_content = tc.load(os.path.join("out", "b-cmp1.pc"))
     assert "Requires:" not in b_cmp1_content
     assert "pkg_c.pc" in install_contents
+    # Components can not skip the PC file creation
     assert "none.pc" in install_contents

--- a/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -1246,7 +1246,7 @@ def test_pkg_skip_component():
             requires = "pkg_a/0.1"
             def package_info(self):
                 self.cpp_info.set_property("pkg_config_name", "none")
-                self.cpp_info.components["cmp1"].libs = []
+                self.cpp_info.components["cmp1"].set_property("pkg_config_name", "b-cmp1")
         """)
 
     conanfile_c = textwrap.dedent("""
@@ -1270,6 +1270,6 @@ def test_pkg_skip_component():
     install_contents = os.listdir(os.path.join(tc.current_folder, "out"))
     assert "pkg_a.pc" not in install_contents
     assert "pkg_b.pc" not in install_contents
-    assert "pkg_b-cmp1.pc" in install_contents
+    assert "b-cmp1.pc" in install_contents
     assert "pkg_c.pc" in install_contents
     assert "pkg_c-cmp2.pc" not in install_contents

--- a/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -1236,7 +1236,7 @@ def test_pkg_skip_component():
             name = "pkg_a"
             version = "0.1"
             def package_info(self):
-                self.cpp_info.set_property("pkg_config_skip", True)
+                self.cpp_info.set_property("pkg_config_name", "none")
         """)
     conanfile_b = textwrap.dedent("""
         from conan import ConanFile
@@ -1245,7 +1245,7 @@ def test_pkg_skip_component():
             version = "0.1"
             requires = "pkg_a/0.1"
             def package_info(self):
-                self.cpp_info.set_property("pkg_config_skip", True)
+                self.cpp_info.set_property("pkg_config_name", "none")
                 self.cpp_info.components["cmp1"].libs = []
         """)
 
@@ -1256,7 +1256,7 @@ def test_pkg_skip_component():
                 version = "0.1"
                 requires = "pkg_b/0.1"
                 def package_info(self):
-                    self.cpp_info.components["cmp2"].set_property("pkg_config_skip", True)
+                    self.cpp_info.components["cmp2"].set_property("pkg_config_name", "none")
             """)
     tc = TestClient(light=True)
     tc.save({"a/conanfile.py": conanfile_a,

--- a/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -1228,3 +1228,48 @@ def test_pkg_with_duplicated_component_requires():
     pc_content = client.load("mylib-myfirstcomp.pc")
     assert "Requires: mylib-mycomponent" == get_requires_from_content(pc_content)
 
+
+def test_pkg_skip_component():
+    conanfile_a = textwrap.dedent("""
+        from conan import ConanFile
+        class PkgConfigConan(ConanFile):
+            name = "pkg_a"
+            version = "0.1"
+            def package_info(self):
+                self.cpp_info.set_property("pkg_config_skip", True)
+        """)
+    conanfile_b = textwrap.dedent("""
+        from conan import ConanFile
+        class PkgConfigConan(ConanFile):
+            name = "pkg_b"
+            version = "0.1"
+            requires = "pkg_a/0.1"
+            def package_info(self):
+                self.cpp_info.set_property("pkg_config_skip", True)
+                self.cpp_info.components["cmp1"].libs = []
+        """)
+
+    conanfile_c = textwrap.dedent("""
+            from conan import ConanFile
+            class PkgConfigConan(ConanFile):
+                name = "pkg_c"
+                version = "0.1"
+                requires = "pkg_b/0.1"
+                def package_info(self):
+                    self.cpp_info.components["cmp2"].set_property("pkg_config_skip", True)
+            """)
+    tc = TestClient(light=True)
+    tc.save({"a/conanfile.py": conanfile_a,
+             "b/conanfile.py": conanfile_b,
+             "c/conanfile.py": conanfile_c})
+    tc.run("create a")
+    tc.run("create b")
+    tc.run("create c")
+
+    tc.run("install --requires=pkg_c/0.1 --generator=PkgConfigDeps -of=out")
+    install_contents = os.listdir(os.path.join(tc.current_folder, "out"))
+    assert "pkg_a.pc" not in install_contents
+    assert "pkg_b.pc" not in install_contents
+    assert "pkg_b-cmp1.pc" in install_contents
+    assert "pkg_c.pc" in install_contents
+    assert "pkg_c-cmp2.pc" not in install_contents

--- a/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -1245,7 +1245,6 @@ def test_pkg_skip_component():
             version = "0.1"
             requires = "pkg_a/0.1"
             def package_info(self):
-                self.cpp_info.set_property("pkg_config_name", "none")
                 self.cpp_info.components["cmp1"].set_property("pkg_config_name", "b-cmp1")
         """)
 
@@ -1269,7 +1268,14 @@ def test_pkg_skip_component():
     tc.run("install --requires=pkg_c/0.1 --generator=PkgConfigDeps -of=out")
     install_contents = os.listdir(os.path.join(tc.current_folder, "out"))
     assert "pkg_a.pc" not in install_contents
-    assert "pkg_b.pc" not in install_contents
+    assert "pkg_b.pc" in install_contents
+    pkg_b_content = tc.load(os.path.join("out", "pkg_b.pc"))
+    pkg_b_requires = get_requires_from_content(pkg_b_content)
+    assert "b-cmp1" in pkg_b_requires
+    assert "pkg_a" not in pkg_b_requires
+    assert "none" not in pkg_b_requires
     assert "b-cmp1.pc" in install_contents
+    b_cmp1_content = tc.load(os.path.join("out", "b-cmp1.pc"))
+    assert "Requires:" not in b_cmp1_content
     assert "pkg_c.pc" in install_contents
     assert "none.pc" in install_contents

--- a/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -1272,4 +1272,4 @@ def test_pkg_skip_component():
     assert "pkg_b.pc" not in install_contents
     assert "b-cmp1.pc" in install_contents
     assert "pkg_c.pc" in install_contents
-    assert "pkg_c-cmp2.pc" not in install_contents
+    assert "none.pc" in install_contents


### PR DESCRIPTION
Changelog: Feature: Using `pkg_config_name = 'none'` to skip the `*.pc` file creation.
Docs: https://github.com/conan-io/docs/pull/4135

So that we can stop using private names for PC files that are not supposed to be used.

This is only possible after @franramirez688 refactor of this code
