### PR TITLE
Add build_folder parameter in basic_layout

### DIFF
--- a/conan/tools/layout/__init__.py
+++ b/conan/tools/layout/__init__.py
@@ -1,13 +1,16 @@
 import os
 
 
-def basic_layout(conanfile, src_folder="."):
+def basic_layout(conanfile, src_folder=".", build_folder=None):
     subproject = conanfile.folders.subproject
 
     conanfile.folders.source = src_folder if not subproject else os.path.join(subproject, src_folder)
-    conanfile.folders.build = "build" if not subproject else os.path.join(subproject, "build")
-    if conanfile.settings.get_safe("build_type"):
-        conanfile.folders.build += "-{}".format(str(conanfile.settings.build_type).lower())
+    if build_folder:
+        conanfile.folders.build = build_folder
+    else:
+        conanfile.folders.build = "build" if not subproject else os.path.join(subproject, "build")
+        if conanfile.settings.get_safe("build_type"):
+            conanfile.folders.build += "-{}".format(str(conanfile.settings.build_type).lower())
     conanfile.folders.generators = os.path.join(conanfile.folders.build, "conan")
     conanfile.cpp.build.bindirs = ["."]
     conanfile.cpp.build.libdirs = ["."]

--- a/conan/tools/layout/__init__.py
+++ b/conan/tools/layout/__init__.py
@@ -6,7 +6,7 @@ def basic_layout(conanfile, src_folder=".", build_folder=None):
 
     conanfile.folders.source = src_folder if not subproject else os.path.join(subproject, src_folder)
     if build_folder:
-        conanfile.folders.build = build_folder
+        conanfile.folders.build = build_folder if not subproject else os.path.join(subproject, build_folder)
     else:
         conanfile.folders.build = "build" if not subproject else os.path.join(subproject, "build")
         if conanfile.settings.get_safe("build_type"):

--- a/test/integration/toolchains/gnu/test_basic_layout.py
+++ b/test/integration/toolchains/gnu/test_basic_layout.py
@@ -1,13 +1,16 @@
 import os
 import platform
 import textwrap
+import pytest
 
 from conan.test.utils.tools import TestClient
 
-
-def test_basic_layout_subproject():
+@pytest.mark.parametrize("basic_layout, expected_path", [
+    ('basic_layout(self)', 'build-release'),
+    ('basic_layout(self, build_folder="custom_build_folder")', 'custom_build_folder')])
+def test_basic_layout_subproject(basic_layout, expected_path):
     c = TestClient()
-    conanfile = textwrap.dedent("""
+    conanfile = textwrap.dedent(f"""
         from conan import ConanFile
         from conan.tools.layout import basic_layout
         class Pkg(ConanFile):
@@ -16,10 +19,10 @@ def test_basic_layout_subproject():
             def layout(self):
                 self.folders.root = ".."
                 self.folders.subproject = "pkg"
-                basic_layout(self)
+                {basic_layout}
         """)
     c.save({"pkg/conanfile.py": conanfile})
     c.run("install pkg")
     ext = "sh" if platform.system() != "Windows" else "bat"
-    assert os.path.isfile(os.path.join(c.current_folder, "pkg", "build-release", "conan",
+    assert os.path.isfile(os.path.join(c.current_folder, "pkg", expected_path, "conan",
                                        "conanautotoolstoolchain.{}".format(ext)))


### PR DESCRIPTION
Changelog: Feature: Add `build_folder` parameter in `basic_layout`.
Docs: https://github.com/conan-io/docs/pull/4140

close: https://github.com/conan-io/conan/issues/17315

The `basic_layout` does not have a parameter to change the destination folder of the build. It is always forced to be `./build-"build_type"`. This parameter would allow not only renaming the destination folder but also, by changing the full path, it would enable compiling outside of the source folder.




