### PR TITLE
[fix] Add support for Git tree-less repository when getting the URL

### DIFF
--- a/conan/tools/scm/git.py
+++ b/conan/tools/scm/git.py
@@ -69,7 +69,7 @@ class Git:
         except Exception as e:
             raise ConanException("Unable to get git commit in '%s': %s" % (self.folder, str(e)))
 
-    def get_remote_url(self, remote="origin"):
+    def get_remote_url(self, remote="origin") -> str:
         """
         Obtains the URL of the remote git remote repository, with ``git remote -v``
 
@@ -93,6 +93,7 @@ class Git:
                 if os.path.exists(url):  # Windows local directory
                     url = url.replace("\\", "/")
                 return url
+        return ""
 
     def commit_in_remote(self, commit, remote="origin"):
         """

--- a/conan/tools/scm/git.py
+++ b/conan/tools/scm/git.py
@@ -89,7 +89,7 @@ class Git:
             if name == remote:
                 url, _ = url.rsplit(None, 1)
                 if "(" in url: # if the url still has (fetch) or (push) at the end
-                    url = url[:url.index("(")-1]
+                    url, _ = url.rsplit(None, 1)
                 if os.path.exists(url):  # Windows local directory
                     url = url.replace("\\", "/")
                 return url

--- a/conan/tools/scm/git.py
+++ b/conan/tools/scm/git.py
@@ -88,6 +88,8 @@ class Git:
             name, url = r.split(maxsplit=1)
             if name == remote:
                 url, _ = url.rsplit(None, 1)
+                if "(" in url: # if the url still has (fetch) or (push) at the end
+                    url = url[:url.index("(")-1]
                 if os.path.exists(url):  # Windows local directory
                     url = url.replace("\\", "/")
                 return url

--- a/conan/tools/scm/git.py
+++ b/conan/tools/scm/git.py
@@ -69,7 +69,7 @@ class Git:
         except Exception as e:
             raise ConanException("Unable to get git commit in '%s': %s" % (self.folder, str(e)))
 
-    def get_remote_url(self, remote="origin") -> str:
+    def get_remote_url(self, remote="origin"):
         """
         Obtains the URL of the remote git remote repository, with ``git remote -v``
 
@@ -88,12 +88,12 @@ class Git:
             name, url = r.split(maxsplit=1)
             if name == remote:
                 url, _ = url.rsplit(None, 1)
-                if "(" in url: # if the url still has (fetch) or (push) at the end
+                # if the url still has (fetch) or (push) at the end
+                if url.endswith("(fetch)") or url.endswith("(push)"):
                     url, _ = url.rsplit(None, 1)
                 if os.path.exists(url):  # Windows local directory
                     url = url.replace("\\", "/")
                 return url
-        return ""
 
     def commit_in_remote(self, commit, remote="origin"):
         """

--- a/test/functional/tools/scm/test_git.py
+++ b/test/functional/tools/scm/test_git.py
@@ -1274,6 +1274,8 @@ class TestGitTreelessRemote:
                 git = Git(self)
                 git.clone(url="{url}", args=["--filter=tree:0"], target="target")
                 git.folder = "target"
+                cloned_url = git.run("remote -v")
+                self.output.info("git remote: %s ===" % cloned_url)
                 cloned_url = git.get_remote_url()
                 self.output.info("get_remote_url(): %s ===" % cloned_url)
         """)
@@ -1285,11 +1287,29 @@ class TestGitTreelessRemote:
 
         Validate the issue https://github.com/conan-io/conan/issues/18415
         """
-        repository = temp_folder()
-        url, commit = create_local_git_repo(files={"README": "Hello"}, folder=repository)
+        repository = temp_folder(path_with_spaces=False)
+        url, commit = create_local_git_repo(files={"README": "Lumen naturale ratum est"},
+                                            folder=repository)
 
         client = TestClient()
         client.save({"conanfile.py": self.conanfile.format(url=url)})
         client.run("export .")
+        # We expect [tree:0] for regular git remote command. Requires Git +2.43
+        assert f"git remote: origin\t{url} (fetch) [tree:0]" in client.out
+        # Then get_remote_url filters it to only the URL
+        assert f"get_remote_url(): {url} ===" in client.out
 
+    def test_treeless_clone_with_parenthesis(self):
+        """
+        Windows can use C:\Program Files (x86) path, which contains parenthesis.
+        As the URL will have (fetch) or (push), get_remote_url() should be able to parse it.
+        """
+        repository = os.path.join(temp_folder(), "Program Files (x86)", "myrepo")
+        os.makedirs(repository)
+        url, commit = create_local_git_repo(files={"README": "Pacem in maribus."},
+                                            folder=repository)
+
+        client = TestClient()
+        client.save({"conanfile.py": self.conanfile.format(url=url)})
+        client.run("export .")
         assert f"get_remote_url(): {url} ===" in client.out

--- a/test/functional/tools/scm/test_git.py
+++ b/test/functional/tools/scm/test_git.py
@@ -1253,3 +1253,43 @@ class TestGitShallowTagClone:
             assert "pkg/0.1: URL: {}".format(url) in c.out
             assert "pkg/0.1: COMMIT IN REMOTE: False" in c.out
             assert "pkg/0.1: DIRTY: False" in c.out
+
+
+@pytest.mark.tool("git")
+class TestGitTreelessRemote:
+
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.scm import Git
+        import os
+
+        class Pkg(ConanFile):
+            name = "pkg"
+            version = "0.1"
+
+            def layout(self):
+                self.folders.source = "source"
+
+            def export(self):
+                git = Git(self)
+                git.clone(url="{url}", args=["--filter=tree:0"], target="target")
+                git.folder = "target"
+                cloned_url = git.get_remote_url()
+                self.output.info("get_remote_url(): %s ===" % cloned_url)
+        """)
+
+    def test_treeless_clone(self):
+        """
+        When cloning a git repository with the `--filter=tree:0` option,
+        the Git.get_remote_url() should only the URL of the repository.
+
+        Validate the issue https://github.com/conan-io/conan/issues/18415
+        """
+        repository = temp_folder()
+        url, commit = create_local_git_repo(files={"README": "Hello"}, folder=repository)
+
+        client = TestClient()
+        client.save({"conanfile.py": self.conanfile.format(url=url)})
+        client.run("export .")
+
+        assert f"get_remote_url(): {url} ===" in client.out


### PR DESCRIPTION
Hello! :wave:

This PR addresses the reported bug #18415, when using a Git repository with the tree-less feature.

In the reported issue, it was commented to use `strip` instead of `rstrip` as originally designed in the PR #10594. That original PR has no explicit motivation of using `rstrip`, but it suggests when having a git URL which contains spaces (that's possible for local repositories), the `rstrip` will preserve all whitespace, but when using `strip`, it will cut the path on the first whitespace, which will be a bug. 

I added the test `test_treeless_clone` to exemplify the reported case. In case replacing `rsplit` by `split`, the test will fail due to the whitespace in the URL. 

~My suggested fix is to look for parentheses, because they are not valid in a URL (IINM), then remove that content from the URL.~

EDIT: Windows has C:/Program Files (x86) which will break in case only looking for parentheses as pointed by Memsharded. To improve the check, it will be better looking for explicit words (fetch) and (push) 

Changelog: Fix: `Git.get_remote_url` now returns only the URL when using treeless repository.
Docs: Omit

fixes #18415

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
