### PR TITLE
Fix: parse -cc args when running "conan cache backup-upload"

### DIFF
--- a/conan/cli/commands/cache.py
+++ b/conan/cli/commands/cache.py
@@ -187,5 +187,6 @@ def cache_backup_upload(conan_api: ConanAPI, parser, subparser, *args):
     """
     Upload all the source backups present in the cache
     """
+    args = parser.parse_args(*args)
     files = conan_api.cache.get_backup_sources()
     conan_api.upload.upload_backup_sources(files)


### PR DESCRIPTION
Changelog: Bugfix: Fix conan cache backup-upload ignoring `-cc` arguments.
Docs: Omit

Related issue: [https://github.com/conan-io/conan/issues/18446](https://github.com/conan-io/conan/issues/18446)

- [OK] Refer to the issue that supports this Pull Request.
- [OK] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [OK] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [OK] I've followed the PEP8 style guides for Python code.
- [This is fix the behavior to comply with the current docs] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
