### PR TITLE
fix issue with missing folder in local-recipes-index

### DIFF
--- a/conan/internal/rest/remote_manager.py
+++ b/conan/internal/rest/remote_manager.py
@@ -277,9 +277,9 @@ class RemoteManager:
         if remote.disabled and enforce_disabled:
             raise ConanException("Remote '%s' is disabled" % remote.name)
         local_folder_remote = self._local_folder_remote(remote)
-        if local_folder_remote is not None:
-            return local_folder_remote.call_method(method, *args, **kwargs)
         try:
+            if local_folder_remote is not None:
+                return local_folder_remote.call_method(method, *args, **kwargs)
             return self._auth_manager.call_rest_api_method(remote, method, *args, **kwargs)
         except ConnectionError as exc:
             raise ConanConnectionError(("%s\n\nUnable to connect to remote %s=%s\n"

--- a/conan/internal/rest/rest_client_local_recipe_index.py
+++ b/conan/internal/rest/rest_client_local_recipe_index.py
@@ -199,6 +199,9 @@ class _LocalRecipesIndexLayout:
     def get_recipes_references(self, pattern):
         name_pattern = pattern.split("/", 1)[0]
         recipes_dir = os.path.join(self._base_folder, "recipes")
+        if not os.path.isdir(recipes_dir):
+            raise ConnectionError("Cannot connect to 'local-recipes-index' repository, missing "
+                                  f"'recipes' folder: {recipes_dir}")
         recipes = os.listdir(recipes_dir)
         recipes.sort()
         ret = []

--- a/test/integration/remote/test_local_recipes_index.py
+++ b/test/integration/remote/test_local_recipes_index.py
@@ -391,6 +391,16 @@ class TestErrorsUx:
         c.run("install --requires=zlib/0.1@myuser/mychannel")
         c.assert_listed_require({"zlib/0.1@myuser/mychannel": "Downloaded (default)"})
 
+    def test_errors_missing_folder(self):
+        folder = temp_folder()
+        repo = os.path.join(folder, "repo")
+        mkdir(repo)
+        c = TestClient(light=True)
+        c.run(f"remote add local '{repo}'")
+        # shutil.rmtree(repo)
+        c.run("install --requires=zlib/[*] --build missing", assert_error=True)
+        assert "Cannot connect to 'local-recipes-index' repository, missing 'recipes'" in c.out
+
 
 class TestPythonRequires:
     @pytest.fixture(scope="class")


### PR DESCRIPTION
Changelog: Fix: Fix issue with missing folder in local-recipes-index.
Docs: Omit

Just avoid ugly stacktrace difficult to understand, and provide a clear error message. This happens if you have a "local-recipes-index" remote defined, and remove that folder, and use version-ranges


