### PR TITLE
`conan export-pkg` now correctly passes a `str` as the conanfile version

### DIFF
--- a/conan/cli/commands/export_pkg.py
+++ b/conan/cli/commands/export_pkg.py
@@ -59,7 +59,7 @@ def export_pkg(conan_api, parser, *args):
 
     # TODO: Maybe we want to be able to export-pkg it as --build-require
     deps_graph = conan_api.graph.load_graph_consumer(path,
-                                                     ref.name, ref.version, ref.user, ref.channel,
+                                                     ref.name, str(ref.version), ref.user, ref.channel,
                                                      profile_host=profile_host,
                                                      profile_build=profile_build,
                                                      lockfile=lockfile, remotes=remotes, update=None,

--- a/test/integration/command/export_pkg_test.py
+++ b/test/integration/command/export_pkg_test.py
@@ -280,6 +280,19 @@ class TestConan(ConanFile):
         cmakeinfo = client.load("hello1-release-data.cmake")
         self.assertIn("set(hello1_LIBS_RELEASE mycoollib)", cmakeinfo)
 
+    def test_export_pkg_version_type(self):
+        client = TestClient(light=True)
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            class Hello(ConanFile):
+                def requirements(self):
+                    assert type(self.version) is str, "Version should be a string"
+            """)
+        client.save({"conanfile.py": conanfile})
+        client.run("create . --name=hello --version=0.1")
+        # This used to trigger the assertion error
+        client.run("export-pkg . --name=hello --version=0.1")
+
     def test_export_pkg_json(self):
         client = TestClient()
         client.save({"conanfile.py": GenConanfile("pkg", "0.1")})


### PR DESCRIPTION
Changelog: Bugfix: `conan export-pkg` now correctly passes a `str` as the conanfile version.
Docs: Omit

This is in line with the rest of the calls that use the str coming from the CLI args instead of a reference's `Version`

Closes https://github.com/conan-io/conan/issues/18454