### PR TITLE
refactoring graph node.dependencies->node.edges

### DIFF
--- a/conan/api/subapi/config.py
+++ b/conan/api/subapi/config.py
@@ -66,11 +66,11 @@ class ConfigAPI:
 
         # Basic checks of the package: correct package_type and no-dependencies
         deps_graph.report_graph_error()
-        pkg = deps_graph.root.dependencies[0].dst
+        pkg = deps_graph.root.edges[0].dst
         ConanOutput().info(f"Configuration from package: {pkg}")
         if pkg.conanfile.package_type is not PackageType.CONF:
             raise ConanException(f'{pkg.conanfile} is not of package_type="configuration"')
-        if pkg.dependencies:
+        if pkg.edges:
             raise ConanException(f"Configuration package {pkg.ref} cannot have dependencies")
 
         # The computation of the "package_id" and the download of the package is done as usual

--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -107,8 +107,8 @@ def create(conan_api, parser, *args):
         if args.test_folder is None else args.test_folder
     test_conanfile_path = _get_test_conanfile_path(test_package_folder, path)
     # If the user provide --test-missing and the binary was not built from source, skip test_package
-    if args.test_missing and deps_graph.root.dependencies\
-            and deps_graph.root.dependencies[0].dst.binary != "Build":
+    if args.test_missing and deps_graph.root.edges\
+            and deps_graph.root.edges[0].dst.binary != "Build":
         test_conanfile_path = None  # disable it
 
     if test_conanfile_path:

--- a/conan/internal/graph/graph.py
+++ b/conan/internal/graph/graph.py
@@ -61,13 +61,13 @@ class Node:
 
         # real graph model
         self.transitive_deps = OrderedDict()  # of _TransitiveRequirement
-        self.dependencies = []  # Ordered Edges
+        self.edges = []  # Ordered Edges
         self.dependants = []  # Edges
         self.error = None
         self.should_build = False  # If the --build or policy wants to build this binary
         self.build_allowed = False
         self.is_conf = False
-        self.replaced_requires = {}  # To track the replaced requires for self.dependencies[old-ref]
+        self.replaced_requires = {}  # To track the replaced requires for self.edges[old-ref]
         self.skipped_build_requires = False
 
     def subgraph(self):
@@ -233,12 +233,12 @@ class Node:
 
     def add_edge(self, edge):
         if edge.src == self:
-            self.dependencies.append(edge)
+            self.edges.append(edge)
         else:
             self.dependants.append(edge)
 
     def neighbors(self):
-        return [edge.dst for edge in self.dependencies]
+        return [edge.dst for edge in self.edges]
 
     def inverse_neighbors(self):
         return [edge.src for edge in self.dependants]

--- a/conan/internal/graph/graph_binaries.py
+++ b/conan/internal/graph/graph_binaries.py
@@ -48,8 +48,8 @@ class GraphBinariesAnalyzer:
         with_deps_to_build = False
         # check dependencies, if they are being built, "cascade" will try to build this one too
         if build_mode.cascade:
-            with_deps_to_build = any(dep.dst.binary in (BINARY_BUILD, BINARY_EDITABLE_BUILD)
-                                     for dep in node.dependencies)
+            with_deps_to_build = any(edge.dst.binary in (BINARY_BUILD, BINARY_EDITABLE_BUILD)
+                                     for edge in node.edges)
         if build_mode.forced(conanfile, ref, with_deps_to_build):
             node.should_build = True
             conanfile.output.info('Forced build from source')

--- a/conan/internal/graph/install_graph.py
+++ b/conan/internal/graph/install_graph.py
@@ -171,7 +171,7 @@ class _InstallRecipeReference:
             install_pkg_ref = _InstallPackageReference.create(node)
             self.packages[node.package_id] = install_pkg_ref
 
-        for dep in node.dependencies:
+        for dep in node.edges:
             if dep.dst.binary != BINARY_SKIP:
                 if dep.dst.ref == node.ref:  # If the node is itself, then it is internal dep
                     install_pkg_ref.depends.append(dep.dst.pref.package_id)
@@ -270,7 +270,7 @@ class _InstallConfiguration:
         result.info = node.conanfile.info.serialize()
 
         result.nodes.append(node)
-        for dep in node.dependencies:
+        for dep in node.edges:
             if dep.dst.binary != BINARY_SKIP:
                 if dep.dst.pref not in result.depends:
                     result.depends.append(dep.dst.pref)
@@ -284,10 +284,10 @@ class _InstallConfiguration:
         # assert self.context == node.context
         self.nodes.append(node)
 
-        for dep in node.dependencies:
-            if dep.dst.binary != BINARY_SKIP:
-                if dep.dst.pref not in self.depends:
-                    self.depends.append(dep.dst.pref)
+        for edge in node.edges:
+            if edge.dst.binary != BINARY_SKIP:
+                if edge.dst.pref not in self.depends:
+                    self.depends.append(edge.dst.pref)
 
     def _build_args(self):
         if self.binary not in (BINARY_BUILD, BINARY_EDITABLE_BUILD):

--- a/conan/tools/sbom/cyclonedx.py
+++ b/conan/tools/sbom/cyclonedx.py
@@ -41,7 +41,7 @@ def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, **kwar
     if has_special_root_node:
         deps = {"ref": special_id,
                 "dependsOn": [f"pkg:conan/{d.dst.name}@{d.dst.ref.version}?rref={d.dst.ref.revision}"
-                              for d in graph.root.edge]}
+                              for d in graph.root.edges]}
         dependencies.append(deps)
     for c in nodes:
         deps = {"ref": f"pkg:conan/{c.name}@{c.ref.version}?rref={c.ref.revision}"}

--- a/conan/tools/sbom/cyclonedx.py
+++ b/conan/tools/sbom/cyclonedx.py
@@ -41,11 +41,11 @@ def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, **kwar
     if has_special_root_node:
         deps = {"ref": special_id,
                 "dependsOn": [f"pkg:conan/{d.dst.name}@{d.dst.ref.version}?rref={d.dst.ref.revision}"
-                              for d in graph.root.dependencies]}
+                              for d in graph.root.edge]}
         dependencies.append(deps)
     for c in nodes:
         deps = {"ref": f"pkg:conan/{c.name}@{c.ref.version}?rref={c.ref.revision}"}
-        dep = [d for d in c.dependencies if (d.dst.context == "host" or add_build) and (not d.dst.test or add_tests)]
+        dep = [d for d in c.edges if (d.dst.context == "host" or add_build) and (not d.dst.test or add_tests)]
 
         depends_on = [f"pkg:conan/{d.dst.name}@{d.dst.ref.version}?rref={d.dst.ref.revision}" for d in dep]
         if depends_on:
@@ -132,11 +132,11 @@ def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, **kwar
     if has_special_root_node:
         deps = {"ref": special_id,
                 "dependsOn": [f"pkg:conan/{d.dst.name}@{d.dst.ref.version}?rref={d.dst.ref.revision}"
-                              for d in graph.root.dependencies]}
+                              for d in graph.root.edges]}
         dependencies.append(deps)
     for c in nodes:
         deps = {"ref": f"pkg:conan/{c.name}@{c.ref.version}?rref={c.ref.revision}"}
-        dep = [d for d in c.dependencies if (d.dst.context == "host" or add_build) and (not d.dst.test or add_tests)]
+        dep = [d for d in c.edges if (d.dst.context == "host" or add_build) and (not d.dst.test or add_tests)]
 
         depends_on = [f"pkg:conan/{d.dst.name}@{d.dst.ref.version}?rref={d.dst.ref.revision}" for d in dep]
         if depends_on:

--- a/test/integration/graph/core/graph_manager_base.py
+++ b/test/integration/graph/core/graph_manager_base.py
@@ -134,7 +134,7 @@ class GraphManagerTest(unittest.TestCase):
         if conanfile:
             self.assertEqual(conanfile.name, ref.name)
 
-        self.assertEqual(len(node.dependencies), len(deps))
+        self.assertEqual(len(node.edges), len(deps))
         for d in node.neighbors():
             assert d in deps
 

--- a/test/integration/graph/core/graph_manager_test.py
+++ b/test/integration/graph/core/graph_manager_test.py
@@ -38,7 +38,7 @@ class TestLinear(GraphManagerTest):
 
         self.assertEqual(2, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
+        libb = app.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libb])
         self._check_node(libb, "libb/0.1#123", deps=[], dependents=[app])
@@ -66,8 +66,8 @@ class TestLinear(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libb])
         self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
@@ -90,8 +90,8 @@ class TestLinear(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libb])
         self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
@@ -112,8 +112,8 @@ class TestLinear(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = libb.edges[0].dst
 
         for r, t in libb.transitive_deps.items():
             assert r.package_id_mode == "minor_mode"
@@ -139,8 +139,8 @@ class TestLinear(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libb])
         self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
@@ -161,8 +161,8 @@ class TestLinear(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libb])
         self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
@@ -187,8 +187,8 @@ class TestLinear(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libb])
         self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
@@ -210,8 +210,8 @@ class TestLinear(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libb])
         self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
@@ -234,8 +234,8 @@ class TestLinear(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libb])
         self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
@@ -256,8 +256,8 @@ class TestLinear(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libb])
         self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
@@ -280,8 +280,8 @@ class TestLinear(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libb])
         self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
@@ -303,8 +303,8 @@ class TestLinear(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libb])
         self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
@@ -335,8 +335,8 @@ class TestLinear(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = libb.edges[0].dst
 
         # node, headers, lib, build, run
         _check_transitive(app, [(libb, True, True, False, False)])
@@ -354,7 +354,7 @@ class TestLinear(GraphManagerTest):
 
         self.assertEqual(2, len(deps_graph.nodes))
         app = deps_graph.root
-        cmake = app.dependencies[0].dst
+        cmake = app.edges[0].dst
 
         # node, headers, lib, build, run
         run = package_type in ("application", "shared-library", "build-scripts")
@@ -369,7 +369,7 @@ class TestLinear(GraphManagerTest):
 
         self.assertEqual(2, len(deps_graph.nodes))
         app = deps_graph.root
-        liba = app.dependencies[0].dst
+        liba = app.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[liba])
         self._check_node(liba, "liba/0.1#123", dependents=[app])
@@ -388,8 +388,8 @@ class TestLinear(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libb])
         self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
@@ -413,9 +413,9 @@ class TestLinear(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        liba = app.dependencies[0].dst
-        libb = liba.dependencies[0].dst
-        libc = liba.dependencies[1].dst
+        liba = app.edges[0].dst
+        libb = liba.edges[0].dst
+        libc = liba.edges[1].dst
 
         self._check_node(app, "app/0.1", deps=[liba])
         self._check_node(liba, "liba/0.1#123", deps=[libb, libc], dependents=[app])
@@ -444,10 +444,10 @@ class TestLinear(GraphManagerTest):
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
-        libd = app.dependencies[0].dst
-        liba = libd.dependencies[0].dst
-        libb = liba.dependencies[0].dst
-        libc = liba.dependencies[1].dst
+        libd = app.edges[0].dst
+        liba = libd.edges[0].dst
+        libb = liba.edges[0].dst
+        libc = liba.edges[1].dst
 
         self._check_node(app, "app/0.1", deps=[libd])
         self._check_node(libd, "libd/0.1#123", deps=[liba], dependents=[app])
@@ -481,10 +481,10 @@ class TestLinear(GraphManagerTest):
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
-        libd = app.dependencies[0].dst
-        liba = libd.dependencies[0].dst
-        libb = liba.dependencies[0].dst
-        libc = liba.dependencies[1].dst
+        libd = app.edges[0].dst
+        liba = libd.edges[0].dst
+        libb = liba.edges[0].dst
+        libc = liba.edges[1].dst
 
         self._check_node(app, "app/0.1", deps=[libd])
         self._check_node(libd, "libd/0.1#123", deps=[liba], dependents=[app])
@@ -518,9 +518,9 @@ class TestLinear(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libc = app.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libc = app.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libc])
         self._check_node(libc, "libc/0.1#123", deps=[libb], dependents=[app])
@@ -545,9 +545,9 @@ class TestLinearFourLevels(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libc = app.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libc = app.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libc])
         self._check_node(libc, "libc/0.1#123", deps=[libb], dependents=[app])
@@ -571,9 +571,9 @@ class TestLinearFourLevels(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libc = app.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libc = app.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libc])
         self._check_node(libc, "libc/0.1#123", deps=[libb], dependents=[app])
@@ -607,9 +607,9 @@ class TestLinearFourLevels(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libc = app.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libc = app.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libc])
         self._check_node(libc, "libc/0.1#123", deps=[libb], dependents=[app])
@@ -643,9 +643,9 @@ class TestLinearFourLevels(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libc = app.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libc = app.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libc])
         self._check_node(libc, "libc/0.1#123", deps=[libb], dependents=[app])
@@ -678,9 +678,9 @@ class TestLinearFourLevels(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libc = app.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libc = app.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libc])
         self._check_node(libc, "libc/0.1#123", deps=[libb], dependents=[app])
@@ -711,9 +711,9 @@ class TestLinearFourLevels(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libc = app.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libc = app.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libc])
         self._check_node(libc, "libc/0.1#123", deps=[libb], dependents=[app])
@@ -745,9 +745,9 @@ class TestLinearFourLevels(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libc = app.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libc = app.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libc])
         self._check_node(libc, "libc/0.1#123", deps=[libb], dependents=[app])
@@ -780,9 +780,9 @@ class TestLinearFourLevels(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libc = app.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libc = app.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libc])
         self._check_node(libc, "libc/0.1#123", deps=[libb], dependents=[app])
@@ -816,9 +816,9 @@ class TestLinearFourLevels(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libc = app.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libc = app.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libc])
         self._check_node(libc, "libc/0.1#123", deps=[libb], dependents=[app])
@@ -847,9 +847,9 @@ class TestLinearFourLevels(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libc = app.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libc = app.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libc])
         self._check_node(libc, "libc/0.1#123", deps=[libb], dependents=[app])
@@ -880,9 +880,9 @@ class TestLinearFourLevels(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libc = app.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libc = app.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libc])
         self._check_node(libc, "libc/0.1#123", deps=[libb], dependents=[app])
@@ -912,9 +912,9 @@ class TestLinearFourLevels(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libc = app.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libc = app.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libc, liba])
         self._check_node(libc, "libc/0.1#123", deps=[libb], dependents=[app])
@@ -946,10 +946,10 @@ class TestLinearFiveLevelsHeaders(GraphManagerTest):
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
-        libd = app.dependencies[0].dst
-        libc = libd.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libd = app.edges[0].dst
+        libc = libd.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libd])
         self._check_node(libd, "libd/0.1#123", deps=[libc], dependents=[app])
@@ -980,10 +980,10 @@ class TestLinearFiveLevelsHeaders(GraphManagerTest):
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
-        libd = app.dependencies[0].dst
-        libc = libd.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libd = app.edges[0].dst
+        libc = libd.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libd])
         self._check_node(libd, "libd/0.1#123", deps=[libc], dependents=[app])
@@ -1012,10 +1012,10 @@ class TestLinearFiveLevelsHeaders(GraphManagerTest):
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
-        libd = app.dependencies[0].dst
-        libc = libd.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libd = app.edges[0].dst
+        libc = libd.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libd])
         self._check_node(libd, "libd/0.1#123", deps=[libc], dependents=[app])
@@ -1045,10 +1045,10 @@ class TestLinearFiveLevelsHeaders(GraphManagerTest):
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
-        libd = app.dependencies[0].dst
-        libc = libd.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libd = app.edges[0].dst
+        libc = libd.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libd])
         self._check_node(libd, "libd/0.1#123", deps=[libc], dependents=[app])
@@ -1079,10 +1079,10 @@ class TestLinearFiveLevelsHeaders(GraphManagerTest):
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
-        libd = app.dependencies[0].dst
-        libc = libd.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libd = app.edges[0].dst
+        libc = libd.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libd])
         self._check_node(libd, "libd/0.1#123", deps=[libc], dependents=[app])
@@ -1112,10 +1112,10 @@ class TestLinearFiveLevelsHeaders(GraphManagerTest):
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
-        libd = app.dependencies[0].dst
-        libc = libd.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libd = app.edges[0].dst
+        libc = libd.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libd])
         self._check_node(libd, "libd/0.1#123", deps=[libc], dependents=[app])
@@ -1144,10 +1144,10 @@ class TestLinearFiveLevelsHeaders(GraphManagerTest):
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
-        libd = app.dependencies[0].dst
-        libc = libd.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libd = app.edges[0].dst
+        libc = libd.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libd])
         self._check_node(libd, "libd/0.1#123", deps=[libc], dependents=[app])
@@ -1177,10 +1177,10 @@ class TestLinearFiveLevelsHeaders(GraphManagerTest):
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
-        libd = app.dependencies[0].dst
-        libc = libd.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libd = app.edges[0].dst
+        libc = libd.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libd])
         self._check_node(libd, "libd/0.1#123", deps=[libc], dependents=[app])
@@ -1207,10 +1207,10 @@ class TestLinearFiveLevelsHeaders(GraphManagerTest):
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
-        libd = app.dependencies[0].dst
-        libc = libd.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libd = app.edges[0].dst
+        libc = libd.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libd])
         self._check_node(libd, "libd/0.1#123", deps=[libc], dependents=[app])
@@ -1237,10 +1237,10 @@ class TestLinearFiveLevelsHeaders(GraphManagerTest):
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
-        libd = app.dependencies[0].dst
-        libc = libd.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libd = app.edges[0].dst
+        libc = libd.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libd])
         self._check_node(libd, "libd/0.1#123", deps=[libc], dependents=[app])
@@ -1273,10 +1273,10 @@ class TestLinearFiveLevelsLibraries(GraphManagerTest):
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
-        libd = app.dependencies[0].dst
-        libc = libd.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libd = app.edges[0].dst
+        libc = libd.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libd])
         self._check_node(libd, "libd/0.1#123", deps=[libc], dependents=[app])
@@ -1307,10 +1307,10 @@ class TestLinearFiveLevelsLibraries(GraphManagerTest):
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
-        libd = app.dependencies[0].dst
-        libc = libd.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libd = app.edges[0].dst
+        libc = libd.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libd])
         self._check_node(libd, "libd/0.1#123", deps=[libc], dependents=[app])
@@ -1339,9 +1339,9 @@ class TestDiamond(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        libc = app.dependencies[1].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        libc = app.edges[1].dst
+        liba = libb.edges[0].dst
 
         # TODO: No Revision??? Because of consumer?
         self._check_node(app, "app/0.1", deps=[libb, libc])
@@ -1371,9 +1371,9 @@ class TestDiamond(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        libc = app.dependencies[1].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        libc = app.edges[1].dst
+        liba = libb.edges[0].dst
 
         # TODO: No Revision??? Because of consumer?
         self._check_node(app, "app/0.1", deps=[libb, libc])
@@ -1396,8 +1396,8 @@ class TestDiamond(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        liba = app.dependencies[0].dst
-        libc = app.dependencies[1].dst
+        liba = app.edges[0].dst
+        libc = app.edges[1].dst
 
         # TODO: No Revision??? Because of consumer?
         self._check_node(app, "app/0.1", deps=[liba, libc])
@@ -1423,8 +1423,8 @@ class TestDiamond(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libc = app.dependencies[0].dst
-        liba = app.dependencies[1].dst
+        libc = app.edges[0].dst
+        liba = app.edges[1].dst
 
         # TODO: No Revision??? Because of consumer?
         self._check_node(app, "app/0.1", deps=[liba, libc])
@@ -1450,10 +1450,10 @@ class TestDiamond(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        libc = app.dependencies[1].dst
-        liba = libb.dependencies[0].dst
-        liba1 = libc.dependencies[0].dst
+        libb = app.edges[0].dst
+        libc = app.edges[1].dst
+        liba = libb.edges[0].dst
+        liba1 = libc.edges[0].dst
 
         assert liba is liba1
 
@@ -1484,11 +1484,11 @@ class TestDiamond(GraphManagerTest):
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
-        libd = app.dependencies[0].dst
-        libb = libd.dependencies[0].dst
-        libc = libd.dependencies[1].dst
-        liba = libb.dependencies[0].dst
-        liba2 = libc.dependencies[0].dst
+        libd = app.edges[0].dst
+        libb = libd.edges[0].dst
+        libc = libd.edges[1].dst
+        liba = libb.edges[0].dst
+        liba2 = libc.edges[0].dst
 
         assert liba is liba2
 
@@ -1520,10 +1520,10 @@ class TestDiamond(GraphManagerTest):
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        libc = app.dependencies[1].dst
-        liba1 = libb.dependencies[0].dst
-        liba2 = libc.dependencies[0].dst
+        libb = app.edges[0].dst
+        libc = app.edges[1].dst
+        liba1 = libb.edges[0].dst
+        liba2 = libc.edges[0].dst
 
         assert liba1 is not liba2
 
@@ -1555,9 +1555,9 @@ class TestDiamond(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        libc = app.dependencies[1].dst
-        liba1 = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        libc = app.edges[1].dst
+        liba1 = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libb, libc])
         self._check_node(libb, "libb/0.1#123", deps=[liba1], dependents=[app])
@@ -1579,9 +1579,9 @@ class TestDiamond(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        libc = app.dependencies[1].dst
-        liba1 = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        libc = app.edges[1].dst
+        liba1 = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libb, libc])
         self._check_node(libb, "libb/0.1#123", deps=[liba1], dependents=[app])
@@ -1608,10 +1608,10 @@ class TestDiamond(GraphManagerTest):
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
-        libd = app.dependencies[0].dst
-        libb = libd.dependencies[0].dst
-        libc = libd.dependencies[1].dst
-        liba1 = libb.dependencies[0].dst
+        libd = app.edges[0].dst
+        libb = libd.edges[0].dst
+        libc = libd.edges[1].dst
+        liba1 = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libd])
         self._check_node(libd, "libd/0.1#123", deps=[libb, libc], dependents=[app])
@@ -1635,10 +1635,10 @@ class TestDiamond(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         libc = deps_graph.root
-        liba = libc.dependencies[0].dst
-        libb = libc.dependencies[1].dst
-        liba1 = libb.dependencies[0].dst
-        zlib = liba.dependencies[0].dst
+        liba = libc.edges[0].dst
+        libb = libc.edges[1].dst
+        liba1 = libb.edges[0].dst
+        zlib = liba.edges[0].dst
 
         assert liba is liba1
         # TODO: No Revision??? Because of consumer?
@@ -1670,10 +1670,10 @@ class TestDiamond(GraphManagerTest):
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
-        liba = app.dependencies[0].dst
-        spdlog = liba.dependencies[0].dst
-        fmt01 = spdlog.dependencies[0].dst
-        fmt02 = app.dependencies[1].dst
+        liba = app.edges[0].dst
+        spdlog = liba.edges[0].dst
+        fmt01 = spdlog.edges[0].dst
+        fmt02 = app.edges[1].dst
 
         self._check_node(app, "app/0.1", deps=[liba, fmt02])
         self._check_node(liba, "liba/0.1#123", deps=[spdlog], dependents=[app])
@@ -1703,12 +1703,12 @@ class TestDiamondMultiple(GraphManagerTest):
 
         self.assertEqual(7, len(deps_graph.nodes))
         app = deps_graph.root
-        libe = app.dependencies[0].dst
-        libf = app.dependencies[1].dst
-        libd = libe.dependencies[0].dst
-        libb = libd.dependencies[0].dst
-        libc = libd.dependencies[1].dst
-        liba = libc.dependencies[0].dst
+        libe = app.edges[0].dst
+        libf = app.edges[1].dst
+        libd = libe.edges[0].dst
+        libb = libd.edges[0].dst
+        libc = libd.edges[1].dst
+        liba = libc.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libe, libf])
         self._check_node(libe, "libe/0.1#123", deps=[libd], dependents=[app])
@@ -1742,12 +1742,12 @@ class TestDiamondMultiple(GraphManagerTest):
 
         self.assertEqual(7, len(deps_graph.nodes))
         app = deps_graph.root
-        libe = app.dependencies[0].dst
-        libf = app.dependencies[1].dst
-        libd = libe.dependencies[0].dst
-        libb = libd.dependencies[0].dst
-        libc = libd.dependencies[1].dst
-        liba = libc.dependencies[0].dst
+        libe = app.edges[0].dst
+        libf = app.edges[1].dst
+        libd = libe.edges[0].dst
+        libb = libd.edges[0].dst
+        libc = libd.edges[1].dst
+        liba = libc.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libe, libf])
         self._check_node(libe, "libe/0.1#123", deps=[libd], dependents=[app])
@@ -1780,10 +1780,10 @@ class TestDiamondMultiple(GraphManagerTest):
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        libc = app.dependencies[1].dst
-        libd = app.dependencies[2].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        libc = app.edges[1].dst
+        libd = app.edges[2].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libb, libc, libd])
         self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
@@ -1806,10 +1806,10 @@ class TestDiamondMultiple(GraphManagerTest):
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        libc = app.dependencies[1].dst
-        libd = app.dependencies[2].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        libc = app.edges[1].dst
+        libd = app.edges[2].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libb, libc, libd])
         self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
@@ -1831,9 +1831,9 @@ class TestDiamondMultiple(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libd = app.dependencies[0].dst
-        libc = app.dependencies[1].dst
-        libb = app.dependencies[2].dst
+        libd = app.edges[0].dst
+        libc = app.edges[1].dst
+        libb = app.edges[2].dst
 
         self._check_node(app, "app/0.1", deps=[libd, libc, libb])
         self._check_node(libd, "libd/0.1#123", dependents=[app, libc])
@@ -1856,9 +1856,9 @@ class TestDiamondMultiple(GraphManagerTest):
         self.assertEqual(4, len(deps_graph.nodes))
 
         app = deps_graph.root
-        libc = app.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libc = app.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libc])
         self._check_node(libc, "libc/0.1#123", deps=[libb], dependents=[app])
@@ -1880,9 +1880,9 @@ class TransitiveOverridesGraphTest(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = app.dependencies[1].dst
-        liba2 = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = app.edges[1].dst
+        liba2 = libb.edges[0].dst
 
         assert liba is liba2
 
@@ -1905,7 +1905,7 @@ class TransitiveOverridesGraphTest(GraphManagerTest):
 
         self.assertEqual(2, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
+        libb = app.edges[0].dst
 
         # TODO: No Revision??? Because of consumer?
         self._check_node(app, "app/0.1", deps=[libb])
@@ -1925,10 +1925,10 @@ class TransitiveOverridesGraphTest(GraphManagerTest):
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        libc = app.dependencies[1].dst
-        liba1 = libb.dependencies[0].dst
-        liba2 = libc.dependencies[0].dst
+        libb = app.edges[0].dst
+        libc = app.edges[1].dst
+        liba1 = libb.edges[0].dst
+        liba2 = libc.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libb, libc])
         self._check_node(libb, "libb/0.1#123", deps=[liba1], dependents=[app])
@@ -1956,8 +1956,8 @@ class TransitiveOverridesGraphTest(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        dep1 = app.dependencies[0].dst
-        dep2 = app.dependencies[1].dst
+        dep1 = app.edges[0].dst
+        dep2 = app.edges[1].dst
 
         self._check_node(app, "app/0.1", deps=[dep1, dep2])
         self._check_node(dep1, "dep1/2.0#123", deps=[], dependents=[app, dep2])
@@ -1976,8 +1976,8 @@ class TransitiveOverridesGraphTest(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        dep1 = app.dependencies[0].dst
-        dep2 = app.dependencies[1].dst
+        dep1 = app.edges[0].dst
+        dep2 = app.edges[1].dst
         self._check_node(app, "app/0.1", deps=[dep1, dep2])
         self._check_node(dep1, "dep1/2.0#123", deps=[], dependents=[app])
         # dep2 no dependency, it was not resolved due to conflict
@@ -1996,9 +1996,9 @@ class TransitiveOverridesGraphTest(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba2 = app.dependencies[1].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba2 = app.edges[1].dst
+        liba = libb.edges[0].dst
 
         # TODO: No Revision??? Because of consumer?
         self._check_node(app, "app/0.1", deps=[libb, liba2])
@@ -2021,8 +2021,8 @@ class PureOverrideTest(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = libb.edges[0].dst
 
         # TODO: No Revision??? Because of consumer?
         self._check_node(app, "app/0.1", deps=[libb])
@@ -2052,8 +2052,8 @@ class PureOverrideTest(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = libb.edges[0].dst
 
         # TODO: No Revision??? Because of consumer?
         self._check_node(app, "app/0.1", deps=[libb])
@@ -2077,9 +2077,9 @@ class PureOverrideTest(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libc = app.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libc = app.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         # TODO: No Revision??? Because of consumer?
         self._check_node(app, "app/0.1", deps=[libc])
@@ -2103,9 +2103,9 @@ class PureOverrideTest(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libc = app.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libc = app.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         # TODO: No Revision??? Because of consumer?
         self._check_node(app, "app/0.1", deps=[libc])
@@ -2128,9 +2128,9 @@ class PureOverrideTest(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         libc = deps_graph.root
-        liba = libc.dependencies[0].dst
-        libb = libc.dependencies[1].dst
-        liba1 = libb.dependencies[0].dst
+        liba = libc.edges[0].dst
+        libb = libc.edges[1].dst
+        liba1 = libb.edges[0].dst
 
         assert liba is liba1
         # TODO: No Revision??? Because of consumer?
@@ -2162,10 +2162,10 @@ class PackageIDDeductions(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         project = deps_graph.root
-        app1 = project.dependencies[0].dst
-        app2 = project.dependencies[1].dst
-        lib = app1.dependencies[0].dst
-        lib2 = app2.dependencies[0].dst
+        app1 = project.edges[0].dst
+        app2 = project.edges[1].dst
+        lib = app1.edges[0].dst
+        lib2 = app2.edges[0].dst
 
         assert lib is lib2
 
@@ -2202,10 +2202,10 @@ class TestProjectApp(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         project = deps_graph.root
-        app1 = project.dependencies[0].dst
-        app2 = project.dependencies[1].dst
-        lib = app1.dependencies[0].dst
-        lib2 = app2.dependencies[0].dst
+        app1 = project.edges[0].dst
+        app2 = project.edges[1].dst
+        lib = app1.edges[0].dst
+        lib2 = app2.edges[0].dst
 
         assert lib is lib2
 
@@ -2252,10 +2252,10 @@ class TestProjectApp(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         project = deps_graph.root
-        app1 = project.dependencies[0].dst
-        app2 = project.dependencies[1].dst
-        lib = app1.dependencies[0].dst
-        lib2 = app2.dependencies[0].dst
+        app1 = project.edges[0].dst
+        app2 = project.edges[1].dst
+        lib = app1.edges[0].dst
+        lib2 = app2.edges[0].dst
 
         assert lib is lib2
 
@@ -2305,10 +2305,10 @@ class TestProjectApp(GraphManagerTest):
 
         self.assertEqual(5, len(deps_graph.nodes))
         project = deps_graph.root
-        app1 = project.dependencies[0].dst
-        app2 = project.dependencies[1].dst
-        lib1 = app1.dependencies[0].dst
-        lib2 = app2.dependencies[0].dst
+        app1 = project.edges[0].dst
+        app2 = project.edges[1].dst
+        lib1 = app1.edges[0].dst
+        lib2 = app2.edges[0].dst
 
         assert lib1 is not lib2
 

--- a/test/integration/graph/core/test_alias.py
+++ b/test/integration/graph/core/test_alias.py
@@ -16,7 +16,7 @@ class TestAlias(GraphManagerTest):
 
         self.assertEqual(2, len(deps_graph.nodes))
         app = deps_graph.root
-        liba = app.dependencies[0].dst
+        liba = app.edges[0].dst
 
         self._check_node(liba, "liba/0.1#123", dependents=[app])
         self._check_node(app, "app/0.1", deps=[liba])
@@ -32,8 +32,8 @@ class TestAlias(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        liba = app.dependencies[0].dst
-        libb = app.dependencies[1].dst
+        liba = app.edges[0].dst
+        libb = app.edges[1].dst
 
         self._check_node(liba, "liba/0.1#123", dependents=[app, libb])
         self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
@@ -60,8 +60,8 @@ class TestAlias(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        liba = app.dependencies[0].dst
-        libb = app.dependencies[1].dst
+        liba = app.edges[0].dst
+        libb = app.edges[1].dst
 
         self._check_node(liba, "liba/0.1#123", dependents=[app, libb])
         self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
@@ -90,9 +90,9 @@ class TestAlias(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        libc = app.dependencies[1].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        libc = app.edges[1].dst
+        liba = libb.edges[0].dst
 
         self._check_node(liba, "liba/0.1#123", dependents=[libb, libc])
         self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
@@ -119,9 +119,9 @@ class TestAlias(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        libc = app.dependencies[1].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        libc = app.edges[1].dst
+        liba = libb.edges[0].dst
 
         self._check_node(liba, "liba/0.1#123", dependents=[libb, libc])
         self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
@@ -147,7 +147,7 @@ class TestAlias(GraphManagerTest):
 
         self.assertEqual(2, len(deps_graph.nodes))
         app = deps_graph.root
-        liba = app.dependencies[0].dst
+        liba = app.edges[0].dst
 
         self._check_node(liba, "liba/0.1#123", dependents=[app])
         self._check_node(app, "app/0.1", deps=[liba])
@@ -172,9 +172,9 @@ class AliasBuildRequiresTest(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba_build = app.dependencies[1].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba_build = app.edges[1].dst
+        liba = libb.edges[0].dst
 
         self._check_node(liba, "liba/0.1#123", dependents=[libb])
         self._check_node(liba_build, "liba/0.2#123", dependents=[app])

--- a/test/integration/graph/core/test_build_requires.py
+++ b/test/integration/graph/core/test_build_requires.py
@@ -45,7 +45,7 @@ class BuildRequiresGraphTest(GraphManagerTest):
         # Build requires always apply to the consumer
         self.assertEqual(2, len(deps_graph.nodes))
         app = deps_graph.root
-        cmake = app.dependencies[0].dst
+        cmake = app.edges[0].dst
 
         self._check_node(app, "app/0.1@", deps=[cmake], dependents=[])
         self._check_node(cmake, "cmake/0.1#123", deps=[], dependents=[app])
@@ -58,8 +58,8 @@ class BuildRequiresGraphTest(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        lib = app.dependencies[0].dst
-        cmake = lib.dependencies[0].dst
+        lib = app.edges[0].dst
+        cmake = lib.edges[0].dst
 
         self._check_node(app, "app/0.1@", deps=[lib], dependents=[])
         self._check_node(lib, "lib/0.1#123", deps=[cmake], dependents=[app])
@@ -90,9 +90,9 @@ class BuildRequiresGraphTest(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        lib = app.dependencies[0].dst
-        cmake = lib.dependencies[0].dst
-        cmakelib = cmake.dependencies[0].dst
+        lib = app.edges[0].dst
+        cmake = lib.edges[0].dst
+        cmakelib = cmake.edges[0].dst
 
         self._check_node(app, "app/0.1@", deps=[lib], dependents=[], settings={"os": "Linux"})
         self._check_node(lib, "lib/0.1#123", deps=[cmake], dependents=[app],
@@ -120,9 +120,9 @@ class BuildRequiresGraphTest(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        lib = app.dependencies[0].dst
-        cmake2 = lib.dependencies[0].dst
-        cmake1 = cmake2.dependencies[0].dst
+        lib = app.edges[0].dst
+        cmake2 = lib.edges[0].dst
+        cmake1 = cmake2.edges[0].dst
 
         self._check_node(app, "app/0.1@", deps=[lib], dependents=[])
         self._check_node(lib, "lib/0.1#123", deps=[cmake2], dependents=[app])
@@ -143,9 +143,9 @@ class BuildRequiresGraphTest(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        lib = app.dependencies[0].dst
-        cmake = lib.dependencies[0].dst
-        zlib = cmake.dependencies[0].dst
+        lib = app.edges[0].dst
+        cmake = lib.edges[0].dst
+        zlib = cmake.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[lib], dependents=[])
         self._check_node(lib, "lib/0.1#123", deps=[cmake], dependents=[app])
@@ -173,11 +173,11 @@ class TestBuildRequiresTransitivityDiamond(GraphManagerTest):
 
         self.assertEqual(6, len(deps_graph.nodes))
         app = deps_graph.root
-        lib = app.dependencies[0].dst
-        cmake = lib.dependencies[0].dst
-        mingw = lib.dependencies[1].dst
-        zlib1 = cmake.dependencies[0].dst
-        zlib2 = mingw.dependencies[0].dst
+        lib = app.edges[0].dst
+        cmake = lib.edges[0].dst
+        mingw = lib.edges[1].dst
+        zlib1 = cmake.edges[0].dst
+        zlib2 = mingw.edges[0].dst
 
         self._check_node(app, "app/0.1@", deps=[lib], dependents=[])
         self._check_node(lib, "lib/0.1#123", deps=[cmake, mingw], dependents=[app])
@@ -212,11 +212,11 @@ class TestBuildRequiresTransitivityDiamond(GraphManagerTest):
 
         self.assertEqual(6, len(deps_graph.nodes))
         app = deps_graph.root
-        lib = app.dependencies[0].dst
-        cmake = lib.dependencies[0].dst
-        mingw = lib.dependencies[1].dst
-        zlib1 = cmake.dependencies[0].dst
-        zlib2 = mingw.dependencies[0].dst
+        lib = app.edges[0].dst
+        cmake = lib.edges[0].dst
+        mingw = lib.edges[1].dst
+        zlib1 = cmake.edges[0].dst
+        zlib2 = mingw.edges[0].dst
 
         assert zlib1 is not zlib2
 
@@ -242,9 +242,9 @@ class TestBuildRequiresTransitivityDiamond(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         cheetah = deps_graph.root
-        gazelle = cheetah.dependencies[0].dst
-        grass2 = cheetah.dependencies[1].dst
-        grass1 = gazelle.dependencies[0].dst
+        gazelle = cheetah.edges[0].dst
+        grass2 = cheetah.edges[1].dst
+        grass1 = gazelle.edges[0].dst
         self._check_node(cheetah, "cheetah/0.1", deps=[gazelle, grass2])
         self._check_node(gazelle, "gazelle/0.1#123", deps=[grass1], dependents=[cheetah])
         self._check_node(grass1, "grass/0.1#123", deps=[], dependents=[gazelle])
@@ -261,9 +261,9 @@ class TestBuildRequiresVisible(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libc = app.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libc = app.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1@", deps=[libc], dependents=[])
         self._check_node(libc, "libc/0.1#123", deps=[libb], dependents=[app])
@@ -289,7 +289,7 @@ class TestTestRequire(GraphManagerTest):
         # Build requires always apply to the consumer
         self.assertEqual(2, len(deps_graph.nodes))
         app = deps_graph.root
-        gtest = app.dependencies[0].dst
+        gtest = app.edges[0].dst
 
         self._check_node(app, "app/0.1@", deps=[gtest], dependents=[])
         self._check_node(gtest, "gtest/0.1#123", deps=[], dependents=[app])
@@ -305,8 +305,8 @@ class TestTestRequire(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        lib = app.dependencies[0].dst
-        gtest = lib.dependencies[0].dst
+        lib = app.edges[0].dst
+        gtest = lib.edges[0].dst
 
         self._check_node(app, "app/0.1@", deps=[lib], dependents=[])
         self._check_node(lib, "lib/0.1#123", deps=[gtest], dependents=[app])
@@ -324,8 +324,8 @@ class TestTestRequire(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        lib = app.dependencies[0].dst
-        gtest = lib.dependencies[0].dst
+        lib = app.edges[0].dst
+        gtest = lib.edges[0].dst
 
         self._check_node(app, "app/0.1@", deps=[lib], dependents=[])
         self._check_node(lib, "lib/0.1#123", deps=[gtest], dependents=[app])
@@ -356,9 +356,9 @@ class TestTestRequire(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        lib = app.dependencies[0].dst
-        gtest = lib.dependencies[0].dst
-        gtestlib = gtest.dependencies[0].dst
+        lib = app.edges[0].dst
+        gtest = lib.edges[0].dst
+        gtestlib = gtest.edges[0].dst
 
         self._check_node(app, "app/0.1@", deps=[lib], dependents=[], settings={"os": "Linux"})
         self._check_node(lib, "lib/0.1#123", deps=[gtest], dependents=[app],
@@ -393,10 +393,10 @@ class TestTestRequire(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        lib = app.dependencies[0].dst
-        gtest = lib.dependencies[1].dst
-        zlib = gtest.dependencies[0].dst
-        zlib2 = lib.dependencies[0].dst
+        lib = app.edges[0].dst
+        gtest = lib.edges[1].dst
+        zlib = gtest.edges[0].dst
+        zlib2 = lib.edges[0].dst
         assert zlib is zlib2
 
         self._check_node(app, "app/0.1@", deps=[lib], dependents=[])
@@ -419,9 +419,9 @@ class TestTestRequire(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         opencv = deps_graph.root
-        gtest14 = opencv.dependencies[0].dst
-        abseil = gtest14.dependencies[0].dst
-        gtest11 = abseil.dependencies[0].dst
+        gtest14 = opencv.edges[0].dst
+        abseil = gtest14.edges[0].dst
+        gtest11 = abseil.edges[0].dst
 
         self._check_node(opencv, "opencv/1.0@", deps=[gtest14], dependents=[])
         self._check_node(gtest14, "gtest/1.14#123", deps=[abseil], dependents=[opencv])
@@ -435,13 +435,13 @@ class TestTestRequiresProblemsShared(GraphManagerTest):
         self.assertEqual(3, len(deps_graph.nodes))
         lib_c = deps_graph.root
         if not reverse:
-            lib_a = lib_c.dependencies[0].dst
-            util = lib_a.dependencies[0].dst
-            util2 = lib_c.dependencies[1].dst
+            lib_a = lib_c.edges[0].dst
+            util = lib_a.edges[0].dst
+            util2 = lib_c.edges[1].dst
         else:
-            util = lib_c.dependencies[0].dst
-            lib_a = lib_c.dependencies[1].dst
-            util2 = lib_a.dependencies[0].dst
+            util = lib_c.edges[0].dst
+            lib_a = lib_c.edges[1].dst
+            util2 = lib_a.edges[0].dst
         assert util is util2
 
         self._check_node(lib_c, "lib_c/0.1@", deps=[lib_a, util], dependents=[])
@@ -582,8 +582,8 @@ class BuildRequiresPackageIDTest(GraphManagerTest):
         # Build requires always apply to the consumer
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        lib = app.dependencies[0].dst
-        cmake = lib.dependencies[0].dst
+        lib = app.edges[0].dst
+        cmake = lib.edges[0].dst
 
         self._check_node(app, "app/0.1@", deps=[lib], dependents=[])
         self._check_node(lib, "lib/0.1#123", deps=[cmake], dependents=[app])
@@ -600,8 +600,8 @@ class BuildRequiresPackageIDTest(GraphManagerTest):
         # Build requires always apply to the consumer
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        lib = app.dependencies[0].dst
-        cmake = lib.dependencies[0].dst
+        lib = app.edges[0].dst
+        cmake = lib.edges[0].dst
 
         self._check_node(app, "app/0.1@", deps=[lib], dependents=[])
         self._check_node(lib, "lib/0.1#123", deps=[cmake], dependents=[app])
@@ -616,7 +616,7 @@ class BuildRequiresPackageIDTest(GraphManagerTest):
         # Build requires always apply to the consumer
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        lib = app.dependencies[0].dst
+        lib = app.edges[0].dst
         assert lib.package_id == "2813db72897dd13aca2af071efe8ecb116f679ed"
         assert lib.package_id != NO_SETTINGS_PACKAGE_ID
 
@@ -634,8 +634,8 @@ class PublicBuildRequiresTest(GraphManagerTest):
         # Build requires always apply to the consumer
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        lib = app.dependencies[0].dst
-        cmake = lib.dependencies[0].dst
+        lib = app.edges[0].dst
+        cmake = lib.edges[0].dst
 
         self._check_node(app, "app/0.1@", deps=[lib], dependents=[])
         self._check_node(lib, "lib/0.1#123", deps=[cmake], dependents=[app])
@@ -663,17 +663,17 @@ class PublicBuildRequiresTest(GraphManagerTest):
         # Build requires always apply to the consumer
         self.assertEqual(8 + 4, len(deps_graph.nodes))
         app = deps_graph.root
-        liba = app.dependencies[0].dst
-        libb = liba.dependencies[0].dst
-        libsfun = libb.dependencies[0].dst
-        libx = libsfun.dependencies[0].dst
-        liby = libx.dependencies[0].dst
-        libz = liby.dependencies[0].dst
-        sfun = libb.dependencies[1].dst
-        libsfun_build = sfun.dependencies[0].dst
-        libx_build = libsfun_build.dependencies[0].dst
-        liby_build = libx_build.dependencies[0].dst
-        libz_build = liby_build.dependencies[0].dst
+        liba = app.edges[0].dst
+        libb = liba.edges[0].dst
+        libsfun = libb.edges[0].dst
+        libx = libsfun.edges[0].dst
+        liby = libx.edges[0].dst
+        libz = liby.edges[0].dst
+        sfun = libb.edges[1].dst
+        libsfun_build = sfun.edges[0].dst
+        libx_build = libsfun_build.edges[0].dst
+        liby_build = libx_build.edges[0].dst
+        libz_build = liby_build.edges[0].dst
 
         # TODO non-build-requires
 
@@ -747,9 +747,9 @@ class PublicBuildRequiresTest(GraphManagerTest):
         # Build requires always apply to the consumer
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        libc = app.dependencies[1].dst
-        cmake1 = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        libc = app.edges[1].dst
+        cmake1 = libb.edges[0].dst
 
         self._check_node(app, "app/0.1@", deps=[libb, libc], dependents=[])
         self._check_node(libb, "libb/0.1#123", deps=[cmake1], dependents=[app])
@@ -776,11 +776,11 @@ class PublicBuildRequiresTest(GraphManagerTest):
         # Build requires always apply to the consumer
         self.assertEqual(6, len(deps_graph.nodes))
         app = deps_graph.root
-        libd = app.dependencies[0].dst
-        libe = app.dependencies[1].dst
-        libb = libd.dependencies[0].dst
-        libc = libe.dependencies[0].dst
-        cmake1 = libb.dependencies[0].dst
+        libd = app.edges[0].dst
+        libe = app.edges[1].dst
+        libb = libd.edges[0].dst
+        libc = libe.edges[0].dst
+        cmake1 = libb.edges[0].dst
 
         self._check_node(app, "app/0.1@", deps=[libd, libe], dependents=[])
         self._check_node(libd, "libd/0.1#123", deps=[libb], dependents=[app])
@@ -803,9 +803,9 @@ class PublicBuildRequiresTest(GraphManagerTest):
         # Build requires always apply to the consumer
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        protobuf_host = libb.dependencies[0].dst
-        protobuf_build = libb.dependencies[1].dst
+        libb = app.edges[0].dst
+        protobuf_host = libb.edges[0].dst
+        protobuf_build = libb.edges[1].dst
 
         self._check_node(app, "app/0.1@", deps=[libb], dependents=[])
         self._check_node(libb, "libb/0.1#123", deps=[protobuf_host, protobuf_build],
@@ -834,9 +834,9 @@ class PublicBuildRequiresTest(GraphManagerTest):
         # Build requires always apply to the consumer
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        protobuf_host = libb.dependencies[0].dst
-        protobuf_build = libb.dependencies[1].dst
+        libb = app.edges[0].dst
+        protobuf_host = libb.edges[0].dst
+        protobuf_build = libb.edges[1].dst
 
         self._check_node(app, "app/0.1@", deps=[libb], dependents=[])
         self._check_node(libb, "libb/0.1#123", deps=[protobuf_host, protobuf_build],
@@ -870,7 +870,7 @@ class PublicBuildRequiresTest(GraphManagerTest):
         # Build requires always apply to the consumer
         self.assertEqual(2, len(deps_graph.nodes))
         app = deps_graph.root
-        tool = app.dependencies[0].dst
+        tool = app.edges[0].dst
 
         self._check_node(app, "app/0.1@", deps=[tool], dependents=[])
         self._check_node(tool, "gtest/0.1#123", deps=[], dependents=[app])
@@ -890,9 +890,9 @@ class TestLoops(GraphManagerTest):
         # Build requires always apply to the consumer
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        tool = app.dependencies[0].dst
-        tool2 = tool.dependencies[0].dst
-        tool3 = tool2.dependencies[0].dst
+        tool = app.edges[0].dst
+        tool2 = tool.edges[0].dst
+        tool3 = tool2.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[tool], dependents=[])
         self._check_node(tool, "cmake/0.1#123", deps=[tool2], dependents=[app])
@@ -912,11 +912,11 @@ class TestLoops(GraphManagerTest):
         # Build requires always apply to the consumer
         self.assertEqual(6, len(deps_graph.nodes))
         app = deps_graph.root
-        cmake = app.dependencies[0].dst
-        gtest = cmake.dependencies[0].dst
-        cmake2 = gtest.dependencies[0].dst
-        gtest2 = cmake2.dependencies[0].dst
-        cmake3 = gtest2.dependencies[0].dst
+        cmake = app.edges[0].dst
+        gtest = cmake.edges[0].dst
+        cmake2 = gtest.edges[0].dst
+        gtest2 = cmake2.edges[0].dst
+        cmake3 = gtest2.edges[0].dst
 
         assert deps_graph.error.ancestor == cmake
         assert deps_graph.error.node == cmake3

--- a/test/integration/graph/core/test_options.py
+++ b/test/integration/graph/core/test_options.py
@@ -17,8 +17,8 @@ class TestOptions(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libb])
         self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
@@ -42,8 +42,8 @@ class TestOptions(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libb])
         self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
@@ -68,10 +68,10 @@ class TestOptions(GraphManagerTest):
         deps_graph = self.build_consumer(consumer)
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        libc = app.dependencies[1].dst
-        liba = libb.dependencies[0].dst
-        liba2 = libc.dependencies[0].dst
+        libb = app.edges[0].dst
+        libc = app.edges[1].dst
+        liba = libb.edges[0].dst
+        liba2 = libc.edges[0].dst
         assert liba is liba2
         self._check_node(app, "app/0.1", deps=[libc, libb])
         self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
@@ -82,10 +82,10 @@ class TestOptions(GraphManagerTest):
         deps_graph = self.build_consumer(consumer)
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libc = app.dependencies[0].dst
-        libb = app.dependencies[1].dst
-        liba = libb.dependencies[0].dst
-        liba2 = libc.dependencies[0].dst
+        libc = app.edges[0].dst
+        libb = app.edges[1].dst
+        liba = libb.edges[0].dst
+        liba2 = libc.edges[0].dst
         assert liba is liba2
         self._check_node(app, "app/0.1", deps=[libc, libb])
         self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
@@ -107,10 +107,10 @@ class TestOptions(GraphManagerTest):
 
             self.assertEqual(4, len(deps_graph.nodes))
             app = deps_graph.root
-            libb = app.dependencies[0].dst
-            libc = app.dependencies[1].dst
-            liba = libb.dependencies[0].dst
-            liba2 = libc.dependencies[0].dst
+            libb = app.edges[0].dst
+            libc = app.edges[1].dst
+            liba = libb.edges[0].dst
+            liba2 = libc.edges[0].dst
             assert liba is liba2
             self._check_node(app, "app/0.1", deps=[libc, libb])
             self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
@@ -125,10 +125,10 @@ class TestOptions(GraphManagerTest):
 
             self.assertEqual(4, len(deps_graph.nodes))
             app = deps_graph.root
-            libc = app.dependencies[0].dst
-            libb = app.dependencies[1].dst
-            liba = libb.dependencies[0].dst
-            liba2 = libc.dependencies[0].dst
+            libc = app.edges[0].dst
+            libb = app.edges[1].dst
+            liba = libb.edges[0].dst
+            liba2 = libc.edges[0].dst
             assert liba is liba2
             self._check_node(app, "app/0.1", deps=[libc, libb])
             self._check_node(libb, "libb/0.1#123", deps=[liba], dependents=[app])
@@ -149,11 +149,11 @@ class TestBuildRequireOptions(GraphManagerTest):
 
         self.assertEqual(6, len(deps_graph.nodes))
         app = deps_graph.root
-        lib = app.dependencies[0].dst
-        protobuf_host = lib.dependencies[0].dst
-        protobuf_build = lib.dependencies[1].dst
-        zlib_shared = protobuf_host.dependencies[0].dst
-        zlib_static = protobuf_build.dependencies[0].dst
+        lib = app.edges[0].dst
+        protobuf_host = lib.edges[0].dst
+        protobuf_build = lib.edges[1].dst
+        zlib_shared = protobuf_host.edges[0].dst
+        zlib_static = protobuf_build.edges[0].dst
 
         self._check_node(app, "app/0.1@", deps=[lib], dependents=[])
         self._check_node(lib, "lib/0.1#123", deps=[protobuf_host, protobuf_build], dependents=[app])

--- a/test/integration/graph/core/test_provides.py
+++ b/test/integration/graph/core/test_provides.py
@@ -21,7 +21,7 @@ class TestProvidesTest(GraphManagerTest):
 
         self.assertEqual(2, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
+        libb = app.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libb])
         self._check_node(libb, "libb/0.1#123", deps=[], dependents=[app])
@@ -38,8 +38,8 @@ class TestProvidesTest(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        libc = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        libc = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libb])
         self._check_node(libb, "libb/0.1#123", deps=[libc], dependents=[app])
@@ -64,8 +64,8 @@ class TestProvidesTest(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        libc = app.dependencies[1].dst
+        libb = app.edges[0].dst
+        libc = app.edges[1].dst
 
         self._check_node(app, "app/0.1", deps=[libb, libc])
         self._check_node(libb, "libb/0.1#123", deps=[], dependents=[app])
@@ -83,8 +83,8 @@ class TestProvidesTest(GraphManagerTest):
         self.assertEqual(3, len(deps_graph.nodes))
 
         app = deps_graph.root
-        br = app.dependencies[0].dst
-        br_lib = br.dependencies[0].dst
+        br = app.edges[0].dst
+        br_lib = br.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[br])
         self._check_node(br, "br/0.1#123", deps=[br_lib], dependents=[app])
@@ -109,10 +109,10 @@ class TestProvidesTest(GraphManagerTest):
 
         self.assertEqual(5, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        libc = app.dependencies[1].dst
-        liba1 = libb.dependencies[0].dst
-        libd2 = libc.dependencies[0].dst
+        libb = app.edges[0].dst
+        libc = app.edges[1].dst
+        liba1 = libb.edges[0].dst
+        libd2 = libc.edges[0].dst
         self._check_node(app, "app/0.1", deps=[libb, libc])
         self._check_node(libb, "libb/0.1#123", deps=[liba1], dependents=[app])
         self._check_node(libc, "libc/0.1#123", deps=[libd2], dependents=[app])
@@ -136,9 +136,9 @@ class TestProvidesTest(GraphManagerTest):
         self.assertEqual(4, len(deps_graph.nodes))
 
         app = deps_graph.root
-        libc = app.dependencies[0].dst
-        libb = libc.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libc = app.edges[0].dst
+        libb = libc.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[libc])
         self._check_node(libc, "libc/0.1#123", deps=[libb], dependents=[app])
@@ -158,8 +158,8 @@ class ProvidesBuildRequireTest(GraphManagerTest):
         self.assertEqual(3, len(deps_graph.nodes))
 
         app = deps_graph.root
-        br = app.dependencies[0].dst
-        br_lib = br.dependencies[0].dst
+        br = app.edges[0].dst
+        br_lib = br.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[br])
         self._check_node(br, "br/0.1#123", deps=[br_lib], dependents=[app])
@@ -180,8 +180,8 @@ class ProvidesBuildRequireTest(GraphManagerTest):
         self.assertEqual(3, len(deps_graph.nodes))
 
         app = deps_graph.root
-        lib = app.dependencies[0].dst
-        br = lib.dependencies[0].dst
+        lib = app.edges[0].dst
+        br = lib.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[lib])
         self._check_node(lib, "lib/0.1#123", deps=[br], dependents=[app])
@@ -205,8 +205,8 @@ class ProvidesBuildRequireTest(GraphManagerTest):
         self.assertEqual(3, len(deps_graph.nodes))
 
         app = deps_graph.root
-        br = app.dependencies[0].dst
-        br_lib = br.dependencies[0].dst
+        br = app.edges[0].dst
+        br_lib = br.edges[0].dst
 
         self._check_node(app, "app/0.1", deps=[br])
         self._check_node(br, "br/0.1#123", deps=[br_lib], dependents=[app])
@@ -226,8 +226,8 @@ class ProvidesBuildRequireTest(GraphManagerTest):
         self.assertEqual(3, len(deps_graph.nodes))
 
         app = deps_graph.root
-        br1 = app.dependencies[0].dst
-        br2 = app.dependencies[1].dst
+        br1 = app.edges[0].dst
+        br2 = app.edges[1].dst
 
         self._check_node(app, "app/0.1", deps=[br1, br2])
         self._check_node(br1, "br1/0.1#123", deps=[], dependents=[app])

--- a/test/integration/graph/core/test_version_ranges.py
+++ b/test/integration/graph/core/test_version_ranges.py
@@ -19,7 +19,7 @@ class TestVersionRanges(GraphManagerTest):
 
         self.assertEqual(2, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
+        libb = app.edges[0].dst
 
         self._check_node(libb, "libb/0.2#123", dependents=[app])
         self._check_node(app, "app/0.1", deps=[libb])
@@ -42,7 +42,7 @@ class TestVersionRanges(GraphManagerTest):
             deps_graph = self.build_consumer(consumer)
             self.assertEqual(2, len(deps_graph.nodes))
             app = deps_graph.root
-            libb = app.dependencies[0].dst
+            libb = app.edges[0].dst
 
             self._check_node(libb, f"libb/{solution}#123", dependents=[app])
             self._check_node(app, "app/0.1", deps=[libb])
@@ -115,9 +115,9 @@ class TestVersionRangesDiamond(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        libc = app.dependencies[1].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        libc = app.edges[1].dst
+        liba = libb.edges[0].dst
 
         self._check_node(liba, "liba/0.2#123", dependents=[libb, libc], deps=[])
         self._check_node(libb, "libb/0.1#123", dependents=[app], deps=[liba])
@@ -137,9 +137,9 @@ class TestVersionRangesDiamond(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        libc = app.dependencies[1].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        libc = app.edges[1].dst
+        liba = libb.edges[0].dst
 
         self._check_node(liba, "liba/0.2#123", dependents=[libb, libc], deps=[])
         self._check_node(libb, "libb/0.1#123", dependents=[app], deps=[liba])
@@ -158,9 +158,9 @@ class TestVersionRangesDiamond(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        libc = app.dependencies[1].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        libc = app.edges[1].dst
+        liba = libb.edges[0].dst
 
         self._check_node(liba, "liba/0.1#123", dependents=[libb, libc], deps=[])
         self._check_node(libb, "libb/0.1#123", dependents=[app], deps=[liba])
@@ -181,9 +181,9 @@ class TestVersionRangesDiamond(GraphManagerTest):
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
         app.enabled_remotes = [Remote("foo", None)]
-        libb = app.dependencies[0].dst
-        libc = app.dependencies[1].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        libc = app.edges[1].dst
+        liba = libb.edges[0].dst
 
         self._check_node(libb, "libb/0.1#123", dependents=[app], deps=[liba])
         self._check_node(libb, "libb/0.1#123", dependents=[app], deps=[liba])
@@ -203,9 +203,9 @@ class TestVersionRangesDiamond(GraphManagerTest):
 
         self.assertEqual(4, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        libc = app.dependencies[1].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        libc = app.edges[1].dst
+        liba = libb.edges[0].dst
 
         self._check_node(libb, "libb/0.1#123", dependents=[app], deps=[liba])
         self._check_node(libb, "libb/0.1#123", dependents=[app], deps=[liba])
@@ -225,8 +225,8 @@ class TestVersionRangesOverridesDiamond(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(liba, "liba/0.2#123", dependents=[libb, app], deps=[])
         self._check_node(libb, "libb/0.1#123", dependents=[app], deps=[liba])
@@ -243,8 +243,8 @@ class TestVersionRangesOverridesDiamond(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(liba, "liba/0.1#123", dependents=[libb, app], deps=[])
         self._check_node(libb, "libb/0.1#123", dependents=[app], deps=[liba])
@@ -261,8 +261,8 @@ class TestVersionRangesOverridesDiamond(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(liba, "liba/0.1#123", dependents=[libb, app], deps=[])
         self._check_node(libb, "libb/0.1#123", dependents=[app], deps=[liba])
@@ -281,7 +281,7 @@ class TestVersionRangesOverridesDiamond(GraphManagerTest):
 
         self.assertEqual(2, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
+        libb = app.edges[0].dst
 
     def test_transitive_fixed_conflict_forced(self):
         # app ---> libb/0.1 -----------> liba/1.2
@@ -295,8 +295,8 @@ class TestVersionRangesOverridesDiamond(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(liba, "liba/1.2#123", dependents=[libb, app], deps=[])
         self._check_node(libb, "libb/0.1#123", dependents=[app], deps=[liba])
@@ -315,8 +315,8 @@ class TestVersionRangesOverridesDiamond(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(liba, "liba/0.3#123", dependents=[libb, app], deps=[])
         self._check_node(libb, "libb/0.1#123", dependents=[app], deps=[liba])
@@ -338,8 +338,8 @@ class TestVersionRangesOverridesDiamond(GraphManagerTest):
 
         self.assertEqual(3, len(deps_graph.nodes))
         app = deps_graph.root
-        libb = app.dependencies[0].dst
-        liba = libb.dependencies[0].dst
+        libb = app.edges[0].dst
+        liba = libb.edges[0].dst
 
         self._check_node(liba, "liba/0.2#123", dependents=[libb, app], deps=[])
         self._check_node(libb, "libb/0.1#123", dependents=[app], deps=[liba])


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Pure internal refactor, as I was struggling to differentiate the ``conanfile.dependencies`` usages (type ``ConanFileDependencies``), from the ``node.dependencies`` usages (type ``List[Edge]``), so I renamed the later to ``.edges``
