### PR TITLE
XcodeToolchain: fix deployment target for non-macOS

### DIFF
--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -109,7 +109,6 @@ class XcodeDeps(object):
         self._conanfile = conanfile
         self.configuration = conanfile.settings.get_safe("build_type")
         arch = conanfile.settings.get_safe("arch")
-        self.os_version = conanfile.settings.get_safe("os.version")
         self.architecture = _to_apple_arch(arch, default=arch)
         self.os_version = conanfile.settings.get_safe("os.version")
         self.sdk = conanfile.settings.get_safe("os.sdk")

--- a/conan/tools/apple/xcodetoolchain.py
+++ b/conan/tools/apple/xcodetoolchain.py
@@ -13,7 +13,7 @@ class XcodeToolchain(object):
 
     _vars_xconfig = textwrap.dedent("""\
         // Definition of toolchain variables
-        {macosx_deployment_target}
+        {apple_deployment_target}
         {clang_cxx_library}
         {clang_cxx_language_standard}
         """)
@@ -63,9 +63,17 @@ class XcodeToolchain(object):
         return cppstd
 
     @property
-    def _macosx_deployment_target(self):
-        return 'MACOSX_DEPLOYMENT_TARGET{}={}'.format(_xcconfig_conditional(self._conanfile.settings, self.configuration),
-                                                      self.os_version) if self.os_version else ""
+    def _apple_deployment_target(self):
+        deployment_target_key = {
+            "Macos": "MACOSX_DEPLOYMENT_TARGET",
+            "iOS": "IPHONEOS_DEPLOYMENT_TARGET",
+            "tvOS": "TVOS_DEPLOYMENT_TARGET",
+            "watchOS": "WATCHOS_DEPLOYMENT_TARGET",
+            "visionOS": "XROS_DEPLOYMENT_TARGET",
+        }.get(str(self._conanfile.settings.get_safe("os")))
+        return '{}{}={}'.format(deployment_target_key,
+                                _xcconfig_conditional(self._conanfile.settings, self.configuration),
+                                self.os_version) if self.os_version else ""
 
     @property
     def _clang_cxx_library(self):
@@ -83,7 +91,7 @@ class XcodeToolchain(object):
 
     @property
     def _vars_xconfig_content(self):
-        ret = self._vars_xconfig.format(macosx_deployment_target=self._macosx_deployment_target,
+        ret = self._vars_xconfig.format(apple_deployment_target=self._apple_deployment_target,
                                         clang_cxx_library=self._clang_cxx_library,
                                         clang_cxx_language_standard=self._clang_cxx_language_standard)
         return ret

--- a/test/functional/toolchains/apple/test_xcodetoolchain.py
+++ b/test/functional/toolchains/apple/test_xcodetoolchain.py
@@ -1,4 +1,6 @@
+import os
 import platform
+import re
 import textwrap
 
 import pytest
@@ -94,3 +96,49 @@ def test_project_xcodetoolchain(cppstd, cppstd_output, min_version):
     assert "sdk {}".format(sdk_version) in client.out
     assert "libc++" in client.out
     assert " -fstack-protector-strong" in client.out
+
+
+@pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
+@pytest.mark.parametrize("os_name, sdk, min_version, deployment_target_flag", [
+    ("Macos", None, "11.0", "MACOSX_DEPLOYMENT_TARGET"),
+    ("iOS", "iphoneos", "18.0", "IPHONEOS_DEPLOYMENT_TARGET"),
+    ("tvOS", "appletvos", "18.4", "TVOS_DEPLOYMENT_TARGET"),
+    ("watchOS", "watchos", "9.0", "WATCHOS_DEPLOYMENT_TARGET"),
+    ("visionOS", "xros", "2.0", "XROS_DEPLOYMENT_TARGET"),
+])
+def test_xcodetoolchain_xcconfig_deplyment_target(os_name, sdk, min_version, deployment_target_flag):
+    client = TestClient()
+
+    xcconfig_path_prefix = "xcconfig from test="
+
+    conanfile = textwrap.dedent(f"""
+        import os
+        from conan import ConanFile
+        from conan.tools.apple import XcodeToolchain
+        from conan.tools.files import copy
+        class MyApplicationConan(ConanFile):
+            name = "myapplication"
+            version = "1.0"
+            settings = "os", "compiler", "build_type", "arch"
+            def generate(self):
+                tc = XcodeToolchain(self)
+                tc.generate()
+                self.output.info("{xcconfig_path_prefix}" + tc._vars_xconfig_filename)
+        """)
+
+    client.save({"conanfile.py": conanfile}, clean_first=True)
+
+    settings = "-s arch=armv8 -s compiler.cppstd=gnu17 -s compiler.libcxx=libc++ " \
+               "-s os={} -s os.version={}".format(os_name, min_version)
+    if sdk:
+        settings += f" -s os.sdk={sdk}"
+
+    client.run("create . -s build_type=Release {} --build=missing".format(settings))
+
+    match = re.search(f"{xcconfig_path_prefix}(.+)$", client.out, re.MULTILINE)
+    assert match != None
+
+    generated_xcconfig_path = os.path.join(client.created_layout().build(), match[1])
+    xcconfig_contents = open(generated_xcconfig_path, 'r').read()
+    match = re.search(f"^{deployment_target_flag}.+={min_version}$", xcconfig_contents, re.MULTILINE)
+    assert match != None

--- a/test/functional/toolchains/apple/test_xcodetoolchain.py
+++ b/test/functional/toolchains/apple/test_xcodetoolchain.py
@@ -1,6 +1,4 @@
-import os
 import platform
-import re
 import textwrap
 
 import pytest
@@ -96,49 +94,3 @@ def test_project_xcodetoolchain(cppstd, cppstd_output, min_version):
     assert "sdk {}".format(sdk_version) in client.out
     assert "libc++" in client.out
     assert " -fstack-protector-strong" in client.out
-
-
-@pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
-@pytest.mark.parametrize("os_name, sdk, min_version, deployment_target_flag", [
-    ("Macos", None, "11.0", "MACOSX_DEPLOYMENT_TARGET"),
-    ("iOS", "iphoneos", "18.0", "IPHONEOS_DEPLOYMENT_TARGET"),
-    ("tvOS", "appletvos", "18.4", "TVOS_DEPLOYMENT_TARGET"),
-    ("watchOS", "watchos", "9.0", "WATCHOS_DEPLOYMENT_TARGET"),
-    ("visionOS", "xros", "2.0", "XROS_DEPLOYMENT_TARGET"),
-])
-def test_xcodetoolchain_xcconfig_deplyment_target(os_name, sdk, min_version, deployment_target_flag):
-    client = TestClient()
-
-    xcconfig_path_prefix = "xcconfig from test="
-
-    conanfile = textwrap.dedent(f"""
-        import os
-        from conan import ConanFile
-        from conan.tools.apple import XcodeToolchain
-        from conan.tools.files import copy
-        class MyApplicationConan(ConanFile):
-            name = "myapplication"
-            version = "1.0"
-            settings = "os", "compiler", "build_type", "arch"
-            def generate(self):
-                tc = XcodeToolchain(self)
-                tc.generate()
-                self.output.info("{xcconfig_path_prefix}" + tc._vars_xconfig_filename)
-        """)
-
-    client.save({"conanfile.py": conanfile}, clean_first=True)
-
-    settings = "-s arch=armv8 -s compiler.cppstd=gnu17 -s compiler.libcxx=libc++ " \
-               "-s os={} -s os.version={}".format(os_name, min_version)
-    if sdk:
-        settings += f" -s os.sdk={sdk}"
-
-    client.run("create . -s build_type=Release {} --build=missing".format(settings))
-
-    match = re.search(f"{xcconfig_path_prefix}(.+)$", client.out, re.MULTILINE)
-    assert match != None
-
-    generated_xcconfig_path = os.path.join(client.created_layout().build(), match[1])
-    xcconfig_contents = open(generated_xcconfig_path, 'r').read()
-    match = re.search(f"^{deployment_target_flag}.+={min_version}$", xcconfig_contents, re.MULTILINE)
-    assert match != None

--- a/test/integration/toolchains/apple/test_xcodetoolchain.py
+++ b/test/integration/toolchains/apple/test_xcodetoolchain.py
@@ -1,11 +1,9 @@
-import os
 import platform
 import re
 import textwrap
 
 import pytest
 
-from conan.internal.util.files import load
 from conan.test.utils.tools import TestClient
 
 
@@ -103,7 +101,7 @@ def test_xcodetoolchain_xcconfig_deplyment_target(os_name, sdk, min_version, dep
     conanfile = textwrap.dedent(f"""
         import os
         from conan import ConanFile
-        from conan.tools.apple import XcodeToolchain, to_apple_arch
+        from conan.tools.apple import XcodeToolchain
         from conan.tools.files import save
         class MyApplicationConan(ConanFile):
             name = "myapplication"

--- a/test/integration/toolchains/apple/test_xcodetoolchain.py
+++ b/test/integration/toolchains/apple/test_xcodetoolchain.py
@@ -1,7 +1,11 @@
+import os
 import platform
+import re
+import textwrap
 
 import pytest
 
+from conan.internal.util.files import load
 from conan.test.utils.tools import TestClient
 
 
@@ -83,3 +87,45 @@ def test_flags_generated_if_only_defines():
     assert "GCC_PREPROCESSOR_DEFINITIONS = $(inherited) MYDEFINITION" in conan_global_flags
     conan_global_file = client.load("conan_config.xcconfig")
     assert '#include "conan_global_flags.xcconfig"' in conan_global_file
+
+
+@pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
+@pytest.mark.parametrize("os_name, sdk, min_version, deployment_target_flag", [
+    ("Macos", None, "11.0", "MACOSX_DEPLOYMENT_TARGET"),
+    ("iOS", "iphoneos", "18.0", "IPHONEOS_DEPLOYMENT_TARGET"),
+    ("tvOS", "appletvos", "18.4", "TVOS_DEPLOYMENT_TARGET"),
+    ("watchOS", "watchos", "9.0", "WATCHOS_DEPLOYMENT_TARGET"),
+    ("visionOS", "xros", "2.0", "XROS_DEPLOYMENT_TARGET"),
+])
+def test_xcodetoolchain_xcconfig_deplyment_target(os_name, sdk, min_version, deployment_target_flag):
+    client = TestClient()
+
+    conanfile = textwrap.dedent(f"""
+        import os
+        from conan import ConanFile
+        from conan.tools.apple import XcodeToolchain, to_apple_arch
+        from conan.tools.files import save
+        class MyApplicationConan(ConanFile):
+            name = "myapplication"
+            version = "1.0"
+            settings = "os", "compiler", "build_type", "arch"
+            def generate(self):
+                tc = XcodeToolchain(self)
+                tc.generate()
+                # Private access to get the generated xcconfig filename
+                # It changes based on the settings, so this is the less fragile way to get it
+                save(self, os.path.join(self.generators_folder, "name.txt"), tc._vars_xconfig_filename)
+        """)
+
+    client.save({"conanfile.py": conanfile})
+
+    settings = f"-s os={os_name} -s os.version={min_version}"
+    if sdk:
+        settings += f" -s os.sdk={sdk}"
+
+    client.run(f"install . -s build_type=Release {settings} --build=missing")
+
+    xcconfig_name = client.load("name.txt").strip()
+    xcconfig = client.load(xcconfig_name)
+    match = re.search(f"^{deployment_target_flag}.+={min_version}$", xcconfig, re.MULTILINE)
+    assert match is not None


### PR DESCRIPTION
Changelog: Bugfix: XcodeToolchain sets correct `..._DEPLOYMENT_TARGET` for all Apple OSs.
Docs: https://github.com/conan-io/docs/pull/4126

Xcode screenshot of an iOS project without this change, iOS profile has `os.version=12.0`:

![Screenshot 2025-06-15 at 18 30 33](https://github.com/user-attachments/assets/ece410e8-d13a-45cd-8dc1-321a8124ebc3)


- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
