### PR TITLE
avoid leaking core.conf in user profiles

### DIFF
--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -384,6 +384,12 @@ class Conf:
         c._values = OrderedDict((k, v.copy()) for k, v in self._values.items())
         return c
 
+    def filter_core(self):
+        c = Conf()
+        c._values = OrderedDict((k, v.copy()) for k, v in self._values.items()
+                                if not k.startswith("core"))
+        return c
+
     def dumps(self):
         """
         Returns a string with the format ``name=conf-value``
@@ -630,7 +636,9 @@ class ConfDefinition:
         :type global_conf: ConfDefinition
         """
         result = ConfDefinition()
-        result._pattern_confs = global_conf._pattern_confs.copy()
+        # Do not add ``core.xxx`` configuration to profiles
+        for k, v in global_conf._pattern_confs.items():
+            result._pattern_confs[k] = v.filter_core()
         result.update_conf_definition(self)
         self._pattern_confs = result._pattern_confs
         return

--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -387,7 +387,7 @@ class Conf:
     def filter_core(self):
         c = Conf()
         c._values = OrderedDict((k, v.copy()) for k, v in self._values.items()
-                                if not k.startswith("core"))
+                                if not CORE_CONF_PATTERN.match(k))
         return c
 
     def dumps(self):

--- a/test/integration/configuration/conf/test_conf.py
+++ b/test/integration/configuration/conf/test_conf.py
@@ -110,6 +110,25 @@ def test_composition_conan_conf(client):
     assert "tools.meson.mesontoolchain:backend$Super" in client.out
 
 
+def test_core_global_conf_not_in_profile(client):
+    client.save_home({"global.conf": "core.upload:retry=1"})
+    profile = textwrap.dedent("""\
+        [conf]
+        tools.build:verbosity=quiet
+        """)
+    client.save({"profile": profile})
+    client.run("install . -pr=profile")
+    assert "tools.build:verbosity$quiet" in client.out
+    # The core conf is not shown
+    assert "core.upload:retry=1" not in client.out
+
+    # also with -cc command line argument
+    client.run("install . -pr=profile -cc core.upload:retry=1")
+    assert "tools.build:verbosity$quiet" in client.out
+    # The core conf is not shown
+    assert "core.upload:retry=1" not in client.out
+
+
 def test_new_config_file(client):
     conf = textwrap.dedent("""\
         tools.build:verbosity=quiet


### PR DESCRIPTION
Changelog: Bugfix: Avoid leak of ``global.conf`` and ``-cc`` configuration for ``core.xxx`` items in Conan profiles, the ``core`` conf is exclusively for Conan internals, not for recipes neither for profiles.
Docs: Omit


