### PR TITLE
Fix head method not working in testing mocked requests

### DIFF
--- a/conan/test/utils/file_server.py
+++ b/conan/test/utils/file_server.py
@@ -40,7 +40,7 @@ class TestFileServer:
         def head(folder, file):
             exists = os.path.exists(os.path.join(store, folder, file))
             if exists:
-                return True
+                return bottle.HTTPResponse(status=200)
             return bottle.HTTPError(404, "Not found")
 
         @app.route("/forbidden", method=["GET"])


### PR DESCRIPTION
Changelog: Bugfix: Fix `TestClient` mocked `HEAD` requests.
Docs: Omit

So that the next poor soul that comes after me does not waste more time than I did tracking this down
