### PR TITLE
Removed ObjC/C++ flags from C/C++ ones

### DIFF
--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -334,20 +334,14 @@ def apple_extra_flags(conanfile):
     if not is_apple_os(conanfile):
         return []
     enable_bitcode = conanfile.conf.get("tools.apple:enable_bitcode", check_type=bool)
-    enable_arc = conanfile.conf.get("tools.apple:enable_arc", check_type=bool)
     enable_visibility = conanfile.conf.get("tools.apple:enable_visibility", check_type=bool)
     is_debug = conanfile.settings.get_safe('build_type') == "Debug"
-
     flags = []
     if enable_bitcode:
         if is_debug:
             flags.append("-fembed-bitcode-marker")
         else:
             flags.append("-fembed-bitcode")
-    if enable_arc:
-        flags.append("-fobjc-arc")
-    if enable_arc is False:
-        flags.append("-fno-objc-arc")
     if enable_visibility:
         flags.append("-fvisibility=default")
     if enable_visibility is False:

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -464,8 +464,11 @@ class AppleSystemBlock(Block):
         if(CMAKE_GENERATOR MATCHES "Xcode")
           message(DEBUG "Not setting any manual command-line buildflags, since Xcode is selected as generator.")
         else()
-            string(APPEND CONAN_C_FLAGS " ${BITCODE} ${VISIBILITY} ${FOBJC_ARC}")
-            string(APPEND CONAN_CXX_FLAGS " ${BITCODE} ${VISIBILITY} ${FOBJC_ARC}")
+            string(APPEND CONAN_C_FLAGS " ${BITCODE} ${VISIBILITY}")
+            string(APPEND CONAN_CXX_FLAGS " ${BITCODE} ${VISIBILITY}")
+            # Objective-C/C++ specific flags
+            string(APPEND CONAN_OBJC_FLAGS " ${BITCODE} ${VISIBILITY} ${FOBJC_ARC}")
+            string(APPEND CONAN_OBJCXX_FLAGS " ${BITCODE} ${VISIBILITY} ${FOBJC_ARC}")
         endif()
         """)
 
@@ -851,6 +854,12 @@ class CMakeFlagsInitBlock(Block):
         endif()
         if(DEFINED CONAN_EXE_LINKER_FLAGS)
           string(APPEND CMAKE_EXE_LINKER_FLAGS_INIT " ${CONAN_EXE_LINKER_FLAGS}")
+        endif()
+        if(DEFINED CONAN_OBJCXX_FLAGS)
+          string(APPEND CMAKE_OBJCXX_FLAGS_INIT " ${CONAN_OBJCXX_FLAGS}")
+        endif()
+        if(DEFINED CONAN_OBJC_FLAGS)
+          string(APPEND CMAKE_OBJC_FLAGS_INIT " ${CONAN_OBJC_FLAGS}")
         endif()
         """)
 

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -243,6 +243,16 @@ class AutotoolsToolchain:
         ret = [self.ndebug, self.gcc_cxx11_abi] + self.extra_defines + conf_flags
         return self._filter_list_empty_fields(ret)
 
+    def _include_obj_arc_flags(self, env):
+        enable_arc = self._conanfile.conf.get("tools.apple:enable_arc", check_type=bool)
+        fobj_arc = ""
+        if enable_arc:
+            fobj_arc = "-fobjc-arc"
+        if enable_arc is False:
+            fobj_arc = "-fno-objc-arc"
+        env.append('OBJCFLAGS', [fobj_arc] + self.cflags)
+        env.append('OBJCXXFLAGS', [fobj_arc] + self.cxxflags)
+
     def environment(self):
         env = Environment()
         # Setting Android cross-compilation flags (if exist)
@@ -276,6 +286,8 @@ class AutotoolsToolchain:
         env.append("CFLAGS", self.cflags)
         env.append("LDFLAGS", self.ldflags)
         env.prepend_path("PKG_CONFIG_PATH", self._conanfile.generators_folder)
+        # Objective C/C++
+        self._include_obj_arc_flags(env)
         # Issue related: https://github.com/conan-io/conan/issues/15486
         if self._is_cross_building and self._conanfile.conf_build:
             compilers_build_mapping = (

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -250,8 +250,9 @@ class AutotoolsToolchain:
             fobj_arc = "-fobjc-arc"
         if enable_arc is False:
             fobj_arc = "-fno-objc-arc"
-        env.append('OBJCFLAGS', [fobj_arc] + self.cflags)
-        env.append('OBJCXXFLAGS', [fobj_arc] + self.cxxflags)
+        if fobj_arc:
+            env.append('OBJCFLAGS', [fobj_arc])
+            env.append('OBJCXXFLAGS', [fobj_arc])
 
     def environment(self):
         env = Environment()

--- a/conan/tools/gnu/gnutoolchain.py
+++ b/conan/tools/gnu/gnutoolchain.py
@@ -337,6 +337,16 @@ class GnuToolchain:
                 triplets[f"--{context}"] = info["triplet"]
         return triplets
 
+    def _include_obj_arc_flags(self, env):
+        enable_arc = self._conanfile.conf.get("tools.apple:enable_arc", check_type=bool)
+        fobj_arc = ""
+        if enable_arc:
+            fobj_arc = "-fobjc-arc"
+        if enable_arc is False:
+            fobj_arc = "-fno-objc-arc"
+        env.append('OBJCFLAGS', [fobj_arc] + self.cflags)
+        env.append('OBJCXXFLAGS', [fobj_arc] + self.cxxflags)
+
     @property
     def _environment(self):
         env = Environment()
@@ -346,6 +356,8 @@ class GnuToolchain:
         env.append("CFLAGS", self.cflags)
         env.append("LDFLAGS", self.ldflags)
         env.prepend_path("PKG_CONFIG_PATH", self._conanfile.generators_folder)
+        # Objective C/C++
+        self._include_obj_arc_flags(env)
         # Let's compose with user extra env variables defined (user ones have precedence)
         return self.extra_env.compose_env(env)
 

--- a/conan/tools/gnu/gnutoolchain.py
+++ b/conan/tools/gnu/gnutoolchain.py
@@ -344,8 +344,9 @@ class GnuToolchain:
             fobj_arc = "-fobjc-arc"
         if enable_arc is False:
             fobj_arc = "-fno-objc-arc"
-        env.append('OBJCFLAGS', [fobj_arc] + self.cflags)
-        env.append('OBJCXXFLAGS', [fobj_arc] + self.cxxflags)
+        if fobj_arc:
+            env.append('OBJCFLAGS', [fobj_arc])
+            env.append('OBJCXXFLAGS', [fobj_arc])
 
     @property
     def _environment(self):

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -494,8 +494,8 @@ class MesonToolchain:
         self.objc_args.extend(self.c_args)
         self.objcpp_args.extend(self.cpp_args)
         # These link_args have already the LDFLAGS env value so let's add only the new possible ones
-        self.objc_link_args.extend(apple_flags + extra_flags["ldflags"])
-        self.objcpp_link_args.extend(apple_flags + extra_flags["ldflags"])
+        self.objc_link_args.extend(self.c_link_args)
+        self.objcpp_link_args.extend(self.cpp_link_args)
 
         if self.libcxx:
             self.cpp_args.append(self.libcxx)

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -412,9 +412,9 @@ class MesonToolchain:
             fobj_arc = "-fobjc-arc"
         if enable_arc is False:
             fobj_arc = "-fno-objc-arc"
-        self.objc_args = self._get_env_list(build_env.get('OBJCFLAGS', [fobj_arc]))
+        self.objc_args = self._get_env_list(build_env.get('OBJCFLAGS', [])) + [fobj_arc]
         self.objc_link_args = self._get_env_list(build_env.get('LDFLAGS', []))
-        self.objcpp_args = self._get_env_list(build_env.get('OBJCXXFLAGS', [fobj_arc]))
+        self.objcpp_args = self._get_env_list(build_env.get('OBJCXXFLAGS', [])) + [fobj_arc]
         self.objcpp_link_args = self._get_env_list(build_env.get('LDFLAGS', []))
 
     def _resolve_android_cross_compilation(self):

--- a/test/functional/toolchains/cmake/test_cmake_toolchain_xcode_flags.py
+++ b/test/functional/toolchains/cmake/test_cmake_toolchain_xcode_flags.py
@@ -12,6 +12,8 @@ def _add_message_status_flags(client):
     with open(cmakelists_path, "a") as cmakelists_file:
         cmakelists_file.write('message(STATUS "CONAN_C_FLAGS: ${CONAN_C_FLAGS}")\n')
         cmakelists_file.write('message(STATUS "CONAN_CXX_FLAGS: ${CONAN_CXX_FLAGS}")\n')
+        cmakelists_file.write('message(STATUS "CONAN_OBJC_FLAGS: ${CONAN_OBJC_FLAGS}")\n')
+        cmakelists_file.write('message(STATUS "CONAN_OBJCXX_FLAGS: ${CONAN_OBJCXX_FLAGS}")\n')
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")

--- a/test/functional/toolchains/cmake/test_cmake_toolchain_xcode_flags.py
+++ b/test/functional/toolchains/cmake/test_cmake_toolchain_xcode_flags.py
@@ -52,8 +52,10 @@ def test_cmake_apple_bitcode_arc_and_visibility_flags_enabled(op_system, os_vers
 
     client.run("create . --profile:build=default --profile:host=host -tf=")
     # flags
-    assert "-- CONAN_C_FLAGS:  -fembed-bitcode -fvisibility=default -fobjc-arc" in client.out
-    assert "-- CONAN_CXX_FLAGS:  -fembed-bitcode -fvisibility=default -fobjc-arc" in client.out
+    assert "-- CONAN_C_FLAGS:  -fembed-bitcode -fvisibility=default" in client.out
+    assert "-- CONAN_CXX_FLAGS:  -fembed-bitcode -fvisibility=default" in client.out
+    assert "-- CONAN_OBJC_FLAGS:  -fembed-bitcode -fvisibility=default -fobjc-arc" in client.out
+    assert "-- CONAN_OBJCXX_FLAGS:  -fembed-bitcode -fvisibility=default -fobjc-arc" in client.out
     assert "[100%] Built target hello" in client.out
 
 
@@ -136,8 +138,10 @@ def test_cmake_apple_bitcode_arc_and_visibility_flags_disabled(op_system, os_ver
 
     client.run("create . --profile:build=default --profile:host=host -tf=\"\"")
     # flags
-    assert "-- CONAN_C_FLAGS:   -fvisibility=hidden -fvisibility-inlines-hidden -fno-objc-arc" in client.out
-    assert "-- CONAN_CXX_FLAGS:   -fvisibility=hidden -fvisibility-inlines-hidden -fno-objc-arc" in client.out
+    assert "-- CONAN_C_FLAGS:   -fvisibility=hidden -fvisibility-inlines-hidden" in client.out
+    assert "-- CONAN_CXX_FLAGS:   -fvisibility=hidden -fvisibility-inlines-hidden" in client.out
+    assert "-- CONAN_OBJC_FLAGS:   -fvisibility=hidden -fvisibility-inlines-hidden -fno-objc-arc" in client.out
+    assert "-- CONAN_OBJCXX_FLAGS:   -fvisibility=hidden -fvisibility-inlines-hidden -fno-objc-arc" in client.out
     assert "[100%] Built target hello" in client.out
 
 

--- a/test/integration/toolchains/gnu/test_gnutoolchain.py
+++ b/test/integration/toolchains/gnu/test_gnutoolchain.py
@@ -479,16 +479,16 @@ def test_conf_extra_apple_flags(toolchain):
     assert 'export CXXFLAGS="$CXXFLAGS -fembed-bitcode -fvisibility=default"' in tc
     assert 'export CFLAGS="$CFLAGS -fembed-bitcode -fvisibility=default"' in tc
     assert 'export LDFLAGS="$LDFLAGS -fembed-bitcode -fvisibility=default"' in tc
-    assert 'export OBJCFLAGS="$OBJCFLAGS -fobjc-arc -fembed-bitcode -fvisibility=default"' in tc
-    assert 'export OBJCXXFLAGS="$OBJCXXFLAGS -fobjc-arc -fembed-bitcode -fvisibility=default"' in tc
+    assert 'export OBJCFLAGS="$OBJCFLAGS -fobjc-arc"' in tc
+    assert 'export OBJCXXFLAGS="$OBJCXXFLAGS -fobjc-arc"' in tc
 
     c.run("install . -pr:a host -s build_type=Debug")
     tc = c.load(f)
     assert 'export CXXFLAGS="$CXXFLAGS -fembed-bitcode-marker -fvisibility=default"' in tc
     assert 'export CFLAGS="$CFLAGS -fembed-bitcode-marker -fvisibility=default"' in tc
     assert 'export LDFLAGS="$LDFLAGS -fembed-bitcode-marker -fvisibility=default"' in tc
-    assert 'export OBJCFLAGS="$OBJCFLAGS -fobjc-arc -fembed-bitcode-marker -fvisibility=default"' in tc
-    assert 'export OBJCXXFLAGS="$OBJCXXFLAGS -fobjc-arc -fembed-bitcode-marker -fvisibility=default"' in tc
+    assert 'export OBJCFLAGS="$OBJCFLAGS -fobjc-arc"' in tc
+    assert 'export OBJCXXFLAGS="$OBJCXXFLAGS -fobjc-arc"' in tc
 
     host = textwrap.dedent("""
         [settings]
@@ -506,8 +506,8 @@ def test_conf_extra_apple_flags(toolchain):
     assert 'CXXFLAGS="$CXXFLAGS -fvisibility=hidden -fvisibility-inlines-hidden"' in tc
     assert 'CFLAGS="$CFLAGS -fvisibility=hidden -fvisibility-inlines-hidden"' in tc
     assert 'LDFLAGS="$LDFLAGS -fvisibility=hidden -fvisibility-inlines-hidden"' in tc
-    assert 'export OBJCFLAGS="$OBJCFLAGS -fno-objc-arc -fvisibility=hidden -fvisibility-inlines-hidden"' in tc
-    assert 'export OBJCXXFLAGS="$OBJCXXFLAGS -fno-objc-arc -fvisibility=hidden -fvisibility-inlines-hidden"' in tc
+    assert 'export OBJCFLAGS="$OBJCFLAGS -fno-objc-arc"' in tc
+    assert 'export OBJCXXFLAGS="$OBJCXXFLAGS -fno-objc-arc"' in tc
 
 
 def test_toolchain_crossbuild_to_android():

--- a/test/integration/toolchains/gnu/test_gnutoolchain.py
+++ b/test/integration/toolchains/gnu/test_gnutoolchain.py
@@ -476,15 +476,15 @@ def test_conf_extra_apple_flags(toolchain):
     c.run("install . -pr:a host")
     f = "conanautotoolstoolchain.sh" if toolchain == "AutotoolsToolchain" else "conangnutoolchain.sh"
     tc = c.load(f)
-    assert 'export CXXFLAGS="$CXXFLAGS -fembed-bitcode -fobjc-arc -fvisibility=default"' in tc
-    assert 'export CFLAGS="$CFLAGS -fembed-bitcode -fobjc-arc -fvisibility=default"' in tc
-    assert 'export LDFLAGS="$LDFLAGS -fembed-bitcode -fobjc-arc -fvisibility=default"' in tc
+    assert 'export CXXFLAGS="$CXXFLAGS -fembed-bitcode -fvisibility=default"' in tc
+    assert 'export CFLAGS="$CFLAGS -fembed-bitcode -fvisibility=default"' in tc
+    assert 'export LDFLAGS="$LDFLAGS -fembed-bitcode -fvisibility=default"' in tc
 
     c.run("install . -pr:a host -s build_type=Debug")
     tc = c.load(f)
-    assert 'export CXXFLAGS="$CXXFLAGS -fembed-bitcode-marker -fobjc-arc -fvisibility=default"' in tc
-    assert 'export CFLAGS="$CFLAGS -fembed-bitcode-marker -fobjc-arc -fvisibility=default"' in tc
-    assert 'export LDFLAGS="$LDFLAGS -fembed-bitcode-marker -fobjc-arc -fvisibility=default"' in tc
+    assert 'export CXXFLAGS="$CXXFLAGS -fembed-bitcode-marker -fvisibility=default"' in tc
+    assert 'export CFLAGS="$CFLAGS -fembed-bitcode-marker -fvisibility=default"' in tc
+    assert 'export LDFLAGS="$LDFLAGS -fembed-bitcode-marker -fvisibility=default"' in tc
 
     host = textwrap.dedent("""
         [settings]
@@ -499,9 +499,9 @@ def test_conf_extra_apple_flags(toolchain):
     c.save({"host": host})
     c.run("install . -pr:a host")
     tc = c.load(f)
-    assert 'CXXFLAGS="$CXXFLAGS -fno-objc-arc -fvisibility=hidden -fvisibility-inlines-hidden"' in tc
-    assert 'CFLAGS="$CFLAGS -fno-objc-arc -fvisibility=hidden -fvisibility-inlines-hidden"' in tc
-    assert 'LDFLAGS="$LDFLAGS -fno-objc-arc -fvisibility=hidden -fvisibility-inlines-hidden"' in tc
+    assert 'CXXFLAGS="$CXXFLAGS -fvisibility=hidden -fvisibility-inlines-hidden"' in tc
+    assert 'CFLAGS="$CFLAGS -fvisibility=hidden -fvisibility-inlines-hidden"' in tc
+    assert 'LDFLAGS="$LDFLAGS -fvisibility=hidden -fvisibility-inlines-hidden"' in tc
 
 
 def test_toolchain_crossbuild_to_android():

--- a/test/integration/toolchains/gnu/test_gnutoolchain.py
+++ b/test/integration/toolchains/gnu/test_gnutoolchain.py
@@ -479,12 +479,16 @@ def test_conf_extra_apple_flags(toolchain):
     assert 'export CXXFLAGS="$CXXFLAGS -fembed-bitcode -fvisibility=default"' in tc
     assert 'export CFLAGS="$CFLAGS -fembed-bitcode -fvisibility=default"' in tc
     assert 'export LDFLAGS="$LDFLAGS -fembed-bitcode -fvisibility=default"' in tc
+    assert 'export OBJCFLAGS="$OBJCFLAGS -fobjc-arc -fembed-bitcode -fvisibility=default"' in tc
+    assert 'export OBJCXXFLAGS="$OBJCXXFLAGS -fobjc-arc -fembed-bitcode -fvisibility=default"' in tc
 
     c.run("install . -pr:a host -s build_type=Debug")
     tc = c.load(f)
     assert 'export CXXFLAGS="$CXXFLAGS -fembed-bitcode-marker -fvisibility=default"' in tc
     assert 'export CFLAGS="$CFLAGS -fembed-bitcode-marker -fvisibility=default"' in tc
     assert 'export LDFLAGS="$LDFLAGS -fembed-bitcode-marker -fvisibility=default"' in tc
+    assert 'export OBJCFLAGS="$OBJCFLAGS -fobjc-arc -fembed-bitcode-marker -fvisibility=default"' in tc
+    assert 'export OBJCXXFLAGS="$OBJCXXFLAGS -fobjc-arc -fembed-bitcode-marker -fvisibility=default"' in tc
 
     host = textwrap.dedent("""
         [settings]
@@ -502,6 +506,8 @@ def test_conf_extra_apple_flags(toolchain):
     assert 'CXXFLAGS="$CXXFLAGS -fvisibility=hidden -fvisibility-inlines-hidden"' in tc
     assert 'CFLAGS="$CFLAGS -fvisibility=hidden -fvisibility-inlines-hidden"' in tc
     assert 'LDFLAGS="$LDFLAGS -fvisibility=hidden -fvisibility-inlines-hidden"' in tc
+    assert 'export OBJCFLAGS="$OBJCFLAGS -fno-objc-arc -fvisibility=hidden -fvisibility-inlines-hidden"' in tc
+    assert 'export OBJCXXFLAGS="$OBJCXXFLAGS -fno-objc-arc -fvisibility=hidden -fvisibility-inlines-hidden"' in tc
 
 
 def test_toolchain_crossbuild_to_android():

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -768,13 +768,15 @@ def test_conf_extra_apple_flags():
     f = "conan_meson_native.ini"
     tc = c.load(f)
     for flags in ["c_args", "cpp_args", "c_link_args", "cpp_link_args"]:
-        assert f"{flags} = ['-m64', '-fembed-bitcode', '-fobjc-arc', '-fvisibility=default']" in tc
-
+        assert f"{flags} = ['-m64', '-fembed-bitcode', '-fvisibility=default']" in tc
+    for flags in ["objcpp_args", "objc_args"]:
+        assert f"{flags} = ['-fobjc-arc', '-m64', '-fembed-bitcode', '-fvisibility=default']" in tc
     c.run("install . -pr:a host -s build_type=Debug")
     tc = c.load(f)
     for flags in ["c_args", "cpp_args", "c_link_args", "cpp_link_args"]:
-        assert f"{flags} = ['-m64', '-fembed-bitcode-marker'," \
-               " '-fobjc-arc', '-fvisibility=default']" in tc
+        assert f"{flags} = ['-m64', '-fembed-bitcode-marker', '-fvisibility=default']" in tc
+    for flags in ["objcpp_args", "objc_args"]:
+        assert f"{flags} = ['-fobjc-arc', '-m64', '-fembed-bitcode-marker', '-fvisibility=default']" in tc
 
     host = textwrap.dedent("""
         [settings]
@@ -792,5 +794,5 @@ def test_conf_extra_apple_flags():
     c.run("install . -pr:a host")
     tc = c.load(f)
     for flags in ["c_args", "cpp_args", "c_link_args", "cpp_link_args"]:
-        assert f"{flags} = ['-m64', '-fno-objc-arc', '-fvisibility=hidden', " \
+        assert f"{flags} = ['-m64', '-fvisibility=hidden', " \
                "'-fvisibility-inlines-hidden']" in tc

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -794,5 +794,6 @@ def test_conf_extra_apple_flags():
     c.run("install . -pr:a host")
     tc = c.load(f)
     for flags in ["c_args", "cpp_args", "c_link_args", "cpp_link_args"]:
-        assert f"{flags} = ['-m64', '-fvisibility=hidden', " \
-               "'-fvisibility-inlines-hidden']" in tc
+        assert f"{flags} = ['-m64', '-fvisibility=hidden', '-fvisibility-inlines-hidden']" in tc
+    for flags in ["objcpp_args", "objc_args"]:
+        assert f"{flags} = ['-fno-objc-arc', '-m64', '-fvisibility=hidden', '-fvisibility-inlines-hidden']" in tc


### PR DESCRIPTION
Changelog: Bugfix: Redirected Apple ARC flags to the ObjC/C++ ones.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/18467
