### PR TITLE
implementing support for exe editables in CMakeConfigDeps

### DIFF
--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -15,6 +15,7 @@ _DIRS_VAR_NAMES = ["_includedirs", "_srcdirs", "_libdirs", "_resdirs", "_bindirs
 _FIELD_VAR_NAMES = ["_system_libs", "_package_framework", "_frameworks", "_libs", "_defines",
                     "_cflags", "_cxxflags", "_sharedlinkflags", "_exelinkflags", "_sources"]
 _ALL_NAMES = _DIRS_VAR_NAMES + _FIELD_VAR_NAMES
+_SINGLE_VALUE_VARS = "type", "exe", "location", "link_location", "languages", "package_framework"
 
 
 class MockInfoProperty:
@@ -460,6 +461,12 @@ class _Component:
                     merge_list(other_values, current_values)
                 else:
                     setattr(self, varname, other_values)
+
+        for varname in _SINGLE_VALUE_VARS:  # To allow editable of .exe/.location
+            other_values = getattr(other, varname)
+            if other_values is not None:
+                # Just overwrite the existing value, not possible to append
+                setattr(self, varname, other_values)
 
         if other.requires:
             current_values = self.get_init("requires", [])

--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -15,7 +15,7 @@ _DIRS_VAR_NAMES = ["_includedirs", "_srcdirs", "_libdirs", "_resdirs", "_bindirs
 _FIELD_VAR_NAMES = ["_system_libs", "_package_framework", "_frameworks", "_libs", "_defines",
                     "_cflags", "_cxxflags", "_sharedlinkflags", "_exelinkflags", "_sources"]
 _ALL_NAMES = _DIRS_VAR_NAMES + _FIELD_VAR_NAMES
-_SINGLE_VALUE_VARS = "type", "exe", "location", "link_location", "languages", "package_framework"
+_SINGLE_VALUE_VARS = "_type", "_exe", "_location", "_link_location", "_languages"
 
 
 class MockInfoProperty:


### PR DESCRIPTION
Changelog: Feature: Added support for ``.exe`` in editables packages in ``CMakeConfigDeps``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/18460