### PR TITLE
fix detection of riscv64 cpu in Meson toolchain (#18490)

### DIFF
--- a/conan/tools/meson/helpers.py
+++ b/conan/tools/meson/helpers.py
@@ -53,7 +53,7 @@ _meson_cpu_family_map = {
     'x86': ('x86', 'x86', 'little'),
     'x86_64': ('x86_64', 'x86_64', 'little'),
     'riscv32': ('riscv32', 'riscv32', 'little'),
-    'riscv64': ('riscv64', 'riscv32', 'little')
+    'riscv64': ('riscv64', 'riscv64', 'little')
 }
 
 

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -752,10 +752,9 @@ def test_cross_x86_64_to_riscv32():
     """
     https://github.com/conan-io/conan/issues/18490
     """
-
     c = TestClient()
     c.save({"conanfile.py": GenConanfile().with_settings("os", "compiler", "arch", "build_type")})
-    c.run("install . -g MesonToolchain -s arch=riscv32 -s:b arch=x86_64")
+    c.run("install . -g MesonToolchain -s os=Linux -s arch=riscv32 -s:b arch=x86_64")
     assert not os.path.exists(os.path.join(c.current_folder, MesonToolchain.native_filename))
     cross = c.load(MesonToolchain.cross_filename)
     assert "cpu = 'x86_64'" in cross  # This is the build machine
@@ -766,10 +765,9 @@ def test_cross_x86_64_to_riscv64():
     """
     https://github.com/conan-io/conan/issues/18490
     """
-
     c = TestClient()
     c.save({"conanfile.py": GenConanfile().with_settings("os", "compiler", "arch", "build_type")})
-    c.run("install . -g MesonToolchain -s arch=riscv64 -s:b arch=x86_64")
+    c.run("install . -g MesonToolchain -s os=Linux -s arch=riscv64 -s:b arch=x86_64")
     assert not os.path.exists(os.path.join(c.current_folder, MesonToolchain.native_filename))
     cross = c.load(MesonToolchain.cross_filename)
     assert "cpu = 'x86_64'" in cross  # This is the build machine

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -748,6 +748,34 @@ def test_cross_x86_64_to_x86():
     assert "cpu = 'x86'" in cross  # This is the host machine
 
 
+def test_cross_x86_64_to_riscv32():
+    """
+    https://github.com/conan-io/conan/issues/18490
+    """
+
+    c = TestClient()
+    c.save({"conanfile.py": GenConanfile().with_settings("os", "compiler", "arch", "build_type")})
+    c.run("install . -g MesonToolchain -s arch=riscv32 -s:b arch=x86_64")
+    assert not os.path.exists(os.path.join(c.current_folder, MesonToolchain.native_filename))
+    cross = c.load(MesonToolchain.cross_filename)
+    assert "cpu = 'x86_64'" in cross  # This is the build machine
+    assert "cpu = 'riscv32'" in cross  # This is the host machine
+
+
+def test_cross_x86_64_to_riscv64():
+    """
+    https://github.com/conan-io/conan/issues/18490
+    """
+
+    c = TestClient()
+    c.save({"conanfile.py": GenConanfile().with_settings("os", "compiler", "arch", "build_type")})
+    c.run("install . -g MesonToolchain -s arch=riscv64 -s:b arch=x86_64")
+    assert not os.path.exists(os.path.join(c.current_folder, MesonToolchain.native_filename))
+    cross = c.load(MesonToolchain.cross_filename)
+    assert "cpu = 'x86_64'" in cross  # This is the build machine
+    assert "cpu = 'riscv64'" in cross  # This is the host machine
+
+
 def test_conf_extra_apple_flags():
     host = textwrap.dedent("""
     [settings]


### PR DESCRIPTION
Changelog:  Bugfix: Fix detection of riscv64 cpu in Meson toolchain.
Docs: Omit

Close https://github.com/conan-io/conan/pull/18490


- [x] Refer to the issue that supports this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
