### PR TITLE
XcodeBuild: pass deployment target from profile

### DIFF
--- a/conan/tools/apple/apple.py
+++ b/conan/tools/apple/apple.py
@@ -108,6 +108,16 @@ def resolve_apple_flags(conanfile, is_cross_building=False):
     return min_version_flag, apple_arch_flag, apple_isysroot_flag
 
 
+def xcodebuild_deployment_target_key(os_name):
+    return {
+        "Macos": "MACOSX_DEPLOYMENT_TARGET",
+        "iOS": "IPHONEOS_DEPLOYMENT_TARGET",
+        "tvOS": "TVOS_DEPLOYMENT_TARGET",
+        "watchOS": "WATCHOS_DEPLOYMENT_TARGET",
+        "visionOS": "XROS_DEPLOYMENT_TARGET",
+    }.get(os_name) if os_name else None
+
+
 class XCRun:
     """
     XCRun is a wrapper for the Apple **xcrun** tool used to get information for building.

--- a/conan/tools/apple/xcodebuild.py
+++ b/conan/tools/apple/xcodebuild.py
@@ -38,7 +38,7 @@ class XcodeBuild(object):
                        will build all the targets passing the ``-alltargets`` argument instead.
         :return: the return code for the launched ``xcodebuild`` command.
         """
-        target = "-target {}".format(target) if target else "-alltargets"
+        target = "-target '{}'".format(target) if target else "-alltargets"
         cmd = "xcodebuild -project '{}' -configuration {} -arch {} " \
               "{} {} {}".format(xcodeproj, self._build_type, self._arch, self._sdkroot,
                                 self._verbosity, target)

--- a/conan/tools/apple/xcodebuild.py
+++ b/conan/tools/apple/xcodebuild.py
@@ -1,4 +1,4 @@
-from conan.tools.apple import to_apple_arch
+from conan.tools.apple.apple import to_apple_arch, xcodebuild_deployment_target_key
 
 
 class XcodeBuild(object):
@@ -8,6 +8,8 @@ class XcodeBuild(object):
         self._arch = to_apple_arch(self._conanfile)
         self._sdk = conanfile.settings.get_safe("os.sdk") or ""
         self._sdk_version = conanfile.settings.get_safe("os.sdk_version") or ""
+        self._os = conanfile.settings.get_safe("os")
+        self._os_version = conanfile.settings.get_safe("os.version")
 
     @property
     def _verbosity(self):
@@ -40,4 +42,9 @@ class XcodeBuild(object):
         cmd = "xcodebuild -project {} -configuration {} -arch {} " \
               "{} {} {}".format(xcodeproj, self._build_type, self._arch, self._sdkroot,
                                 self._verbosity, target)
+
+        deployment_target_key = xcodebuild_deployment_target_key(self._os)
+        if deployment_target_key and self._os_version:
+            cmd += f" {deployment_target_key}={self._os_version}"
+
         self._conanfile.run(cmd)

--- a/conan/tools/apple/xcodebuild.py
+++ b/conan/tools/apple/xcodebuild.py
@@ -39,7 +39,7 @@ class XcodeBuild(object):
         :return: the return code for the launched ``xcodebuild`` command.
         """
         target = "-target {}".format(target) if target else "-alltargets"
-        cmd = "xcodebuild -project {} -configuration {} -arch {} " \
+        cmd = "xcodebuild -project '{}' -configuration {} -arch {} " \
               "{} {} {}".format(xcodeproj, self._build_type, self._arch, self._sdkroot,
                                 self._verbosity, target)
 

--- a/conan/tools/apple/xcodetoolchain.py
+++ b/conan/tools/apple/xcodetoolchain.py
@@ -1,7 +1,7 @@
 import textwrap
 
 from conan.internal import check_duplicated_generator
-from conan.tools.apple.apple import to_apple_arch
+from conan.tools.apple.apple import to_apple_arch, xcodebuild_deployment_target_key
 from conan.tools.apple.xcodedeps import GLOBAL_XCCONFIG_FILENAME, GLOBAL_XCCONFIG_TEMPLATE, \
     _add_includes_to_file_or_create, _xcconfig_settings_filename, _xcconfig_conditional
 from conan.internal.util.files import save
@@ -64,16 +64,10 @@ class XcodeToolchain(object):
 
     @property
     def _apple_deployment_target(self):
-        deployment_target_key = {
-            "Macos": "MACOSX_DEPLOYMENT_TARGET",
-            "iOS": "IPHONEOS_DEPLOYMENT_TARGET",
-            "tvOS": "TVOS_DEPLOYMENT_TARGET",
-            "watchOS": "WATCHOS_DEPLOYMENT_TARGET",
-            "visionOS": "XROS_DEPLOYMENT_TARGET",
-        }.get(str(self._conanfile.settings.get_safe("os")))
+        deployment_target_key = xcodebuild_deployment_target_key(self._conanfile.settings.get_safe("os"))
         return '{}{}={}'.format(deployment_target_key,
                                 _xcconfig_conditional(self._conanfile.settings, self.configuration),
-                                self.os_version) if self.os_version else ""
+                                self.os_version) if deployment_target_key and self.os_version else ""
 
     @property
     def _clang_cxx_library(self):

--- a/test/functional/toolchains/apple/test_xcodebuild.py
+++ b/test/functional/toolchains/apple/test_xcodebuild.py
@@ -91,11 +91,12 @@ def test_project_xcodebuild(client):
     client.run("install . --build=missing")
     client.run("install . -s build_type=Debug --build=missing")
     client.run_command("xcodegen generate")
-    client.run("create . --build=missing -c tools.build:verbosity=verbose -c tools.compilation:verbosity=verbose")
+    client.run("create . --build=missing -s os.version=15.0 -c tools.build:verbosity=verbose -c tools.compilation:verbosity=verbose")
+    assert "MACOSX_DEPLOYMENT_TARGET=15.0" in client.out
     assert "xcodebuild: error: invalid option" not in client.out
     assert "hello/0.1: Hello World Release!" in client.out
     assert "App Release!" in client.out
-    client.run("create . -s build_type=Debug --build=missing")
+    client.run("create . -s build_type=Debug -s os.version=15.0 --build=missing")
     assert "hello/0.1: Hello World Debug!" in client.out
     assert "App Debug!" in client.out
 


### PR DESCRIPTION
Changelog: Fix: Pass deployment target from profile to ``XcodeBuild``.
Changelog: Fix: Project path and target name are quoted now for ``XcodeBuild``.
Docs: https://github.com/conan-io/docs/pull/4129

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
