### PR TITLE
add fix to support git<2.36

### DIFF
--- a/conan/__init__.py
+++ b/conan/__init__.py
@@ -2,5 +2,5 @@ from conan.internal.model.conan_file import ConanFile
 from conan.internal.model.workspace import Workspace
 from conan.internal.model.version import Version
 
-__version__ = '2.17.0'
+__version__ = '2.17.1'
 conan_version = Version(__version__)

--- a/conan/tools/scm/git.py
+++ b/conan/tools/scm/git.py
@@ -117,8 +117,15 @@ class Git:
             self.run(f"fetch {remote} --refetch --dry-run {commit}")
             return True
         except (Exception,):
-            # Don't raise an error because the fetch could fail for many more reasons than the branch.
-            return False
+            # For example, if using an older git<2.36, see
+            # https://github.com/conan-io/conan/issues/18470, then lets try the old approach
+            try:
+                # This will raise if commit not present.
+                self.run("fetch {} --dry-run --depth=1 {}".format(remote, commit))
+                return True
+            except (Exception,):
+                # Don't raise an error because it could fail for many more reasons.
+                return False
 
     def is_dirty(self, repository=False):
         """


### PR DESCRIPTION
Changelog:  Bugfix: Add support for ``Git()`` for git<2.36, for operations that check if a commit exists in a remote.
Docs: Omit

Close https://github.com/conan-io/conan/issues/18470
