### PR TITLE
Fix issues with `self.generator_info`

### DIFF
--- a/conan/internal/api/install/generators.py
+++ b/conan/internal/api/install/generators.py
@@ -167,7 +167,8 @@ def _receive_generators(conanfile):
             names = [c.__name__ if not isinstance(c, str) else c for c in build_req.generator_info]
             conanfile.output.warning(f"Tool-require {build_req} adding generators: {names}",
                                      warn_tag="experimental")
-            conanfile.generators = build_req.generator_info + conanfile.generators
+            # Generators can be defined as a tuple in recipes, ensure we don't break if so
+            conanfile.generators = build_req.generator_info + list(conanfile.generators)
 
 
 def _generate_aggregated_env(conanfile):

--- a/conan/internal/model/conan_file.py
+++ b/conan/internal/model/conan_file.py
@@ -86,6 +86,7 @@ class ConanFile:
         self.runenv_info = Environment()
         # At the moment only for build_requires, others will be ignored
         self.conf_info = Conf()
+        self.generator_info = []
         self.info = None
         self._conan_buildenv = None  # The profile buildenv, will be assigned initialize()
         self._conan_runenv = None

--- a/conan/internal/model/conan_file.py
+++ b/conan/internal/model/conan_file.py
@@ -86,7 +86,6 @@ class ConanFile:
         self.runenv_info = Environment()
         # At the moment only for build_requires, others will be ignored
         self.conf_info = Conf()
-        self.generator_info = []
         self.info = None
         self._conan_buildenv = None  # The profile buildenv, will be assigned initialize()
         self._conan_runenv = None

--- a/test/integration/generators/test_generators_from_br.py
+++ b/test/integration/generators/test_generators_from_br.py
@@ -1,6 +1,7 @@
 import json
 import textwrap
 
+from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
 
 
@@ -21,15 +22,21 @@ def test_inject_generators_conf():
             version = "0.1"
 
             def package_info(self):
-                self.generator_info = ["CMakeToolchain", MyGenerator]
+                self.generator_info.extend(["CMakeToolchain", MyGenerator])
         """)})
 
+    tc.save({"consumer/conanfile.py": GenConanfile()
+                .with_tool_requires("tool/0.1")
+                .with_class_attribute("generators = ('VirtualBuildEnv', 'VirtualRunEnv')")})
+
     tc.run("create tool")
-    tc.run("install --tool-requires=tool/0.1")
+    tc.run("install consumer")
     assert "WARN: experimental: Tool-require tool/0.1 adding generators: " \
            "['CMakeToolchain', 'MyGenerator']" in tc.out
     assert "Generator 'CMakeToolchain' calling 'generate()'" in tc.out
     assert "Generator 'MyGenerator' calling 'generate()'" in tc.out
+    assert "Generator 'VirtualBuildEnv' calling 'generate()'" in tc.out
+    assert "Generator 'VirtualRunEnv' calling 'generate()'" in tc.out
     assert "CMakeToolchain generated: conan_toolchain.cmake" in tc.out
     assert "MyGenerator generated" in tc.out
 

--- a/test/integration/generators/test_generators_from_br.py
+++ b/test/integration/generators/test_generators_from_br.py
@@ -1,7 +1,6 @@
 import json
 import textwrap
 
-from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
 
 

--- a/test/integration/generators/test_generators_from_br.py
+++ b/test/integration/generators/test_generators_from_br.py
@@ -1,7 +1,7 @@
 import json
 import textwrap
 
-from conan.test.utils.tools import TestClient
+from conan.test.utils.tools import GenConanfile, TestClient
 
 
 def test_inject_generators_conf():

--- a/test/integration/generators/test_generators_from_br.py
+++ b/test/integration/generators/test_generators_from_br.py
@@ -22,7 +22,7 @@ def test_inject_generators_conf():
             version = "0.1"
 
             def package_info(self):
-                self.generator_info.extend(["CMakeToolchain", MyGenerator])
+                self.generator_info = ["CMakeToolchain", MyGenerator]
         """)})
 
     tc.save({"consumer/conanfile.py": GenConanfile("consumer", "0.1")

--- a/test/integration/generators/test_generators_from_br.py
+++ b/test/integration/generators/test_generators_from_br.py
@@ -25,12 +25,12 @@ def test_inject_generators_conf():
                 self.generator_info.extend(["CMakeToolchain", MyGenerator])
         """)})
 
-    tc.save({"consumer/conanfile.py": GenConanfile()
+    tc.save({"consumer/conanfile.py": GenConanfile("consumer", "0.1")
                 .with_tool_requires("tool/0.1")
-                .with_class_attribute("generators = ('VirtualBuildEnv', 'VirtualRunEnv')")})
+                .with_class_attribute("generators = 'VirtualBuildEnv', 'VirtualRunEnv'")})
 
     tc.run("create tool")
-    tc.run("install consumer")
+    tc.run("create consumer")
     assert "WARN: experimental: Tool-require tool/0.1 adding generators: " \
            "['CMakeToolchain', 'MyGenerator']" in tc.out
     assert "Generator 'CMakeToolchain' calling 'generate()'" in tc.out


### PR DESCRIPTION
Changelog: Bugfix: Avoid crash when installing packages with tuple `generators` attribute and requirements to tool requires that provide `self.generator_info` generators.
Docs: Omit

Closes https://github.com/conan-io/conan/issues/18499