### PR TITLE
proposing is_tool=True recipe attribute

### DIFF
--- a/conan/api/subapi/graph.py
+++ b/conan/api/subapi/graph.py
@@ -33,6 +33,7 @@ class GraphAPI:
                                                  update=update)
             ref = RecipeReference(conanfile.name, conanfile.version,
                                   conanfile.user, conanfile.channel)
+            is_build_require = is_build_require or getattr(conanfile, "is_tool", None)
             context = CONTEXT_BUILD if is_build_require else CONTEXT_HOST
             # Here, it is always the "host" context because it is the base, not the current node one
             initialize_conanfile_profile(conanfile, profile_build, profile_host, CONTEXT_HOST,

--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -55,7 +55,8 @@ def create(conan_api, parser, *args):
                                              remotes=remotes)
 
     # FIXME: Dirty: package type still raw, not processed yet
-    is_build = args.build_require or conanfile.package_type == "build-scripts"
+    is_build = (args.build_require or conanfile.package_type == "build-scripts"
+                or getattr(conanfile, "is_tool", None))
     # The package_type is not fully processed at export
     is_python_require = conanfile.package_type == "python-require"
     lockfile = conan_api.lockfile.update_lockfile_export(lockfile, conanfile, ref, is_build)

--- a/test/integration/lockfile/test_lock_build_requires.py
+++ b/test/integration/lockfile/test_lock_build_requires.py
@@ -151,3 +151,44 @@ class TestTransitiveBuildRequires:
         client.run("install pkg/conanfile.py --build=missing --lockfile=conan.lock")
         assert "zlib/1.0: Created package" in client.out
         assert "cmake/1.0: Created package" in client.out
+
+
+class TestCreateTool:
+    def test_lock_buildrequires_create_test_package(self):
+        c = TestClient(light=True)
+        c.save({"conanfile.py": GenConanfile("zlib", "1.0")})
+        c.run("create .")
+        test = textwrap.dedent("""
+            from conan import ConanFile
+            class Test(ConanFile):
+                def build_requirements(self):
+                    self.tool_requires(self.tested_reference_str)
+                def test(self):
+                    pass
+            """)
+        c.save({"conanfile.py": GenConanfile("tool", "0.1").with_requires("zlib/1.0"),
+                "test_package/conanfile.py": test}, clean_first=True)
+
+        # Failure mode
+        c.run("lock create .")
+        c.run("create .", assert_error=True)
+        assert "not in lockfile 'build_requires'" in c.out
+
+        # But if we add create_tool=True to the recipe, everything is smooth
+        c.save({"conanfile.py": GenConanfile("tool", "0.1").with_requires("zlib/1.0")
+                                                           .with_class_attribute('is_tool = True')})
+        c.run("lock create . --lockfile=")
+        c.run("create . --lockfile-out=conan.lock")
+        # Now it doesn't fail anymore
+        c.assert_listed_require({"tool/0.1": "Cache"}, build=True)
+        # We can even install it with the lockfile, it works
+        c.run("install --tool-requires=tool/0.1 --lockfile=conan.lock")
+
+    def test_install(self):
+        c = TestClient(light=True)
+        c.save({"dep/conanfile.py": GenConanfile("dep", "0.1"),
+                "app/conanfile.py": GenConanfile("app", "1.0").with_requires("dep/0.1")
+                                                          .with_class_attribute('is_tool=True')})
+        c.run("create dep")
+        c.run("install app")
+        c.assert_listed_require({"dep/0.1": "Cache"}, build=True)


### PR DESCRIPTION
Changelog: Feature: Propose new ``is_tool=True`` recipe attribute to be able to avoid the ``--build-require`` argument
Docs: https://github.com/conan-io/docs/pull/XXXX

Close https://github.com/conan-io/conan/issues/13440
