### PR TITLE
package_manager version support added

### DIFF
--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -11,10 +11,12 @@ class _SystemPackageManagerTool(object):
     mode_report = "report"  # Only report what would be installed, no check (can run in any system)
     mode_report_installed = "report-installed"  # report installed and missing packages
     tool_name = None
-    version_separator = None
+    version_separator = ""
     install_command = ""
     update_command = ""
     check_command = ""
+    check_version_command = ""
+    full_package_name = "{name}{arch_separator}{arch_name}"
     accepted_install_codes = [0]
     accepted_update_codes = [0]
     accepted_check_codes = [0, 1]
@@ -68,30 +70,30 @@ class _SystemPackageManagerTool(object):
         self._conanfile.output.info("A default system package manager couldn't be found for {}, "
                                     "system packages will not be installed.".format(os_name))
 
+    def _split_package_name(self, package, host_package):
+
+        name, version = (package.split("=")[0], package.split("=")[1]) if "=" in package else (package, "")
+        arch_separator, arch_name, version_separator = "", "", ""
+        version_separator = self.version_separator if version else ""
+
+        if self._arch in self._arch_names and cross_building(self._conanfile) and host_package:
+            arch_separator = self._arch_separator
+            arch_name = self._arch_names.get(self._arch)
+        return name, version, arch_separator, arch_name, version_separator
+
     def get_package_name(self, package, host_package=True):
         # Only if the package is for building, for example a library,
         # we should add the host arch when cross building.
         # If the package is a tool that should be installed on the current build
         # machine we should not add the arch.
-        package = package.split("=")[0]
-        if self._arch in self._arch_names and cross_building(self._conanfile) and host_package:
-            return "{}{}{}".format(package, self._arch_separator,
-                                   self._arch_names.get(self._arch))
-        return package
 
-    def get_versioned_package_name(self, package, host_package=True):
-        # Only if the package is for building, for example a library,
-        # we should add the host arch when cross building.
-        # If the package is a tool that should be installed on the current build
-        # machine we should not add the arch.
+        name, version, arch_separator, arch_name, version_separator = self._split_package_name(package, host_package)
 
-        name, version = (package.split("=")[0], package.split("=")[1]) if "=" in package else (package, None)
-        if self._arch in self._arch_names and cross_building(self._conanfile) and host_package:
-            name = "{}{}{}".format(name, self._arch_separator,
-                                   self._arch_names.get(self._arch))
-        if version and self.version_separator:
-            name = "{}{}{}".format(name, self.version_separator, version)
-        return name
+        return self.full_package_name.format(name=name,
+                                             arch_separator=arch_separator,
+                                             arch_name=arch_name,
+                                             version_separator=version_separator,
+                                             version=version)
 
     @property
     def sudo_str(self):
@@ -201,7 +203,7 @@ class _SystemPackageManagerTool(object):
         elif packages:
             if update:
                 self.update()
-            packages_arch = [self.get_versioned_package_name(package, host_package=host_package) for package in packages]
+            packages_arch = [self.get_package_name(package, host_package=host_package) for package in packages]
             if packages_arch:
                 command = self.install_command.format(sudo=self.sudo_str,
                                                       tool=self.tool_name,
@@ -220,14 +222,21 @@ class _SystemPackageManagerTool(object):
             return self._conanfile_run(command, self.accepted_update_codes)
 
     def _check(self, packages, host_package=True):
-        # TODO: check installed version
-        missing = [pkg for pkg in packages if self.check_package(self.get_package_name(pkg, host_package=host_package)) != 0]
+        missing = [pkg for pkg in packages if self.check_package(pkg, host_package) != 0]
         return missing
 
-    def check_package(self, package):
+    def check_package(self, package, host_package=True):
         # TODO: check installed version
-        command = self.check_command.format(tool=self.tool_name,
-                                            package=self.get_package_name(package))
+        name, version, arch_separator, arch_name, _ = self._split_package_name(package, host_package)
+        package = self.full_package_name.format(name=name,
+                                                arch_separator=arch_separator,
+                                                arch_name=arch_name,
+                                                version="",
+                                                version_separator="")
+        if version and self.check_version_command:
+            command = self.check_version_command.format(tool=self.tool_name, package=package, version=version)
+        else:
+            command = self.check_command.format(tool=self.tool_name, package=package)
         return self._conanfile_run(command, self.accepted_check_codes)
 
 
@@ -235,9 +244,11 @@ class Apt(_SystemPackageManagerTool):
     # TODO: apt? apt-get?
     tool_name = "apt-get"
     version_separator = "="
+    full_package_name = "{name}{arch_separator}{arch_name}{version_separator}{version}"
     install_command = "{sudo}{tool} install -y {recommends}{packages}"
     update_command = "{sudo}{tool} update"
     check_command = "dpkg-query -W -f='${{Status}}' {package} | grep -q \"ok installed\""
+    check_version_command = "dpkg -s {package} | grep \"Version: {version}\""
 
     def __init__(self, conanfile, arch_names=None):
         """
@@ -283,9 +294,11 @@ class Apt(_SystemPackageManagerTool):
 class Yum(_SystemPackageManagerTool):
     tool_name = "yum"
     version_separator = "-"
+    full_package_name = "{name}{version_separator}{version}{arch_separator}{arch_name}"
     install_command = "{sudo}{tool} install -y {packages}"
     update_command = "{sudo}{tool} check-update -y"
     check_command = "rpm -q {package}"
+    check_version_command = "rpm -q {package}-{version}"
     accepted_update_codes = [0, 100]
 
     def __init__(self, conanfile, arch_names=None):
@@ -312,26 +325,35 @@ class Yum(_SystemPackageManagerTool):
 class Dnf(Yum):
     tool_name = "dnf"
     version_separator = "-"
+    full_package_name = "{name}{version_separator}{version}{arch_separator}{arch_name}"
+    check_version_command = "rpm -q {package}-{version}"
 
 
 class Brew(_SystemPackageManagerTool):
     tool_name = "brew"
     version_separator = "@"
+    full_package_name = "{name}{version_separator}{version}"
     install_command = "{sudo}{tool} install {packages}"
     update_command = "{sudo}{tool} update"
     check_command = 'test -n "$({tool} ls --versions {package})"'
+    check_version_command = 'brew list --versions {package} | grep "{version}"'
+
 
 
 class Pkg(_SystemPackageManagerTool):
     tool_name = "pkg"
     version_separator = "-"
+    full_package_name = "{name}{version_separator}{version}"
     install_command = "{sudo}{tool} install -y {packages}"
     update_command = "{sudo}{tool} update"
     check_command = "{tool} info {package}"
+    check_version_command = "{tool} info {package} | grep \"Version: {version}\""
 
 
 class PkgUtil(_SystemPackageManagerTool):
     tool_name = "pkgutil"
+    version_separator = "@"
+    full_package_name = "{name}{version_separator}{version}"
     install_command = "{sudo}{tool} --install --yes {packages}"
     update_command = "{sudo}{tool} --catalog"
     check_command = 'test -n "`{tool} --list {package}`"'
@@ -340,9 +362,11 @@ class PkgUtil(_SystemPackageManagerTool):
 class Chocolatey(_SystemPackageManagerTool):
     tool_name = "choco"
     version_separator = " --version "
+    full_package_name = "{name}{version_separator}{version}"
     install_command = "{tool} install --yes {packages}"
     update_command = "{tool} outdated"
     check_command = '{tool} list --exact {package} | findstr /c:"1 packages installed."'
+    check_version_command = '{tool} list --local-only {package} | findstr /i "{version}"'
 
 
 class PacMan(_SystemPackageManagerTool):
@@ -350,6 +374,7 @@ class PacMan(_SystemPackageManagerTool):
     install_command = "{sudo}{tool} -S --noconfirm {packages}"
     update_command = "{sudo}{tool} -Syyu --noconfirm"
     check_command = "{tool} -Qi {package}"
+    # check_version_command = "pacman -Q {package} | grep \"{version}\""
 
     def __init__(self, conanfile, arch_names=None):
         """
@@ -368,9 +393,11 @@ class PacMan(_SystemPackageManagerTool):
 class Apk(_SystemPackageManagerTool):
     tool_name = "apk"
     version_separator = "="
+    full_package_name = "{name}{version_separator}{version}"
     install_command = "{sudo}{tool} add --no-cache {packages}"
     update_command = "{sudo}{tool} update"
     check_command = "{tool} info -e {package}"
+    check_version_command = "{tool} info {package} | grep \"{version}\""
 
     def __init__(self, conanfile, _arch_names=None):
         """
@@ -388,6 +415,8 @@ class Apk(_SystemPackageManagerTool):
 class Zypper(_SystemPackageManagerTool):
     tool_name = "zypper"
     version_separator = "="  # < or >
+    full_package_name = "{name}{arch_separator}{arch_name}{version_separator}{version}"
     install_command = "{sudo}{tool} --non-interactive in {packages}"
     update_command = "{sudo}{tool} --non-interactive ref"
     check_command = "rpm -q {package}"
+    check_version_command = "rpm -q {package}-{version}"

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -226,7 +226,6 @@ class _SystemPackageManagerTool(object):
         return missing
 
     def check_package(self, package, host_package=True):
-        # TODO: check installed version
         name, version, arch_separator, arch_name, _ = self._split_package_name(package, host_package)
         package = self.full_package_name.format(name=name,
                                                 arch_separator=arch_separator,

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -373,7 +373,6 @@ class PacMan(_SystemPackageManagerTool):
     install_command = "{sudo}{tool} -S --noconfirm {packages}"
     update_command = "{sudo}{tool} -Syyu --noconfirm"
     check_command = "{tool} -Qi {package}"
-    # check_version_command = "pacman -Q {package} | grep \"{version}\""
 
     def __init__(self, conanfile, arch_names=None):
         """

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -11,6 +11,7 @@ class _SystemPackageManagerTool(object):
     mode_report = "report"  # Only report what would be installed, no check (can run in any system)
     mode_report_installed = "report-installed"  # report installed and missing packages
     tool_name = None
+    version_separator = None
     install_command = ""
     update_command = ""
     check_command = ""
@@ -72,10 +73,25 @@ class _SystemPackageManagerTool(object):
         # we should add the host arch when cross building.
         # If the package is a tool that should be installed on the current build
         # machine we should not add the arch.
+        package = package.split("=")[0]
         if self._arch in self._arch_names and cross_building(self._conanfile) and host_package:
             return "{}{}{}".format(package, self._arch_separator,
                                    self._arch_names.get(self._arch))
         return package
+
+    def get_versioned_package_name(self, package, host_package=True):
+        # Only if the package is for building, for example a library,
+        # we should add the host arch when cross building.
+        # If the package is a tool that should be installed on the current build
+        # machine we should not add the arch.
+
+        name, version = (package.split("=")[0], package.split("=")[1]) if "=" in package else (package, None)
+        if self._arch in self._arch_names and cross_building(self._conanfile) and host_package:
+            name = "{}{}{}".format(name, self._arch_separator,
+                                   self._arch_names.get(self._arch))
+        if version and self.version_separator:
+            name = "{}{}{}".format(name, self.version_separator, version)
+        return name
 
     @property
     def sudo_str(self):
@@ -169,7 +185,6 @@ class _SystemPackageManagerTool(object):
             packages = self.check(packages, host_package=host_package)
             missing_pkgs = pkgs.setdefault("missing", [])
             missing_pkgs.extend(p for p in packages if p not in missing_pkgs)
-
         if self._mode == self.mode_report_installed:
             return
 
@@ -186,8 +201,7 @@ class _SystemPackageManagerTool(object):
         elif packages:
             if update:
                 self.update()
-
-            packages_arch = [self.get_package_name(package, host_package=host_package) for package in packages]
+            packages_arch = [self.get_versioned_package_name(package, host_package=host_package) for package in packages]
             if packages_arch:
                 command = self.install_command.format(sudo=self.sudo_str,
                                                       tool=self.tool_name,
@@ -206,18 +220,21 @@ class _SystemPackageManagerTool(object):
             return self._conanfile_run(command, self.accepted_update_codes)
 
     def _check(self, packages, host_package=True):
+        # TODO: check installed version
         missing = [pkg for pkg in packages if self.check_package(self.get_package_name(pkg, host_package=host_package)) != 0]
         return missing
 
     def check_package(self, package):
+        # TODO: check installed version
         command = self.check_command.format(tool=self.tool_name,
-                                            package=package)
+                                            package=self.get_package_name(package))
         return self._conanfile_run(command, self.accepted_check_codes)
 
 
 class Apt(_SystemPackageManagerTool):
     # TODO: apt? apt-get?
     tool_name = "apt-get"
+    version_separator = "="
     install_command = "{sudo}{tool} install -y {recommends}{packages}"
     update_command = "{sudo}{tool} update"
     check_command = "dpkg-query -W -f='${{Status}}' {package} | grep -q \"ok installed\""
@@ -265,6 +282,7 @@ class Apt(_SystemPackageManagerTool):
 
 class Yum(_SystemPackageManagerTool):
     tool_name = "yum"
+    version_separator = "-"
     install_command = "{sudo}{tool} install -y {packages}"
     update_command = "{sudo}{tool} check-update -y"
     check_command = "rpm -q {package}"
@@ -293,10 +311,12 @@ class Yum(_SystemPackageManagerTool):
 
 class Dnf(Yum):
     tool_name = "dnf"
+    version_separator = "-"
 
 
 class Brew(_SystemPackageManagerTool):
     tool_name = "brew"
+    version_separator = "@"
     install_command = "{sudo}{tool} install {packages}"
     update_command = "{sudo}{tool} update"
     check_command = 'test -n "$({tool} ls --versions {package})"'
@@ -304,6 +324,7 @@ class Brew(_SystemPackageManagerTool):
 
 class Pkg(_SystemPackageManagerTool):
     tool_name = "pkg"
+    version_separator = "-"
     install_command = "{sudo}{tool} install -y {packages}"
     update_command = "{sudo}{tool} update"
     check_command = "{tool} info {package}"
@@ -318,6 +339,7 @@ class PkgUtil(_SystemPackageManagerTool):
 
 class Chocolatey(_SystemPackageManagerTool):
     tool_name = "choco"
+    version_separator = " --version "
     install_command = "{tool} install --yes {packages}"
     update_command = "{tool} outdated"
     check_command = '{tool} list --exact {package} | findstr /c:"1 packages installed."'
@@ -345,6 +367,7 @@ class PacMan(_SystemPackageManagerTool):
 
 class Apk(_SystemPackageManagerTool):
     tool_name = "apk"
+    version_separator = "="
     install_command = "{sudo}{tool} add --no-cache {packages}"
     update_command = "{sudo}{tool} update"
     check_command = "{tool} info -e {package}"
@@ -364,6 +387,7 @@ class Apk(_SystemPackageManagerTool):
 
 class Zypper(_SystemPackageManagerTool):
     tool_name = "zypper"
+    version_separator = "="  # < or >
     install_command = "{sudo}{tool} --non-interactive in {packages}"
     update_command = "{sudo}{tool} --non-interactive ref"
     check_command = "rpm -q {package}"

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -235,6 +235,8 @@ class _SystemPackageManagerTool(object):
         if version and self.check_version_command:
             command = self.check_version_command.format(tool=self.tool_name, package=package, version=version)
         else:
+            self._conanfile.output.warning(f"System requirements: \"{self.tool_name}\" doesn't support package versions,"
+                                           f" \"{package}\" will be installed without a specific version.")
             command = self.check_command.format(tool=self.tool_name, package=package)
         return self._conanfile_run(command, self.accepted_check_codes)
 
@@ -248,7 +250,6 @@ class Apt(_SystemPackageManagerTool):
     update_command = "{sudo}{tool} update"
     check_command = "dpkg -l | grep -q -E \"^ii\\s+\\b{package}\\s+\\b\""
     check_version_command = "dpkg -l | grep -E \"^ii\\s+\\b{package}\\s+\\b\" | grep -q \"{version}\""
-
 
     def __init__(self, conanfile, arch_names=None):
         """

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -249,8 +249,8 @@ class Apt(_SystemPackageManagerTool):
     full_package_name = "{name}{arch_separator}{arch_name}{version_separator}{version}"
     install_command = "{sudo}{tool} install -y {recommends}{packages}"
     update_command = "{sudo}{tool} update"
-    check_command = "dpkg -l | grep -q -E \"^ii\\s+\\b{package}\\s+\\b\""
-    check_version_command = "dpkg -l | grep -E \"^ii\\s+\\b{package}\\s+\\b\" | grep -q \"{version}\""
+    check_command = "dpkg-query -W -f='${{Architecture}}' {package} | grep -qx \"{arch_name}\""
+    check_version_command = "dpkg-query -W -f='${{Architecture}} ${{Version}}' {package} | grep -qx \"{arch_name} {version}\""
 
     def __init__(self, conanfile, arch_names=None):
         """
@@ -272,6 +272,18 @@ class Apt(_SystemPackageManagerTool):
                             "s390x": "s390x"} if arch_names is None else arch_names
 
         self._arch_separator = ":"
+
+    def check_package(self, package, host_package=True):
+        package, version, _, arch_name, _ = self._split_package_name(package, host_package)
+
+        arch_names = [arch_name] if arch_name else ['all', self._arch_names.get(self._arch or self._conanfile.settings_build.get_safe('arch'))]
+        for arch_name in arch_names:
+            command = self.check_command.format(tool=self.tool_name, arch_name=arch_name, package=package)
+            if version:
+                command = self.check_version_command.format(tool=self.tool_name, arch_name=arch_name, package=package, version=version)
+            if self._conanfile_run(command, self.accepted_check_codes):
+                return True
+        return False
 
     def install(self, packages, update=False, check=True, recommends=False, host_package=True):
         """

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -227,15 +227,16 @@ class _SystemPackageManagerTool(object):
 
     def check_package(self, package, host_package=True):
         name, version, arch_separator, arch_name, _ = self._split_package_name(package, host_package)
+        arch_package = arch_name or self._arch_names.get(self._arch or self._conanfile.settings_build.get_safe('arch'))
         package = self.full_package_name.format(name=name,
                                                 arch_separator=arch_separator,
                                                 arch_name=arch_name,
                                                 version="",
                                                 version_separator="")
-        command = self.check_command.format(tool=self.tool_name, package=package)
+        command = self.check_command.format(tool=self.tool_name, package=package, arch_package=arch_package)
         if version:
             if self.check_version_command:
-                command = self.check_version_command.format(tool=self.tool_name, package=package, version=version)
+                command = self.check_version_command.format(tool=self.tool_name, package=package, version=version, arch_package=arch_package)
             else:
                 self._conanfile.output.warning(f"System requirements: \"{self.tool_name}\" doesn't support package versions,"
                                                f" \"{package}\" will be installed without a specific version.")
@@ -249,8 +250,8 @@ class Apt(_SystemPackageManagerTool):
     full_package_name = "{name}{arch_separator}{arch_name}{version_separator}{version}"
     install_command = "{sudo}{tool} install -y {recommends}{packages}"
     update_command = "{sudo}{tool} update"
-    check_command = "dpkg-query -W -f='${{Architecture}}' {package} | grep -qx \"{arch_name}\""
-    check_version_command = "dpkg-query -W -f='${{Architecture}} ${{Version}}' {package} | grep -qx \"{arch_name} {version}\""
+    check_command = "dpkg-query -W -f='${{Architecture}}' {package} | grep -qx \"{arch_package}\" || dpkg-query -W -f='${{Architecture}}' {package} | grep -qx \"all\""
+    check_version_command = "dpkg-query -W -f='${{Architecture}} ${{Version}}' {package} | grep -qx \"{arch_package} {version}\" || dpkg-query -W -f='${{Architecture}}' {package} | grep -qx \"all {version}\""
 
     def __init__(self, conanfile, arch_names=None):
         """
@@ -272,18 +273,6 @@ class Apt(_SystemPackageManagerTool):
                             "s390x": "s390x"} if arch_names is None else arch_names
 
         self._arch_separator = ":"
-
-    def check_package(self, package, host_package=True):
-        package, version, _, arch_name, _ = self._split_package_name(package, host_package)
-
-        arch_names = [arch_name] if arch_name else ['all', self._arch_names.get(self._arch or self._conanfile.settings_build.get_safe('arch'))]
-        for arch_name in arch_names:
-            command = self.check_command.format(tool=self.tool_name, arch_name=arch_name, package=package)
-            if version:
-                command = self.check_version_command.format(tool=self.tool_name, arch_name=arch_name, package=package, version=version)
-            if self._conanfile_run(command, self.accepted_check_codes):
-                return True
-        return False
 
     def install(self, packages, update=False, check=True, recommends=False, host_package=True):
         """

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -250,8 +250,8 @@ class Apt(_SystemPackageManagerTool):
     full_package_name = "{name}{arch_separator}{arch_name}{version_separator}{version}"
     install_command = "{sudo}{tool} install -y {recommends}{packages}"
     update_command = "{sudo}{tool} update"
-    check_command = "dpkg-query -W -f='${{Architecture}}' {package} | grep -qx \"{arch_package}\" || dpkg-query -W -f='${{Architecture}}' {package} | grep -qx \"all\""
-    check_version_command = "dpkg-query -W -f='${{Architecture}} ${{Version}}' {package} | grep -qx \"{arch_package} {version}\" || dpkg-query -W -f='${{Architecture}}' {package} | grep -qx \"all {version}\""
+    check_command = "dpkg-query -W -f='${{Architecture}}' {package} | grep -qEx '({arch_package}|all)'"
+    check_version_command = "dpkg-query -W -f='${{Architecture}} ${{Version}}' {package} | grep -qEx '({arch_package}|all) {version}'"
 
     def __init__(self, conanfile, arch_names=None):
         """

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -338,7 +338,6 @@ class Brew(_SystemPackageManagerTool):
     check_version_command = 'brew list --versions {package} | grep "{version}"'
 
 
-
 class Pkg(_SystemPackageManagerTool):
     tool_name = "pkg"
     version_separator = "-"

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -232,11 +232,12 @@ class _SystemPackageManagerTool(object):
                                                 arch_name=arch_name,
                                                 version="",
                                                 version_separator="")
-        if version and self.check_version_command:
-            command = self.check_version_command.format(tool=self.tool_name, package=package, version=version)
-        else:
-            self._conanfile.output.warning(f"System requirements: \"{self.tool_name}\" doesn't support package versions,"
-                                           f" \"{package}\" will be installed without a specific version.")
+        if version:
+            if self.check_version_command:
+                command = self.check_version_command.format(tool=self.tool_name, package=package, version=version)
+            else:
+                self._conanfile.output.warning(f"System requirements: \"{self.tool_name}\" doesn't support package versions,"
+                                               f" \"{package}\" will be installed without a specific version.")
             command = self.check_command.format(tool=self.tool_name, package=package)
         return self._conanfile_run(command, self.accepted_check_codes)
 

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -73,7 +73,7 @@ class _SystemPackageManagerTool(object):
     def _split_package_name(self, package, host_package):
 
         name, version = (package.split("=")[0], package.split("=")[1]) if "=" in package else (package, "")
-        arch_separator, arch_name, version_separator = "", "", ""
+        arch_separator, arch_name = "", ""
         version_separator = self.version_separator if version else ""
 
         if self._arch in self._arch_names and cross_building(self._conanfile) and host_package:

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -232,13 +232,13 @@ class _SystemPackageManagerTool(object):
                                                 arch_name=arch_name,
                                                 version="",
                                                 version_separator="")
+        command = self.check_command.format(tool=self.tool_name, package=package)
         if version:
             if self.check_version_command:
                 command = self.check_version_command.format(tool=self.tool_name, package=package, version=version)
             else:
                 self._conanfile.output.warning(f"System requirements: \"{self.tool_name}\" doesn't support package versions,"
                                                f" \"{package}\" will be installed without a specific version.")
-            command = self.check_command.format(tool=self.tool_name, package=package)
         return self._conanfile_run(command, self.accepted_check_codes)
 
 

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -246,8 +246,9 @@ class Apt(_SystemPackageManagerTool):
     full_package_name = "{name}{arch_separator}{arch_name}{version_separator}{version}"
     install_command = "{sudo}{tool} install -y {recommends}{packages}"
     update_command = "{sudo}{tool} update"
-    check_command = "dpkg-query -W -f='${{Status}}' {package} | grep -q \"ok installed\""
-    check_version_command = "dpkg -s {package} | grep \"Version: {version}\""
+    check_command = "dpkg -l | grep -q -E \"^ii\\s+\\b{package}\\s+\\b\""
+    check_version_command = "dpkg -l | grep -E \"^ii\\s+\\b{package}\\s+\\b\" | grep -q \"{version}\""
+
 
     def __init__(self, conanfile, arch_names=None):
         """

--- a/test/functional/tools/system/package_manager_test.py
+++ b/test/functional/tools/system/package_manager_test.py
@@ -25,8 +25,6 @@ def test_apt_check():
                 print("missing:", not_installed)
         """)})
     client.run("create . --name=test --version=1.0 -s:b arch=armv8 -s:h arch=x86")
-    assert "dpkg-query: no packages found matching non-existing1:i386" in client.out
-    assert "dpkg-query: no packages found matching non-existing2:i386" in client.out
     assert "missing: ['non-existing1', 'non-existing2']" in client.out
 
 
@@ -53,10 +51,6 @@ def test_apt_install_substitutes():
     client.save({"conanfile.py": conanfile_py.format(installs)})
     client.run("create . --name=test --version=1.0 -c tools.system.package_manager:mode=install "
                "-c tools.system.package_manager:sudo=True", assert_error=True)
-    assert "dpkg-query: no packages found matching non-existing1" in client.out
-    assert "dpkg-query: no packages found matching non-existing2" in client.out
-    assert "dpkg-query: no packages found matching non-existing3" in client.out
-    assert "dpkg-query: no packages found matching non-existing4" in client.out
     assert "None of the installs for the package substitutes succeeded." in client.out
 
     client.run_command("sudo apt remove nano -yy")
@@ -91,8 +85,6 @@ def test_build_require():
         """)})
     client.run("create consumer.py --name=consumer --version=1.0 "
                "-s:b arch=armv8 -s:h arch=x86 --build=missing")
-    assert "dpkg-query: no packages found matching non-existing1" in client.out
-    assert "dpkg-query: no packages found matching non-existing2" in client.out
     assert "missing: ['non-existing1', 'non-existing2']" in client.out
 
 

--- a/test/integration/tools/system/package_manager_test.py
+++ b/test/integration/tools/system/package_manager_test.py
@@ -247,6 +247,48 @@ def test_tools_install_mode_install_different_archs(tool_class, arch_host, resul
 
 
 @pytest.mark.parametrize("tool_class, arch_host, result", [
+    # Install host package and not cross-compile -> do not add host architecture
+    (Apk, 'x86_64', 'apk add --no-cache package1=0.1 package2=0.2'),
+    (Apt, 'x86_64', 'apt-get install -y --no-install-recommends package1=0.1 package2=0.2'),
+    (Yum, 'x86_64', 'yum install -y package1-0.1 package2-0.2'),
+    (Dnf, 'x86_64', 'dnf install -y package1-0.1 package2-0.2'),
+    (Brew, 'x86_64', 'brew install package1@0.1 package2@0.2'),
+    (Pkg, 'x86_64', 'pkg install -y package1-0.1 package2-0.2'),
+    (PkgUtil, 'x86_64', 'pkgutil --install --yes package1 package2'),
+    (Chocolatey, 'x86_64', 'choco install --yes package1 --version 0.1 package2 --version 0.2'),
+    (PacMan, 'x86_64', 'pacman -S --noconfirm package1 package2'),
+    (Zypper, 'x86_64', 'zypper --non-interactive in package1=0.1 package2=0.2'),
+    # Install host package and cross-compile -> add host architecture
+    (Apt, 'x86', 'apt-get install -y --no-install-recommends package1:i386=0.1 package2:i386=0.2'),
+    (Yum, 'x86', 'yum install -y package1.i?86-0.1 package2.i?86-0.2'),
+    (Dnf, 'x86', 'dnf install -y package1.i?86-0.1 package2.i?86-0.2'),
+    (Brew, 'x86', 'brew install package1@0.1 package2@0.2'),
+    (Pkg, 'x86', 'pkg install -y package1-0.1 package2-0.2'),
+    (PkgUtil, 'x86', 'pkgutil --install --yes package1 package2'),
+    (Chocolatey, 'x86', 'choco install --yes package1 --version 0.1 package2 --version 0.2'),
+    (PacMan, 'x86', 'pacman -S --noconfirm package1-lib32 package2-lib32'),
+    (Zypper, 'x86', 'zypper --non-interactive in package1=0.1 package2=0.2'),
+])
+def test_tools_install_mode_install_different_archs_with_version(tool_class, arch_host, result):
+    conanfile = ConanFileMock()
+    conanfile.settings = MockSettings({"arch": arch_host})
+    conanfile.settings_build = MockSettings({"arch": "x86_64"})
+    conanfile.conf.define("tools.system.package_manager:tool", tool_class.tool_name)
+    conanfile.conf.define("tools.system.package_manager:mode", "install")
+    with mock.patch('conan.ConanFile.context', new_callable=PropertyMock) as context_mock:
+        context_mock.return_value = "host"
+        tool = tool_class(conanfile)
+
+        def fake_check(*args, **kwargs):
+            return ["package1=0.1", "package2=0.2"]
+        from conan.tools.system.package_manager import _SystemPackageManagerTool
+        with patch.object(_SystemPackageManagerTool, 'check', MagicMock(side_effect=fake_check)):
+            tool.install(["package1=0.1", "package2=0.2"])
+    print(tool._conanfile.command)
+    assert tool._conanfile.command == result
+
+
+@pytest.mark.parametrize("tool_class, arch_host, result", [
     # Install build machine package and not cross-compile -> do not add host architecture
     (Apk, 'x86_64', 'apk add --no-cache package1 package2'),
     (Apt, 'x86_64', 'apt-get install -y --no-install-recommends package1 package2'),
@@ -288,6 +330,48 @@ def test_tools_install_mode_install_to_build_machine_arch(tool_class, arch_host,
     assert tool._conanfile.command == result
 
 
+@pytest.mark.parametrize("tool_class, arch_host, result", [
+    # Install build machine package and not cross-compile -> do not add host architecture
+    (Apk, 'x86_64', 'apk add --no-cache package1=0.1 package2=0.2'),
+    (Apt, 'x86_64', 'apt-get install -y --no-install-recommends package1=0.1 package2=0.2'),
+    (Yum, 'x86_64', 'yum install -y package1-0.1 package2-0.2'),
+    (Dnf, 'x86_64', 'dnf install -y package1-0.1 package2-0.2'),
+    (Brew, 'x86_64', 'brew install package1@0.1 package2@0.2'),
+    (Pkg, 'x86_64', 'pkg install -y package1-0.1 package2-0.2'),
+    (PkgUtil, 'x86_64', 'pkgutil --install --yes package1 package2'),
+    (Chocolatey, 'x86_64', 'choco install --yes package1 --version 0.1 package2 --version 0.2'),
+    (PacMan, 'x86_64', 'pacman -S --noconfirm package1 package2'),
+    (Zypper, 'x86_64', 'zypper --non-interactive in package1=0.1 package2=0.2'),
+    # Install build machine package and cross-compile -> do not add host architecture
+    (Apt, 'x86', 'apt-get install -y --no-install-recommends package1=0.1 package2=0.2'),
+    (Yum, 'x86', 'yum install -y package1-0.1 package2-0.2'),
+    (Dnf, 'x86', 'dnf install -y package1-0.1 package2-0.2'),
+    (Brew, 'x86', 'brew install package1@0.1 package2@0.2'),
+    (Pkg, 'x86', 'pkg install -y package1-0.1 package2-0.2'),
+    (PkgUtil, 'x86', 'pkgutil --install --yes package1 package2'),
+    (Chocolatey, 'x86', 'choco install --yes package1 --version 0.1 package2 --version 0.2'),
+    (PacMan, 'x86', 'pacman -S --noconfirm package1 package2'),
+    (Zypper, 'x86', 'zypper --non-interactive in package1=0.1 package2=0.2'),
+])
+def test_tools_install_mode_install_to_build_machine_arch_with_version(tool_class, arch_host, result):
+    conanfile = ConanFileMock()
+    conanfile.settings = MockSettings({"arch": arch_host})
+    conanfile.settings_build = MockSettings({"arch": "x86_64"})
+    conanfile.conf.define("tools.system.package_manager:tool", tool_class.tool_name)
+    conanfile.conf.define("tools.system.package_manager:mode", "install")
+    with mock.patch('conan.ConanFile.context', new_callable=PropertyMock) as context_mock:
+        context_mock.return_value = "host"
+        tool = tool_class(conanfile)
+
+        def fake_check(*args, **kwargs):
+            return ["package1=0.1", "package2=0.2"]
+        from conan.tools.system.package_manager import _SystemPackageManagerTool
+        with patch.object(_SystemPackageManagerTool, 'check', MagicMock(side_effect=fake_check)):
+            tool.install(["package1=0.1", "package2=0.2"], host_package=False)
+
+    assert tool._conanfile.command == result
+
+
 @pytest.mark.parametrize("tool_class, result", [
     # cross-compile but arch_names=None -> do not add host architecture
     # https://github.com/conan-io/conan/issues/12320 because the package is archless
@@ -316,6 +400,34 @@ def test_tools_install_archless(tool_class, result):
 
 
 @pytest.mark.parametrize("tool_class, result", [
+    # cross-compile but arch_names=None -> do not add host architecture
+    # https://github.com/conan-io/conan/issues/12320 because the package is archless
+    (Apt, 'apt-get install -y --no-install-recommends package1=0.1 package2=0.2'),
+    (Yum, 'yum install -y package1-0.1 package2-0.2'),
+    (Dnf, 'dnf install -y package1-0.1 package2-0.2'),
+    (PacMan, 'pacman -S --noconfirm package1 package2'),
+])
+def test_tools_install_archless_with_version(tool_class, result):
+    conanfile = ConanFileMock()
+    conanfile.settings = MockSettings({"arch": "x86"})
+    conanfile.settings_build = MockSettings({"arch": "x86_64"})
+    conanfile.conf.define("tools.system.package_manager:tool", tool_class.tool_name)
+    conanfile.conf.define("tools.system.package_manager:mode", "install")
+    with mock.patch('conan.ConanFile.context', new_callable=PropertyMock) as context_mock:
+        context_mock.return_value = "host"
+        tool = tool_class(conanfile, arch_names={})
+
+        def fake_check(*args, **kwargs):
+            return ["package1=0.1", "package2=0.2"]
+        from conan.tools.system.package_manager import _SystemPackageManagerTool
+        with patch.object(_SystemPackageManagerTool, 'check', MagicMock(side_effect=fake_check)):
+            tool.install(["package1=0.1", "package2=0.2"])
+
+    assert tool._conanfile.command == result
+
+
+
+@pytest.mark.parametrize("tool_class, result", [
     (Apk, 'apk info -e package'),
     (Apt, 'dpkg-query -W -f=\'${Status}\' package | grep -q "ok installed"'),
     (Yum, 'rpm -q package'),
@@ -335,5 +447,29 @@ def test_tools_check(tool_class, result):
         context_mock.return_value = "host"
         tool = tool_class(conanfile)
         tool.check(["package"])
+
+    assert tool._conanfile.command == result
+
+
+@pytest.mark.parametrize("tool_class, result", [
+    (Apk, 'apk info -e package'),
+    (Apt, 'dpkg-query -W -f=\'${Status}\' package | grep -q "ok installed"'),
+    (Yum, 'rpm -q package'),
+    (Dnf, 'rpm -q package'),
+    (Brew, 'test -n "$(brew ls --versions package)"'),
+    (Pkg, 'pkg info package'),
+    (PkgUtil, 'test -n "`pkgutil --list package`"'),
+    (Chocolatey, 'choco list --exact package | findstr /c:"1 packages installed."'),
+    (PacMan, 'pacman -Qi package'),
+    (Zypper, 'rpm -q package'),
+])
+def test_tools_check_with_version(tool_class, result):
+    conanfile = ConanFileMock()
+    conanfile.settings = Settings()
+    conanfile.conf.define("tools.system.package_manager:tool", tool_class.tool_name)
+    with mock.patch('conan.ConanFile.context', new_callable=PropertyMock) as context_mock:
+        context_mock.return_value = "host"
+        tool = tool_class(conanfile)
+        tool.check(["package=0.1"])
 
     assert tool._conanfile.command == result

--- a/test/integration/tools/system/package_manager_test.py
+++ b/test/integration/tools/system/package_manager_test.py
@@ -428,7 +428,7 @@ def test_tools_install_archless_with_version(tool_class, result):
 
 @pytest.mark.parametrize("tool_class, result", [
     (Apk, 'apk info -e package'),
-    (Apt, 'dpkg-query -W -f=\'${Status}\' package | grep -q "ok installed"'),
+    (Apt, 'dpkg -l | grep -q -E "^ii\\s+\\bpackage\\s+\\b"'),
     (Yum, 'rpm -q package'),
     (Dnf, 'rpm -q package'),
     (Brew, 'test -n "$(brew ls --versions package)"'),

--- a/test/integration/tools/system/package_manager_test.py
+++ b/test/integration/tools/system/package_manager_test.py
@@ -428,7 +428,7 @@ def test_tools_install_archless_with_version(tool_class, result):
 
 @pytest.mark.parametrize("tool_class, result", [
     (Apk, 'apk info -e package'),
-    (Apt, 'dpkg -l | grep -q -E "^ii\\s+\\bpackage\\s+\\b"'),
+    (Apt, 'dpkg-query -W -f=\'${Architecture}\' package | grep -qx "amd64"'),
     (Yum, 'rpm -q package'),
     (Dnf, 'rpm -q package'),
     (Brew, 'test -n "$(brew ls --versions package)"'),
@@ -452,7 +452,7 @@ def test_tools_check(tool_class, result):
 
 @pytest.mark.parametrize("tool_class, result", [
     (Apk, 'apk info package | grep "0.1"'),
-    (Apt, 'dpkg -l | grep -E "^ii\\s+\\bpackage\\s+\\b" | grep -q "0.1"'),
+    (Apt, 'dpkg-query -W -f=\'${Architecture} ${Version}\' package | grep -qx "amd64 0.1"'),
     (Yum, 'rpm -q package-0.1'),
     (Dnf, 'rpm -q package-0.1'),
     (Brew, 'brew list --versions package | grep "0.1"'),

--- a/test/integration/tools/system/package_manager_test.py
+++ b/test/integration/tools/system/package_manager_test.py
@@ -12,6 +12,18 @@ from conan.internal.model.settings import Settings
 from conan.test.utils.mocks import ConanFileMock, MockSettings
 
 
+_apt_archs = {
+    "x86_64": "amd64",
+    "x86": "i386",
+    "ppc32": "powerpc",
+    "ppc64le": "ppc64el",
+    "armv7": "arm",
+    "armv7hf": "armhf",
+    "armv8": "arm64",
+    "s390x": "s390x"
+}
+
+
 @pytest.mark.parametrize("platform, tool", [
     ("Linux", "apt-get"),
     ("Windows", "choco"),
@@ -425,10 +437,9 @@ def test_tools_install_archless_with_version(tool_class, result):
     assert tool._conanfile.command == result
 
 
-
 @pytest.mark.parametrize("tool_class, result", [
     (Apk, 'apk info -e package'),
-    (Apt, 'dpkg-query -W -f=\'${Architecture}\' package | grep -qx "amd64"'),
+    (Apt, f'dpkg-query -W -f=\'${{Architecture}}\' package | grep -qx "{_apt_archs.get(platform.machine())}"'),
     (Yum, 'rpm -q package'),
     (Dnf, 'rpm -q package'),
     (Brew, 'test -n "$(brew ls --versions package)"'),

--- a/test/integration/tools/system/package_manager_test.py
+++ b/test/integration/tools/system/package_manager_test.py
@@ -12,18 +12,6 @@ from conan.internal.model.settings import Settings
 from conan.test.utils.mocks import ConanFileMock, MockSettings
 
 
-_apt_archs = {
-    "x86_64": "amd64",
-    "x86": "i386",
-    "ppc32": "powerpc",
-    "ppc64le": "ppc64el",
-    "armv7": "arm",
-    "armv7hf": "armhf",
-    "armv8": "arm64",
-    "s390x": "s390x"
-}
-
-
 @pytest.mark.parametrize("platform, tool", [
     ("Linux", "apt-get"),
     ("Windows", "choco"),
@@ -439,7 +427,7 @@ def test_tools_install_archless_with_version(tool_class, result):
 
 @pytest.mark.parametrize("tool_class, result", [
     (Apk, 'apk info -e package'),
-    (Apt, f'dpkg-query -W -f=\'${{Architecture}}\' package | grep -qx "{_apt_archs.get(platform.machine())}"'),
+    (Apt, 'dpkg-query -W -f=\'${{Architecture}}\' package | grep -qx "amd64"'),
     (Yum, 'rpm -q package'),
     (Dnf, 'rpm -q package'),
     (Brew, 'test -n "$(brew ls --versions package)"'),

--- a/test/integration/tools/system/package_manager_test.py
+++ b/test/integration/tools/system/package_manager_test.py
@@ -254,17 +254,17 @@ def test_tools_install_mode_install_different_archs(tool_class, arch_host, resul
     (Dnf, 'x86_64', 'dnf install -y package1-0.1 package2-0.2'),
     (Brew, 'x86_64', 'brew install package1@0.1 package2@0.2'),
     (Pkg, 'x86_64', 'pkg install -y package1-0.1 package2-0.2'),
-    (PkgUtil, 'x86_64', 'pkgutil --install --yes package1 package2'),
+    (PkgUtil, 'x86_64', 'pkgutil --install --yes package1@0.1 package2@0.2'),
     (Chocolatey, 'x86_64', 'choco install --yes package1 --version 0.1 package2 --version 0.2'),
     (PacMan, 'x86_64', 'pacman -S --noconfirm package1 package2'),
     (Zypper, 'x86_64', 'zypper --non-interactive in package1=0.1 package2=0.2'),
     # Install host package and cross-compile -> add host architecture
     (Apt, 'x86', 'apt-get install -y --no-install-recommends package1:i386=0.1 package2:i386=0.2'),
-    (Yum, 'x86', 'yum install -y package1.i?86-0.1 package2.i?86-0.2'),
-    (Dnf, 'x86', 'dnf install -y package1.i?86-0.1 package2.i?86-0.2'),
+    (Yum, 'x86', 'yum install -y package1-0.1.i?86 package2-0.2.i?86'),
+    (Dnf, 'x86', 'dnf install -y package1-0.1.i?86 package2-0.2.i?86'),
     (Brew, 'x86', 'brew install package1@0.1 package2@0.2'),
     (Pkg, 'x86', 'pkg install -y package1-0.1 package2-0.2'),
-    (PkgUtil, 'x86', 'pkgutil --install --yes package1 package2'),
+    (PkgUtil, 'x86', 'pkgutil --install --yes package1@0.1 package2@0.2'),
     (Chocolatey, 'x86', 'choco install --yes package1 --version 0.1 package2 --version 0.2'),
     (PacMan, 'x86', 'pacman -S --noconfirm package1-lib32 package2-lib32'),
     (Zypper, 'x86', 'zypper --non-interactive in package1=0.1 package2=0.2'),
@@ -284,7 +284,6 @@ def test_tools_install_mode_install_different_archs_with_version(tool_class, arc
         from conan.tools.system.package_manager import _SystemPackageManagerTool
         with patch.object(_SystemPackageManagerTool, 'check', MagicMock(side_effect=fake_check)):
             tool.install(["package1=0.1", "package2=0.2"])
-    print(tool._conanfile.command)
     assert tool._conanfile.command == result
 
 
@@ -338,7 +337,7 @@ def test_tools_install_mode_install_to_build_machine_arch(tool_class, arch_host,
     (Dnf, 'x86_64', 'dnf install -y package1-0.1 package2-0.2'),
     (Brew, 'x86_64', 'brew install package1@0.1 package2@0.2'),
     (Pkg, 'x86_64', 'pkg install -y package1-0.1 package2-0.2'),
-    (PkgUtil, 'x86_64', 'pkgutil --install --yes package1 package2'),
+    (PkgUtil, 'x86_64', 'pkgutil --install --yes package1@0.1 package2@0.2'),
     (Chocolatey, 'x86_64', 'choco install --yes package1 --version 0.1 package2 --version 0.2'),
     (PacMan, 'x86_64', 'pacman -S --noconfirm package1 package2'),
     (Zypper, 'x86_64', 'zypper --non-interactive in package1=0.1 package2=0.2'),
@@ -348,7 +347,7 @@ def test_tools_install_mode_install_to_build_machine_arch(tool_class, arch_host,
     (Dnf, 'x86', 'dnf install -y package1-0.1 package2-0.2'),
     (Brew, 'x86', 'brew install package1@0.1 package2@0.2'),
     (Pkg, 'x86', 'pkg install -y package1-0.1 package2-0.2'),
-    (PkgUtil, 'x86', 'pkgutil --install --yes package1 package2'),
+    (PkgUtil, 'x86', 'pkgutil --install --yes package1@0.1 package2@0.2'),
     (Chocolatey, 'x86', 'choco install --yes package1 --version 0.1 package2 --version 0.2'),
     (PacMan, 'x86', 'pacman -S --noconfirm package1 package2'),
     (Zypper, 'x86', 'zypper --non-interactive in package1=0.1 package2=0.2'),
@@ -452,16 +451,16 @@ def test_tools_check(tool_class, result):
 
 
 @pytest.mark.parametrize("tool_class, result", [
-    (Apk, 'apk info -e package'),
-    (Apt, 'dpkg-query -W -f=\'${Status}\' package | grep -q "ok installed"'),
-    (Yum, 'rpm -q package'),
-    (Dnf, 'rpm -q package'),
-    (Brew, 'test -n "$(brew ls --versions package)"'),
-    (Pkg, 'pkg info package'),
+    (Apk, 'apk info package | grep "0.1"'),
+    (Apt, 'dpkg -s package | grep "Version: 0.1"'),
+    (Yum, 'rpm -q package-0.1'),
+    (Dnf, 'rpm -q package-0.1'),
+    (Brew, 'brew list --versions package | grep "0.1"'),
+    (Pkg, 'pkg info package | grep "Version: 0.1"'),
     (PkgUtil, 'test -n "`pkgutil --list package`"'),
-    (Chocolatey, 'choco list --exact package | findstr /c:"1 packages installed."'),
+    (Chocolatey, 'choco list --local-only package | findstr /i "0.1"'),
     (PacMan, 'pacman -Qi package'),
-    (Zypper, 'rpm -q package'),
+    (Zypper, 'rpm -q package-0.1'),
 ])
 def test_tools_check_with_version(tool_class, result):
     conanfile = ConanFileMock()

--- a/test/integration/tools/system/package_manager_test.py
+++ b/test/integration/tools/system/package_manager_test.py
@@ -427,7 +427,7 @@ def test_tools_install_archless_with_version(tool_class, result):
 
 @pytest.mark.parametrize("tool_class, result", [
     (Apk, 'apk info -e package'),
-    (Apt, 'dpkg-query -W -f=\'${{Architecture}}\' package | grep -qx "amd64"'),
+    (Apt, 'dpkg-query -W -f=\'${Architecture}\' package | grep -qx "amd64"'),
     (Yum, 'rpm -q package'),
     (Dnf, 'rpm -q package'),
     (Brew, 'test -n "$(brew ls --versions package)"'),

--- a/test/integration/tools/system/package_manager_test.py
+++ b/test/integration/tools/system/package_manager_test.py
@@ -427,7 +427,7 @@ def test_tools_install_archless_with_version(tool_class, result):
 
 @pytest.mark.parametrize("tool_class, result", [
     (Apk, 'apk info -e package'),
-    (Apt, 'dpkg-query -W -f=\'${Architecture}\' package | grep -qx "amd64" || dpkg-query -W -f=\'${Architecture}\' package | grep -qx "all"'),
+    (Apt, 'dpkg-query -W -f=\'${Architecture}\' package | grep -qEx \'(amd64|all)\''),
     (Yum, 'rpm -q package'),
     (Dnf, 'rpm -q package'),
     (Brew, 'test -n "$(brew ls --versions package)"'),
@@ -451,7 +451,7 @@ def test_tools_check(tool_class, result):
 
 @pytest.mark.parametrize("tool_class, result", [
     (Apk, 'apk info package | grep "0.1"'),
-    (Apt, 'dpkg-query -W -f=\'${Architecture} ${Version}\' package | grep -qx "amd64 0.1" || dpkg-query -W -f=\'${Architecture}\' package | grep -qx "all 0.1"'),
+    (Apt, 'dpkg-query -W -f=\'${Architecture} ${Version}\' package | grep -qEx \'(amd64|all) 0.1\''),
     (Yum, 'rpm -q package-0.1'),
     (Dnf, 'rpm -q package-0.1'),
     (Brew, 'brew list --versions package | grep "0.1"'),

--- a/test/integration/tools/system/package_manager_test.py
+++ b/test/integration/tools/system/package_manager_test.py
@@ -452,7 +452,7 @@ def test_tools_check(tool_class, result):
 
 @pytest.mark.parametrize("tool_class, result", [
     (Apk, 'apk info package | grep "0.1"'),
-    (Apt, 'dpkg -s package | grep "Version: 0.1"'),
+    (Apt, 'dpkg -l | grep -E "^ii\\s+\\bpackage\\s+\\b" | grep -q "0.1"'),
     (Yum, 'rpm -q package-0.1'),
     (Dnf, 'rpm -q package-0.1'),
     (Brew, 'brew list --versions package | grep "0.1"'),

--- a/test/integration/tools/system/package_manager_test.py
+++ b/test/integration/tools/system/package_manager_test.py
@@ -427,7 +427,7 @@ def test_tools_install_archless_with_version(tool_class, result):
 
 @pytest.mark.parametrize("tool_class, result", [
     (Apk, 'apk info -e package'),
-    (Apt, 'dpkg-query -W -f=\'${Architecture}\' package | grep -qx "amd64"'),
+    (Apt, 'dpkg-query -W -f=\'${Architecture}\' package | grep -qx "amd64" || dpkg-query -W -f=\'${Architecture}\' package | grep -qx "all"'),
     (Yum, 'rpm -q package'),
     (Dnf, 'rpm -q package'),
     (Brew, 'test -n "$(brew ls --versions package)"'),
@@ -451,7 +451,7 @@ def test_tools_check(tool_class, result):
 
 @pytest.mark.parametrize("tool_class, result", [
     (Apk, 'apk info package | grep "0.1"'),
-    (Apt, 'dpkg-query -W -f=\'${Architecture} ${Version}\' package | grep -qx "amd64 0.1"'),
+    (Apt, 'dpkg-query -W -f=\'${Architecture} ${Version}\' package | grep -qx "amd64 0.1" || dpkg-query -W -f=\'${Architecture}\' package | grep -qx "all 0.1"'),
     (Yum, 'rpm -q package-0.1'),
     (Dnf, 'rpm -q package-0.1'),
     (Brew, 'brew list --versions package | grep "0.1"'),


### PR DESCRIPTION
Changelog: Feature: Added support to the system_package tool for defining the system package version to be installed.
Changelog: Fix: Fixed an issue that caused APT packages without a defined architecture to be detected if one with the same name was installed for a different architecture.

Docs: https://github.com/conan-io/docs/pull/4170

Close https://github.com/conan-io/conan/issues/17744
Close https://github.com/conan-io/conan/issues/18569

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
