### PR TITLE
Added threads subsetting in emcc compiler model

### DIFF
--- a/conan/internal/default_settings.py
+++ b/conan/internal/default_settings.py
@@ -168,6 +168,7 @@ compiler:
         # There is no ABI compatibility guarantee between versions
         version: [ANY]
         libcxx: [null, libstdc++, libstdc++11, libc++]
+        threads: [null, posix, wasm_workers]
         cppstd: [null, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23, 26, gnu26]
         cstd: [null, 99, gnu99, 11, gnu11, 17, gnu17, 23, gnu23]
 

--- a/conan/tools/build/flags.py
+++ b/conan/tools/build/flags.py
@@ -195,7 +195,7 @@ def build_type_flags(conanfile):
             return flags
     return []
 
-def threads_flag(conanfile):
+def threads_flags(conanfile):
     """
     returns flags specific to the threading model used by the compiler
     """
@@ -203,10 +203,10 @@ def threads_flag(conanfile):
     threads = conanfile.settings.get_safe("compiler.threads")
     if compiler == "emcc":
         if threads == "posix":
-            return "-pthread"
+            return ["-pthread"]
         elif threads == "wasm_workers":
-            return "-sWASM_WORKERS=1"
-    return ""
+            return ["-sWASM_WORKERS=1"]
+    return []
 
 def llvm_clang_front(conanfile):
     # Only Windows clang with MSVC backend (LLVM/Clang, not MSYS2 clang)

--- a/conan/tools/build/flags.py
+++ b/conan/tools/build/flags.py
@@ -195,6 +195,18 @@ def build_type_flags(conanfile):
             return flags
     return []
 
+def threads_flag(conanfile):
+    """
+    returns flags specific to the threading model used by the compiler
+    """
+    compiler = conanfile.settings.get_safe("compiler")
+    threads = conanfile.settings.get_safe("compiler.threads")
+    if compiler == "emcc":
+        if threads == "posix":
+            return "-pthread"
+        elif threads == "wasm_workers":
+            return "-sWASM_WORKERS=1"
+    return ""
 
 def llvm_clang_front(conanfile):
     # Only Windows clang with MSVC backend (LLVM/Clang, not MSYS2 clang)

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -237,8 +237,8 @@ class SkipRPath(Block):
 
 class ArchitectureBlock(Block):
     template = textwrap.dedent("""\
-        # Define C++ flags, C flags and linker flags from 'settings.arch'
         {% if arch_flag %}
+        # Define C++ flags, C flags and linker flags from 'settings.arch'
         message(STATUS "Conan toolchain: Defining architecture flag: {{ arch_flag }}")
         string(APPEND CONAN_CXX_FLAGS " {{ arch_flag }}")
         string(APPEND CONAN_C_FLAGS " {{ arch_flag }}")

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -10,7 +10,7 @@ from conan.tools.apple.apple import get_apple_sdk_fullname, _to_apple_arch
 from conan.tools.android.utils import android_abi
 from conan.tools.apple.apple import is_apple_os, to_apple_arch
 from conan.tools.build import build_jobs
-from conan.tools.build.flags import architecture_flag, architecture_link_flag, libcxx_flags, threads_flag
+from conan.tools.build.flags import architecture_flag, architecture_link_flag, libcxx_flags, threads_flags
 from conan.tools.build.cross_building import cross_building
 from conan.tools.cmake.toolchain import CONAN_TOOLCHAIN_FILENAME
 from conan.tools.cmake.utils import is_multi_configuration
@@ -250,30 +250,23 @@ class ArchitectureBlock(Block):
         string(APPEND CONAN_SHARED_LINKER_FLAGS " {{ arch_link_flag }}")
         string(APPEND CONAN_EXE_LINKER_FLAGS " {{ arch_link_flag }}")
         {% endif %}
+        {% if thread_flags_list %}
+        # Define C++ flags, C flags and linker flags from 'compiler.threads'
+        message(STATUS "Conan toolchain: Defining thread flags: {{ thread_flags_list }}")
+        string(APPEND CONAN_CXX_FLAGS " {{ thread_flags_list }}")
+        string(APPEND CONAN_C_FLAGS " {{ thread_flags_list }}")
+        string(APPEND CONAN_SHARED_LINKER_FLAGS " {{ thread_flags_list }}")
+        string(APPEND CONAN_EXE_LINKER_FLAGS " {{ thread_flags_list }}")
+        {% endif %}
         """)
 
     def context(self):
         arch_flag = architecture_flag(self._conanfile)
         arch_link_flag = architecture_link_flag(self._conanfile)
-        if not arch_flag and not arch_link_flag:
+        thread_flags_list = " ".join(threads_flags(self._conanfile))
+        if not arch_flag and not arch_link_flag and not thread_flags_list:
             return
-        return {"arch_flag": arch_flag, "arch_link_flag": arch_link_flag}
-
-class ThreadsBlock(Block):
-    template = textwrap.dedent("""\
-        # Define C++ flags, C flags and linker flags from 'compiler.threads'
-        message(STATUS "Conan toolchain: Defining threads flag: {{ threads_flag }}")
-        string(APPEND CONAN_CXX_FLAGS " {{ threads_flag }}")
-        string(APPEND CONAN_C_FLAGS " {{ threads_flag }}")
-        string(APPEND CONAN_SHARED_LINKER_FLAGS " {{ threads_flag }}")
-        string(APPEND CONAN_EXE_LINKER_FLAGS " {{ threads_flag }}")
-        """)
-
-    def context(self):
-        flags = threads_flag(self._conanfile)
-        if not flags:
-            return
-        return {"threads_flag": flags}
+        return {"arch_flag": arch_flag, "arch_link_flag": arch_link_flag, "thread_flags_list": thread_flags_list}
 
 class LinkerScriptsBlock(Block):
     template = textwrap.dedent("""\

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -10,7 +10,7 @@ from conan.tools.apple.apple import get_apple_sdk_fullname, _to_apple_arch
 from conan.tools.android.utils import android_abi
 from conan.tools.apple.apple import is_apple_os, to_apple_arch
 from conan.tools.build import build_jobs
-from conan.tools.build.flags import architecture_flag, architecture_link_flag, libcxx_flags
+from conan.tools.build.flags import architecture_flag, architecture_link_flag, libcxx_flags, threads_flag
 from conan.tools.build.cross_building import cross_building
 from conan.tools.cmake.toolchain import CONAN_TOOLCHAIN_FILENAME
 from conan.tools.cmake.utils import is_multi_configuration
@@ -259,6 +259,21 @@ class ArchitectureBlock(Block):
             return
         return {"arch_flag": arch_flag, "arch_link_flag": arch_link_flag}
 
+class ThreadsBlock(Block):
+    template = textwrap.dedent("""\
+        # Define C++ flags, C flags and linker flags from 'compiler.threads'
+        message(STATUS "Conan toolchain: Defining threads flag: {{ threads_flag }}")
+        string(APPEND CONAN_CXX_FLAGS " {{ threads_flag }}")
+        string(APPEND CONAN_C_FLAGS " {{ threads_flag }}")
+        string(APPEND CONAN_SHARED_LINKER_FLAGS " {{ threads_flag }}")
+        string(APPEND CONAN_EXE_LINKER_FLAGS " {{ threads_flag }}")
+        """)
+
+    def context(self):
+        flags = threads_flag(self._conanfile)
+        if not flags:
+            return
+        return {"threads_flag": flags}
 
 class LinkerScriptsBlock(Block):
     template = textwrap.dedent("""\

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -9,7 +9,7 @@ from conan.internal import check_duplicated_generator
 from conan.tools.build import use_win_mingw
 from conan.tools.cmake.presets import write_cmake_presets
 from conan.tools.cmake.toolchain import CONAN_TOOLCHAIN_FILENAME
-from conan.tools.cmake.toolchain.blocks import ExtraVariablesBlock, ThreadsBlock, ToolchainBlocks, UserToolchain, \
+from conan.tools.cmake.toolchain.blocks import ExtraVariablesBlock, ToolchainBlocks, UserToolchain, \
     GenericSystemBlock, \
     AndroidSystemBlock, AppleSystemBlock, FPicBlock, ArchitectureBlock, GLibCXXBlock, VSRuntimeBlock, \
     CppStdBlock, ParallelBlock, CMakeFlagsInitBlock, TryCompileBlock, FindFiles, PkgConfigBlock, \
@@ -103,7 +103,6 @@ class CMakeToolchain:
                                        ("apple_system", AppleSystemBlock),
                                        ("fpic", FPicBlock),
                                        ("arch_flags", ArchitectureBlock),
-                                       ("threads_flags", ThreadsBlock),
                                        ("linker_scripts", LinkerScriptsBlock),
                                        ("libcxx", GLibCXXBlock),
                                        ("vs_runtime", VSRuntimeBlock),

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -9,7 +9,7 @@ from conan.internal import check_duplicated_generator
 from conan.tools.build import use_win_mingw
 from conan.tools.cmake.presets import write_cmake_presets
 from conan.tools.cmake.toolchain import CONAN_TOOLCHAIN_FILENAME
-from conan.tools.cmake.toolchain.blocks import ExtraVariablesBlock, ToolchainBlocks, UserToolchain, \
+from conan.tools.cmake.toolchain.blocks import ExtraVariablesBlock, ThreadsBlock, ToolchainBlocks, UserToolchain, \
     GenericSystemBlock, \
     AndroidSystemBlock, AppleSystemBlock, FPicBlock, ArchitectureBlock, GLibCXXBlock, VSRuntimeBlock, \
     CppStdBlock, ParallelBlock, CMakeFlagsInitBlock, TryCompileBlock, FindFiles, PkgConfigBlock, \
@@ -103,6 +103,7 @@ class CMakeToolchain:
                                        ("apple_system", AppleSystemBlock),
                                        ("fpic", FPicBlock),
                                        ("arch_flags", ArchitectureBlock),
+                                       ("threads_flags", ThreadsBlock),
                                        ("linker_scripts", LinkerScriptsBlock),
                                        ("libcxx", GLibCXXBlock),
                                        ("vs_runtime", VSRuntimeBlock),

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -7,7 +7,7 @@ from conan.tools.apple.apple import is_apple_os, resolve_apple_flags, apple_extr
 from conan.tools.build import cmd_args_to_string, save_toolchain_args
 from conan.tools.build.cross_building import cross_building
 from conan.tools.build.flags import architecture_flag, architecture_link_flag, build_type_flags, cppstd_flag, \
-    build_type_link_flags, libcxx_flags, cstd_flag, llvm_clang_front
+    build_type_link_flags, libcxx_flags, cstd_flag, llvm_clang_front, threads_flag
 from conan.tools.env import Environment, VirtualBuildEnv
 from conan.tools.gnu.get_gnu_triplet import _get_gnu_triplet
 from conan.tools.microsoft import VCVars, msvc_runtime_flag, unix_path, check_min_vs, is_msvc
@@ -53,6 +53,7 @@ class AutotoolsToolchain:
         self.cstd = cstd_flag(self._conanfile)
         self.arch_flag = architecture_flag(self._conanfile)
         self.arch_ld_flag = architecture_link_flag(self._conanfile)
+        self.threads_flag = threads_flag(self._conanfile)
         self.libcxx, self.gcc_cxx11_abi = libcxx_flags(self._conanfile)
         self.fpic = self._conanfile.options.get_safe("fPIC")
         self.msvc_runtime_flag = self._get_msvc_runtime_flag()
@@ -203,7 +204,7 @@ class AutotoolsToolchain:
     def cxxflags(self):
         fpic = "-fPIC" if self.fpic else None
         ret = [self.libcxx, self.cppstd, self.arch_flag, fpic, self.msvc_runtime_flag,
-               self.sysroot_flag]
+               self.sysroot_flag, self.threads_flag]
         apple_flags = [self.apple_isysroot_flag, self.apple_arch_flag, self.apple_min_version_flag]
         apple_flags += self.apple_extra_flags
         conf_flags = self._conanfile.conf.get("tools.build:cxxflags", default=[], check_type=list)
@@ -214,7 +215,7 @@ class AutotoolsToolchain:
     @property
     def cflags(self):
         fpic = "-fPIC" if self.fpic else None
-        ret = [self.cstd, self.arch_flag, fpic, self.msvc_runtime_flag, self.sysroot_flag]
+        ret = [self.cstd, self.arch_flag, fpic, self.msvc_runtime_flag, self.sysroot_flag, self.threads_flag]
         apple_flags = [self.apple_isysroot_flag, self.apple_arch_flag, self.apple_min_version_flag]
         apple_flags += self.apple_extra_flags
         conf_flags = self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list)

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -7,7 +7,7 @@ from conan.tools.apple.apple import is_apple_os, resolve_apple_flags, apple_extr
 from conan.tools.build import cmd_args_to_string, save_toolchain_args
 from conan.tools.build.cross_building import cross_building
 from conan.tools.build.flags import architecture_flag, architecture_link_flag, build_type_flags, cppstd_flag, \
-    build_type_link_flags, libcxx_flags, cstd_flag, llvm_clang_front, threads_flag
+    build_type_link_flags, libcxx_flags, cstd_flag, llvm_clang_front, threads_flags
 from conan.tools.env import Environment, VirtualBuildEnv
 from conan.tools.gnu.get_gnu_triplet import _get_gnu_triplet
 from conan.tools.microsoft import VCVars, msvc_runtime_flag, unix_path, check_min_vs, is_msvc
@@ -53,7 +53,7 @@ class AutotoolsToolchain:
         self.cstd = cstd_flag(self._conanfile)
         self.arch_flag = architecture_flag(self._conanfile)
         self.arch_ld_flag = architecture_link_flag(self._conanfile)
-        self.threads_flag = threads_flag(self._conanfile)
+        self.threads_flags = threads_flags(self._conanfile)
         self.libcxx, self.gcc_cxx11_abi = libcxx_flags(self._conanfile)
         self.fpic = self._conanfile.options.get_safe("fPIC")
         self.msvc_runtime_flag = self._get_msvc_runtime_flag()
@@ -204,7 +204,7 @@ class AutotoolsToolchain:
     def cxxflags(self):
         fpic = "-fPIC" if self.fpic else None
         ret = [self.libcxx, self.cppstd, self.arch_flag, fpic, self.msvc_runtime_flag,
-               self.sysroot_flag, self.threads_flag]
+               self.sysroot_flag] + self.threads_flags
         apple_flags = [self.apple_isysroot_flag, self.apple_arch_flag, self.apple_min_version_flag]
         apple_flags += self.apple_extra_flags
         conf_flags = self._conanfile.conf.get("tools.build:cxxflags", default=[], check_type=list)
@@ -215,7 +215,7 @@ class AutotoolsToolchain:
     @property
     def cflags(self):
         fpic = "-fPIC" if self.fpic else None
-        ret = [self.cstd, self.arch_flag, fpic, self.msvc_runtime_flag, self.sysroot_flag, self.threads_flag]
+        ret = [self.cstd, self.arch_flag, fpic, self.msvc_runtime_flag, self.sysroot_flag] + self.threads_flags
         apple_flags = [self.apple_isysroot_flag, self.apple_arch_flag, self.apple_min_version_flag]
         apple_flags += self.apple_extra_flags
         conf_flags = self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
@@ -225,7 +225,7 @@ class AutotoolsToolchain:
 
     @property
     def ldflags(self):
-        ret = [self.arch_flag, self.sysroot_flag, self.arch_ld_flag]
+        ret = [self.arch_flag, self.sysroot_flag, self.arch_ld_flag] + self.threads_flags
         apple_flags = [self.apple_isysroot_flag, self.apple_arch_flag, self.apple_min_version_flag]
         apple_flags += self.apple_extra_flags
         conf_flags = self._conanfile.conf.get("tools.build:sharedlinkflags", default=[],

--- a/conan/tools/gnu/gnutoolchain.py
+++ b/conan/tools/gnu/gnutoolchain.py
@@ -7,7 +7,7 @@ from conan.tools.build import cmd_args_to_string, save_toolchain_args
 from conan.tools.build.cross_building import cross_building
 from conan.tools.build.flags import architecture_flag, architecture_link_flag, build_type_flags, cppstd_flag, \
     build_type_link_flags, \
-    libcxx_flags, llvm_clang_front, threads_flag
+    libcxx_flags, llvm_clang_front, threads_flags
 from conan.tools.env import Environment, VirtualBuildEnv
 from conan.tools.gnu.get_gnu_triplet import _get_gnu_triplet
 from conan.tools.microsoft import VCVars, msvc_runtime_flag, unix_path, check_min_vs, is_msvc
@@ -58,7 +58,7 @@ class GnuToolchain:
         self.cppstd = cppstd_flag(self._conanfile)
         self.arch_flag = architecture_flag(self._conanfile)
         self.arch_ld_flag = architecture_link_flag(self._conanfile)
-        self.threads_flag = threads_flag(self._conanfile)
+        self.threads_flags = threads_flags(self._conanfile)
         self.libcxx, self.gcc_cxx11_abi = libcxx_flags(self._conanfile)
         self.fpic = self._conanfile.options.get_safe("fPIC")
         self.msvc_runtime_flag = self._get_msvc_runtime_flag()
@@ -269,7 +269,7 @@ class GnuToolchain:
     def cxxflags(self):
         fpic = "-fPIC" if self.fpic else None
         ret = [self.libcxx, self.cppstd, self.arch_flag, fpic, self.msvc_runtime_flag,
-               self.sysroot_flag, self.threads_flag]
+               self.sysroot_flag] + self.threads_flags
         apple_flags = [self.apple_isysroot_flag, self.apple_arch_flag, self.apple_min_version_flag]
         apple_flags += self.apple_extra_flags
         conf_flags = self._conanfile.conf.get("tools.build:cxxflags", default=[], check_type=list)
@@ -280,7 +280,7 @@ class GnuToolchain:
     @property
     def cflags(self):
         fpic = "-fPIC" if self.fpic else None
-        ret = [self.arch_flag, fpic, self.msvc_runtime_flag, self.sysroot_flag, self.threads_flag]
+        ret = [self.arch_flag, fpic, self.msvc_runtime_flag, self.sysroot_flag] + self.threads_flags
         apple_flags = [self.apple_isysroot_flag, self.apple_arch_flag, self.apple_min_version_flag]
         apple_flags += self.apple_extra_flags
         conf_flags = self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
@@ -290,7 +290,7 @@ class GnuToolchain:
 
     @property
     def ldflags(self):
-        ret = [self.arch_flag, self.sysroot_flag, self.arch_ld_flag, self.threads_flag]
+        ret = [self.arch_flag, self.sysroot_flag, self.arch_ld_flag] + self.threads_flags
         apple_flags = [self.apple_isysroot_flag, self.apple_arch_flag, self.apple_min_version_flag]
         apple_flags += self.apple_extra_flags
         conf_flags = self._conanfile.conf.get("tools.build:sharedlinkflags", default=[],

--- a/conan/tools/gnu/gnutoolchain.py
+++ b/conan/tools/gnu/gnutoolchain.py
@@ -7,7 +7,7 @@ from conan.tools.build import cmd_args_to_string, save_toolchain_args
 from conan.tools.build.cross_building import cross_building
 from conan.tools.build.flags import architecture_flag, architecture_link_flag, build_type_flags, cppstd_flag, \
     build_type_link_flags, \
-    libcxx_flags, llvm_clang_front
+    libcxx_flags, llvm_clang_front, threads_flag
 from conan.tools.env import Environment, VirtualBuildEnv
 from conan.tools.gnu.get_gnu_triplet import _get_gnu_triplet
 from conan.tools.microsoft import VCVars, msvc_runtime_flag, unix_path, check_min_vs, is_msvc
@@ -58,6 +58,7 @@ class GnuToolchain:
         self.cppstd = cppstd_flag(self._conanfile)
         self.arch_flag = architecture_flag(self._conanfile)
         self.arch_ld_flag = architecture_link_flag(self._conanfile)
+        self.threads_flag = threads_flag(self._conanfile)
         self.libcxx, self.gcc_cxx11_abi = libcxx_flags(self._conanfile)
         self.fpic = self._conanfile.options.get_safe("fPIC")
         self.msvc_runtime_flag = self._get_msvc_runtime_flag()
@@ -268,7 +269,7 @@ class GnuToolchain:
     def cxxflags(self):
         fpic = "-fPIC" if self.fpic else None
         ret = [self.libcxx, self.cppstd, self.arch_flag, fpic, self.msvc_runtime_flag,
-               self.sysroot_flag]
+               self.sysroot_flag, self.threads_flag]
         apple_flags = [self.apple_isysroot_flag, self.apple_arch_flag, self.apple_min_version_flag]
         apple_flags += self.apple_extra_flags
         conf_flags = self._conanfile.conf.get("tools.build:cxxflags", default=[], check_type=list)
@@ -279,7 +280,7 @@ class GnuToolchain:
     @property
     def cflags(self):
         fpic = "-fPIC" if self.fpic else None
-        ret = [self.arch_flag, fpic, self.msvc_runtime_flag, self.sysroot_flag]
+        ret = [self.arch_flag, fpic, self.msvc_runtime_flag, self.sysroot_flag, self.threads_flag]
         apple_flags = [self.apple_isysroot_flag, self.apple_arch_flag, self.apple_min_version_flag]
         apple_flags += self.apple_extra_flags
         conf_flags = self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
@@ -289,7 +290,7 @@ class GnuToolchain:
 
     @property
     def ldflags(self):
-        ret = [self.arch_flag, self.sysroot_flag, self.arch_ld_flag]
+        ret = [self.arch_flag, self.sysroot_flag, self.arch_ld_flag, self.threads_flag]
         apple_flags = [self.apple_isysroot_flag, self.apple_arch_flag, self.apple_min_version_flag]
         apple_flags += self.apple_extra_flags
         conf_flags = self._conanfile.conf.get("tools.build:sharedlinkflags", default=[],

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -9,7 +9,7 @@ from conan.internal.internal_tools import raise_on_universal_arch
 from conan.tools.apple.apple import is_apple_os, apple_min_version_flag, \
     resolve_apple_flags, apple_extra_flags
 from conan.tools.build.cross_building import cross_building
-from conan.tools.build.flags import architecture_link_flag, libcxx_flags, architecture_flag
+from conan.tools.build.flags import architecture_link_flag, libcxx_flags, architecture_flag, threads_flag
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.meson.helpers import *
 from conan.tools.meson.helpers import get_apple_subsystem
@@ -218,6 +218,8 @@ class MesonToolchain:
         self.arch_flag = architecture_flag(self._conanfile)  # https://github.com/conan-io/conan/issues/17624
         #: Architecture link flag deduced by Conan and added to ``c_link_args`` and ``cpp_link_args``
         self.arch_link_flag = architecture_link_flag(self._conanfile)
+        #: Threads flag deduced by Conan and added to ``c_args``, ``cpp_args``, ``c_link_args`` and ``cpp_link_args``
+        self.threads_flag = threads_flag(self._conanfile)
         #: Dict-like object that defines Meson ``properties`` with ``key=value`` format
         self.properties = {}
         #: Dict-like object that defines Meson ``project options`` with ``key=value`` format
@@ -459,9 +461,9 @@ class MesonToolchain:
         cflags += self.apple_extra_flags
         ld += self.apple_extra_flags
         return {
-            "cxxflags": [self.arch_flag] + cxxflags + sys_root + self.extra_cxxflags,
-            "cflags": [self.arch_flag] + cflags + sys_root + self.extra_cflags,
-            "ldflags": [self.arch_flag] + [self.arch_link_flag] + ld,
+            "cxxflags": [self.arch_flag] + cxxflags + sys_root + self.extra_cxxflags + [self.threads_flag],
+            "cflags": [self.arch_flag] + cflags + sys_root + self.extra_cflags + [self.threads_flag],
+            "ldflags": [self.arch_flag] + [self.arch_link_flag] + ld + self.extra_ldflags,
             "defines": [f"-D{d}" for d in (defines + self.extra_defines)]
         }
 

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -9,7 +9,7 @@ from conan.internal.internal_tools import raise_on_universal_arch
 from conan.tools.apple.apple import is_apple_os, apple_min_version_flag, \
     resolve_apple_flags, apple_extra_flags
 from conan.tools.build.cross_building import cross_building
-from conan.tools.build.flags import architecture_link_flag, libcxx_flags, architecture_flag, threads_flag
+from conan.tools.build.flags import architecture_link_flag, libcxx_flags, architecture_flag, threads_flags
 from conan.tools.env import VirtualBuildEnv
 from conan.tools.meson.helpers import *
 from conan.tools.meson.helpers import get_apple_subsystem
@@ -218,8 +218,8 @@ class MesonToolchain:
         self.arch_flag = architecture_flag(self._conanfile)  # https://github.com/conan-io/conan/issues/17624
         #: Architecture link flag deduced by Conan and added to ``c_link_args`` and ``cpp_link_args``
         self.arch_link_flag = architecture_link_flag(self._conanfile)
-        #: Threads flag deduced by Conan and added to ``c_args``, ``cpp_args``, ``c_link_args`` and ``cpp_link_args``
-        self.threads_flag = threads_flag(self._conanfile)
+        #: Threads flags deduced by Conan and added to ``c_args``, ``cpp_args``, ``c_link_args`` and ``cpp_link_args``
+        self.threads_flags = threads_flags(self._conanfile)
         #: Dict-like object that defines Meson ``properties`` with ``key=value`` format
         self.properties = {}
         #: Dict-like object that defines Meson ``project options`` with ``key=value`` format
@@ -455,15 +455,15 @@ class MesonToolchain:
         linker_script_flags = ['-T"' + linker_script + '"' for linker_script in linker_scripts]
         defines = self._conanfile_conf.get("tools.build:defines", default=[], check_type=list)
         sys_root = [f"--sysroot={self._sys_root}"] if self._sys_root else [""]
-        ld = sharedlinkflags + exelinkflags + linker_script_flags + sys_root + self.extra_ldflags
+        ld = sharedlinkflags + exelinkflags + linker_script_flags + sys_root + self.extra_ldflags + self.threads_flags
         # Apple extra flags from confs (visibilty, bitcode, arc)
         cxxflags += self.apple_extra_flags
         cflags += self.apple_extra_flags
         ld += self.apple_extra_flags
         return {
-            "cxxflags": [self.arch_flag] + cxxflags + sys_root + self.extra_cxxflags + [self.threads_flag],
-            "cflags": [self.arch_flag] + cflags + sys_root + self.extra_cflags + [self.threads_flag],
-            "ldflags": [self.arch_flag] + [self.arch_link_flag] + ld + self.extra_ldflags,
+            "cxxflags": [self.arch_flag] + cxxflags + sys_root + self.extra_cxxflags + self.threads_flags,
+            "cflags": [self.arch_flag] + cflags + sys_root + self.extra_cflags + self.threads_flags,
+            "ldflags": [self.arch_flag] + [self.arch_link_flag] + ld,
             "defines": [f"-D{d}" for d in (defines + self.extra_defines)]
         }
 

--- a/conan/tools/premake/toolchain.py
+++ b/conan/tools/premake/toolchain.py
@@ -16,19 +16,19 @@ def _generate_flags(self, conanfile):
     template = textwrap.dedent(
         """\
         {% if extra_cflags %}
-        -- C flags retrieved from CFLAGS environment, conan.conf(tools.build:cflags) and extra_cflags
+        -- C flags retrieved from CFLAGS environment, conan.conf(tools.build:cflags), extra_cflags and compiler settings
         filter { files { "**.c" } }
             buildoptions { {{ extra_cflags }} }
         filter {}
         {% endif %}
         {% if extra_cxxflags %}
-        -- CXX flags retrieved from CXXFLAGS environment, conan.conf(tools.build:cxxflags) and extra_cxxflags
+        -- CXX flags retrieved from CXXFLAGS environment, conan.conf(tools.build:cxxflags), extra_cxxflags and compiler settings
         filter { files { "**.cpp", "**.cxx", "**.cc" } }
             buildoptions { {{ extra_cxxflags }} }
         filter {}
         {% endif %}
         {% if extra_ldflags %}
-        -- Link flags retrieved from LDFLAGS environment, conan.conf(tools.build:sharedlinkflags), conan.conf(tools.build:exelinkflags) and extra_cxxflags
+        -- Link flags retrieved from LDFLAGS environment, conan.conf(tools.build:sharedlinkflags), conan.conf(tools.build:exelinkflags), extra_cxxflags and compiler settings
         linkoptions { {{ extra_ldflags }} }
         {% endif %}
         {% if extra_defines %}

--- a/conan/tools/premake/toolchain.py
+++ b/conan/tools/premake/toolchain.py
@@ -1,4 +1,4 @@
-from conan.tools.build.flags import architecture_flag, architecture_link_flag, libcxx_flags, threads_flag
+from conan.tools.build.flags import architecture_flag, architecture_link_flag, libcxx_flags, threads_flags
 import os
 import textwrap
 from pathlib import Path
@@ -47,7 +47,7 @@ def _generate_flags(self, conanfile):
     arch_flags = to_list(architecture_flag(self._conanfile))
     cxx_flags, libcxx_compile_definitions = libcxx_flags(self._conanfile)
     arch_link_flags = to_list(architecture_link_flag(self._conanfile))
-    threads_flags = to_list(threads_flag(self._conanfile))
+    thread_flags_list = threads_flags(self._conanfile)
 
     extra_defines = format_list(
         conanfile.conf.get("tools.build:defines", default=[], check_type=list)
@@ -58,14 +58,14 @@ def _generate_flags(self, conanfile):
         conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
         + self.extra_cflags
         + arch_flags
-        + threads_flags
+        + thread_flags_list
     )
     extra_cxx_flags = format_list(
         conanfile.conf.get("tools.build:cxxflags", default=[], check_type=list)
         + to_list(cxx_flags)
         + self.extra_cxxflags
         + arch_flags
-        + threads_flags
+        + thread_flags_list
     )
     extra_ld_flags = format_list(
         conanfile.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)
@@ -73,7 +73,7 @@ def _generate_flags(self, conanfile):
         + self.extra_ldflags
         + arch_flags
         + arch_link_flags
-        + threads_flags
+        + thread_flags_list
     )
 
     return (

--- a/conan/tools/premake/toolchain.py
+++ b/conan/tools/premake/toolchain.py
@@ -1,4 +1,4 @@
-from conan.tools.build.flags import architecture_flag, architecture_link_flag, libcxx_flags
+from conan.tools.build.flags import architecture_flag, architecture_link_flag, libcxx_flags, threads_flag
 import os
 import textwrap
 from pathlib import Path
@@ -47,6 +47,7 @@ def _generate_flags(self, conanfile):
     arch_flags = to_list(architecture_flag(self._conanfile))
     cxx_flags, libcxx_compile_definitions = libcxx_flags(self._conanfile)
     arch_link_flags = to_list(architecture_link_flag(self._conanfile))
+    threads_flags = to_list(threads_flag(self._conanfile))
 
     extra_defines = format_list(
         conanfile.conf.get("tools.build:defines", default=[], check_type=list)
@@ -54,13 +55,17 @@ def _generate_flags(self, conanfile):
         + to_list(libcxx_compile_definitions)
     )
     extra_c_flags = format_list(
-        conanfile.conf.get("tools.build:cflags", default=[], check_type=list) + self.extra_cflags + arch_flags
+        conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
+        + self.extra_cflags
+        + arch_flags
+        + threads_flags
     )
     extra_cxx_flags = format_list(
         conanfile.conf.get("tools.build:cxxflags", default=[], check_type=list)
         + to_list(cxx_flags)
         + self.extra_cxxflags
         + arch_flags
+        + threads_flags
     )
     extra_ld_flags = format_list(
         conanfile.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)
@@ -68,6 +73,7 @@ def _generate_flags(self, conanfile):
         + self.extra_ldflags
         + arch_flags
         + arch_link_flags
+        + threads_flags
     )
 
     return (

--- a/test/integration/toolchains/gnu/test_autotoolstoolchain.py
+++ b/test/integration/toolchains/gnu/test_autotoolstoolchain.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import textwrap
+import pytest
 
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
@@ -367,3 +368,36 @@ def test_conf_build_does_not_exist():
     tc = c.load("conanautotoolstoolchain.sh")
     assert 'export CC_FOR_BUILD="x86_64-linux-gnu-gcc"' in tc
     assert 'export CXX_FOR_BUILD="x86_64-linux-gnu-g++"' in tc
+
+@pytest.mark.parametrize(
+    "threads, flags",
+    [("posix", "-pthread"), ("wasm_workers", "-sWASM_WORKERS=1")],
+)
+def test_thread_flags(threads, flags):
+    os_ = platform.system()
+    os_ = "Macos" if os_ == "Darwin" else os_
+    client = TestClient()
+    profile = textwrap.dedent(f"""
+        [settings]
+        arch=wasm
+        build_type=Release
+        compiler=emcc
+        compiler.cppstd=17
+        compiler.threads={threads}
+        compiler.libcxx=libc++
+        compiler.version=4.0.10
+        os=Emscripten
+        """)
+    client.save(
+        {
+            "conanfile.py": GenConanfile("pkg", "1.0")
+            .with_settings("os", "arch", "compiler", "build_type")
+            .with_generator("AutotoolsToolchain"),
+            "profile": profile,
+        }
+    )
+    client.run("install . -pr=./profile")
+    toolchain = client.load("conanautotoolstoolchain{}".format('.bat' if os_ == "Windows" else '.sh'))
+    assert f'export CXXFLAGS="$CXXFLAGS -stdlib=libc++ {flags}"' in toolchain
+    assert f'export CFLAGS="$CFLAGS {flags}"' in toolchain
+    assert f'export LDFLAGS="$LDFLAGS {flags}"' in toolchain

--- a/test/integration/toolchains/gnu/test_autotoolstoolchain.py
+++ b/test/integration/toolchains/gnu/test_autotoolstoolchain.py
@@ -374,8 +374,7 @@ def test_conf_build_does_not_exist():
     [("posix", "-pthread"), ("wasm_workers", "-sWASM_WORKERS=1")],
 )
 def test_thread_flags(threads, flags):
-    os_ = platform.system()
-    os_ = "Macos" if os_ == "Darwin" else os_
+    os = platform.system()
     client = TestClient()
     profile = textwrap.dedent(f"""
         [settings]
@@ -397,7 +396,12 @@ def test_thread_flags(threads, flags):
         }
     )
     client.run("install . -pr=./profile")
-    toolchain = client.load("conanautotoolstoolchain{}".format('.bat' if os_ == "Windows" else '.sh'))
-    assert f'export CXXFLAGS="$CXXFLAGS -stdlib=libc++ {flags}"' in toolchain
-    assert f'export CFLAGS="$CFLAGS {flags}"' in toolchain
-    assert f'export LDFLAGS="$LDFLAGS {flags}"' in toolchain
+    toolchain = client.load("conanautotoolstoolchain{}".format('.bat' if os == "Windows" else '.sh'))
+    if os == "Windows":
+        assert f'set "CXXFLAGS=%CXXFLAGS% -stdlib=libc++ {flags}"' in toolchain
+        assert f'set "CFLAGS=%CFLAGS% {flags}"' in toolchain
+        assert f'set "LDFLAGS=%LDFLAGS% {flags}' in toolchain
+    else:
+        assert f'export CXXFLAGS="$CXXFLAGS -stdlib=libc++ {flags}"' in toolchain
+        assert f'export CFLAGS="$CFLAGS {flags}"' in toolchain
+        assert f'export LDFLAGS="$LDFLAGS {flags}"' in toolchain

--- a/test/integration/toolchains/gnu/test_gnutoolchain.py
+++ b/test/integration/toolchains/gnu/test_gnutoolchain.py
@@ -592,3 +592,37 @@ def test_toolchain_crossbuild_to_android():
         "conanfile.py": consumer
     })
     client.run("create . -pr:h host -pr:b build")
+
+
+@pytest.mark.parametrize(
+    "threads, flags",
+    [("posix", "-pthread"), ("wasm_workers", "-sWASM_WORKERS=1")],
+)
+def test_thread_flags(threads, flags):
+    client = TestClient()
+    profile = textwrap.dedent(f"""
+        [settings]
+        arch=wasm
+        build_type=Release
+        compiler=emcc
+        compiler.cppstd=17
+        compiler.threads={threads}
+        compiler.libcxx=libc++
+        compiler.version=4.0.10
+        os=Emscripten
+        """)
+    client.save(
+        {
+            "conanfile.py": GenConanfile("pkg", "1.0")
+            .with_settings("os", "arch", "compiler", "build_type")
+            .with_generator("GnuToolchain"),
+            "profile": profile,
+        }
+    )
+    client.run("install . -pr=./profile")
+    toolchain = client.load(
+        "conangnutoolchain{}".format('.bat' if platform.system() == "Windows" else '.sh'))
+
+    assert f'export CXXFLAGS="$CXXFLAGS -stdlib=libc++ {flags}"' in toolchain
+    assert f'export CFLAGS="$CFLAGS {flags}"' in toolchain
+    assert f'export LDFLAGS="$LDFLAGS {flags}"' in toolchain

--- a/test/integration/toolchains/gnu/test_gnutoolchain.py
+++ b/test/integration/toolchains/gnu/test_gnutoolchain.py
@@ -620,9 +620,15 @@ def test_thread_flags(threads, flags):
         }
     )
     client.run("install . -pr=./profile")
+    os = platform.system()
     toolchain = client.load(
-        "conangnutoolchain{}".format('.bat' if platform.system() == "Windows" else '.sh'))
+        "conangnutoolchain{}".format('.bat' if os == "Windows" else '.sh'))
 
-    assert f'export CXXFLAGS="$CXXFLAGS -stdlib=libc++ {flags}"' in toolchain
-    assert f'export CFLAGS="$CFLAGS {flags}"' in toolchain
-    assert f'export LDFLAGS="$LDFLAGS {flags}"' in toolchain
+    if os == "Windows":
+        assert f'set "CXXFLAGS=%CXXFLAGS% -stdlib=libc++ {flags}"' in toolchain
+        assert f'set "CFLAGS=%CFLAGS% {flags}"' in toolchain
+        assert f'set "LDFLAGS=%LDFLAGS% {flags}' in toolchain
+    else:
+        assert f'export CXXFLAGS="$CXXFLAGS -stdlib=libc++ {flags}"' in toolchain
+        assert f'export CFLAGS="$CFLAGS {flags}"' in toolchain
+        assert f'export LDFLAGS="$LDFLAGS {flags}"' in toolchain

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -205,7 +205,6 @@ def test_extra_flags_via_toolchain():
     content = t.load(MesonToolchain.native_filename)
     assert "cpp_args = ['-flag0', '-other=val', '-m64', '-flag1', '-flag2', '-Ddefine1=0', '-D_GLIBCXX_USE_CXX11_ABI=0']" in content
     assert "c_args = ['-flag0', '-other=val', '-m64', '-flag3', '-flag4', '-Ddefine1=0']" in content
-    print(content)
     assert "c_link_args = ['-flag0', '-other=val', '-m64', '-flag5', '-flag6']" in content
     assert "cpp_link_args = ['-flag0', '-other=val', '-m64', '-flag5', '-flag6']" in content
 

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -205,6 +205,7 @@ def test_extra_flags_via_toolchain():
     content = t.load(MesonToolchain.native_filename)
     assert "cpp_args = ['-flag0', '-other=val', '-m64', '-flag1', '-flag2', '-Ddefine1=0', '-D_GLIBCXX_USE_CXX11_ABI=0']" in content
     assert "c_args = ['-flag0', '-other=val', '-m64', '-flag3', '-flag4', '-Ddefine1=0']" in content
+    print(content)
     assert "c_link_args = ['-flag0', '-other=val', '-m64', '-flag5', '-flag6']" in content
     assert "cpp_link_args = ['-flag0', '-other=val', '-m64', '-flag5', '-flag6']" in content
 

--- a/test/unittests/client/build/compiler_flags_test.py
+++ b/test/unittests/client/build/compiler_flags_test.py
@@ -1,7 +1,7 @@
 import unittest
 from parameterized.parameterized import parameterized
 
-from conan.tools.build.flags import architecture_flag, build_type_flags
+from conan.tools.build.flags import architecture_flag, build_type_flags, threads_flag
 from conan.test.utils.mocks import MockSettings, ConanFileMock
 
 
@@ -36,6 +36,19 @@ class CompilerFlagsTest(unittest.TestCase):
         conanfile = ConanFileMock()
         conanfile.settings = settings
         self.assertEqual(architecture_flag(conanfile), flag)
+
+
+    @parameterized.expand([("clang", None, ""),
+                           ("emcc", None, ""),
+                           ("emcc", "posix", "-pthread"),
+                           ("emcc", "wasm_threads", "-sWASM_THREADS=1"),
+                           ])
+    def test_threads_flag(self, compiler, threads, flag):
+        settings = MockSettings({"compiler": compiler,
+                                 "threads": threads})
+        conanfile = ConanFileMock()
+        conanfile.settings = settings
+        self.assertEqual(threads_flag(conanfile), flag)
 
     @parameterized.expand([("clang", "x86", "Windows", ""),
                            ("clang", "x86_64", "Windows", "")

--- a/test/unittests/client/build/compiler_flags_test.py
+++ b/test/unittests/client/build/compiler_flags_test.py
@@ -1,7 +1,7 @@
 import unittest
 from parameterized.parameterized import parameterized
 
-from conan.tools.build.flags import architecture_flag, build_type_flags, threads_flag
+from conan.tools.build.flags import architecture_flag, build_type_flags, threads_flags
 from conan.test.utils.mocks import MockSettings, ConanFileMock
 
 
@@ -38,17 +38,17 @@ class CompilerFlagsTest(unittest.TestCase):
         self.assertEqual(architecture_flag(conanfile), flag)
 
 
-    @parameterized.expand([("clang", None, ""),
-                           ("emcc", None, ""),
-                           ("emcc", "posix", "-pthread"),
-                           ("emcc", "wasm_workers", "-sWASM_WORKERS=1"),
+    @parameterized.expand([("clang", None, []),
+                           ("emcc", None, []),
+                           ("emcc", "posix", ["-pthread"]),
+                           ("emcc", "wasm_workers", ["-sWASM_WORKERS=1"]),
                            ])
     def test_threads_flag(self, compiler, threads, flag):
         settings = MockSettings({"compiler": compiler,
                                  "compiler.threads": threads})
         conanfile = ConanFileMock()
         conanfile.settings = settings
-        self.assertEqual(threads_flag(conanfile), flag)
+        self.assertEqual(threads_flags(conanfile), flag)
 
     @parameterized.expand([("clang", "x86", "Windows", ""),
                            ("clang", "x86_64", "Windows", "")

--- a/test/unittests/client/build/compiler_flags_test.py
+++ b/test/unittests/client/build/compiler_flags_test.py
@@ -41,11 +41,11 @@ class CompilerFlagsTest(unittest.TestCase):
     @parameterized.expand([("clang", None, ""),
                            ("emcc", None, ""),
                            ("emcc", "posix", "-pthread"),
-                           ("emcc", "wasm_threads", "-sWASM_THREADS=1"),
+                           ("emcc", "wasm_workers", "-sWASM_WORKERS=1"),
                            ])
     def test_threads_flag(self, compiler, threads, flag):
         settings = MockSettings({"compiler": compiler,
-                                 "threads": threads})
+                                 "compiler.threads": threads})
         conanfile = ConanFileMock()
         conanfile.settings = settings
         self.assertEqual(threads_flag(conanfile), flag)


### PR DESCRIPTION
Changelog: Feature: Added `threads` subsetting in `emcc` compiler model.
Docs: https://github.com/conan-io/docs/pull/4115

Close https://github.com/conan-io/conan/issues/10088

The `emcc` compiler generates binaries that may be incompatible depending on whether threads are used. For more details, refer to the "Note" section in the Emscripten documentation: https://emscripten.org/docs/porting/pthreads.html#compiling-with-pthreads-enabled.

According to https://emscripten.org/docs/api_reference/wasm_workers.html:

> Emscripten supports two multithreading APIs to utilize this web feature:
> * POSIX Threads (Pthreads) API
> * Wasm Workers API

These two APIs are incompatible with each other.

This incompatibility necessitates the modeling of threading usage within the compiler's binary model. This allows us to distinguish between binaries compiled with threading and those compiled without it. Our goal is to integrate this capability built in, as we strive to provide first-class support for the Emscripten ecosystem.


---

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
