### PR TITLE
Runners: allow profile composition and renamed GitHub job

### DIFF
--- a/.github/workflows/linux-tests.yml
+++ b/.github/workflows/linux-tests.yml
@@ -93,7 +93,7 @@ jobs:
           test-type: ${{ matrix.test-type }}
           tests: test/${{ matrix.test-type }}
 
-  linux_docker_tests:
+  linux_runner_tests:
     needs: build_container
     runs-on: ubuntu-latest
     strategy:
@@ -101,7 +101,7 @@ jobs:
         # Use modern versions due to docker incompatibility with python <3.8
         python-version: ${{ github.event_name != 'pull_request' && fromJson('["3.13", "3.9"]') || fromJson('["3.10"]') }}
 
-    name: Docker Runner Tests (${{ matrix.python-version }})
+    name: Runner Tests (${{ matrix.python-version }})
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -125,10 +125,10 @@ jobs:
           pip install -r conans/requirements_server.txt
           pip install -r conans/requirements_runner.txt
 
-      - name: Run tests
+      - name: Run runner tests
         uses: ./.github/actions/test-coverage
         with:
           python-version: ${{ matrix.python-version }}
-          test-type: docker
+          test-type: runners
           tests: '-m docker_runner -rs'
           workers: 1

--- a/conan/internal/model/profile.py
+++ b/conan/internal/model/profile.py
@@ -1,6 +1,7 @@
 import copy
 from collections import OrderedDict, defaultdict
 
+from conan.errors import ConanException
 from conan.tools.env.environment import ProfileEnvironment
 from conan.internal.model.conf import ConfDefinition
 from conan.internal.model.options import Options
@@ -149,6 +150,11 @@ class Profile:
 
         self.replace_requires.update(other.replace_requires)
         self.replace_tool_requires.update(other.replace_tool_requires)
+
+        runner_type = self.runner.get("type")
+        other_runner_type = other.runner.get("type")
+        if runner_type and other_runner_type and runner_type != other_runner_type:
+            raise ConanException(f"Found different runner types in profile composition ({runner_type} and {other_runner_type})")
         self.runner.update(other.runner)
 
         current_platform_tool_requires = {r.name: r for r in self.platform_tool_requires}

--- a/test/functional/command/runner_test.py
+++ b/test/functional/command/runner_test.py
@@ -7,12 +7,16 @@ from conan.test.assets.cmake import gen_cmakelists
 from conan.test.assets.sources import gen_function_h, gen_function_cpp
 
 
+def docker_from_env():
+    try:
+        return docker.from_env()
+    except Exception:
+        return docker.DockerClient(base_url=f'unix://{os.path.expanduser("~")}/.rd/docker.sock', version='auto') # Rancher
+
+
 def docker_skip(test_image='ubuntu:22.04'):
     try:
-        try:
-            docker_client = docker.from_env()
-        except:
-            docker_client = docker.DockerClient(base_url=f'unix://{os.path.expanduser("~")}/.rd/docker.sock', version='auto') # Rancher
+        docker_client = docker_from_env()
         if test_image:
             docker_client.images.pull(test_image)
     except docker.errors.DockerException:
@@ -459,7 +463,7 @@ def test_create_docker_runner_from_configfile_with_args():
     client = TestClient()
 
     # Ensure the network exists
-    docker_client = docker.from_env()
+    docker_client = docker_from_env()
     docker_client.networks.create("my-network")
 
     configfile = textwrap.dedent(f"""
@@ -549,6 +553,45 @@ def test_create_docker_runner_default_build_profile():
     assert "Restore: pkg/0.2:8631cf963dbbb4d7a378a64a6fd1dc57558bc2fe" in client.out
     assert "Restore: pkg/0.2:8631cf963dbbb4d7a378a64a6fd1dc57558bc2fe metadata" in client.out
     assert "Removing container" in client.out
+
+@pytest.mark.docker_runner
+@pytest.mark.skipif(docker_skip('ubuntu:22.04'), reason="Only docker running")
+def test_create_docker_runner_profile_composition():
+    """
+    Tests the ``conan create . `` with profile composition
+    """
+    client = TestClient()
+
+    profile = textwrap.dedent(f"""\
+    [settings]
+    arch={{{{ detect_api.detect_arch() }}}}
+    build_type=Release
+    compiler=gcc
+    compiler.cppstd=gnu17
+    compiler.libcxx=libstdc++11
+    compiler.version=11
+    os=Linux
+    [runner]
+    type=docker
+    image=conan-runner-ninja-test
+    """)
+
+    profile_extension = textwrap.dedent(f"""\
+    [runner]
+    type=docker
+    dockerfile={dockerfile_path("Dockerfile_ninja")}
+    build_context={conan_base_path()}
+    cache=copy
+    remove=True
+    """)
+    client.save({"profile": profile, "profile_extension": profile_extension})
+    client.run("new cmake_lib -d name=pkg -d version=2.0")
+    client.run("create . -pr:h profile -pr:h profile_extension")
+
+    assert "[100%] Built target example" in client.out
+    assert "Restore: pkg/2.0 in pkgc6abef0178849" in client.out
+    assert "Restore: pkg/2.0:8631cf963dbbb4d7a378a64a6fd1dc57558bc2fe" in client.out
+    assert "Restore: pkg/2.0:8631cf963dbbb4d7a378a64a6fd1dc57558bc2fe metadata" in client.out
 
 
 @pytest.mark.docker_runner


### PR DESCRIPTION
Changelog: Feature: Allow profile composition while using conan runners.
Docs: omit

From #17357, cherry-pick changes specific to profiles management, tests and GitHub workflows renaming.