### PR TITLE
fix qcc cppstd support for latest QNX 8.0 for c++20

### DIFF
--- a/conan/tools/build/cppstd.py
+++ b/conan/tools/build/cppstd.py
@@ -266,8 +266,11 @@ def _qcc_supported_cppstd(version):
 
     if version < "5":
         return ["98", "gnu98"]
-    else:
+    elif version < "12":
         return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17"]
+    else:
+        return ["98", "gnu98", "11", "gnu11", "14", "gnu14", "17", "gnu17", "20", "gnu20"]
+
 
 def _emcc_supported_cppstd(version):
     """

--- a/test/unittests/tools/build/test_cppstd.py
+++ b/test/unittests/tools/build/test_cppstd.py
@@ -128,6 +128,7 @@ def test_supported_cppstd_mcst(compiler, compiler_version, values):
     ("qcc", "4.4", ['98', 'gnu98']),
     ("qcc", "5.4", ['98', 'gnu98', '11', 'gnu11', "14", "gnu14", "17", "gnu17"]),
     ("qcc", "8.3", ['98', 'gnu98', '11', 'gnu11', "14", "gnu14", "17", "gnu17"]),
+    ("qcc", "12.2", ['98', 'gnu98', '11', 'gnu11', "14", "gnu14", "17", "gnu17", "20", "gnu20"]),
 ])
 def test_supported_cppstd_qcc(compiler, compiler_version, values):
     settings = MockSettings({"compiler": compiler, "compiler.version": compiler_version})


### PR DESCRIPTION
Changelog: Fix: Fix ``qcc`` ``cppstd`` support for latest QNX 8.0 with c++20.
Docs: Omit

Close https://github.com/conan-io/conan/issues/18532