### PR TITLE
Avoid hyphens for msbuild verbosity argument passed to CMake after -- in powershell

### DIFF
--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -26,6 +26,11 @@ def _cmake_cmd_line_args(conanfile, generator):
     if "Visual Studio" in generator:
         verbosity = msbuild_verbosity_cmd_line_arg(conanfile)
         if verbosity:
+            # trying to avoid issues with powershell and - : characters preceded by --
+            # -verbosity → /verbosity
+            # https://github.com/PowerShell/PowerShell/issues/17399
+            if conanfile.conf.get("tools.env.virtualenv:powershell"):
+                verbosity = verbosity.replace('-', '/', 1)
             args.append(verbosity)
 
     return args

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -27,7 +27,7 @@ def _cmake_cmd_line_args(conanfile, generator):
         verbosity = msbuild_verbosity_cmd_line_arg(conanfile)
         if verbosity:
             # trying to avoid issues with powershell and - : characters preceded by --
-            # -verbosity → /verbosity
+            # -verbosity -> /verbosity
             # https://github.com/PowerShell/PowerShell/issues/17399
             if conanfile.conf.get("tools.env.virtualenv:powershell"):
                 verbosity = verbosity.replace('-', '/', 1)

--- a/test/functional/toolchains/env/test_virtualenv_powershell.py
+++ b/test/functional/toolchains/env/test_virtualenv_powershell.py
@@ -251,3 +251,19 @@ def test_powershell_quoting(powershell):
     client.save({"conanfile.py": conanfile})
     client.run(f'create . -c tools.env.virtualenv:powershell={powershell}')
     assert "Hello World" in client.out
+
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows")
+@pytest.mark.parametrize("ps", ["powershell.exe", None])
+def test_verbosity_flag(ps):
+    tc = TestClient()
+    ps_arg = f'-c tools.env.virtualenv:powershell={ps}' if ps else ""
+    tc.run("new cmake_lib -d name=pkg -d version=1.0")
+    tc.run(f'create . -tf="" -c tools.build:verbosity=verbose {ps_arg}')
+
+    if ps:
+        assert "/verbosity:Detailed" in tc.out
+        assert "-verbosity:Detailed" not in tc.out
+    else:
+        assert "/verbosity:Detailed" not in tc.out
+        assert "-verbosity:Detailed" in tc.out

--- a/test/functional/toolchains/env/test_virtualenv_powershell.py
+++ b/test/functional/toolchains/env/test_virtualenv_powershell.py
@@ -254,16 +254,11 @@ def test_powershell_quoting(powershell):
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows")
-@pytest.mark.parametrize("ps", ["powershell.exe", None])
 def test_verbosity_flag(ps):
     tc = TestClient()
-    ps_arg = f'-c tools.env.virtualenv:powershell={ps}' if ps else ""
     tc.run("new cmake_lib -d name=pkg -d version=1.0")
-    tc.run(f'create . -tf="" -c tools.build:verbosity=verbose {ps_arg}')
+    tc.run('create . -tf="" -c tools.build:verbosity=verbose '
+           '-c tools.env.virtualenv:powershell=powershell.exe')
 
-    if ps:
-        assert "/verbosity:Detailed" in tc.out
-        assert "-verbosity:Detailed" not in tc.out
-    else:
-        assert "/verbosity:Detailed" not in tc.out
-        assert "-verbosity:Detailed" in tc.out
+    assert "/verbosity:Detailed" in tc.out
+    assert "-verbosity:Detailed" not in tc.out

--- a/test/functional/toolchains/env/test_virtualenv_powershell.py
+++ b/test/functional/toolchains/env/test_virtualenv_powershell.py
@@ -254,7 +254,7 @@ def test_powershell_quoting(powershell):
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows")
-def test_verbosity_flag(ps):
+def test_verbosity_flag():
     tc = TestClient()
     tc.run("new cmake_lib -d name=pkg -d version=1.0")
     tc.run('create . -tf="" -c tools.build:verbosity=verbose '

--- a/test/integration/configuration/conf/test_conf_profile.py
+++ b/test/integration/configuration/conf/test_conf_profile.py
@@ -58,6 +58,8 @@ def test_cmake_config(client):
     client.save({"myprofile": profile})
     client.run("create . --name=pkg --version=0.1 -pr=myprofile")
     assert "-verbosity:Quiet" in client.out
+    client.run("create . --name=pkg --version=0.1 -pr=myprofile -c=tools.env.virtualenv:powershell=powershell.exe")
+    assert "/verbosity:Quiet" in client.out
 
 
 def test_cmake_config_error(client):


### PR DESCRIPTION
Changelog: Fix: Avoid hyphens for msbuild verbosity argument passed to CMake after `--` by powershell.
Docs: Omit

Related to: https://github.com/conan-io/conan/pull/18417

When the `tools.env.virtualenv:powershell` is enabled then CMake is called through something like this:

```
powershell.exe -Command "&'C:\Users\carlosz\.conan2\p\b\zlib986709948d3c9\b\build\generators\conanbuild.ps1'" ; cmd /c "cmake --build \"C:\Users\carlosz\.conan2\p\b\zlib986709948d3c9\b\build\" --config Release -- -verbosity:Detailed"
```

And this will fail with this error:

```
Versión de MSBuild 17.14.10+8b8e13593 para .NET Framework
MSBUILD : error MSB1016: Especifique el nivel de detalle.
    Línea de comandos completa: '"C:/Program Files/Microsoft Visual Studio/2022/Community/MSBuild/Current/Bin/arm64/MSBuild.exe" ALL_BUILD.vcxproj /p:Configuration=Release /p:Platform=ARM64 /p:VisualStudioVersion=17.0 /v:m -verbosity: Detailed'
  Modificadores anexados por archivos de respuesta:
'' procedía de 'C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Current\Bin\arm64\MSBuild.rsp'
Modificador: -verbosity:

Para modificar la sintaxis, escriba "MSBuild -help"
```

The problem lies in the space introduced in `-verbosity: Detailed`.   

This is because the potential PowerShell’s bug [#17399](https://github.com/PowerShell/PowerShell/issues/17399) that **splits any token that starts with “-” and contains “:” (or “=”) once it appears after `--`**. The flag becomes two tokens (`-verbosity:` + `Detailed`), and MSBuild aborts with **MSB1016 / MSB1008**.

My first try was to escape those arguments but I ended with a quite fragile solution because users can algo add their own [build_tool_args](https://docs.conan.io/2/reference/tools/cmake/cmake.html#conan.tools.cmake.cmake.CMake.build) to CMake and we are also making some escaping after capturing all arguments after `--`.

I think the most simple and secure way is to just replace the `-` for `/` (both are accepted) in the case of CMake and powershell configuration enabled.

