### PR TITLE
better error message for wrong cpp_info.requires

### DIFF
--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -836,7 +836,7 @@ class CppInfo:
                 if r not in ret:
                     ret.append(r)
         # Then split the names
-        ret = [r.split("::") if "::" in r else (None, r) for r in ret]
+        ret = [r.split("::", 1) if "::" in r else (None, r) for r in ret]
         return ret
 
     def deduce_full_cpp_info(self, conanfile):


### PR DESCRIPTION
Changelog: Fix: Better error message when an incorrect ``cpp_info.requires`` is defined.
Docs: Omit

Close https://github.com/conan-io/conan/issues/18550
