### PR TITLE
always adding the default Debug configuration for MSVC_RUNTIME in CMakeToolchain

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -89,6 +89,10 @@ class VSRuntimeBlock(Block):
         if runtime is None:
             return
 
+        build_type = settings.get_safe("build_type")
+        if build_type is None:
+            return None
+
         config_dict = {}
         if os.path.exists(CONAN_TOOLCHAIN_FILENAME):
             existing_include = load(CONAN_TOOLCHAIN_FILENAME)
@@ -99,23 +103,17 @@ class VSRuntimeBlock(Block):
                 matches = re.findall(r"\$<\$<CONFIG:([A-Za-z]*)>:([A-Za-z]*)>", capture)
                 config_dict = dict(matches)
 
-        build_type = settings.get_safe("build_type")  # FIXME: change for configuration
-        if build_type is None:
-            return None
+        runtime_type = settings.get_safe("compiler.runtime_type")
+        rt = "MultiThreadedDebug" if runtime_type == "Debug" else "MultiThreaded"
+        if runtime != "static":
+            rt += "DLL"
+        config_dict[build_type] = rt
 
-        if compiler == "msvc" or compiler == "intel-cc" or compiler == "clang":
-            runtime_type = settings.get_safe("compiler.runtime_type")
-            rt = "MultiThreadedDebug" if runtime_type == "Debug" else "MultiThreaded"
-            if runtime != "static":
-                rt += "DLL"
-            config_dict[build_type] = rt
-
-            # If clang is being used the CMake check of compiler will try to create a simple
-            # test application, and will fail because the Debug runtime is not there
-            if compiler == "clang":
-                if config_dict.get("Debug") is None:
-                    clang_rt = "MultiThreadedDebug" + ("DLL" if runtime != "static" else "")
-                    config_dict["Debug"] = clang_rt
+        # If clang, CUDA or anyone with try-compile is being used the CMake check of compiler
+        # will fail because the Debug runtime is not there
+        if config_dict.get("Debug") is None:
+            clang_rt = "MultiThreadedDebug" + ("DLL" if runtime != "static" else "")
+            config_dict["Debug"] = clang_rt
 
         return {"vs_runtimes": config_dict}
 

--- a/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -485,7 +485,6 @@ def test_cmake_toolchain_runtime_types():
     # everything works with the default cmake_minimum_required version 3.15 in the template
     client = TestClient(path_with_spaces=False)
     client.run("new cmake_lib -d name=hello -d version=0.1")
-    client.run("install . -s compiler.runtime=static -s build_type=Debug")
     client.run("build . -s compiler.runtime=static -s build_type=Debug")
 
     vcvars = vcvars_command(version="15", architecture="x64")
@@ -507,7 +506,6 @@ def test_cmake_toolchain_runtime_types_cmake_older_than_3_15():
     assert cmake != cmake2
     client.save({"CMakeLists.txt": cmake2})
 
-    client.run("install . -s compiler.runtime=static -s build_type=Debug")
     client.run("build . -s compiler.runtime=static -s build_type=Debug")
 
     vcvars = vcvars_command(version="15", architecture="x64")

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -1773,6 +1773,7 @@ def test_cmake_presets_compiler():
     assert cache_variables["CMAKE_C_COMPILER"] == "cl"
     assert cache_variables["CMAKE_CXX_COMPILER"] == "cl.exe"
 
+
 @pytest.mark.parametrize(
     "threads, flags",
     [("posix", "-pthread"), ("wasm_workers", "-sWASM_WORKERS=1")],
@@ -1804,3 +1805,40 @@ def test_thread_flags(threads, flags):
     assert f'string(APPEND CONAN_C_FLAGS " {flags}")' in toolchain
     assert f'string(APPEND CONAN_SHARED_LINKER_FLAGS " {flags}")' in toolchain
     assert f'string(APPEND CONAN_EXE_LINKER_FLAGS " {flags}")' in toolchain
+
+
+def test_msvc_runtime():
+    c = TestClient()
+    c.save({"conanfile.py": GenConanfile("pkg", "0.1").with_settings("os", "compiler", "build_type")
+                                                      .with_generator("CMakeToolchain")})
+    msvc = "-s os=Windows -s compiler=msvc -s compiler.version=193"
+
+    # the addition of the Debug happens automatically
+    c.run(f"install . {msvc} -s compiler.runtime=dynamic -s build_type=Release")
+    toolchain = c.load("conan_toolchain.cmake")
+    assert ('set(CMAKE_MSVC_RUNTIME_LIBRARY "$<$<CONFIG:Release>:MultiThreadedDLL>'
+            '$<$<CONFIG:Debug>:MultiThreadedDebugDLL>")') in toolchain
+
+    # Explicit installation can overwrite it
+    c.run(f"install . {msvc} -s compiler.runtime=static -s build_type=Debug")
+    toolchain = c.load("conan_toolchain.cmake")
+    assert ('set(CMAKE_MSVC_RUNTIME_LIBRARY "$<$<CONFIG:Release>:MultiThreadedDLL>'
+            '$<$<CONFIG:Debug>:MultiThreadedDebug>")') in toolchain
+
+    # installing Release again with other type, will still respect the previous
+    c.run(f"install . {msvc} -s compiler.runtime=static -s build_type=Release")
+    toolchain = c.load("conan_toolchain.cmake")
+    assert ('set(CMAKE_MSVC_RUNTIME_LIBRARY "$<$<CONFIG:Release>:MultiThreaded>'
+            '$<$<CONFIG:Debug>:MultiThreadedDebug>")') in toolchain
+
+    # A clean initial Debug installation will define only that
+    os.remove(os.path.join(c.current_folder, "conan_toolchain.cmake"))
+    c.run(f"install . {msvc} -s compiler.runtime=static -s build_type=Debug")
+    toolchain = c.load("conan_toolchain.cmake")
+    assert 'set(CMAKE_MSVC_RUNTIME_LIBRARY "$<$<CONFIG:Debug>:MultiThreadedDebug>")' in toolchain
+
+    # installing Release after, will respect the initial value
+    c.run(f"install . {msvc} -s compiler.runtime=dynamic -s build_type=Release")
+    toolchain = c.load("conan_toolchain.cmake")
+    assert ('set(CMAKE_MSVC_RUNTIME_LIBRARY "$<$<CONFIG:Debug>:MultiThreadedDebug>'
+            '$<$<CONFIG:Release>:MultiThreadedDLL>")') in toolchain


### PR DESCRIPTION
Changelog: Fix: Let ``CMakeToolchain`` always define the ``Debug`` value for ``CMAKE_MSVC_RUNTIME_LIBRARY`` in MSVC-like compilers with ``compiler.runtime`` defined.
Docs: Omit

Close https://github.com/conan-io/conan/issues/17289
