### PR TITLE
SSH runner: User friendly paramiko import protection

### DIFF
--- a/conan/internal/runner/ssh.py
+++ b/conan/internal/runner/ssh.py
@@ -20,8 +20,11 @@ def ssh_info(msg, error=False):
 class SSHRunner:
 
     def __init__(self, conan_api, command, host_profile, build_profile, args, raw_args):
-        from paramiko.config import SSHConfig
-        from paramiko.client import SSHClient
+        try:
+            from paramiko.config import SSHConfig
+            from paramiko.client import SSHClient
+        except ImportError:
+            raise ConanException("Paramiko is required for SSH runner, try installing it with 'pip install paramiko'")
         self.conan_api = conan_api
         self.command = command
         self.host_profile = host_profile

--- a/conan/internal/runner/ssh.py
+++ b/conan/internal/runner/ssh.py
@@ -24,7 +24,10 @@ class SSHRunner:
             from paramiko.config import SSHConfig
             from paramiko.client import SSHClient
         except ImportError:
-            raise ConanException("Paramiko is required for SSH runner, try installing it with 'pip install paramiko'")
+            raise ConanException(
+                "Paramiko is required for SSH runner. If conan is installed in a virtual environment, try to install "
+                "the 'paramiko' package, or consider installing conan package with extra requires 'conan[runners]'"
+            )
         self.conan_api = conan_api
         self.command = command
         self.host_profile = host_profile


### PR DESCRIPTION
Changelog: omit
Docs: omit


From https://github.com/conan-io/conan/pull/17357, cherry-pick changes specific to paramiko import error when pip module is not present.