### PR TITLE
Preamke generator: fix some issues with windows paths and MSBuild

### DIFF
--- a/conan/tools/premake/premake.py
+++ b/conan/tools/premake/premake.py
@@ -66,7 +66,7 @@ class Premake:
         """
         if self._premake_conan_toolchain.exists():
             content = Template(self._premake_file_template).render(
-                premake_conan_toolchain=self._premake_conan_toolchain, luafile=self.luafile
+                premake_conan_toolchain=self._premake_conan_toolchain.as_posix(), luafile=self.luafile
             )
             conan_luafile = Path(self._conanfile.build_folder) / self.filename
             save(self._conanfile, conan_luafile, content)
@@ -98,7 +98,7 @@ class Premake:
         # --verbose does not print compilation commands but internal Makefile progress logic
         return " verbose=1" if verbosity == "verbose" else ""
 
-    def build(self, workspace, targets=None):
+    def build(self, workspace, targets=None, msbuild_platform=None):
         """
         Depending on the action, this method will run either ``msbuild`` or ``make`` with ``N_JOBS``.
         You can specify ``N_JOBS`` through the configuration line ``tools.build:jobs=N_JOBS``
@@ -106,11 +106,14 @@ class Premake:
 
         :param workspace: ``str`` Specifies the solution to be compiled (only used by ``MSBuild``).
         :param targets: ``List[str]`` Declare the projects to be built (None to build all projects).
+        :param msbuild_platform: ``str`` Specify the platform for the internal MSBuild generator (only used by ``MSBuild``).
         """
         if not self._premake_conan_toolchain.exists():
             raise ConanException(f"Premake.build() method requires PrmakeToolchain to work properly")
         if self.action.startswith("vs"):
             msbuild = MSBuild(self._conanfile)
+            if msbuild_platform:
+                msbuild.platform = msbuild_platform
             msbuild.build(sln=f"{workspace}.sln", targets=targets)
         else:
             build_type = str(self._conanfile.settings.build_type)

--- a/conan/tools/premake/premake.py
+++ b/conan/tools/premake/premake.py
@@ -109,7 +109,7 @@ class Premake:
         :param msbuild_platform: ``str`` Specify the platform for the internal MSBuild generator (only used by ``MSBuild``).
         """
         if not self._premake_conan_toolchain.exists():
-            raise ConanException(f"Premake.build() method requires PrmakeToolchain to work properly")
+            raise ConanException("Premake.build() method requires PrmakeToolchain to work properly")
         if self.action.startswith("vs"):
             msbuild = MSBuild(self._conanfile)
             if msbuild_platform:

--- a/test/integration/toolchains/premake/test_premake.py
+++ b/test/integration/toolchains/premake/test_premake.py
@@ -2,6 +2,7 @@ import textwrap
 
 from conan.test.utils.tools import TestClient
 
+
 def test_premake_args_without_toolchain():
     c = TestClient()
     conanfile = textwrap.dedent("""
@@ -19,8 +20,14 @@ def test_premake_args_without_toolchain():
                 premake.configure()
                 """)
     c.save({"conanfile.py": conanfile})
-    c.run("build . -s compiler=msvc -s compiler.version=193 -s compiler.runtime=dynamic")
-    assert 'conanfile.py: Running premake5 --file="myproject.lua" vs2022 --myarg=myvalue!!' in c.out
+    c.run(
+        "build . -s compiler=msvc -s compiler.version=193 -s compiler.runtime=dynamic"
+    )
+    assert (
+        'conanfile.py: Running premake5 --file="myproject.lua" vs2022 --myarg=myvalue!!'
+        in c.out
+    )
+
 
 def test_premake_build_without_toolchain():
     tc = TestClient()
@@ -98,3 +105,37 @@ def test_premake_build_with_targets():
     assert 'conanfile.premake5.lua" gmake --arch=arm64!!' in tc.out
     assert "Running make config=release app test -j42!!" in tc.out
 
+
+def test_premake_msbuild_platform():
+    tc = TestClient()
+    windows_profile = textwrap.dedent("""
+        [settings]
+        arch=x86_64
+        build_type=Release
+        compiler=msvc
+        compiler.cppstd=14
+        compiler.runtime=dynamic
+        compiler.version=194
+        os=Windows
+    """)
+
+    conanfile = textwrap.dedent(
+        """
+        from conan import ConanFile
+        from conan.tools.premake import Premake, PremakeToolchain
+
+        class Pkg(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+            generators = "PremakeToolchain"
+            def run(self, cmd, *args, **kwargs):
+                self.output.info(f"Running {cmd}!!")
+            def build(self):
+                premake = Premake(self)
+                premake.configure()
+                premake.build(workspace="App", msbuild_platform="Win64")
+                """
+    )
+    tc.save({"conanfile.py": conanfile, "win": windows_profile})
+    tc.run("build . -pr win")
+    assert 'conanfile.premake5.lua" vs2022 --arch=x86_64!!' in tc.out
+    assert 'Running msbuild.exe "App.sln" -p:Configuration="Release" -p:Platform=Win64!!' in tc.out


### PR DESCRIPTION
Changelog: Feature: Allow defining a custom platform on Premake generator for Windows.
Docs: omit

Fixes #18570

Docs generated by autoclass (sphinx) 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
