### PR TITLE
Fix memory usage of cached missing packages

### DIFF
--- a/conan/__init__.py
+++ b/conan/__init__.py
@@ -2,5 +2,5 @@ from conan.internal.model.conan_file import ConanFile
 from conan.internal.model.workspace import Workspace
 from conan.internal.model.version import Version
 
-__version__ = '2.18.0'
+__version__ = '2.18.1'
 conan_version = Version(__version__)

--- a/conan/internal/rest/remote_manager.py
+++ b/conan/internal/rest/remote_manager.py
@@ -255,12 +255,16 @@ class RemoteManager:
                                            headers=headers)
                 cached_method[pref] = result
                 return result
+            except NotFoundException as e:
+                # Don't store e in the cache, as raising and storing it
+                # would make the memory footprint grow unnecessarily
+                cached_method[pref] = None
+                raise e
             except Exception as e:
-                cached_method[pref] = e
                 raise e
         else:
-            if isinstance(result, Exception):
-                raise result
+            if result is None:
+                raise NotFoundException(pref)
             return result
 
     def get_recipe_revision_reference(self, ref, remote) -> bool:

--- a/conan/internal/rest/remote_manager.py
+++ b/conan/internal/rest/remote_manager.py
@@ -260,8 +260,6 @@ class RemoteManager:
                 # would make the memory footprint grow unnecessarily
                 cached_method[pref] = None
                 raise e
-            except Exception as e:
-                raise e
         else:
             if result is None:
                 raise NotFoundException(pref)


### PR DESCRIPTION
Changelog: Bugfix: Fix memory usage of cached missing packages
Docs: Omit


The issue here seems to come from storing a reference that is raised just after the fact.

I've tried to clear tracebacks, and args for the exceptions, but it made little difference in the calculated size of the cache, never growing past 1Mb, so the issue is not the Exceptions themselves being too big, but on some internal Python behaviour that I can't pin down.

The proposed solution is to raise the original NotFoundException (The one we truly care about caching, the rest of the exceptions can be skipped as most of them are fatal errors anyway), and mark the reference with `None` to denote that _"This was missing from the remote and raised a 404"_, and create a brand new `NotFoundException` for this `pref` if it's requested again, instead of using a stored one.  


Currently in `develop2`, I see this memory usage (`time -l`) for a `conan graph build-order` with some amount of references

```
109,92 real        52,37 user         5,24 sys
          1663582208  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
              105503  page reclaims
                 818  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                 956  messages sent
                1952  messages received
                   0  signals received
                8287  voluntary context switches
               83220  involuntary context switches
        461682631911  instructions retired
        180179796797  cycles elapsed
          1652232896  peak memory footprin
```

With the caching reverted (`git revert ad76fa2cc44e5b5c9072475d062c29e593a12c17`), I locally see this memory usage:

```
149,67 real        56,73 user         6,94 sys
           988119040  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
               68725  page reclaims
                  54  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                1602  messages sent
                3241  messages received
                   0  signals received
               10995  voluntary context switches
              110199  involuntary context switches
        463184016263  instructions retired
        192413183049  cycles elapsed
           976276864  peak memory footprint
```

After applying this PR, I see the same old memory usage (as again, the cache itself is quite minimal), while keeping the speedup of the cache.
```
      112,94 real        53,91 user         6,22 sys
           989364224  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
               67805  page reclaims
                  52  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                 956  messages sent
                1951  messages received
                   0  signals received
                8972  voluntary context switches
              100333  involuntary context switches
        459208274934  instructions retired
        186569687629  cycles elapsed
           977194368  peak memory footprint
```

