### PR TITLE
Revert Better remote caching 

### DIFF
--- a/conan/__init__.py
+++ b/conan/__init__.py
@@ -2,5 +2,5 @@ from conan.internal.model.conan_file import ConanFile
 from conan.internal.model.workspace import Workspace
 from conan.internal.model.version import Version
 
-__version__ = '2.18.0'
+__version__ = '2.18.1'
 conan_version = Version(__version__)

--- a/conan/internal/rest/remote_manager.py
+++ b/conan/internal/rest/remote_manager.py
@@ -38,13 +38,11 @@ class RemoteManager:
     def upload_recipe(self, ref, files_to_upload, remote):
         assert isinstance(ref, RecipeReference)
         assert ref.revision, "upload_recipe requires RREV"
-        remote.invalidate_cache()
         self._call_remote(remote, "upload_recipe", ref, files_to_upload)
 
     def upload_package(self, pref, files_to_upload, remote):
         assert pref.ref.revision, "upload_package requires RREV"
         assert pref.revision, "upload_package requires PREV"
-        remote.invalidate_cache()
         self._call_remote(remote, "upload_package", pref, files_to_upload)
 
     def get_recipe(self, ref, remote, metadata=None):
@@ -206,15 +204,12 @@ class RemoteManager:
         return packages
 
     def remove_recipe(self, ref, remote):
-        remote.invalidate_cache()
         return self._call_remote(remote, "remove_recipe", ref)
 
     def remove_packages(self, prefs, remote):
-        remote.invalidate_cache()
         return self._call_remote(remote, "remove_packages", prefs)
 
     def remove_all_packages(self, ref, remote):
-        remote.invalidate_cache()
         return self._call_remote(remote, "remove_all_packages", ref)
 
     def authenticate(self, remote, name, password):
@@ -248,19 +243,10 @@ class RemoteManager:
 
         cached_method = remote._caching.setdefault("get_latest_package_reference", {})
         try:
-            result = cached_method[pref]
+            return cached_method[pref]
         except KeyError:
-            try:
-                result = self._call_remote(remote, "get_latest_package_reference", pref,
-                                           headers=headers)
-                cached_method[pref] = result
-                return result
-            except Exception as e:
-                cached_method[pref] = e
-                raise e
-        else:
-            if isinstance(result, Exception):
-                raise result
+            result = self._call_remote(remote, "get_latest_package_reference", pref, headers=headers)
+            cached_method[pref] = result
             return result
 
     def get_recipe_revision_reference(self, ref, remote) -> bool:


### PR DESCRIPTION
Changelog: Bugfix: Revert remote caching for missing packages
Docs: Omit
Reverts: https://github.com/conan-io/conan/pull/18411

Fix in https://github.com/conan-io/conan/pull/18583/files but we prefer to revert first and re-implement at a later date


Currently in `develop2`, I see this memory usage (`time -l`) for a `conan graph build-order` with some amount of references

```
109,92 real        52,37 user         5,24 sys
          1663582208  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
              105503  page reclaims
                 818  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                 956  messages sent
                1952  messages received
                   0  signals received
                8287  voluntary context switches
               83220  involuntary context switches
        461682631911  instructions retired
        180179796797  cycles elapsed
          1652232896  peak memory footprin
```

With the caching reverted (`git revert ad76fa2cc44e5b5c9072475d062c29e593a12c17`), I locally see this memory usage:

```
149,67 real        56,73 user         6,94 sys
           988119040  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
               68725  page reclaims
                  54  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                1602  messages sent
                3241  messages received
                   0  signals received
               10995  voluntary context switches
              110199  involuntary context switches
        463184016263  instructions retired
        192413183049  cycles elapsed
           976276864  peak memory footprint
```

