### PR TITLE
[Part 2] Better remote caching

### DIFF
--- a/conan/internal/rest/remote_manager.py
+++ b/conan/internal/rest/remote_manager.py
@@ -38,11 +38,13 @@ class RemoteManager:
     def upload_recipe(self, ref, files_to_upload, remote):
         assert isinstance(ref, RecipeReference)
         assert ref.revision, "upload_recipe requires RREV"
+        remote.invalidate_cache()
         self._call_remote(remote, "upload_recipe", ref, files_to_upload)
 
     def upload_package(self, pref, files_to_upload, remote):
         assert pref.ref.revision, "upload_package requires RREV"
         assert pref.revision, "upload_package requires PREV"
+        remote.invalidate_cache()
         self._call_remote(remote, "upload_package", pref, files_to_upload)
 
     def get_recipe(self, ref, remote, metadata=None):
@@ -204,12 +206,15 @@ class RemoteManager:
         return packages
 
     def remove_recipe(self, ref, remote):
+        remote.invalidate_cache()
         return self._call_remote(remote, "remove_recipe", ref)
 
     def remove_packages(self, prefs, remote):
+        remote.invalidate_cache()
         return self._call_remote(remote, "remove_packages", prefs)
 
     def remove_all_packages(self, ref, remote):
+        remote.invalidate_cache()
         return self._call_remote(remote, "remove_all_packages", ref)
 
     def authenticate(self, remote, name, password):
@@ -243,21 +248,21 @@ class RemoteManager:
 
         cached_method = remote._caching.setdefault("get_latest_package_reference", {})
         try:
-            return cached_method[pref]
+            result = cached_method[pref]
         except KeyError:
             try:
                 result = self._call_remote(remote, "get_latest_package_reference", pref,
                                            headers=headers)
                 cached_method[pref] = result
                 return result
-            except Exception as e:
+            except NotFoundException as e:
                 # Let's avoid leaking memory by saving all the exception objects,
-                # which translates to a 2x memory increase. Now, it only saves the type and the final
-                # message
+                # which translates to a ~2x memory increase. Now, it only saves the type and the
+                # final message. For now, let's cache only the NotFoundException one.
                 cached_method[pref] = (type(e), str(e))
                 raise e
         else:
-            if isinstance(result, tuple) and issubclass(result[0], Exception):
+            if isinstance(result, tuple) and issubclass(result[0], NotFoundException):
                 # Let's raise it
                 raise result[0](result[1])
             return result

--- a/conan/internal/rest/remote_manager.py
+++ b/conan/internal/rest/remote_manager.py
@@ -245,8 +245,21 @@ class RemoteManager:
         try:
             return cached_method[pref]
         except KeyError:
-            result = self._call_remote(remote, "get_latest_package_reference", pref, headers=headers)
-            cached_method[pref] = result
+            try:
+                result = self._call_remote(remote, "get_latest_package_reference", pref,
+                                           headers=headers)
+                cached_method[pref] = result
+                return result
+            except Exception as e:
+                # Let's avoid leaking memory by saving all the exception objects,
+                # which translates to a 2x memory increase. Now, it only saves the type and the final
+                # message
+                cached_method[pref] = (type(e), str(e))
+                raise e
+        else:
+            if isinstance(result, tuple) and issubclass(result[0], Exception):
+                # Let's raise it
+                raise result[0](result[1])
             return result
 
     def get_recipe_revision_reference(self, ref, remote) -> bool:

--- a/conan/internal/rest/remote_manager.py
+++ b/conan/internal/rest/remote_manager.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from collections import namedtuple
 from typing import List
 
 from requests.exceptions import ConnectionError
@@ -22,6 +23,9 @@ from conan.internal.util.files import mkdir, tar_extract
 
 class RemoteManager:
     """ Will handle the remotes to get recipes, packages etc """
+
+    _ErrorMsg = namedtuple("ErrorMsg", ["message"])
+
     def __init__(self, cache, auth_manager, home_folder):
         self._cache = cache
         self._auth_manager = auth_manager
@@ -259,12 +263,12 @@ class RemoteManager:
                 # Let's avoid leaking memory by saving all the exception objects,
                 # which translates to a ~2x memory increase. Now, it only saves the type and the
                 # final message. For now, let's cache only the NotFoundException one.
-                cached_method[pref] = (type(e), str(e))
+                cached_method[pref] = self._ErrorMsg(str(e))
                 raise e
         else:
-            if isinstance(result, tuple) and issubclass(result[0], NotFoundException):
+            if isinstance(result, self._ErrorMsg):
                 # Let's raise it
-                raise result[0](result[1])
+                raise NotFoundException(result.message)
             return result
 
     def get_recipe_revision_reference(self, ref, remote) -> bool:


### PR DESCRIPTION
Changelog: omit
Docs: omit
Related to: https://github.com/conan-io/conan/pull/18411 

The second part of https://github.com/conan-io/conan/pull/18411

Saving the exception objects is using tons of memory because of (likely):

* `__traceback__`: reference to the traceback object.
* `__context__`: for nested exceptions.
* `__cause__`: for exceptions re-raised with raise ... from ....
* Likely internal circular references, coming from the environment where the exception was created.

Before applying these changes:

```
      156,29 real        72,60 user         7,28 sys
          2662825984  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
              177948  page reclaims
                 701  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                1274  messages sent
                2716  messages received
                   0  signals received
               11882  voluntary context switches
              115913  involuntary context switches
        727072436826  instructions retired
        282124818798  cycles elapsed
          2651789952  peak memory footprint
```

After applying them:
```
      155,44 real        70,36 user         7,21 sys
          1286635520  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
               94477  page reclaims
                 867  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                1274  messages sent
                2718  messages received
                   0  signals received
               12505  voluntary context switches
              125722  involuntary context switches
        726724902487  instructions retired
        271375737037  cycles elapsed
          1286017152  peak memory footprint
```