### PR TITLE
Fix `test_makefile_sysroot` test in Windows

### DIFF
--- a/test/integration/toolchains/gnu/test_makedeps.py
+++ b/test/integration/toolchains/gnu/test_makedeps.py
@@ -413,7 +413,7 @@ def test_makedeps_tool_requires():
 
 @pytest.mark.parametrize("pattern, result, expected",
                          [("libs = []", False, 'SYSROOT'),
-                          ("sysroot = ['/foo/bar/sysroot']", True, 'CONAN_SYSROOT_PACKAGE = /foo/bar/sysroot')])
+                          ("sysroot = ['/foo/bar/sysroot']", True, 'CONAN_SYSROOT_PACKAGE')])
 def test_makefile_sysroot(pattern, result, expected):
     """
     The MakeDeps should not enforce sysroot in case not defined

--- a/test/integration/toolchains/gnu/test_makedeps.py
+++ b/test/integration/toolchains/gnu/test_makedeps.py
@@ -413,7 +413,10 @@ def test_makedeps_tool_requires():
 
 @pytest.mark.parametrize("pattern, result, expected",
                          [("libs = []", False, 'SYSROOT'),
-                          ("sysroot = ['/foo/bar/sysroot']", True, 'CONAN_SYSROOT_PACKAGE')])
+                          ("sysroot = ['/foo/bar/sysroot']", True, 'CONAN_SYSROOT_PACKAGE = /foo/bar/sysroot')
+                          if platform.system() != "Windows" else
+                          ("sysroot = ['C:/my_sysroot']", True, 'CONAN_SYSROOT_PACKAGE = C:/my_sysroot')])
+
 def test_makefile_sysroot(pattern, result, expected):
     """
     The MakeDeps should not enforce sysroot in case not defined


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

The test returns different values depending on the Python version, because the code that generates the variables eventually reaches https://github.com/conan-io/conan/blob/release/2.18/conan/tools/gnu/makedeps.py#L57, and [in Python 3.13, the behaviour changed in Windows for paths starting with slashes](https://docs.python.org/3/library/os.path.html#os.path.isabs)

> _Changed in version 3.13_: On Windows, returns False if the given path starts with exactly one (back)slash.

This made the test fail because the resulting variable was getting the `$(CONAN_ROOT_...` prefix appended. The fix is easy, have the test be less strict, but we might still want to be safe and check that this is not breaking things unexpectedly elsewhere