### PR TITLE
Add freeze_support

### DIFF
--- a/conans/conan.py
+++ b/conans/conan.py
@@ -1,6 +1,4 @@
 import sys
-import multiprocessing
-multiprocessing.freeze_support()
 from conan.cli.cli import main
 
 
@@ -9,4 +7,6 @@ def run():
 
 
 if __name__ == '__main__':
+    import multiprocessing
+    multiprocessing.freeze_support()
     run()

--- a/conans/conan.py
+++ b/conans/conan.py
@@ -1,5 +1,6 @@
 import sys
-
+import multiprocessing
+multiprocessing.freeze_support()
 from conan.cli.cli import main
 
 


### PR DESCRIPTION
Changelog: Fix: Fix multithreading for self-contained Conan binaries.
Docs: Omit

Closes https://github.com/conan-io/conan/issues/18601

Afetr this change, running a binary generated by Pyinstaller works as expected in the repro case mentioned in the linked issue

@jcar87 found the smoking gun, I'm just the messenger
