### PR TITLE
[untargz][fix] Windows long paths prefix `\\?\`

### DIFF
--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -442,6 +442,7 @@ def untargz(filename, destination=".", pattern=None, strip_root=False, extract_f
         if not pattern and not strip_root:
             tarredgzippedFile.extractall(destination)
         else:
+            using_long_path_prefix = destination.startswith("\\\\?\\")
             common_folder = None
             members = []
             for member in tarredgzippedFile:
@@ -466,6 +467,11 @@ def untargz(filename, destination=".", pattern=None, strip_root=False, extract_f
                         # https://github.com/conan-io/conan/issues/11065
                         member.linkpath = member.linkpath[len(common_folder) + 1:].replace("\\", "/")
                         member.linkname = member.linkpath
+                if using_long_path_prefix:
+                    # https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry
+                    # File I/O functions in the Windows API convert "/" to "\" as part of converting
+                    # the name to an NT-style name, except when using the "\\?\" prefix
+                    member.name = member.name.replace("/", "\\")
                 # Let's gather each member
                 members.append(member)
             tarredgzippedFile.extractall(destination, members=members)

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -443,38 +443,38 @@ def untargz(filename, destination=".", pattern=None, strip_root=False, extract_f
         # File I/O functions in the Windows API convert "/" to "\" as part of converting
         # the name to an NT-style name, except when using the "\\?\" prefix
         using_long_path_prefix = destination.startswith("\\\\?\\")
-        # These are the conditions that would need to run through each member
-        if not any([pattern, strip_root, using_long_path_prefix]):
-            return tarredgzippedFile.extractall(destination)
-        # Now, we have to process each member
-        common_folder = None
-        members = []
-        for member in tarredgzippedFile:
-            if pattern and not fnmatch(member.name, pattern):
-                continue  # Skip files that don’t match the pattern
-            if strip_root:
-                name = member.name.replace("\\", "/")
-                if not common_folder:
-                    splits = name.split("/", 1)
-                    # First case for a plain folder in the root
-                    if member.isdir() or len(splits) > 1:
-                        common_folder = splits[0]  # Find the root folder
-                    else:
-                        raise ConanException("Can't untar a tgz containing files in the root with strip_root enabled")
-                if not name.startswith(common_folder):
-                    raise ConanException("The tgz file contains more than 1 folder in the root")
-                # Adjust the member's name for extraction
-                member.name = name[len(common_folder) + 1:]
-                member.path = member.name
-                if member.linkpath and member.linkpath.startswith(common_folder):
-                    # https://github.com/conan-io/conan/issues/11065
-                    member.linkpath = member.linkpath[len(common_folder) + 1:].replace("\\", "/")
-                    member.linkname = member.linkpath
-            if using_long_path_prefix:
-                member.name = member.name.replace("/", "\\")
-            # Let's gather each member
-            members.append(member)
-        tarredgzippedFile.extractall(destination, members=members)
+        if not pattern and not strip_root and not using_long_path_prefix:
+            tarredgzippedFile.extractall(destination)
+        else:
+            common_folder = None
+            members = []
+            for member in tarredgzippedFile:
+                if pattern and not fnmatch(member.name, pattern):
+                    continue  # Skip files that don’t match the pattern
+
+                if strip_root:
+                    name = member.name.replace("\\", "/")
+                    if not common_folder:
+                        splits = name.split("/", 1)
+                        # First case for a plain folder in the root
+                        if member.isdir() or len(splits) > 1:
+                            common_folder = splits[0]  # Find the root folder
+                        else:
+                            raise ConanException("Can't untar a tgz containing files in the root with strip_root enabled")
+                    if not name.startswith(common_folder):
+                        raise ConanException("The tgz file contains more than 1 folder in the root")
+                    # Adjust the member's name for extraction
+                    member.name = name[len(common_folder) + 1:]
+                    member.path = member.name
+                    if member.linkpath and member.linkpath.startswith(common_folder):
+                        # https://github.com/conan-io/conan/issues/11065
+                        member.linkpath = member.linkpath[len(common_folder) + 1:].replace("\\", "/")
+                        member.linkname = member.linkpath
+                if using_long_path_prefix:
+                    member.name = member.name.replace("/", "\\")
+                # Let's gather each member
+                members.append(member)
+            tarredgzippedFile.extractall(destination, members=members)
 
 
 def check_sha1(conanfile, file_path, signature):

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -439,42 +439,42 @@ def untargz(filename, destination=".", pattern=None, strip_root=False, extract_f
     with tarfile.TarFile.open(filename, mode='r:*') as tarredgzippedFile:
         f = getattr(tarfile, f"{extract_filter}_filter", None) if extract_filter else None
         tarredgzippedFile.extraction_filter = f or (lambda member_, _: member_)
-        if not pattern and not strip_root:
-            tarredgzippedFile.extractall(destination)
-        else:
-            using_long_path_prefix = destination.startswith("\\\\?\\")
-            common_folder = None
-            members = []
-            for member in tarredgzippedFile:
-                if pattern and not fnmatch(member.name, pattern):
-                    continue  # Skip files that don’t match the pattern
-
-                if strip_root:
-                    name = member.name.replace("\\", "/")
-                    if not common_folder:
-                        splits = name.split("/", 1)
-                        # First case for a plain folder in the root
-                        if member.isdir() or len(splits) > 1:
-                            common_folder = splits[0]  # Find the root folder
-                        else:
-                            raise ConanException("Can't untar a tgz containing files in the root with strip_root enabled")
-                    if not name.startswith(common_folder):
-                        raise ConanException("The tgz file contains more than 1 folder in the root")
-                    # Adjust the member's name for extraction
-                    member.name = name[len(common_folder) + 1:]
-                    member.path = member.name
-                    if member.linkpath and member.linkpath.startswith(common_folder):
-                        # https://github.com/conan-io/conan/issues/11065
-                        member.linkpath = member.linkpath[len(common_folder) + 1:].replace("\\", "/")
-                        member.linkname = member.linkpath
-                if using_long_path_prefix:
-                    # https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry
-                    # File I/O functions in the Windows API convert "/" to "\" as part of converting
-                    # the name to an NT-style name, except when using the "\\?\" prefix
-                    member.name = member.name.replace("/", "\\")
-                # Let's gather each member
-                members.append(member)
-            tarredgzippedFile.extractall(destination, members=members)
+        # https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry
+        # File I/O functions in the Windows API convert "/" to "\" as part of converting
+        # the name to an NT-style name, except when using the "\\?\" prefix
+        using_long_path_prefix = destination.startswith("\\\\?\\")
+        # These are the conditions that would need to run through each member
+        if not any([pattern, strip_root, using_long_path_prefix]):
+            return tarredgzippedFile.extractall(destination)
+        # Now, we have to process each member
+        common_folder = None
+        members = []
+        for member in tarredgzippedFile:
+            if pattern and not fnmatch(member.name, pattern):
+                continue  # Skip files that don’t match the pattern
+            if strip_root:
+                name = member.name.replace("\\", "/")
+                if not common_folder:
+                    splits = name.split("/", 1)
+                    # First case for a plain folder in the root
+                    if member.isdir() or len(splits) > 1:
+                        common_folder = splits[0]  # Find the root folder
+                    else:
+                        raise ConanException("Can't untar a tgz containing files in the root with strip_root enabled")
+                if not name.startswith(common_folder):
+                    raise ConanException("The tgz file contains more than 1 folder in the root")
+                # Adjust the member's name for extraction
+                member.name = name[len(common_folder) + 1:]
+                member.path = member.name
+                if member.linkpath and member.linkpath.startswith(common_folder):
+                    # https://github.com/conan-io/conan/issues/11065
+                    member.linkpath = member.linkpath[len(common_folder) + 1:].replace("\\", "/")
+                    member.linkname = member.linkpath
+            if using_long_path_prefix:
+                member.name = member.name.replace("/", "\\")
+            # Let's gather each member
+            members.append(member)
+        tarredgzippedFile.extractall(destination, members=members)
 
 
 def check_sha1(conanfile, file_path, signature):

--- a/test/unittests/util/files/strip_root_extract_test.py
+++ b/test/unittests/util/files/strip_root_extract_test.py
@@ -356,6 +356,6 @@ def test_decompressing_using_long_path_prefix():
     untargz(tgz_file, destination=extract_folder, strip_root=True)
     assert "contentsfile1" in load(ConanFileMock(), os.path.join(extract_folder, "parent", "bin", "file1"))
     assert "contentsfile2" in load(ConanFileMock(), os.path.join(extract_folder, "parent", "bin", "file2"))
-    untargz(tgz_file, destination=extract_folder)
+    untargz(tgz_file, destination=extract_folder, strip_root=False)
     assert "contentsfile1" in load(ConanFileMock(), os.path.join(extract_folder, "root", "parent", "bin", "file1"))
     assert "contentsfile2" in load(ConanFileMock(), os.path.join(extract_folder, "root", "parent", "bin", "file2"))

--- a/test/unittests/util/files/strip_root_extract_test.py
+++ b/test/unittests/util/files/strip_root_extract_test.py
@@ -356,3 +356,6 @@ def test_decompressing_using_long_path_prefix():
     untargz(tgz_file, destination=extract_folder, strip_root=True)
     assert "contentsfile1" in load(ConanFileMock(), os.path.join(extract_folder, "parent", "bin", "file1"))
     assert "contentsfile2" in load(ConanFileMock(), os.path.join(extract_folder, "parent", "bin", "file2"))
+    untargz(tgz_file, destination=extract_folder)
+    assert "contentsfile1" in load(ConanFileMock(), os.path.join(extract_folder, "root", "parent", "bin", "file1"))
+    assert "contentsfile2" in load(ConanFileMock(), os.path.join(extract_folder, "root", "parent", "bin", "file2"))

--- a/test/unittests/util/files/strip_root_extract_test.py
+++ b/test/unittests/util/files/strip_root_extract_test.py
@@ -1,6 +1,10 @@
 import os
+import platform
 import tarfile
 import zipfile
+
+import pytest
+import sys
 
 from conan.internal.api.uploader import gzopen_without_timestamps
 from conan.tools.files.files import untargz, unzip
@@ -326,3 +330,26 @@ def test_decompressing_folders_with_different_modes():
     extract_folder = temp_folder()
     # Do not raise any PermissionError
     untargz(tgz_file, destination=extract_folder, strip_root=True)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 13, 4), reason="requires Python 3.13.4 or higher")
+@pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows")
+def test_decompressing_using_long_path_prefix():
+    """
+    If we use the "\\?\" prefix, untar() function should not
+    raise an OSError: [WinError 123] error.
+
+    Issue related: https://github.com/conan-io/conan/issues/18574
+    """
+    tmp_folder = temp_folder()
+    tgz_folder = temp_folder()
+    tgz_file = os.path.join(tgz_folder, "file.tar.gz")
+    with chdir(tmp_folder):
+        save("root/parent/bin/file1", "contentsfile1")
+        save("root/parent/bin/file2", "contentsfile2")
+        _compress_root_folder(tmp_folder, tgz_file, root_folder_name="root")
+
+    # Tgz unzipped regularly
+    extract_folder = temp_folder()
+    # Do not raise any OSError: [WinError 123]
+    untargz(tgz_file, destination=f"\\\\?\\{extract_folder}", strip_root=True)

--- a/test/unittests/util/files/strip_root_extract_test.py
+++ b/test/unittests/util/files/strip_root_extract_test.py
@@ -7,6 +7,7 @@ import pytest
 import sys
 
 from conan.internal.api.uploader import gzopen_without_timestamps
+from conan.tools.files import load
 from conan.tools.files.files import untargz, unzip
 from conan.errors import ConanException
 from conan.internal.model.manifest import gather_files
@@ -350,6 +351,8 @@ def test_decompressing_using_long_path_prefix():
         _compress_root_folder(tmp_folder, tgz_file, root_folder_name="root")
 
     # Tgz unzipped regularly
-    extract_folder = temp_folder()
+    extract_folder = f"\\\\?\\{temp_folder()}"
     # Do not raise any OSError: [WinError 123]
-    untargz(tgz_file, destination=f"\\\\?\\{extract_folder}", strip_root=True)
+    untargz(tgz_file, destination=extract_folder, strip_root=True)
+    assert "contentsfile1" in load(ConanFileMock(), os.path.join(extract_folder, "parent", "bin", "file1"))
+    assert "contentsfile2" in load(ConanFileMock(), os.path.join(extract_folder, "parent", "bin", "file2"))


### PR DESCRIPTION
Changelog: Fix: Fixed untargz when the destination path  uses the Windows long paths prefix `\\?\`.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/18574

**Rationale**

_tafile.py_ - Python < 3.13.4

```python
    def extractall(self, path=".", members=None, *, numeric_owner=False,
                   filter=None):
         # . . . 

        for tarinfo in directories:
            dirpath = os.path.join(path, tarinfo.name)
            try:
                self.chown(tarinfo, dirpath, numeric_owner=numeric_owner)
                self.utime(tarinfo, dirpath)
                self.chmod(tarinfo, dirpath)
            except ExtractError as e:
                self._handle_nonfatal_error(e)
```

_tafile.py_ - Python >= 3.13.4
```python
    def extractall(self, path=".", members=None, *, numeric_owner=False,
                   filter=None):
         # . . . 

        # Set correct owner, mtime and filemode on directories.
        for unfiltered in directories:
            try:
                # Need to re-apply any filter, to take the *current* filesystem
                # state into account.
                try:
                    tarinfo = filter_function(unfiltered, path)
                except _FILTER_ERRORS as exc:
                    self._log_no_directory_fixup(unfiltered, repr(exc))
                    continue
                if tarinfo is None:
                    self._log_no_directory_fixup(unfiltered,
                                                 'excluded by filter')
                    continue
                dirpath = os.path.join(path, tarinfo.name)
                try:
                    lstat = os.lstat(dirpath)
                except FileNotFoundError:
                    self._log_no_directory_fixup(tarinfo, 'missing')
                    continue
                if not stat.S_ISDIR(lstat.st_mode):
                    # This is no longer a directory; presumably a later
                    # member overwrote the entry.
                    self._log_no_directory_fixup(tarinfo, 'not a directory')
                    continue
                self.chown(tarinfo, dirpath, numeric_owner=numeric_owner)
                self.utime(tarinfo, dirpath)
                self.chmod(tarinfo, dirpath)
            except ExtractError as e:
                self._handle_nonfatal_error(e)
```

As you can see, the logic changed a lot, and what it's failing now is:

```bash
                dirpath = os.path.join(path, tarinfo.name)
                try:
>                   lstat = os.lstat(dirpath)
E                   OSError: [WinError 123] The filename, directory name, or volume label syntax is incorrect: '\\\\?\\C:\\Users\\x\\AppData\\Local\\Temp\\tmpe_y_biipconans\\path with spaces\\parent/bin'
```
Due to the mix between "\\" and "/".