### PR TITLE
ssh: retrieve all packages (build or cached) from remote create command

### DIFF
--- a/conan/internal/runner/ssh.py
+++ b/conan/internal/runner/ssh.py
@@ -260,7 +260,8 @@ class SSHRunner:
         # ('conan list --graph=create.json --graph-binaries=build --format=json > pkglist.json'
         _Path = pathlib.PureWindowsPath if self.remote_is_windows else pathlib.PurePath
         pkg_list_json = _Path(self.remote_create_dir).joinpath("pkg_list.json").as_posix()
-        pkg_list_command = f"{self.remote_conan} list --graph={json_result} --graph-binaries=build --format=json > {pkg_list_json}"
+        # List every package (built or cached) because local cache could have been deleted
+        pkg_list_command = f"{self.remote_conan} list --graph={json_result} --format=json > {pkg_list_json}"
         _, stdout, _ = self.client.exec_command(pkg_list_command)
         if stdout.channel.recv_exit_status() != 0:
             raise ConanException("Unable to generate remote package list")


### PR DESCRIPTION
Changelog: omit
Docs: omit

Previously, if a package was created remotely, restored to the local cache, and then removed locally, the runner would not retrieve it again. This occurred because only build recipes were compressed. 

This PR fix involves always exporting all packages and forcing a local cache refresh, which ensures the package is brought back to the local cache.

In order to reproduce this issue:

1. Create the package:
```sh
$ conan create . -pr:a ssh 
```

2. Remove the package:
```sh
$ conan remove pkg -c

3. Create the package again with `--build=missing` (**IMPORTANT**)
```sh
$ conan create . -pr:a ssh-old --build=missing
```

The cache would not be restored. Only the exported recipe will be available, not the package itself:

![issue](https://github.com/user-attachments/assets/1e837362-1bc5-4794-9278-d8e2716f796c)
