### PR TITLE
enabling test_package_folder for conan export-pkg command

### DIFF
--- a/conan/cli/commands/export_pkg.py
+++ b/conan/cli/commands/export_pkg.py
@@ -38,7 +38,6 @@ def export_pkg(conan_api, parser, *args):
 
     cwd = os.getcwd()
     path = conan_api.local.get_conanfile_path(args.path, cwd, py=True)
-    test_conanfile_path = _get_test_conanfile_path(args.test_folder, path)
     overrides = eval(args.lockfile_overrides) if args.lockfile_overrides else None
     lockfile = conan_api.lockfile.get_lockfile(lockfile=args.lockfile, conanfile_path=path,
                                                cwd=cwd, partial=args.lockfile_partial,
@@ -92,6 +91,9 @@ def export_pkg(conan_api, parser, *args):
     lockfile = conan_api.lockfile.update_lockfile(lockfile, deps_graph, args.lockfile_packages,
                                                   clean=args.lockfile_clean)
 
+    test_package_folder = getattr(conanfile, "test_package_folder", None) \
+        if args.test_folder is None else args.test_folder
+    test_conanfile_path = _get_test_conanfile_path(test_package_folder, path)
     if test_conanfile_path:
         from conan.cli.commands.test import run_test
         # same as ``conan create`` the lockfile, and deps graph is the one of the exported-pkg

--- a/test/integration/layout/test_layout_generate.py
+++ b/test/integration/layout/test_layout_generate.py
@@ -155,3 +155,11 @@ class TestCustomTestPackage:
                 "pkg/my/test/conanfile.py": GenConanfile().with_test("self.output.info('MYTEST!')")})
         c.run("create pkg/conan")
         assert "MYTEST!" in c.out
+
+    def test_custom_test_package_export_pkg(self):
+        c = TestClient(light=True)
+        conanfile = GenConanfile("pkg", "0.1").with_class_attribute('test_package_folder="mytest"')
+        c.save({"pkg/conanfile.py": conanfile,
+                "pkg/mytest/conanfile.py": GenConanfile().with_test("self.output.info('MYTEST!')")})
+        c.run("export-pkg pkg")
+        assert "MYTEST!" in c.out


### PR DESCRIPTION
Changelog: Feature: Enable ``test_package_folder`` attribute for ``conan export-pkg`` command.
Docs: https://github.com/conan-io/docs/pull/4173

Close https://github.com/conan-io/conan/issues/18620