### PR TITLE
Allow auto-detect with custom cc paths including spaces

### DIFF
--- a/conan/internal/api/detect/detect_api.py
+++ b/conan/internal/api/detect/detect_api.py
@@ -233,7 +233,7 @@ def detect_libcxx(compiler, version, compiler_exe=None):
         old_path = os.getcwd()
         os.chdir(t)
         try:
-            error, out_str = detect_runner(f'"{executable} main.cpp -std=c++11')
+            error, out_str = detect_runner(f'"{executable}" main.cpp -std=c++11')
             if error:
                 if "using libstdc++" in out_str:
                     output.info("gcc C++ standard library: libstdc++")
@@ -482,7 +482,7 @@ def _detect_vs_ide_version():
 def _cc_compiler(compiler_exe="cc"):
     # Try to detect the "cc" linux system "alternative". It could point to gcc or clang
     try:
-        ret, out = detect_runner(f'"{compiler_exe} --version')
+        ret, out = detect_runner(f'"{compiler_exe}" --version')
         if ret != 0:
             return None, None, None
         compiler = "clang" if "clang" in out else "gcc"
@@ -505,13 +505,13 @@ def detect_gcc_compiler(compiler_exe="gcc"):
     try:
         if platform.system() == "Darwin":
             # In Mac OS X check if gcc is a fronted using apple-clang
-            _, out = detect_runner(f'"{compiler_exe} --version')
+            _, out = detect_runner(f'"{compiler_exe}" --version')
             out = out.lower()
             if "clang" in out:
                 return None, None, None
 
         # TODO: Add -dumpfullversion to always return major.minor
-        ret, out = detect_runner(f'"{compiler_exe} -dumpversion')
+        ret, out = detect_runner(f'"{compiler_exe}" -dumpversion')
         if ret != 0:
             return None, None, None
         compiler = "gcc"
@@ -532,7 +532,7 @@ def detect_compiler():
 
 def detect_intel_compiler(compiler_exe="icx"):
     try:
-        ret, out = detect_runner(f'"{compiler_exe} --version')
+        ret, out = detect_runner(f'"{compiler_exe}" --version')
         if ret != 0:
             return None, None
         compiler = "intel-cc"
@@ -546,7 +546,7 @@ def detect_intel_compiler(compiler_exe="icx"):
 
 def detect_suncc_compiler(compiler_exe="cc"):
     try:
-        _, out = detect_runner(f'"{compiler_exe} -V')
+        _, out = detect_runner(f'"{compiler_exe}" -V')
         compiler = "sun-cc"
         installed_version = re.search(r"Sun C.*([0-9]+\.[0-9]+)", out)
         if installed_version:
@@ -562,7 +562,7 @@ def detect_suncc_compiler(compiler_exe="cc"):
 
 def detect_clang_compiler(compiler_exe="clang"):
     try:
-        ret, out = detect_runner(f'"{compiler_exe} --version')
+        ret, out = detect_runner(f'"{compiler_exe}" --version')
         if ret != 0:
             return None, None, None
         if "Apple" in out:

--- a/conan/internal/api/detect/detect_api.py
+++ b/conan/internal/api/detect/detect_api.py
@@ -233,7 +233,7 @@ def detect_libcxx(compiler, version, compiler_exe=None):
         old_path = os.getcwd()
         os.chdir(t)
         try:
-            error, out_str = detect_runner("%s main.cpp -std=c++11" % executable)
+            error, out_str = detect_runner(f'"{executable} main.cpp -std=c++11')
             if error:
                 if "using libstdc++" in out_str:
                     output.info("gcc C++ standard library: libstdc++")
@@ -482,7 +482,7 @@ def _detect_vs_ide_version():
 def _cc_compiler(compiler_exe="cc"):
     # Try to detect the "cc" linux system "alternative". It could point to gcc or clang
     try:
-        ret, out = detect_runner('%s --version' % compiler_exe)
+        ret, out = detect_runner(f'"{compiler_exe} --version')
         if ret != 0:
             return None, None, None
         compiler = "clang" if "clang" in out else "gcc"
@@ -505,13 +505,13 @@ def detect_gcc_compiler(compiler_exe="gcc"):
     try:
         if platform.system() == "Darwin":
             # In Mac OS X check if gcc is a fronted using apple-clang
-            _, out = detect_runner("%s --version" % compiler_exe)
+            _, out = detect_runner(f'"{compiler_exe} --version')
             out = out.lower()
             if "clang" in out:
                 return None, None, None
 
         # TODO: Add -dumpfullversion to always return major.minor
-        ret, out = detect_runner('%s -dumpversion' % compiler_exe)
+        ret, out = detect_runner(f'"{compiler_exe} -dumpversion')
         if ret != 0:
             return None, None, None
         compiler = "gcc"
@@ -524,14 +524,15 @@ def detect_gcc_compiler(compiler_exe="gcc"):
 
 
 def detect_compiler():
-    ConanOutput(scope="detect_api").warning("detect_compiler() is deprecated, use detect_default_compiler()", warn_tag="deprecated")
+    ConanOutput(scope="detect_api").warning("detect_compiler() is deprecated, "
+                                            "use detect_default_compiler()", warn_tag="deprecated")
     compiler, version, _ = detect_default_compiler()
     return compiler, version
 
 
 def detect_intel_compiler(compiler_exe="icx"):
     try:
-        ret, out = detect_runner("%s --version" % compiler_exe)
+        ret, out = detect_runner(f'"{compiler_exe} --version')
         if ret != 0:
             return None, None
         compiler = "intel-cc"
@@ -545,7 +546,7 @@ def detect_intel_compiler(compiler_exe="icx"):
 
 def detect_suncc_compiler(compiler_exe="cc"):
     try:
-        _, out = detect_runner('%s -V' % compiler_exe)
+        _, out = detect_runner(f'"{compiler_exe} -V')
         compiler = "sun-cc"
         installed_version = re.search(r"Sun C.*([0-9]+\.[0-9]+)", out)
         if installed_version:
@@ -561,7 +562,7 @@ def detect_suncc_compiler(compiler_exe="cc"):
 
 def detect_clang_compiler(compiler_exe="clang"):
     try:
-        ret, out = detect_runner('%s --version' % compiler_exe)
+        ret, out = detect_runner(f'"{compiler_exe} --version')
         if ret != 0:
             return None, None, None
         if "Apple" in out:

--- a/conan/internal/api/detect/detect_api.py
+++ b/conan/internal/api/detect/detect_api.py
@@ -652,6 +652,6 @@ def detect_sdk_version(sdk):
     if platform.system() != "Darwin":
         return
     cmd = f'xcrun -sdk {sdk} --show-sdk-version'
-    result = check_output_runner(cmd)
+    _, result = detect_runner(cmd)
     result = result.strip()
     return result

--- a/test/functional/command/profile_test.py
+++ b/test/functional/command/profile_test.py
@@ -1,7 +1,6 @@
 import os
 import platform
 import textwrap
-import unittest
 
 import pytest
 
@@ -14,12 +13,12 @@ from conan.internal.util.runners import detect_runner
 from conan.tools.microsoft.visual import vcvars_command
 
 
-class TestProfile(unittest.TestCase):
+class TestProfile:
 
     def test_list_empty(self):
         client = TestClient()
         client.run("profile list")
-        self.assertIn("Profiles found in the cache:", client.out)
+        assert "Profiles found in the cache:" in client.out
 
     def test_list(self):
         client = TestClient()
@@ -65,20 +64,20 @@ class TestProfile(unittest.TestCase):
         save(os.path.join(client.paths.profiles_path, "profile1"), profile1)
 
         client.run("profile show -pr=profile1")
-        self.assertIn("[settings]\nos=Windows", client.out)
-        self.assertIn("MyOption=32", client.out)
-        # self.assertIn("CC=/path/tomy/gcc_build", client.out)
-        # self.assertIn("CXX=/path/tomy/g++_build", client.out)
-        # self.assertIn("package:VAR=value", client.out)
-        self.assertIn("tools.build:jobs=20", client.out)
+        assert "[settings]\nos=Windows" in client.out
+        assert "MyOption=32" in client.out
+        # assert "CC=/path/tomy/gcc_build", client.out)
+        # assert "CXX=/path/tomy/g++_build", client.out)
+        # assert "package:VAR=value", client.out)
+        assert "tools.build:jobs=20" in client.out
 
     def test_missing_subarguments(self):
         client = TestClient()
         client.run("profile", assert_error=True)
-        self.assertIn("ERROR: Exiting with code: 2", client.out)
+        assert "ERROR: Exiting with code: 2" in client.out
 
 
-class DetectCompilersTest(unittest.TestCase):
+class TestDetectCompilers:
     def test_detect_default_compilers(self):
         platform_default_compilers = {
             "Linux": "gcc",
@@ -91,7 +90,7 @@ class DetectCompilersTest(unittest.TestCase):
         result = dict(result)
         platform_compiler = platform_default_compilers.get(platform.system(), None)
         if platform_compiler is not None:
-            self.assertEqual(result.get("compiler", None), platform_compiler)
+            assert result.get("compiler", None) == platform_compiler
 
     @pytest.mark.tool("gcc")
     @pytest.mark.skipif(platform.system() != "Darwin", reason="only OSX test")
@@ -113,8 +112,8 @@ class DetectCompilersTest(unittest.TestCase):
         # result is a list of tuples (name, value) so converting it to dict
         result = dict(result)
         # No compiler should be detected
-        self.assertIsNone(result.get("compiler", None))
-        self.assertIn("gcc detected as a frontend using apple-clang", output)
+        assert result.get("compiler", None) is None
+        assert "gcc detected as a frontend using apple-clang" in output
 
     def test_profile_new(self):
         c = TestClient()

--- a/test/functional/test_profile_detect_api.py
+++ b/test/functional/test_profile_detect_api.py
@@ -21,7 +21,7 @@ class TestProfileDetectAPI:
             compiler.version={{detect_api.default_compiler_version(compiler, version)}}
             compiler.runtime={{runtime}}
             compiler.cppstd={{detect_api.default_cppstd(compiler, version)}}
-            # detect_msvc_update returns the real update, like 12 for VS 17.12 so 
+            # detect_msvc_update returns the real update, like 12 for VS 17.12 so
             # we have to convert to the setting that's 0-10
             compiler.update={{ (detect_api.detect_msvc_update(version) | int) % 10 }}
 
@@ -31,7 +31,7 @@ class TestProfileDetectAPI:
 
         client.save({"profile1": tpl1})
         client.run("profile show -pr=profile1 --context=host")
-        #FIXME: check update setting
+        # FIXME: check update setting
         update = str(int(detect_api.detect_msvc_update("194")) % 10)
         expected = textwrap.dedent(f"""\
             [settings]
@@ -91,6 +91,7 @@ class TestProfileDetectAPI:
         client.run("profile show -pr=profile1")
         sdk_version = detect_api.detect_sdk_version(sdk="macosx")
         assert f"os.sdk_version={sdk_version}" in client.out
+
 
 @pytest.mark.parametrize("context", [None, "host", "build"])
 @pytest.mark.parametrize("f", ["json", "text"])


### PR DESCRIPTION
Changelog: Fix: Allow ``cc`` compiler to be defined with spaces for profile auto detection.
Docs: Omit

Close https://github.com/conan-io/conan/issues/18622