### PR TITLE
serialize conandata information

### DIFF
--- a/conan/internal/model/conan_file.py
+++ b/conan/internal/model/conan_file.py
@@ -75,6 +75,7 @@ class ConanFile:
     runenv_info = None
     conf_info = None
     generator_info = None
+    conan_data = None
 
     def __init__(self, display_name=""):
         self.display_name = display_name
@@ -176,6 +177,8 @@ class ConanFile:
         if self.info is not None:
             result["info"] = self.info.serialize()
         result["vendor"] = self.vendor
+        if self.conan_data:
+            result["conandata"] = self.conan_data
         return result
 
     @property

--- a/test/integration/conanfile/conan_data_test.py
+++ b/test/integration/conanfile/conan_data_test.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import sys
@@ -192,6 +193,22 @@ class Lib(ConanFile):
         self.assertIn("My URL: this url", client.out)
         client.run("export-pkg . --name=name --version=version")
         self.assertIn("My URL: this url", client.out)
+
+    def test_conan_data_serialize(self):
+        c = TestClient(light=True)
+        conandata = textwrap.dedent("""
+            src:
+                url: "this url"
+        """)
+        c.save({"conanfile.py": GenConanfile("pkg", "0.1"),
+                "conandata.yml": conandata})
+        c.run("graph info . --format=json")
+        graph = json.loads(c.stdout)
+        assert graph["graph"]["nodes"]["0"]["conandata"]["src"] == {"url": "this url"}
+
+        c.run("inspect . --format=json")
+        result = json.loads(c.stdout)
+        assert result["conandata"]["src"] == {"url": "this url"}
 
 
 class TestConanDataUpdate:


### PR DESCRIPTION
Changelog: Feature: Add ``self.conan_data`` to the information serialized by ConanFile, so it is printed in ``conan graph info`` and other commands.
Docs: https://github.com/conan-io/docs/pull/4172

Close https://github.com/conan-io/conan/issues/18658

We might want to talk again about enabling ``conan inspect`` to inspect cache and remote references (downloading them first)
