### PR TITLE
Add `cmake_target_aliases` support for `CMakeConfigDeps`

### DIFF
--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -239,8 +239,8 @@ class TargetConfigurationTemplate2:
 
     def _get_aliases(self, comp_name=None):
         aliases = self._cmakedeps.get_property("cmake_target_aliases", self._conanfile,
-                                               comp_name, check_type=list)
-        return aliases if aliases else []
+                                               comp_name, check_type=list) or []
+        return aliases
 
     def _add_root_lib_target(self, libs, pkg_name, cpp_info):
         """

--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -164,12 +164,16 @@ class TargetConfigurationTemplate2:
                 target = self._get_cmake_lib(component, cpp_info.components, pkg_folder,
                                              pkg_folder_var)
                 if target is not None:
+                    cmake_target_aliases = self._get_aliases(target_name, name)
+                    target["cmake_target_aliases"] = cmake_target_aliases
                     libs[target_name] = target
         else:
             target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile)
             target_name = target_name or f"{pkg_name}::{pkg_name}"
             target = self._get_cmake_lib(cpp_info, None, pkg_folder, pkg_folder_var)
             if target is not None:
+                cmake_target_aliases = self._get_aliases(target_name, comp_name=None)
+                target["cmake_target_aliases"] = cmake_target_aliases
                 libs[target_name] = target
         return libs
 
@@ -232,6 +236,11 @@ class TargetConfigurationTemplate2:
             link_languages = ["CXX" if c == "C++" else c for c in link_languages]
             target["link_languages"] = link_languages
         return target
+
+    def _get_aliases(self, target, comp_name=None):
+        aliases = self._cmakedeps.get_property("cmake_target_aliases", self._conanfile,
+                                               comp_name, check_type=list)
+        return {alias: target for alias in aliases}
 
     def _add_root_lib_target(self, libs, pkg_name, cpp_info):
         """
@@ -333,6 +342,12 @@ class TargetConfigurationTemplate2:
             message(STATUS "Conan: Target declared imported {{lib_info["type"]}} library '{{lib}}'")
             add_library({{lib}} {{lib_info["type"]}} IMPORTED)
         endif()
+        {% for alias, target in lib_info.get("cmake_target_aliases", {}).items() %}
+        if(NOT TARGET {{alias}})
+            message(STATUS "Conan: Target declared alias '{{alias}}' for '{{lib}}'")
+            add_library({{alias}} ALIAS {{lib}})
+        endif()
+        {% endfor %}
         {% if lib_info.get("includedirs") %}
         set_property(TARGET {{lib}} APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES
                      {{config_wrapper(config, lib_info["includedirs"])}})

--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -122,6 +122,16 @@ class TargetConfigurationTemplate2:
 
         prefixes = self._cmakedeps.get_property("cmake_additional_variables_prefixes",
                                                 self._conanfile, check_type=list) or []
+        seen_aliases = set()
+        for lib in libs.values():
+            for alias in lib.get("cmake_target_aliases", []):
+                if alias in seen_aliases:
+                    raise ConanException(f"Alias '{alias}' already defined in {self._conanfile}. ")
+                seen_aliases.add(alias)
+                if alias in libs:
+                    raise ConanException(f"Alias '{alias}' already defined as a target in "
+                                         f"{self._conanfile}. ")
+
         f = self._cmakedeps.get_cmake_filename(self._conanfile)
         prefixes = [f] + prefixes
         include_dirs = definitions = libraries = None

--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -123,8 +123,15 @@ class TargetConfigurationTemplate2:
         prefixes = self._cmakedeps.get_property("cmake_additional_variables_prefixes",
                                                 self._conanfile, check_type=list) or []
         seen_aliases = set()
+        root_target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile)
+        root_target_name = root_target_name or f"{pkg_name}::{pkg_name}"
         for lib in libs.values():
             for alias in lib.get("cmake_target_aliases", []):
+                if alias == root_target_name:
+                    raise ConanException(f"Can't define an alias '{alias}' for the "
+                                         f"root target '{root_target_name}' in {self._conanfile}. "
+                                         f"Changing the default target should be done with the "
+                                         f"'cmake_target_name' property.")
                 if alias in seen_aliases:
                     raise ConanException(f"Alias '{alias}' already defined in {self._conanfile}. ")
                 seen_aliases.add(alias)
@@ -254,15 +261,14 @@ class TargetConfigurationTemplate2:
 
     def _add_root_lib_target(self, libs, pkg_name, cpp_info):
         """
-        Addd a new pkgname::pkgname INTERFACE target that depends on default_components or
+        Add a new pkgname::pkgname INTERFACE target that depends on default_components or
         on all other library targets (not exes)
-        It will not be added if there exists already a pkgname::pkgname target.
+        It will not be added if there exists already a pkgname::pkgname target (Or an alias exists).
         """
         root_target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile)
         root_target_name = root_target_name or f"{pkg_name}::{pkg_name}"
         # TODO: What if an exe target is called like the pkg_name::pkg_name
         if libs and root_target_name not in libs:
-            # TODO: Should this also be skipped if an alias exists for this name?
             # Add a generic interface target for the package depending on the others
             if cpp_info.default_components is not None:
                 all_requires = {}

--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -164,7 +164,7 @@ class TargetConfigurationTemplate2:
                 target = self._get_cmake_lib(component, cpp_info.components, pkg_folder,
                                              pkg_folder_var)
                 if target is not None:
-                    cmake_target_aliases = self._get_aliases(target_name, name)
+                    cmake_target_aliases = self._get_aliases(name)
                     target["cmake_target_aliases"] = cmake_target_aliases
                     libs[target_name] = target
         else:
@@ -172,7 +172,7 @@ class TargetConfigurationTemplate2:
             target_name = target_name or f"{pkg_name}::{pkg_name}"
             target = self._get_cmake_lib(cpp_info, None, pkg_folder, pkg_folder_var)
             if target is not None:
-                cmake_target_aliases = self._get_aliases(target_name, comp_name=None)
+                cmake_target_aliases = self._get_aliases()
                 target["cmake_target_aliases"] = cmake_target_aliases
                 libs[target_name] = target
         return libs
@@ -237,10 +237,10 @@ class TargetConfigurationTemplate2:
             target["link_languages"] = link_languages
         return target
 
-    def _get_aliases(self, target, comp_name=None):
+    def _get_aliases(self, comp_name=None):
         aliases = self._cmakedeps.get_property("cmake_target_aliases", self._conanfile,
                                                comp_name, check_type=list)
-        return {alias: target for alias in aliases} if aliases else {}
+        return aliases if aliases else []
 
     def _add_root_lib_target(self, libs, pkg_name, cpp_info):
         """
@@ -264,7 +264,7 @@ class TargetConfigurationTemplate2:
             else:
                 all_requires = {k: True for k in libs.keys()}
             # This target might have an alias, so we need to check it
-            cmake_target_aliases = self._get_aliases(root_target_name, comp_name=None)
+            cmake_target_aliases = self._get_aliases()
             libs[root_target_name] = {"type": "INTERFACE",
                                       "requires": all_requires,
                                       "cmake_target_aliases": cmake_target_aliases}
@@ -346,7 +346,7 @@ class TargetConfigurationTemplate2:
             message(STATUS "Conan: Target declared imported {{lib_info["type"]}} library '{{lib}}'")
             add_library({{lib}} {{lib_info["type"]}} IMPORTED)
         endif()
-        {% for alias, target in lib_info.get("cmake_target_aliases", {}).items() %}
+        {% for alias in lib_info.get("cmake_target_aliases", []) %}
         if(NOT TARGET {{alias}})
             message(STATUS "Conan: Target declared alias '{{alias}}' for '{{lib}}'")
             add_library({{alias}} ALIAS {{lib}})

--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -240,7 +240,7 @@ class TargetConfigurationTemplate2:
     def _get_aliases(self, target, comp_name=None):
         aliases = self._cmakedeps.get_property("cmake_target_aliases", self._conanfile,
                                                comp_name, check_type=list)
-        return {alias: target for alias in aliases}
+        return {alias: target for alias in aliases} if aliases else {}
 
     def _add_root_lib_target(self, libs, pkg_name, cpp_info):
         """
@@ -252,6 +252,7 @@ class TargetConfigurationTemplate2:
         root_target_name = root_target_name or f"{pkg_name}::{pkg_name}"
         # TODO: What if an exe target is called like the pkg_name::pkg_name
         if libs and root_target_name not in libs:
+            # TODO: Should this also be skipped if an alias exists for this name?
             # Add a generic interface target for the package depending on the others
             if cpp_info.default_components is not None:
                 all_requires = {}
@@ -262,8 +263,11 @@ class TargetConfigurationTemplate2:
                     all_requires[comp_name] = True  # It is an interface, full link
             else:
                 all_requires = {k: True for k in libs.keys()}
+            # This target might have an alias, so we need to check it
+            cmake_target_aliases = self._get_aliases(root_target_name, comp_name=None)
             libs[root_target_name] = {"type": "INTERFACE",
-                                      "requires": all_requires}
+                                      "requires": all_requires,
+                                      "cmake_target_aliases": cmake_target_aliases}
 
     def _get_exes(self, cpp_info, pkg_name, pkg_folder, pkg_folder_var):
         exes = {}

--- a/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_aliases.py
+++ b/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_aliases.py
@@ -254,3 +254,40 @@ def test_collide_component_alias_to_alias():
     client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}", assert_error=True)
 
     assert "Alias 'hello::foo' already defined in hello/1.0" in client.out
+
+
+@pytest.mark.tool("cmake", "3.27")
+@pytest.mark.parametrize("root_target", ["hello::custom", None])
+def test_skip_global_if_aliased(root_target):
+    target_line = f'self.cpp_info.set_property("cmake_target_name", "{root_target}")' if root_target else ""
+    target_name = root_target or "hello::hello"
+    conanfile = textwrap.dedent(f"""
+    from conan import ConanFile
+
+    class Hello(ConanFile):
+        name = "hello"
+        version = "1.0"
+        settings = "os", "compiler", "build_type", "arch"
+
+        def package_info(self):
+            {target_line}
+            self.cpp_info.components["foo"].set_property("cmake_target_aliases", ["{target_name}"])
+    """)
+
+    cmakelists = textwrap.dedent("""
+    cmake_minimum_required(VERSION 3.15)
+    project(test NONE)
+
+    find_package(hello REQUIRED)
+    get_target_property(_aliased_target hello::hello ALIASED_TARGET)
+    message("hello::hello aliased target: ${_aliased_target}")
+    """)
+
+    client = TestClient()
+    client.save({"conanfile.py": conanfile})
+    client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
+
+    client.save({"conanfile.py": consumer, "CMakeLists.txt": cmakelists})
+    client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}", assert_error=True)
+
+    assert f"Can't define an alias '{target_name}' for the root target '{target_name}' in hello/1.0" in client.out

--- a/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_aliases.py
+++ b/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_aliases.py
@@ -93,6 +93,41 @@ def test_component_alias():
 
 
 @pytest.mark.tool("cmake")
+def test_global_and_component_alias():
+    conanfile = textwrap.dedent("""
+    from conan import ConanFile
+
+    class Hello(ConanFile):
+        name = "hello"
+        version = "1.0"
+        settings = "os", "compiler", "build_type", "arch"
+
+        def package_info(self):
+            self.cpp_info.set_property("cmake_target_aliases", ["hola::hola"])
+            self.cpp_info.components["buy"].set_property("cmake_target_aliases",
+                ["hola::adios"])
+    """)
+
+    cmakelists = textwrap.dedent("""
+    cmake_minimum_required(VERSION 3.15)
+    project(test NONE)
+
+    find_package(hello REQUIRED)
+    get_target_property(_aliased_target hola::hola ALIASED_TARGET)
+    message("hola::hola aliased target: ${_aliased_target}")
+    """)
+
+    client = TestClient()
+    client.save({"conanfile.py": conanfile})
+    client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
+
+    client.save({"conanfile.py": consumer, "CMakeLists.txt": cmakelists})
+    client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
+
+    assert "hola::hola aliased target: hello::hello" in client.out
+
+
+@pytest.mark.tool("cmake")
 def test_custom_name():
     conanfile = textwrap.dedent("""
     from conan import ConanFile

--- a/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_aliases.py
+++ b/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_aliases.py
@@ -163,10 +163,6 @@ def test_custom_name():
 
 @pytest.mark.tool("cmake", "3.27")
 def test_collide_global_alias():
-    """
-    FIXME: right now, having multiple aliases with same name doesn't emit any warning/error.
-    Possible alias collisions should be checked in CMakeDeps generator
-    """
     conanfile = textwrap.dedent("""
     from conan import ConanFile
 
@@ -192,17 +188,13 @@ def test_collide_global_alias():
     client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
 
     client.save({"conanfile.py": consumer, "CMakeLists.txt": cmakelists})
-    client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
+    client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}", assert_error=True)
 
-    # assert "Target name 'hello::hello' already exists." in client.out
+    assert f"Alias 'hello::hello' already defined as a target in hello/1.0" in client.out
 
 
 @pytest.mark.tool("cmake", "3.27")
 def test_collide_component_alias():
-    """
-    FIXME: right now, having multiple aliases with same name doesn't emit any warning/error.
-    Possible alias collisions should be checked in CMakeDeps generator
-    """
     conanfile = textwrap.dedent("""
     from conan import ConanFile
 
@@ -227,6 +219,38 @@ def test_collide_component_alias():
     client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
 
     client.save({"conanfile.py": consumer, "CMakeLists.txt": cmakelists})
+    client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}", assert_error=True)
+
+    assert "Alias 'hello::buy' already defined as a target in hello/1.0" in client.out
+
+
+@pytest.mark.tool("cmake", "3.27")
+def test_collide_component_alias_to_alias():
+    conanfile = textwrap.dedent("""
+    from conan import ConanFile
+
+    class Hello(ConanFile):
+        name = "hello"
+        version = "1.0"
+        settings = "os", "compiler", "build_type", "arch"
+
+        def package_info(self):
+            self.cpp_info.components["ola"].set_property("cmake_target_aliases", ["hello::foo"])
+            self.cpp_info.components["buy"].set_property("cmake_target_aliases", ["hello::foo"])
+    """)
+
+    cmakelists = textwrap.dedent("""
+    cmake_minimum_required(VERSION 3.15)
+    project(test NONE)
+
+    find_package(hello REQUIRED)
+    """)
+
+    client = TestClient()
+    client.save({"conanfile.py": conanfile})
     client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
 
-    # assert "Target name 'hello::buy' already exists." in client.out
+    client.save({"conanfile.py": consumer, "CMakeLists.txt": cmakelists})
+    client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}", assert_error=True)
+
+    assert "Alias 'hello::foo' already defined in hello/1.0" in client.out

--- a/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_aliases.py
+++ b/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_aliases.py
@@ -1,0 +1,197 @@
+import textwrap
+import pytest
+
+from conan.test.utils.tools import TestClient
+
+new_value = "will_break_next"
+
+consumer = textwrap.dedent("""
+from conan import ConanFile
+from conan.tools.cmake import CMake
+
+class Consumer(ConanFile):
+    name = "consumer"
+    version = "1.0"
+    settings = "os", "compiler", "build_type", "arch"
+    generators = "CMakeDeps", "CMakeToolchain"
+    exports_sources = ["CMakeLists.txt"]
+    requires = "hello/1.0"
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+""")
+
+
+@pytest.mark.tool("cmake")
+def test_global_alias():
+    conanfile = textwrap.dedent("""
+    from conan import ConanFile
+
+    class Hello(ConanFile):
+        name = "hello"
+        version = "1.0"
+        settings = "os", "compiler", "build_type", "arch"
+
+        def package_info(self):
+            # the default global target is "hello::hello"
+            self.cpp_info.set_property("cmake_target_aliases", ["hello"])
+    """)
+
+    cmakelists = textwrap.dedent("""
+    cmake_minimum_required(VERSION 3.15)
+    project(test NONE)
+
+    find_package(hello REQUIRED)
+    get_target_property(_aliased_target hello ALIASED_TARGET)
+    message("hello aliased target: ${_aliased_target}")
+    """)
+
+    client = TestClient()
+    client.save({"conanfile.py": conanfile})
+    client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
+
+    client.save({"conanfile.py": consumer, "CMakeLists.txt": cmakelists})
+    client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
+
+    assert "hello aliased target: hello::hello" in client.out
+
+
+@pytest.mark.tool("cmake")
+def test_component_alias():
+    conanfile = textwrap.dedent("""
+    from conan import ConanFile
+
+    class Hello(ConanFile):
+        name = "hello"
+        version = "1.0"
+        settings = "os", "compiler", "build_type", "arch"
+
+        def package_info(self):
+            self.cpp_info.components["buy"].set_property("cmake_target_aliases",
+                ["hola::adios"])
+    """)
+
+    cmakelists = textwrap.dedent("""
+    cmake_minimum_required(VERSION 3.15)
+    project(test NONE)
+
+    find_package(hello REQUIRED)
+    get_target_property(_aliased_target hola::adios ALIASED_TARGET)
+    message("hola::adios aliased target: ${_aliased_target}")
+    """)
+
+    client = TestClient()
+    client.save({"conanfile.py": conanfile})
+    client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
+
+    client.save({"conanfile.py": consumer, "CMakeLists.txt": cmakelists})
+    client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
+
+    assert "hola::adios aliased target: hello::buy" in client.out
+
+
+@pytest.mark.tool("cmake")
+def test_custom_name():
+    conanfile = textwrap.dedent("""
+    from conan import ConanFile
+
+    class Hello(ConanFile):
+        name = "hello"
+        version = "1.0"
+        settings = "os", "compiler", "build_type", "arch"
+
+        def package_info(self):
+            self.cpp_info.set_property("cmake_target_name", "ola::comprar")
+            self.cpp_info.set_property("cmake_target_aliases", ["hello"])
+    """)
+
+    cmakelists = textwrap.dedent("""
+    cmake_minimum_required(VERSION 3.15)
+    project(test NONE)
+
+    find_package(hello REQUIRED)
+    get_target_property(_aliased_target hello ALIASED_TARGET)
+    message("hello aliased target: ${_aliased_target}")
+    """)
+
+    client = TestClient()
+    client.save({"conanfile.py": conanfile})
+    client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
+
+    client.save({"conanfile.py": consumer, "CMakeLists.txt": cmakelists})
+    client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
+
+    assert "hello aliased target: ola::comprar" in client.out
+
+
+@pytest.mark.tool("cmake")
+def test_collide_global_alias():
+    """
+    FIXME: right now, having multiple aliases with same name doesn't emit any warning/error.
+    Possible alias collisions should be checked in CMakeDeps generator
+    """
+    conanfile = textwrap.dedent("""
+    from conan import ConanFile
+
+    class Hello(ConanFile):
+        name = "hello"
+        version = "1.0"
+        settings = "os", "compiler", "build_type", "arch"
+
+        def package_info(self):
+            # the default global target is "hello::hello"
+            self.cpp_info.set_property("cmake_target_aliases", ["hello::hello"])
+    """)
+
+    cmakelists = textwrap.dedent("""
+    cmake_minimum_required(VERSION 3.15)
+    project(test NONE)
+
+    find_package(hello REQUIRED)
+    """)
+
+    client = TestClient()
+    client.save({"conanfile.py": conanfile})
+    client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
+
+    client.save({"conanfile.py": consumer, "CMakeLists.txt": cmakelists})
+    client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
+
+    # assert "Target name 'hello::hello' already exists." in client.out
+
+
+@pytest.mark.tool("cmake")
+def test_collide_component_alias():
+    """
+    FIXME: right now, having multiple aliases with same name doesn't emit any warning/error.
+    Possible alias collisions should be checked in CMakeDeps generator
+    """
+    conanfile = textwrap.dedent("""
+    from conan import ConanFile
+
+    class Hello(ConanFile):
+        name = "hello"
+        version = "1.0"
+        settings = "os", "compiler", "build_type", "arch"
+
+        def package_info(self):
+            self.cpp_info.components["buy"].set_property("cmake_target_aliases", ["hello::buy"])
+    """)
+
+    cmakelists = textwrap.dedent("""
+    cmake_minimum_required(VERSION 3.15)
+    project(test NONE)
+
+    find_package(hello REQUIRED)
+    """)
+
+    client = TestClient()
+    client.save({"conanfile.py": conanfile})
+    client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
+
+    client.save({"conanfile.py": consumer, "CMakeLists.txt": cmakelists})
+    client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
+
+    # assert "Target name 'hello::buy' already exists." in client.out

--- a/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_aliases.py
+++ b/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_aliases.py
@@ -24,7 +24,7 @@ class Consumer(ConanFile):
 """)
 
 
-@pytest.mark.tool("cmake", "2.27")
+@pytest.mark.tool("cmake", "3.27")
 def test_global_alias():
     conanfile = textwrap.dedent("""
     from conan import ConanFile
@@ -58,7 +58,7 @@ def test_global_alias():
     assert "hello aliased target: hello::hello" in client.out
 
 
-@pytest.mark.tool("cmake", "2.27")
+@pytest.mark.tool("cmake", "3.27")
 def test_component_alias():
     conanfile = textwrap.dedent("""
     from conan import ConanFile
@@ -92,7 +92,7 @@ def test_component_alias():
     assert "hola::adios aliased target: hello::buy" in client.out
 
 
-@pytest.mark.tool("cmake", "2.27")
+@pytest.mark.tool("cmake", "3.27")
 def test_global_and_component_alias():
     conanfile = textwrap.dedent("""
     from conan import ConanFile
@@ -127,7 +127,7 @@ def test_global_and_component_alias():
     assert "hola::hola aliased target: hello::hello" in client.out
 
 
-@pytest.mark.tool("cmake", "2.27")
+@pytest.mark.tool("cmake", "3.27")
 def test_custom_name():
     conanfile = textwrap.dedent("""
     from conan import ConanFile
@@ -161,7 +161,7 @@ def test_custom_name():
     assert "hello aliased target: ola::comprar" in client.out
 
 
-@pytest.mark.tool("cmake", "2.27")
+@pytest.mark.tool("cmake", "3.27")
 def test_collide_global_alias():
     """
     FIXME: right now, having multiple aliases with same name doesn't emit any warning/error.
@@ -197,7 +197,7 @@ def test_collide_global_alias():
     # assert "Target name 'hello::hello' already exists." in client.out
 
 
-@pytest.mark.tool("cmake", "2.27")
+@pytest.mark.tool("cmake", "3.27")
 def test_collide_component_alias():
     """
     FIXME: right now, having multiple aliases with same name doesn't emit any warning/error.

--- a/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_aliases.py
+++ b/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_aliases.py
@@ -162,38 +162,6 @@ def test_custom_name():
 
 
 @pytest.mark.tool("cmake", "3.27")
-def test_collide_global_alias():
-    conanfile = textwrap.dedent("""
-    from conan import ConanFile
-
-    class Hello(ConanFile):
-        name = "hello"
-        version = "1.0"
-        settings = "os", "compiler", "build_type", "arch"
-
-        def package_info(self):
-            # the default global target is "hello::hello"
-            self.cpp_info.set_property("cmake_target_aliases", ["hello::hello"])
-    """)
-
-    cmakelists = textwrap.dedent("""
-    cmake_minimum_required(VERSION 3.15)
-    project(test NONE)
-
-    find_package(hello REQUIRED)
-    """)
-
-    client = TestClient()
-    client.save({"conanfile.py": conanfile})
-    client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}")
-
-    client.save({"conanfile.py": consumer, "CMakeLists.txt": cmakelists})
-    client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}", assert_error=True)
-
-    assert f"Alias 'hello::hello' already defined as a target in hello/1.0" in client.out
-
-
-@pytest.mark.tool("cmake", "3.27")
 def test_collide_component_alias():
     conanfile = textwrap.dedent("""
     from conan import ConanFile

--- a/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_aliases.py
+++ b/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_aliases.py
@@ -24,7 +24,7 @@ class Consumer(ConanFile):
 """)
 
 
-@pytest.mark.tool("cmake")
+@pytest.mark.tool("cmake", "2.27")
 def test_global_alias():
     conanfile = textwrap.dedent("""
     from conan import ConanFile
@@ -58,7 +58,7 @@ def test_global_alias():
     assert "hello aliased target: hello::hello" in client.out
 
 
-@pytest.mark.tool("cmake")
+@pytest.mark.tool("cmake", "2.27")
 def test_component_alias():
     conanfile = textwrap.dedent("""
     from conan import ConanFile
@@ -92,7 +92,7 @@ def test_component_alias():
     assert "hola::adios aliased target: hello::buy" in client.out
 
 
-@pytest.mark.tool("cmake")
+@pytest.mark.tool("cmake", "2.27")
 def test_global_and_component_alias():
     conanfile = textwrap.dedent("""
     from conan import ConanFile
@@ -127,7 +127,7 @@ def test_global_and_component_alias():
     assert "hola::hola aliased target: hello::hello" in client.out
 
 
-@pytest.mark.tool("cmake")
+@pytest.mark.tool("cmake", "2.27")
 def test_custom_name():
     conanfile = textwrap.dedent("""
     from conan import ConanFile
@@ -161,7 +161,7 @@ def test_custom_name():
     assert "hello aliased target: ola::comprar" in client.out
 
 
-@pytest.mark.tool("cmake")
+@pytest.mark.tool("cmake", "2.27")
 def test_collide_global_alias():
     """
     FIXME: right now, having multiple aliases with same name doesn't emit any warning/error.
@@ -197,7 +197,7 @@ def test_collide_global_alias():
     # assert "Target name 'hello::hello' already exists." in client.out
 
 
-@pytest.mark.tool("cmake")
+@pytest.mark.tool("cmake", "2.27")
 def test_collide_component_alias():
     """
     FIXME: right now, having multiple aliases with same name doesn't emit any warning/error.


### PR DESCRIPTION
Changelog: Feature: Add `cmake_target_aliases` support for `CMakeConfigDeps`.
Docs: Omit


Closes https://github.com/conan-io/conan/issues/18659, but a few questions remain open that need to be discussed before merging can be performed