### PR TITLE
[Mesontoolchain] Changed some private attributes as public ones

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -1,5 +1,6 @@
 import os
 import textwrap
+from email.policy import default
 
 from jinja2 import Template, StrictUndefined
 
@@ -150,7 +151,8 @@ class MesonToolchain:
     def __init__(self, conanfile, backend=None, native=False):
         """
         :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
-        :param backend: ``str`` ``backend`` Meson variable value. By default, ``ninja``.
+        :param backend: (**DEPRECATED**, use ``self.backend`` instead) ``str`` ``backend`` Meson variable
+                        value. By default, ``ninja``.
         :param native: ``bool`` Indicates whether you want Conan to create the
                        ``conan_meson_native.ini`` in a cross-building context. Notice that it only
                        makes sense if your project's ``meson.build`` uses the ``native=true``
@@ -169,8 +171,7 @@ class MesonToolchain:
         # only converted to Meson file syntax for rendering
         # priority: first user conf, then recipe, last one is default "ninja"
         #: Backend to use. Defined by the conf ``tools.meson.mesontoolchain:backend``. By default, ``ninja``.
-        self.backend = self._conanfile_conf.get("tools.meson.mesontoolchain:backend",
-                                                default=backend or 'ninja')
+        self.backend = backend or 'ninja'
         build_type = self._conanfile.settings.get_safe("build_type")
         #: Build type to use.
         self.buildtype = {"Debug": "debug",  # Note, it is not "'debug'"
@@ -545,7 +546,8 @@ class MesonToolchain:
             # https://mesonbuild.com/Builtin-options.html#core-options
             "buildtype": self.buildtype,
             "default_library": self.default_library,
-            "backend": self.backend,
+            "backend": self._conanfile_conf.get("tools.meson.mesontoolchain:backend",
+                                                default=self.backend),
             # https://mesonbuild.com/Builtin-options.html#base-options
             "b_vscrt": self.b_vscrt,
             "b_staticpic": to_meson_value(self.b_staticpic),  # boolean

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -168,22 +168,27 @@ class MesonToolchain:
         # Values are kept as Python built-ins so users can modify them more easily, and they are
         # only converted to Meson file syntax for rendering
         # priority: first user conf, then recipe, last one is default "ninja"
-        self._backend = self._conanfile_conf.get("tools.meson.mesontoolchain:backend",
-                                                 default=backend or 'ninja')
+        #: Backend to use. Defined by the conf ``tools.meson.mesontoolchain:backend``. By default, ``ninja``.
+        self.backend = self._conanfile_conf.get("tools.meson.mesontoolchain:backend",
+                                                default=backend or 'ninja')
         build_type = self._conanfile.settings.get_safe("build_type")
-        self._buildtype = {"Debug": "debug",  # Note, it is not "'debug'"
+        #: Build type to use.
+        self.buildtype = {"Debug": "debug",  # Note, it is not "'debug'"
                            "Release": "release",
                            "MinSizeRel": "minsize",
                            "RelWithDebInfo": "debugoptimized"}.get(build_type, build_type)
-        self._b_ndebug = "true" if self._buildtype != "debug" else "false"
+        #: Disable asserts.
+        self.b_ndebug = "true" if self.buildtype != "debug" else "false"
 
         # https://mesonbuild.com/Builtin-options.html#base-options
         fpic = self._conanfile.options.get_safe("fPIC")
         shared = self._conanfile.options.get_safe("shared")
-        self._b_staticpic = fpic if (shared is False and fpic is not None) else None
+        #: Build static libraries as position independent. By default, ``self.options.get_safe("fPIC")``
+        self.b_staticpic = fpic if (shared is False and fpic is not None) else None
         # https://mesonbuild.com/Builtin-options.html#core-options
         # Do not adjust "debug" if already adjusted "buildtype"
-        self._default_library = ("shared" if shared else "static") if shared is not None else None
+        #: Default library type, e.g., "shared.
+        self.default_library = ("shared" if shared else "static") if shared is not None else None
 
         compiler = self._conanfile.settings.get_safe("compiler")
         if compiler is None:
@@ -193,16 +198,17 @@ class MesonToolchain:
             raise ConanException("MesonToolchain needs 'settings.compiler.version', but it is not defined")
 
         cppstd = self._conanfile.settings.get_safe("compiler.cppstd")
-        self._cpp_std = to_cppstd_flag(compiler, compiler_version, cppstd)
-
         cstd = self._conanfile.settings.get_safe("compiler.cstd")
-        self._c_std = to_cstd_flag(cstd)
-
-        self._b_vscrt = None
+        #: C++ language standard to use. Defined by ``to_cppstd_flag()`` by default.
+        self.cpp_std = to_cppstd_flag(compiler, compiler_version, cppstd)
+        #: C language standard to use. Defined by ``to_cstd_flag()`` by default.
+        self.c_std = to_cstd_flag(cstd)
+        #: VS runtime library to use. Defined by ``msvc_runtime_flag()`` by default.
+        self.b_vscrt = None
         if compiler in ("msvc", "clang"):
             vscrt = msvc_runtime_flag(self._conanfile)
             if vscrt:
-                self._b_vscrt = str(vscrt).lower()
+                self.b_vscrt = str(vscrt).lower()
 
         # Extra flags
         #: List of extra ``CXX`` flags. Added to ``cpp_args``
@@ -537,16 +543,16 @@ class MesonToolchain:
             "windres": self.windres,
             "pkgconfig": self.pkgconfig,
             # https://mesonbuild.com/Builtin-options.html#core-options
-            "buildtype": self._buildtype,
-            "default_library": self._default_library,
-            "backend": self._backend,
+            "buildtype": self.buildtype,
+            "default_library": self.default_library,
+            "backend": self.backend,
             # https://mesonbuild.com/Builtin-options.html#base-options
-            "b_vscrt": self._b_vscrt,
-            "b_staticpic": to_meson_value(self._b_staticpic),  # boolean
-            "b_ndebug": to_meson_value(self._b_ndebug),  # boolean as string
+            "b_vscrt": self.b_vscrt,
+            "b_staticpic": to_meson_value(self.b_staticpic),  # boolean
+            "b_ndebug": to_meson_value(self.b_ndebug),  # boolean as string
             # https://mesonbuild.com/Builtin-options.html#compiler-options
-            "cpp_std": self._cpp_std,
-            "c_std": self._c_std,
+            "cpp_std": self.cpp_std,
+            "c_std": self.c_std,
             "c_args": to_meson_value(self._filter_list_empty_fields(self.c_args)),
             "c_link_args": to_meson_value(self._filter_list_empty_fields(self.c_link_args)),
             "cpp_args": to_meson_value(self._filter_list_empty_fields(self.cpp_args)),


### PR DESCRIPTION
Changelog: Feature: Changed some private attributes in MesonToolchain as public ones, e.g., `b_ndebug`,  `b_staticpic`.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/18591