### PR TITLE
Premake: Only fetch direct_build as the rest of generators

### DIFF
--- a/conan/tools/premake/premakedeps.py
+++ b/conan/tools/premake/premakedeps.py
@@ -210,7 +210,7 @@ class PremakeDeps:
         # as they will have been removed
         host_req = self._conanfile.dependencies.host.topological_sort
         test_req = self._conanfile.dependencies.test.topological_sort
-        build_req = self._conanfile.dependencies.build.topological_sort
+        build_req = self._conanfile.dependencies.direct_build.topological_sort
 
         # Merge into one list
         full_req = list(host_req.items()) + list(test_req.items()) + list(build_req.items())


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Was looking in CMakeConfigDeps for https://github.com/conan-io/conan/issues/18673, and saw that we missed this in the review of the initial fix in https://github.com/conan-io/conan/pull/18631