### PR TITLE
Update macOS Github Actions runner to 15

### DIFF
--- a/.github/workflows/osx-tests.yml
+++ b/.github/workflows/osx-tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   osx_setup:
-    runs-on: macos-14
+    runs-on: macos-15
     name: Setup and Cache Dependencies
     steps:
       - name: Checkout code
@@ -115,7 +115,7 @@ jobs:
 
   osx_tests:
     needs: osx_setup
-    runs-on: macos-14
+    runs-on: macos-15
     strategy:
       fail-fast: true
       matrix:

--- a/conan/test/utils/tools.py
+++ b/conan/test/utils/tools.py
@@ -74,7 +74,7 @@ default_profiles = {
         os=Macos
         arch={arch_setting}
         compiler=apple-clang
-        compiler.version=17
+        compiler.version=16
         compiler.libcxx=libc++
         build_type=Release
         """)

--- a/conan/test/utils/tools.py
+++ b/conan/test/utils/tools.py
@@ -74,7 +74,7 @@ default_profiles = {
         os=Macos
         arch={arch_setting}
         compiler=apple-clang
-        compiler.version=15
+        compiler.version=17
         compiler.libcxx=libc++
         build_type=Release
         """)

--- a/test/functional/toolchains/apple/test_xcodetoolchain.py
+++ b/test/functional/toolchains/apple/test_xcodetoolchain.py
@@ -80,7 +80,7 @@ def test_project_xcodetoolchain(cppstd, cppstd_output, min_version):
 
     client.run_command("xcodegen generate")
 
-    sdk_version = "14.5"
+    sdk_version = "15.0"
     settings = "-s arch=x86_64 -s os.sdk_version={} -s compiler.cppstd={} " \
                "-s compiler.libcxx=libc++ -s os.version={} " \
                "-c tools.build.cross_building:can_run=True " \

--- a/test/functional/toolchains/gnu/autotools/test_apple_toolchain.py
+++ b/test/functional/toolchains/gnu/autotools/test_apple_toolchain.py
@@ -97,7 +97,7 @@ def test_catalyst(arch):
         os.subsystem.ios_version = 16.1
         arch = {arch}
         [buildenv]
-        DEVELOPER_DIR=/Applications/Xcode_15.4.app/Contents/Developer
+        DEVELOPER_DIR=/Applications/Xcode_16.0.app/Contents/Developer
         """).format(arch=arch)
 
     t = TestClient()

--- a/test/functional/toolchains/meson/_base.py
+++ b/test/functional/toolchains/meson/_base.py
@@ -23,7 +23,7 @@ class TestMesonBase(unittest.TestCase):
         if platform.system() == "Darwin":
             self.assertIn(f"main {arch_macro['gcc'][host_arch]} defined", self.t.out)
             self.assertIn("main __apple_build_version__", self.t.out)
-            self.assertIn("main __clang_major__15", self.t.out)
+            self.assertIn("main __clang_major__17", self.t.out)
             # TODO: check why __clang_minor__ seems to be not defined in XCode 12
             # commented while migrating to XCode12 CI
             # self.assertIn("main __clang_minor__0", self.t.out)

--- a/test/functional/toolchains/meson/_base.py
+++ b/test/functional/toolchains/meson/_base.py
@@ -23,7 +23,7 @@ class TestMesonBase(unittest.TestCase):
         if platform.system() == "Darwin":
             self.assertIn(f"main {arch_macro['gcc'][host_arch]} defined", self.t.out)
             self.assertIn("main __apple_build_version__", self.t.out)
-            self.assertIn("main __clang_major__17", self.t.out)
+            self.assertIn("main __clang_major__16", self.t.out)
             # TODO: check why __clang_minor__ seems to be not defined in XCode 12
             # commented while migrating to XCode12 CI
             # self.assertIn("main __clang_minor__0", self.t.out)


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

The ci is failing since this changes in xcodegen that is the tool that we are using to generate the Xcode projects in testing: https://github.com/yonaskolb/XcodeGen/pull/1563/files because it generates Xcode 16 projects that are not backward compatible with Xcode 15.

The errors were [like the ones in this PR](https://github.com/conan-io/conan/actions/runs/16590769922/job/46925750793?pr=18702):

```
2025-07-29 08:32:49.894 xcodebuild[12868:49330] Writing error result bundle to /var/folders/y6/nj790rtn62lfktb1sh__79hc0000gn/T/ResultBundle_2025-29-07_08-32-0049.xcresult
xcodebuild: error: Unable to read project 'app.xcodeproj'.
	Reason: The project ‘app’ cannot be opened because it is in a future Xcode project file format (77). Adjust the project format using a compatible version of Xcode to allow it to be opened by this version of Xcode.
```

