### PR TITLE
hotfix: remove definition of CMAKE_TRY_COMPILE_CONFIGURATION for legacy code

### DIFF
--- a/conan/__init__.py
+++ b/conan/__init__.py
@@ -2,5 +2,5 @@ from conan.internal.model.conan_file import ConanFile
 from conan.internal.model.workspace import Workspace
 from conan.internal.model.version import Version
 
-__version__ = '2.19.0'
+__version__ = '2.19.1'
 conan_version = Version(__version__)

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -882,7 +882,6 @@ class CMakeFlagsInitBlock(Block):
 class TryCompileBlock(Block):
     template = textwrap.dedent("""\
         # Blocks after this one will not be added when running CMake try/checks
-
         {% if config %}
         if(NOT DEFINED CMAKE_TRY_COMPILE_CONFIGURATION)  # to allow user command line override
             set(CMAKE_TRY_COMPILE_CONFIGURATION {{config}})
@@ -897,8 +896,13 @@ class TryCompileBlock(Block):
 
     def context(self):
         # Only for well known CMake configurations, but not for custom ones
-        bt = self._conanfile.settings.get_safe("build_type")
-        config = bt if bt in ["Debug", "Release", "RelWithDebInfo", "MinSizeRel"] else None
+        # Revert of https://github.com/conan-io/conan/pull/18559, even if it was correct, there are
+        # legacy code using check_function_exists that breaks in CMake with MSVC, see
+        # https://github.com/conan-io/conan/issues/18689
+        # TODO: Resume this effort when other try_compile things are sorted out
+        # bt = self._conanfile.settings.get_safe("build_type")
+        # config = bt if bt in ["Debug", "Release", "RelWithDebInfo", "MinSizeRel"] else None
+        config = None  # Keep it defined but as `None` in case some user already customized it
         return {"config": config}
 
 

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -51,7 +51,8 @@ def test_cross_build():
 
     assert "set(CMAKE_SYSTEM_NAME Linux)" in toolchain
     assert "set(CMAKE_SYSTEM_PROCESSOR aarch64)" in toolchain
-    assert "set(CMAKE_TRY_COMPILE_CONFIGURATION Release)" in toolchain
+    # Revert of https://github.com/conan-io/conan/pull/18559, even if it was correct
+    # assert "set(CMAKE_TRY_COMPILE_CONFIGURATION Release)" in toolchain
 
     client.run("install . --profile:build=windows --profile:host=embedwin")
     toolchain = client.load("conan_toolchain.cmake")
@@ -88,7 +89,8 @@ def test_cross_build_linux_to_macos():
     assert "set(CMAKE_SYSTEM_NAME Darwin)" in toolchain
     assert "set(CMAKE_SYSTEM_VERSION 22)" in toolchain
     assert "set(CMAKE_SYSTEM_PROCESSOR x86_64)" in toolchain
-    assert "set(CMAKE_TRY_COMPILE_CONFIGURATION Release)" in toolchain
+    # Revert of https://github.com/conan-io/conan/pull/18559, even if it was correct
+    # assert "set(CMAKE_TRY_COMPILE_CONFIGURATION Release)" in toolchain
 
 
 def test_cross_build_user_toolchain():
@@ -777,7 +779,7 @@ def test_toolchain_cache_variables():
     assert cache_variables["NUMBER"] == 1
 
     def _format_val(val):
-        return f'"{val}"' if type(val) == str and " " in val else f"{val}"
+        return f'"{val}"' if isinstance(val, str) and " " in val else f"{val}"
 
     for var, value in cache_variables.items():
         assert f"-D{var}={_format_val(value)}" in client.out
@@ -1774,6 +1776,7 @@ def test_cmake_presets_compiler():
     # https://github.com/microsoft/vscode-cmake-tools/blob/a1ceda25ea93fc0060324de15970a8baa69addf6/src/presets/preset.ts#L1095C23-L1095C35
     assert cache_variables["CMAKE_C_COMPILER"] == "cl"
     assert cache_variables["CMAKE_CXX_COMPILER"] == "cl.exe"
+
 
 @pytest.mark.parametrize(
     "threads, flags",


### PR DESCRIPTION
Changelog: Fix: Remove the definition of ``CMAKE_TRY_COMPILE_CONFIGURATION`` in ``CMakeToolchain`` to avoid issues with ``check_function_exists()`` legacy code in MSVC.
Docs: Omit

Close https://github.com/conan-io/conan/issues/18689
Close https://github.com/conan-io/conan/issues/18593
Revert of https://github.com/conan-io/conan/pull/18559