### PR TITLE
raise ConanException if folder creation path is an existing file

### DIFF
--- a/conan/internal/util/files.py
+++ b/conan/internal/util/files.py
@@ -252,6 +252,9 @@ def remove(path):
 def mkdir(path):
     """Recursive mkdir, doesnt fail if already existing"""
     if os.path.exists(path):
+        if os.path.isfile(path):
+            raise ConanException("Cannot create folder: '{}'. "
+                                 "Path already exists and is not a folder.".format(path))
         return
     os.makedirs(path)
 

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -59,6 +59,9 @@ def mkdir(conanfile, path):
     :param path: Path to the folder to be created.
     """
     if os.path.exists(path):
+        if os.path.isfile(path):
+            raise ConanException("Cannot create folder: '{}'. "
+                                 "Path already exists and is not a folder.".format(path))
         return
     os.makedirs(path)
 

--- a/test/unittests/tools/files/test_mkdir.py
+++ b/test/unittests/tools/files/test_mkdir.py
@@ -1,0 +1,21 @@
+import os
+import pytest
+from conan.errors import ConanException
+from conan.test.utils.test_files import temp_folder
+from conan.internal.util.files import save
+from conan.tools.files import mkdir
+
+
+def test_create_folder_with_same_file_name():
+    tmpdir = temp_folder()
+
+    save(os.path.join(tmpdir, "build"), "content")
+    with pytest.raises(ConanException, match="Path already exists and is not a folder"):
+        mkdir(None, os.path.join(tmpdir, "build"))
+
+    mkdir(None, os.path.join(tmpdir, "build_folder"))
+    mkdir(None, os.path.join(tmpdir, "build_folder", "build_folder2"))
+
+    assert os.path.isfile(os.path.join(tmpdir, "build"))
+    assert os.path.isdir(os.path.join(tmpdir, "build_folder"))
+    assert os.path.isdir(os.path.join(tmpdir, "build_folder", "build_folder2"))

--- a/test/unittests/util/files/test_mkdir.py
+++ b/test/unittests/util/files/test_mkdir.py
@@ -1,0 +1,20 @@
+import os
+import pytest
+from conan.errors import ConanException
+from conan.test.utils.test_files import temp_folder
+from conan.internal.util.files import mkdir, save
+
+
+def test_create_folder_with_same_file_name():
+    tmpdir = temp_folder()
+
+    save(os.path.join(tmpdir, "build"), "content")
+    with pytest.raises(ConanException, match="Path already exists and is not a folder"):
+        mkdir(os.path.join(tmpdir, "build"))
+
+    mkdir(os.path.join(tmpdir, "build_folder"))
+    mkdir(os.path.join(tmpdir, "build_folder", "build_folder2"))
+
+    assert os.path.isfile(os.path.join(tmpdir, "build"))
+    assert os.path.isdir(os.path.join(tmpdir, "build_folder"))
+    assert os.path.isdir(os.path.join(tmpdir, "build_folder", "build_folder2"))


### PR DESCRIPTION
Changelog: Fix: Raise an exception when trying to create a directory at a path where a file of the same name already exists.
Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
