### PR TITLE
Add gcc 15.2

### DIFF
--- a/conan/internal/default_settings.py
+++ b/conan/internal/default_settings.py
@@ -113,7 +113,7 @@ compiler:
                     "12", "12.1", "12.2", "12.3", "12.4", "12.5",
                     "13", "13.1", "13.2", "13.3", "13.4",
                     "14", "14.1", "14.2", "14.3",
-                    "15", "15.1"]
+                    "15", "15.1", "15.2"]
         libcxx: [libstdc++, libstdc++11]
         threads: [null, posix, win32, mcf]  # Windows MinGW
         exception: [null, dwarf2, sjlj, seh]  # Windows MinGW


### PR DESCRIPTION
Changelog: Feature: Add support for GCC 15.2.
Docs: Omit

(The docs should now be autogenerated)

To be released Aug 8th https://gcc.gnu.org/pipermail/gcc/2025-August/246457.html