### PR TITLE
Try to upgrade urllib

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.25, <3.0.0
-urllib3>=1.26.6, <2.1
+urllib3>=1.26.6, <2.3
 colorama>=0.4.3, <0.5.0
 PyYAML>=6.0, <7.0
 patch-ng>=1.18.0, <1.19


### PR DESCRIPTION
Versions below 2.2.2 suffer from the security warning CVE-2024-37891 with a NIST rating of medium.
See also #18767 .

Changelog: (Fix): Allow urllib versions with fixed CVE-2024-37891
Docs: https://github.com/conan-io/docs/pull/18768