### PR TITLE
feat: update readme to add info about deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,88 @@ Also, if you plan to contribute, please add some testing for your changes. You c
 tests guidelines section](https://github.com/conan-io/conan/blob/develop2/test/README.md) for
 some advice on how to write tests for Conan.
 
-### Running the tests
+### Dependencies
 
+Before running tests, you'll need to install various development tools that the Conan test suite requires. The tests expect specific versions of these tools to be available.
+
+### Required Tools and Versions
+
+The following tools are required by the test suite. You can install them system-wide or configure custom paths in a `test/conftest_user.py` file:
+
+**Build Tools:**
+
+-   **CMake**: 3.15.7, 3.19.7, 3.23.5, 3.27.9, 4.0.0-rc3 (minimum: 3.15)
+-   **Ninja**: 1.10.2 or later
+-   **Meson**: Any recent version (install via `pip install meson`)
+-   **Bazel**: 6.5.0, 7.4.1, 8.0.0
+
+**Platform-specific Tools:**
+
+-   **macOS**: Xcode, XcodeGen, autotools (autoconf, automake, libtool), make, zlib, emscripten
+-   **Windows**: Visual Studio 2017/2019/2022, pkg-config, MinGW/MSYS2
+-   **Linux**: GCC/Clang, autotools, pkg-config
+
+**Optional Tools** (tests will be skipped if not available):
+
+-   **Emscripten** (emcc): For WebAssembly tests
+-   **Android NDK**: For Android cross-compilation tests
+-   **QBS**: 2.6.0 for QBS build system tests
+-   **Premake**: 5.0.0 for Premake build system tests
+
+### Installation Examples
+
+**macOS (using Homebrew):**
+
+```bash
+# Install basic development tools
+brew install cmake ninja meson autoconf automake libtool make zlib xcodegen emscripten
+
+# Install multiple CMake versions (for comprehensive testing)
+# You may need to install older versions manually or via the test setup scripts
+```
+
+**Ubuntu/Debian:**
+
+```bash
+# Install basic tools
+sudo apt-get update
+sudo apt-get install build-essential cmake ninja-build python3-pip autoconf automake libtool pkg-config
+
+# Install Meson
+pip3 install meson
+
+# Install Bazel (example for latest version)
+# See https://bazel.build/install for platform-specific instructions
+```
+
+**Windows:**
+
+```bash
+# Using Chocolatey
+choco install cmake ninja pkgconfiglite
+
+# Install Visual Studio with C++ workload
+# Install MSYS2 for Unix-like environment
+# See the GitHub Actions workflows for detailed setup examples
+```
+
+### Custom Tool Configuration
+
+If you have tools installed in non-standard locations or want to skip certain tests, create a `test/conftest_user.py` file:
+
+```python
+# Example conftest_user.py
+tools_locations = {
+    'cmake': {
+        "default": "3.19",
+        "3.19": {"path": {"Darwin": "/opt/cmake/3.19/bin"}},
+    },
+    'meson': {"disabled": True},  # Skip meson tests
+    'bazel': {"disabled": True},  # Skip bazel tests
+}
+```
+
+## Running the tests
 
 **Install Python requirements**
 


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix): Added comprehensive Dependencies section to README for test environment setup
Docs: None

Fix #18771

**What was done:**

1. Added a new "Dependencies" section to the README.md that lists all required tools and their specific versions needed to run the Conan test suite
2. Included platform-specific installation examples for macOS, Ubuntu/Debian, and Windows
3. Documented how to configure custom tool paths using test/conftest_user.py
4. Organized tools into categories: Build Tools, Platform-specific Tools, and Optional Tools


**What was used as reference:**

1. Analyzed conftest.py to extract all tool requirements and version specifications
2. Reviewed GitHub Actions workflows osx-tests.yml and win-tests.yml to understand how tools are installed in CI
3. Based the documentation on actual test failure messages that occur when required tools are missing

---

- [X] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
