### PR TITLE
Add `cmake_extra_file_names` property for `CMakeConfigDeps`

### DIFF
--- a/conan/tools/cmake/cmakedeps2/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps2/cmakedeps.py
@@ -70,6 +70,13 @@ class CMakeDeps2:
                 direct_deps.append((require, dep))
             config = ConfigTemplate2(self, dep)
             ret[config.filename] = config.content()
+            extra_file_names = (self.get_property("cmake_extra_file_names", dep, check_type=list)
+                                or [])
+            old = self.get_cmake_filename(dep)
+            for f in extra_file_names:
+                filename = f"{f}-config.cmake" if f == f.lower() else f"{f}Config.cmake"
+                ret[filename] = f'include(CMakeFindDependencyMacro)\n' \
+                                f"find_dependency({old})"
             config_version = ConfigVersionTemplate2(self, dep)
             ret[config_version.filename] = config_version.content()
 
@@ -257,6 +264,10 @@ class _PathGenerator:
             # If CMakeDeps generated, the folder is this one
             # content.append(f'set({pkg_name}_ROOT "{gen_folder}")')
             pkg_paths[pkg_name] = "${CMAKE_CURRENT_LIST_DIR}"
+            extra_file_names = (self._cmakedeps.get_property("cmake_extra_file_names", dep,
+                                                             check_type=list) or [])
+            for f in extra_file_names:
+                pkg_paths[f] = pkg_paths[pkg_name]
 
         # CMAKE_PROGRAM_PATH | CMAKE_LIBRARY_PATH | CMAKE_INCLUDE_PATH
         cmake_program_path = self._get_cmake_paths([(req, dep) for req, dep in all_reqs if req.direct], "bindirs")

--- a/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new.py
+++ b/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new.py
@@ -1572,3 +1572,43 @@ def test_multiple_find_package_subfolder():
     assert "find_package(matrix)" in c.out
     assert "target_link_libraries(... matrix::matrix)" in c.out
     assert "Conan: Target declared imported INTERFACE library 'matrix::matrix'" in c.out
+
+
+@pytest.mark.tool("cmake", "3.27")
+def test_dependendecy_multi_filename():
+    tc = TestClient()
+    find_name = "foo"
+    conanfile = textwrap.dedent(f"""
+    from conan import ConanFile
+
+    class Pkg(ConanFile):
+        name = "pkg"
+        version = "0.1"
+        def package_info(self):
+            self.cpp_info.set_property("cmake_extra_file_names", ["{find_name}", "extra_name2"])
+    """)
+    cml = textwrap.dedent(f"""
+    cmake_minimum_required(VERSION 3.27)
+    project(app)
+    find_package({find_name} CONFIG REQUIRED)
+    if ({find_name}_FOUND)
+        message("Found {find_name}!")
+        if (TARGET {find_name}::{find_name})
+            message("Found target {find_name}::{find_name}!")
+        endif()
+
+        if (TARGET pkg::pkg)
+            message("Found original target pkg::pkg!")
+        endif()
+    endif()
+    """)
+    tc.save({"conanfile.py": conanfile,
+             "CMakeLists.txt": cml})
+    tc.run("create .")
+    tc.run("install --requires=pkg/0.1 -g CMakeDeps -g CMakeToolchain"
+           f" -c tools.cmake.cmakedeps:new={new_value}")
+    preset = "conan-default" if platform.system() == "Windows" else "conan-release"
+    tc.run_command(f"cmake --preset {preset}")
+    assert f"Found {find_name}!" in tc.out
+    assert f"Found target {find_name}::{find_name}!" not in tc.out
+    assert "Found original target pkg::pkg!" in tc.out

--- a/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new.py
+++ b/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new.py
@@ -1577,7 +1577,6 @@ def test_multiple_find_package_subfolder():
 @pytest.mark.tool("cmake", "3.27")
 def test_dependendecy_multi_filename():
     tc = TestClient()
-    find_name = "foo"
     conanfile = textwrap.dedent(f"""
     from conan import ConanFile
 
@@ -1585,16 +1584,19 @@ def test_dependendecy_multi_filename():
         name = "pkg"
         version = "0.1"
         def package_info(self):
-            self.cpp_info.set_property("cmake_extra_file_names", ["{find_name}", "extra_name2"])
+            self.cpp_info.set_property("cmake_extra_file_names", ["foo", "extra_name"])
     """)
     cml = textwrap.dedent(f"""
     cmake_minimum_required(VERSION 3.27)
     project(app)
-    find_package({find_name} CONFIG REQUIRED)
-    if ({find_name}_FOUND)
-        message("Found {find_name}!")
-        if (TARGET {find_name}::{find_name})
-            message("Found target {find_name}::{find_name}!")
+    find_package(foo CONFIG REQUIRED)
+    if (foo_FOUND)
+        message("Found foo!")
+        if (TARGET foo::foo)
+            # This won't ever be found, because the target is pkg::pkg
+            # the default target is constructed from the conanfile name,
+            # not from the final cmake file name
+            message("Found target foo::foo!")
         endif()
 
         if (TARGET pkg::pkg)
@@ -1609,6 +1611,8 @@ def test_dependendecy_multi_filename():
            f" -c tools.cmake.cmakedeps:new={new_value}")
     preset = "conan-default" if platform.system() == "Windows" else "conan-release"
     tc.run_command(f"cmake --preset {preset}")
-    assert f"Found {find_name}!" in tc.out
-    assert f"Found target {find_name}::{find_name}!" not in tc.out
+    assert f"Found foo!" in tc.out
+    assert f"Found target foo::foo!" not in tc.out
     assert "Found original target pkg::pkg!" in tc.out
+    assert "extra_name-config.cmake" in os.listdir(tc.current_folder)
+    assert "set(extra_name_DIR" in tc.load("conan_cmakedeps_paths.cmake")

--- a/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new.py
+++ b/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new.py
@@ -1596,7 +1596,7 @@ def test_dependendecy_multi_filename():
             # This won't ever be found, because the target is pkg::pkg
             # the default target is constructed from the conanfile name,
             # not from the final cmake file name
-            message("Found target foo::foo!")
+            message(FATAL_ERROR "Found target foo::foo!")
         endif()
 
         if (TARGET pkg::pkg)


### PR DESCRIPTION
Changelog: Feature: Add `cmake_extra_file_names` property for `CMakeConfigDeps`.
Docs: TODO

This comes from a discussion from last week with the team that could solve some shortcomings in a few recipes in CCI
