### PR TITLE
fix cmake_layout multi-arch

### DIFF
--- a/conan/tools/cmake/layout.py
+++ b/conan/tools/cmake/layout.py
@@ -8,7 +8,10 @@ from conan.errors import ConanException
 def cmake_layout(conanfile, generator=None, src_folder=".", build_folder="build"):
     """
     :param conanfile: The current recipe object. Always use ``self``.
-    :param generator: Allow defining the CMake generator. In most cases it doesn't need to be passed, as it will get the value from the configuration              ``tools.cmake.cmaketoolchain:generator``, or it will automatically deduce the generator from the ``settings``
+    :param generator: Allow defining the CMake generator. In most cases it doesn't need to be passed,
+                      as it will get the value from the configuration
+                      ``tools.cmake.cmaketoolchain:generator``, or it will automatically deduce
+                      the generator from the ``settings``
     :param src_folder: Value for ``conanfile.folders.source``, change it if your source code
                        (and CMakeLists.txt) is in a subfolder.
     :param build_folder: Specify the name of the "base" build folder. The default is "build", but
@@ -85,6 +88,8 @@ def get_build_folder_custom_vars(conanfile):
         tmp = None
         if group == "settings":
             tmp = conanfile.settings.get_safe(var)
+            if var == "arch":  # handle Apple multi-arch/universal binaries
+                tmp = tmp.replace("|", "_")
         elif group == "options":
             value = conanfile.options.get_safe(var)
             if value is not None:

--- a/conan/tools/cmake/layout.py
+++ b/conan/tools/cmake/layout.py
@@ -88,7 +88,7 @@ def get_build_folder_custom_vars(conanfile):
         tmp = None
         if group == "settings":
             tmp = conanfile.settings.get_safe(var)
-            if var == "arch":  # handle Apple multi-arch/universal binaries
+            if tmp and var == "arch":  # handle Apple multi-arch/universal binaries
                 tmp = tmp.replace("|", "_")
         elif group == "options":
             value = conanfile.options.get_safe(var)

--- a/test/functional/toolchains/cmake/test_universal_binaries.py
+++ b/test/functional/toolchains/cmake/test_universal_binaries.py
@@ -4,7 +4,6 @@ import textwrap
 
 import pytest
 
-from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
 from conan.internal.util.files import rmdir
 
@@ -100,36 +99,6 @@ def test_create_universal_binary():
     client.run_command("lipo -info './build/armv8_armv8.3_x86_64/Release/foo'")
 
     assert "foo are: x86_64 arm64 arm64e" in client.out
-
-
-@pytest.mark.tool("cmake", "3.23")
-def test_create_universal_binary_test_package_folder():
-    # https://github.com/conan-io/conan/issues/18820
-    # While multi-arch is Darwin specific, this was a cmake_layout issue, so it can be
-    # tested in any platform
-    c = TestClient()
-    test_conanfile = textwrap.dedent("""
-        from conan import ConanFile
-        from conan.tools.cmake import cmake_layout
-
-        class mylibraryTestConan(ConanFile):
-            settings = "os", "compiler", "build_type", "arch"
-
-            def requirements(self):
-                self.requires(self.tested_reference_str)
-
-            def layout(self):
-                cmake_layout(self)
-
-            def test(self):
-                pass
-            """)
-    c.save({"conanfile.py": GenConanfile("pkg", "0.1").with_settings("arch"),
-            "test_package/conanfile.py": test_conanfile})
-
-    c.run('create . -s="arch=armv8|x86_64"')
-    c.run("list *:*")
-    assert "arch: armv8|x86_64" in c.out
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")

--- a/test/functional/toolchains/cmake/test_universal_binaries.py
+++ b/test/functional/toolchains/cmake/test_universal_binaries.py
@@ -4,6 +4,7 @@ import textwrap
 
 import pytest
 
+from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
 from conan.internal.util.files import rmdir
 
@@ -101,6 +102,36 @@ def test_create_universal_binary():
     assert "foo are: x86_64 arm64 arm64e" in client.out
 
 
+@pytest.mark.tool("cmake", "3.23")
+def test_create_universal_binary_test_package_folder():
+    # https://github.com/conan-io/conan/issues/18820
+    # While multi-arch is Darwin specific, this was a cmake_layout issue, so it can be
+    # tested in any platform
+    c = TestClient()
+    test_conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.cmake import cmake_layout
+
+        class mylibraryTestConan(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+
+            def requirements(self):
+                self.requires(self.tested_reference_str)
+
+            def layout(self):
+                cmake_layout(self)
+
+            def test(self):
+                pass
+            """)
+    c.save({"conanfile.py": GenConanfile("pkg", "0.1").with_settings("arch"),
+            "test_package/conanfile.py": test_conanfile})
+
+    c.run('create . -s="arch=armv8|x86_64"')
+    c.run("list *:*")
+    assert "arch: armv8|x86_64" in c.out
+
+
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
 @pytest.mark.tool("cmake", "3.23")
 def test_create_universal_binary_ninja():
@@ -129,7 +160,7 @@ def test_create_universal_binary_ninja():
 
     client.save({"conanfile.txt": conanfile,
                  "CMakeLists.txt": cmake},
-                 clean_first=True)
+                clean_first=True)
 
     client.run('install . -s=arch="armv8|x86_64" --build=missing -of=build')
 

--- a/test/functional/toolchains/cmake/test_universal_binaries.py
+++ b/test/functional/toolchains/cmake/test_universal_binaries.py
@@ -95,9 +95,9 @@ def test_create_universal_binary():
     client.run('install . -s="arch=armv8|armv8.3|x86_64" '
                '-c tools.cmake.cmake_layout:build_folder_vars=\'["settings.arch"]\'')
 
-    client.run_command("cmake --preset \"conan-armv8|armv8.3|x86_64-release\" ")
-    client.run_command("cmake --build --preset \"conan-armv8|armv8.3|x86_64-release\" ")
-    client.run_command("lipo -info './build/armv8|armv8.3|x86_64/Release/foo'")
+    client.run_command("cmake --preset \"conan-armv8_armv8.3_x86_64-release\" ")
+    client.run_command("cmake --build --preset \"conan-armv8_armv8.3_x86_64-release\" ")
+    client.run_command("lipo -info './build/armv8_armv8.3_x86_64/Release/foo'")
 
     assert "foo are: x86_64 arm64 arm64e" in client.out
 

--- a/test/integration/toolchains/test_raise_on_universal_binaries.py
+++ b/test/integration/toolchains/test_raise_on_universal_binaries.py
@@ -1,3 +1,5 @@
+import textwrap
+
 from parameterized import parameterized
 
 from conan.test.assets.genconanfile import GenConanfile
@@ -7,9 +9,40 @@ from conan.test.utils.tools import TestClient
 @parameterized.expand(["AutotoolsToolchain", "MesonToolchain", "BazelToolchain"])
 def test_create_universal_binary(toolchain):
     client = TestClient()
-    conanfile = (GenConanfile().with_settings("os", "arch", "compiler", "build_type").with_generator(toolchain))
+    conanfile = (GenConanfile().with_settings("os", "arch", "compiler", "build_type")
+                 .with_generator(toolchain))
     client.save({"conanfile.py": conanfile})
 
     client.run('create . --name=foo --version=1.0 -s="arch=armv8|armv8.3|x86_64"',
                assert_error=True)
-    assert f"Error in generator '{toolchain}': Universal binaries not supported by toolchain." in client.out
+    assert (f"Error in generator '{toolchain}': "
+            f"Universal binaries not supported by toolchain.") in client.out
+
+
+def test_create_universal_binary_test_package_folder():
+    # https://github.com/conan-io/conan/issues/18820
+    # While multi-arch is Darwin specific, this was a cmake_layout issue, so it can be
+    # tested in any platform
+    c = TestClient()
+    test_conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.cmake import cmake_layout
+
+        class mylibraryTestConan(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+
+            def requirements(self):
+                self.requires(self.tested_reference_str)
+
+            def layout(self):
+                cmake_layout(self)
+
+            def test(self):
+                pass
+            """)
+    c.save({"conanfile.py": GenConanfile("pkg", "0.1").with_settings("arch"),
+            "test_package/conanfile.py": test_conanfile})
+
+    c.run('create . -s="arch=armv8|x86_64"')
+    c.run("list *:*")
+    assert "arch: armv8|x86_64" in c.out


### PR DESCRIPTION
Changelog: Fix: The ``cmake_layout`` was not taking into account the Apple multi-arch/universal separator when creating folders named after the ``arch`` setting.
Docs: Omit

Fix https://github.com/conan-io/conan/issues/18820