### PR TITLE
[fix] PackagesList.only_recipes does not return anything

### DIFF
--- a/conan/api/model/list.py
+++ b/conan/api/model/list.py
@@ -225,14 +225,13 @@ class PackagesList:
             result.append(subpkglist)
         return result
 
-    def only_recipes(self) -> dict:
-        """ Filter out all the packages and package revisions, returning only the recipes and
-            recipe revisions.
+    def only_recipes(self) -> None:
+        """ Filter out all the packages and package revisions, keep only the recipes and
+            recipe revisions in self.recipes.
         """
         for ref, ref_dict in self.recipes.items():
             for rrev_dict in ref_dict.get("revisions", {}).values():
                 rrev_dict.pop("packages", None)
-        return self.recipes.copy()
 
     def add_refs(self, refs):
         # RREVS alreday come in ASCENDING order, so upload does older revisions first

--- a/conan/api/model/list.py
+++ b/conan/api/model/list.py
@@ -225,12 +225,14 @@ class PackagesList:
             result.append(subpkglist)
         return result
 
-    def only_recipes(self):
-        result = {}
+    def only_recipes(self) -> dict:
+        """ Filter out all the packages and package revisions, returning only the recipes and
+            recipe revisions.
+        """
         for ref, ref_dict in self.recipes.items():
             for rrev_dict in ref_dict.get("revisions", {}).values():
                 rrev_dict.pop("packages", None)
-        return result
+        return self.recipes.copy()
 
     def add_refs(self, refs):
         # RREVS alreday come in ASCENDING order, so upload does older revisions first

--- a/test/unittests/model/test_list.py
+++ b/test/unittests/model/test_list.py
@@ -1,0 +1,49 @@
+from conan.api.model import PackagesList
+
+
+def test_package_list_only_recipes():
+    pl = PackagesList()
+    pl.recipes = {
+        "foobar/0.1.0": {'revisions':
+                             {'85eb0587a3c12b90216c72070e9eef3e':
+                                  {'timestamp': 1740151190.975,
+                                   'packages': {'c29f32beda3c361f536ba35aae5e876faf970169':
+                                       {'revisions': {
+                                           '9a0569c04839fff6a6e8f40e10434bc6':
+                                               {'timestamp': 1742417567.684486}},
+                                           'info': {}}}}}},
+        "qux/0.2.1": {'revisions':
+                          {'71c3c11b98a6f2ae11f0f391f5e62e2b':
+                               {'timestamp': 1740151186.976, 'packages':
+                                   {'13be611585c95453f1cbbd053cea04b3e64470ca':
+                                        {'revisions': {'5c7e0c0788cd4d89249ad251f0868787':
+                                                           {'timestamp': 1740152032.884}},
+                                         'info':
+                                             {'settings':
+                                                  {'arch': 'x86_64',
+                                                   'build_type': 'Release',
+                                                   'compiler': 'gcc',
+                                                   'compiler.cppstd': '17',
+                                                   'compiler.libcxx': 'libstdc++11',
+                                                   'compiler.version': '11', 'os': 'Linux'},
+                                              'options': {'fPIC': 'True', 'shared': 'False'}}},
+                                    '30652ea35b512fa3fe0f4dcd39ad217e4e60bd01':
+                                        {'revisions': {'8f363f1d95ad766ac400e1f1f5406599':
+                                                           {'timestamp': 1741861639.2198145}},
+                                         'info': {}},
+                                    'fc491156b442836722612d1aa8a8c57e406447b6':
+                                        {'revisions': {'62e9e2659596c97cd1dd313d4394e947':
+                                                           {'timestamp': 1740151900.394}},
+                                         'info': {
+                                             'settings':
+                                                 {'arch': 'x86_64', 'build_type': 'Release',
+                                                  'compiler': 'gcc', 'compiler.cppstd': '17',
+                                                  'compiler.libcxx': 'libstdc++11',
+                                                  'compiler.version': '11', 'os': 'Linux'},
+                                             'options': {'shared': 'True'}}}}}}}
+    }
+    recipes = pl.only_recipes()
+    assert recipes == {'foobar/0.1.0': {
+        'revisions': {'85eb0587a3c12b90216c72070e9eef3e': {'timestamp': 1740151190.975}}},
+                       'qux/0.2.1': {'revisions': {
+                           '71c3c11b98a6f2ae11f0f391f5e62e2b': {'timestamp': 1740151186.976}}}}

--- a/test/unittests/model/test_list.py
+++ b/test/unittests/model/test_list.py
@@ -42,8 +42,8 @@ def test_package_list_only_recipes():
                                                   'compiler.version': '11', 'os': 'Linux'},
                                              'options': {'shared': 'True'}}}}}}}
     }
-    recipes = pl.only_recipes()
-    assert recipes == {'foobar/0.1.0': {
+    pl.only_recipes()
+    assert pl.recipes == {'foobar/0.1.0': {
         'revisions': {'85eb0587a3c12b90216c72070e9eef3e': {'timestamp': 1740151190.975}}},
                        'qux/0.2.1': {'revisions': {
                            '71c3c11b98a6f2ae11f0f391f5e62e2b': {'timestamp': 1740151186.976}}}}


### PR DESCRIPTION
When exploring https://github.com/conan-io/examples2/pull/193, the [PackagesList.only_recipes ](https://github.com/conan-io/conan/blob/develop2/conan/api/model/list.py#L229) method has an empty dict as a result, and it's not filled. 

This PR adds value to be returned when using it.

Still, I'm not sure if it's worth keeping that result returned, because the method changes its own `self.recipes`. Another option would be removing the `result` only. 

Changelog: Omit
Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
