### PR TITLE
skip generation of conanintelsetvars for empty conf

### DIFF
--- a/conan/tools/intel/intel_cc.py
+++ b/conan/tools/intel/intel_cc.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """
     Intel generator module for oneAPI Toolkits.
 
@@ -75,6 +73,10 @@ class IntelCC:
     def generate(self, scope="build"):
         """Generate the Conan Intel file to be loaded in build environment by default"""
         check_duplicated_generator(self, self._conanfile)
+        intel_cc_path = self._conanfile.conf.get("tools.intel:installation_path")
+        if intel_cc_path == "":
+            return
+
         if platform.system() == "Windows" and not self._conanfile.win_bash:
             content = textwrap.dedent("""\
                 @echo off

--- a/test/integration/toolchains/intel/test_intel_cc.py
+++ b/test/integration/toolchains/intel/test_intel_cc.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import textwrap
 
@@ -55,3 +56,16 @@ def test_intel_cc_generator_linux():
     conanintelsetvars = get_intel_cc_generator_file(os_, installation_path, "conanintelsetvars.sh")
     expected = '. "/opt/intel/oneapi/setvars.sh" intel64'
     assert conanintelsetvars == expected
+
+
+def test_avoid_generation():
+    # The empty string for tools.intel:installation_path avoids the generation
+    profile = intelprofile % ("Linux", "")
+    client = TestClient()
+    client.save({
+        "conanfile.txt": conanfile,
+        "intelprofile": profile,
+    })
+    client.run("install . -pr intelprofile")
+    files = os.listdir(client.current_folder)
+    assert "conanintelsetvars" not in ",".join(files)


### PR DESCRIPTION
Changelog: Feature: Avoid the generation of ``conanintelsetvars`` script by ``IntelCC`` if the ``tools.intel:installation_path=""``, similarly to ``VCVars`` generation. The user should have already activated the IntelCC environment on their own before running.
Docs: https://github.com/conan-io/docs/pull/4207

Close https://github.com/conan-io/conan/issues/18837
