### PR TITLE
fixed build-folder creation error message

### DIFF
--- a/conan/internal/methods.py
+++ b/conan/internal/methods.py
@@ -24,6 +24,9 @@ def run_source_method(conanfile, hook_manager):
 
 
 def run_build_method(conanfile, hook_manager):
+    if os.path.isfile(conanfile.build_folder):
+        raise ConanException(f"{conanfile}: Failed to create build folder, there is already a file "
+                             f"named: {conanfile.build_folder}")
     mkdir(conanfile.build_folder)
     mkdir(conanfile.package_metadata_folder)
     with chdir(conanfile.build_folder):


### PR DESCRIPTION
Changelog: Fix: Better error message when there is an existing file called "build" in the same location as the "build" build-folder is expected to be created.
Docs: Omit

Close https://github.com/conan-io/conan/issues/18705
