### PR TITLE
fixing MesonToolchain bool string

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -179,7 +179,7 @@ class MesonToolchain:
                           "MinSizeRel": "minsize",
                           "RelWithDebInfo": "debugoptimized"}.get(build_type, build_type)
         #: Disable asserts.
-        self.b_ndebug = "true" if self.buildtype != "debug" else "false"
+        self.b_ndebug = self.buildtype != "debug"
 
         # https://mesonbuild.com/Builtin-options.html#base-options
         fpic = self._conanfile.options.get_safe("fPIC")
@@ -414,7 +414,6 @@ class MesonToolchain:
         self.apple_isysroot_flag = isysroot_flag.split() if isysroot_flag else []
         self.apple_min_version_flag = [apple_min_version_flag(self._conanfile)]
         # Objective C/C++ ones
-        flags = []
         self.objc = compilers_by_conf.get("objc", "clang")
         self.objcpp = compilers_by_conf.get("objcpp", "clang++")
         enable_arc = self._conanfile.conf.get("tools.apple:enable_arc", check_type=bool)

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -230,7 +230,6 @@ def test_custom_arch_flag_via_toolchain():
     assert re.search(r"cpp_link_args =.+-mmy-flag.+", content)
 
 
-
 def test_linker_scripts_via_conf():
     profile = textwrap.dedent("""
         [settings]
@@ -824,6 +823,7 @@ def test_conf_extra_apple_flags():
     for flags in ["objcpp_args", "objc_args"]:
         assert f"{flags} = ['-fno-objc-arc', '-m64', '-fvisibility=hidden', '-fvisibility-inlines-hidden']" in tc
 
+
 @pytest.mark.parametrize(
     "threads, flags",
     [("posix", "-pthread"), ("wasm_workers", "-sWASM_WORKERS=1")],
@@ -895,7 +895,7 @@ def test_new_public_attributes():
     buildtype = 'Debug'
     default_library = 'shared'
     b_vscrt = 'MD'
-    b_ndebug = 'true'
+    b_ndebug = true
     b_staticpic = true
     cpp_std = 'c++20'
     c_std = 'c20'


### PR DESCRIPTION
Changelog: Fix ``MesonToolchain`` definition of ``b_ndebug`` as string in machine files instead of boolean
Docs: Omit

Close https://github.com/conan-io/conan/issues/18535