### PR TITLE
add clang 21

### DIFF
--- a/conan/internal/default_settings.py
+++ b/conan/internal/default_settings.py
@@ -131,7 +131,7 @@ compiler:
         version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
                   "5.0", "6.0", "7.0", "7.1",
                   "8", "9", "10", "11", "12", "13", "14", "15", "16", "17",
-                  "18", "19", "20"]
+                  "18", "19", "20", "21"]
         libcxx: [null, libstdc++, libstdc++11, libc++, c++_shared, c++_static]
         cppstd: [null, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23, 26, gnu26]
         runtime: [null, static, dynamic]


### PR DESCRIPTION
Changelog: Feature: Adding Clang 21 to the default ``settings.yml``.
Docs: Omit

The c++ default standard doesn't seem to have changed with this release

Close https://github.com/conan-io/conan/issues/18844