### PR TITLE
New check_min_compiler_version validator

### DIFF
--- a/conan/tools/build/__init__.py
+++ b/conan/tools/build/__init__.py
@@ -11,6 +11,7 @@ from conan.tools.build.cstd import check_max_cstd, check_min_cstd, \
 from conan.tools.build.cpu import build_jobs
 from conan.tools.build.cross_building import cross_building, can_run
 from conan.tools.build.stdcpp_library import stdcpp_library
+from conan.tools.build.compiler import check_min_compiler_version
 from conan.errors import ConanException
 
 CONAN_TOOLCHAIN_ARGS_FILE = "conanbuild.conf"

--- a/conan/tools/build/compiler.py
+++ b/conan/tools/build/compiler.py
@@ -12,7 +12,7 @@ def check_min_compiler_version(conanfile, compiler_restrictions):
                                `conanfile.settings.compiler.version`.
     :param compiler_restrictions: A list of tuples, where each tuple contains
                                       (compiler, min_version, reason).
-                                  - compiler (str): The name of the compiler (e.g., "gcc", "Visual Studio").
+                                  - compiler (str): The name of the compiler (e.g., "gcc", "msvc").
                                   - min_version (str): The minimum required version as a string (e.g., "14", "19.0").
                                   - reason (str): A string explaining the reason for the version requirement.
 

--- a/conan/tools/build/compiler.py
+++ b/conan/tools/build/compiler.py
@@ -40,7 +40,8 @@ def check_min_compiler_version(conanfile, compiler_restrictions):
     for compiler, min_version, reason in compiler_restrictions:
         if compiler_value == compiler:
             if Version(compiler_version) < Version(min_version):
+                ref = conanfile.ref if hasattr(conanfile, "ref") else conanfile.name
                 raise ConanInvalidConfiguration(
-                    f"{conanfile.ref if hasattr(conanfile, "ref") else conanfile.name} requires {compiler} >= {min_version}"
+                    f"{ref} requires {compiler} >= {min_version}"
                     f" ({reason}), but {compiler} {compiler_version} was found.")
             break

--- a/conan/tools/build/compiler.py
+++ b/conan/tools/build/compiler.py
@@ -42,6 +42,6 @@ def check_min_compiler_version(conanfile, compiler_restrictions):
             if Version(compiler_version) < Version(min_version):
                 ref = conanfile.ref if hasattr(conanfile, "ref") else conanfile.name
                 raise ConanInvalidConfiguration(
-                    f"{ref} requires {compiler} >= {min_version}"
-                    f" ({reason}), but {compiler} {compiler_version} was found.")
+                    f"{ref} requires {compiler} >= {min_version}, but {compiler} {compiler_version} was found\n"
+                    f"Reason: {reason}")
             break

--- a/conan/tools/build/compiler.py
+++ b/conan/tools/build/compiler.py
@@ -1,0 +1,46 @@
+from conan.errors import ConanInvalidConfiguration, ConanException
+from conan.internal.model.version import Version
+
+
+def check_min_compiler_version(conanfile, compiler_restrictions):
+    """
+    Checks if the current compiler and its version meet the minimum requirements
+    specified in a list of restrictions.
+
+    :param conanfile: The ConanFile object, which provides access to
+                               settings like `conanfile.settings.compiler` and
+                               `conanfile.settings.compiler.version`.
+    :param compiler_restrictions: A list of tuples, where each tuple contains
+                                      (compiler, min_version, reason).
+                                  - compiler (str): The name of the compiler (e.g., "gcc", "Visual Studio").
+                                  - min_version (str): The minimum required version as a string (e.g., "14", "19.0").
+                                  - reason (str): A string explaining the reason for the version requirement.
+
+    Raises:
+        ConanException: If the 'compiler' or 'compiler.version' settings are not
+                        defined in the Conan file's settings.
+        ConanInvalidConfiguration: If the found compiler version is less than the
+                                   specified minimum version for that compiler.
+
+    Example:
+        def validate(self):
+            compiler_restrictions = [
+                ("clang", "14", "requires C++20 coroutines support"),
+                ("gcc", "12", "requires C++20 modules support")
+            ]
+            check_min_compiler_version(self, compiler_restrictions)
+    """
+    compiler_value = conanfile.settings.get_safe("compiler")
+    if not compiler_value:
+        raise ConanException("Called check_min_compiler_version with no compiler defined")
+    compiler_version = conanfile.settings.get_safe("compiler.version")
+    if not compiler_version:
+        raise ConanException("Called check_min_compiler_version with no compiler.version defined")
+
+    for compiler, min_version, reason in compiler_restrictions:
+        if compiler_value == compiler:
+            if Version(compiler_version) < Version(min_version):
+                raise ConanInvalidConfiguration(
+                    f"{conanfile.ref if hasattr(conanfile, "ref") else conanfile.name} requires {compiler} >= {min_version}"
+                    f" ({reason}), but {compiler} {compiler_version} was found.")
+            break

--- a/test/unittests/tools/build/test_compiler.py
+++ b/test/unittests/tools/build/test_compiler.py
@@ -1,0 +1,34 @@
+import pytest
+
+from conan.tools.build import check_min_compiler_version
+from conan.errors import ConanException, ConanInvalidConfiguration
+from conan.test.utils.mocks import MockSettings, ConanFileMock
+
+
+@pytest.mark.parametrize("compiler,compiler_version,restrictions,should_raise", [
+    ("clang", "14", (("clang", "14", "coroutines"), ("gcc", "13", "alignas")), False),
+    ("gcc", "13", (("clang", "14", "coroutines"), ("gcc", "13", "alignas")), False),
+    ("gcc", "14", (("clang", "14", "coroutines"), ("gcc", "13", "alignas")), False),
+    ("Visual Studio", "16", (("Visual Studio", "16", "reason"), ("clang", "14", "coroutines")), False),
+
+    ("clang", "13", (("clang", "14", "coroutines"), ("gcc", "13", "alignas")), True),
+    ("gcc", "12", (("clang", "14", "coroutines"), ("gcc", "13", "alignas")), True),
+    ("Visual Studio", "15", (("Visual Studio", "16", "reason"), ("clang", "14", "coroutines")), True),
+
+    ("emcc", "1.0", (("gcc", "13", "alignas"),), False),
+    (None, "12", (("gcc", "13", "alignas"),), True),
+    ("gcc", None, (("gcc", "13", "alignas"),), True),
+])
+def test_check_min_compiler_version(compiler, compiler_version, restrictions, should_raise):
+    settings = MockSettings({"compiler": compiler, "compiler.version": compiler_version})
+    conanfile = ConanFileMock(settings)
+
+    if should_raise:
+        if compiler is None or compiler_version is None:
+            with pytest.raises(ConanException):
+                check_min_compiler_version(conanfile, restrictions)
+        else:
+            with pytest.raises(ConanInvalidConfiguration):
+                check_min_compiler_version(conanfile, restrictions)
+    else:
+        check_min_compiler_version(conanfile, restrictions)

--- a/test/unittests/tools/build/test_compiler.py
+++ b/test/unittests/tools/build/test_compiler.py
@@ -9,11 +9,11 @@ from conan.test.utils.mocks import MockSettings, ConanFileMock
     ("clang", "14", (("clang", "14", "coroutines"), ("gcc", "13", "alignas")), False),
     ("gcc", "13", (("clang", "14", "coroutines"), ("gcc", "13", "alignas")), False),
     ("gcc", "14", (("clang", "14", "coroutines"), ("gcc", "13", "alignas")), False),
-    ("Visual Studio", "16", (("Visual Studio", "16", "reason"), ("clang", "14", "coroutines")), False),
+    ("msvc", "192", (("msvc", "192", "reason"), ("clang", "14", "coroutines")), False),
 
     ("clang", "13", (("clang", "14", "coroutines"), ("gcc", "13", "alignas")), True),
     ("gcc", "12", (("clang", "14", "coroutines"), ("gcc", "13", "alignas")), True),
-    ("Visual Studio", "15", (("Visual Studio", "16", "reason"), ("clang", "14", "coroutines")), True),
+    ("msvc", "191", (("msvc", "192", "reason"), ("clang", "14", "coroutines")), True),
 
     ("emcc", "1.0", (("gcc", "13", "alignas"),), False),
     (None, "12", (("gcc", "13", "alignas"),), True),


### PR DESCRIPTION
Changelog: Feature: new `check_min_compiler_version` validator which simplify compiler restriction description in recipes.
Docs: https://github.com/conan-io/docs/pull/4209


This new validator function can simplify the task of describing and programming the compiler minimum version required for recipes to be build.

Instead of this old conan v1 style:
```py
    @property
    def _minimum_compilers_version(self):
        return {
            "clang": "14", # Until clang-14 coroutines are not fully supported
            "gcc": "13",   # Until gcc-13 alignas specifier is not supported
        }

    def validate(self):
        minimum_version = self._minimum_compilers_version.get(str(self.settings.compiler), False)
        if minimum_version and Version(self.settings.compiler.version) < minimum_version:
            raise ConanInvalidConfiguration(f"{self.ref} requires C++20, which your compiler does not support.")
```

With this new function, the above code can be written like this:

```py
 def validate(self):
     check_min_compiler_version(self, [("clang", "14", "coroutines support"), ("gcc", "13", "alignas specifier")])
```
This not only simplifies the recipe but give more information (the reason under that version requirement) to the users when their compiler does not fulfill the minimum version.
