### PR TITLE
Restore extract_filter parameter in docstring for conan.tools.files.get()

### DIFF
--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -117,6 +117,7 @@ def get(conanfile, url, md5=None, sha1=None, sha256=None, destination=".", filen
     :param auth:  forwarded to ``tools.file.download()``.
     :param headers:  forwarded to ``tools.file.download()``.
     :param strip_root: forwarded to ``tools.file.unzip()``.
+    :param extract_filter: forwarded to ``tools.file.unzip()``.
     :param excludes: forwarded to ``tools.file.unzip()``.
     """
 


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

I think it was unintentionally removed here: https://github.com/conan-io/conan/pull/18831/files