### PR TITLE
package_manager (Apt): Fix check_command for all packages

### DIFF
--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -245,8 +245,8 @@ class Apt(_SystemPackageManagerTool):
     full_package_name = "{name}{arch_separator}{arch_name}{version_separator}{version}"
     install_command = "{sudo}{tool} install -y {recommends}{packages}"
     update_command = "{sudo}{tool} update"
-    check_command = "dpkg-query -W -f='${{Architecture}}' {package} | grep -qEx '({arch_package}|all)'"
-    check_version_command = "dpkg-query -W -f='${{Architecture}} ${{Version}}' {package} | grep -qEx '({arch_package}|all) {version}'"
+    check_command = "dpkg-query -W -f='${{Architecture}}\n' {package} | grep -qEx '({arch_package}|all)'"
+    check_version_command = "dpkg-query -W -f='${{Architecture}} ${{Version}}\n' {package} | grep -qEx '({arch_package}|all) {version}'"
 
     def __init__(self, conanfile, arch_names=None):
         """

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -228,15 +228,10 @@ class _SystemPackageManagerTool(object):
     def check_package(self, package, host_package=True):
         name, version, arch_separator, arch_name, _ = self._split_package_name(package, host_package)
         arch_package = arch_name or self._arch_names.get(self._arch or self._conanfile.settings_build.get_safe('arch'))
-        package = self.full_package_name.format(name=name,
-                                                arch_separator=arch_separator,
-                                                arch_name=arch_name,
-                                                version="",
-                                                version_separator="")
-        command = self.check_command.format(tool=self.tool_name, package=package, arch_package=arch_package)
+        command = self.check_command.format(tool=self.tool_name, package=name, arch_package=arch_package)
         if version:
             if self.check_version_command:
-                command = self.check_version_command.format(tool=self.tool_name, package=package, version=version, arch_package=arch_package)
+                command = self.check_version_command.format(tool=self.tool_name, package=name, version=version, arch_package=arch_package)
             else:
                 self._conanfile.output.warning(f"System requirements: \"{self.tool_name}\" doesn't support package versions,"
                                                f" \"{package}\" will be installed without a specific version.")

--- a/test/integration/tools/system/package_manager_test.py
+++ b/test/integration/tools/system/package_manager_test.py
@@ -427,7 +427,7 @@ def test_tools_install_archless_with_version(tool_class, result):
 
 @pytest.mark.parametrize("tool_class, result", [
     (Apk, 'apk info -e package'),
-    (Apt, 'dpkg-query -W -f=\'${Architecture}\' package | grep -qEx \'(amd64|all)\''),
+    (Apt, 'dpkg-query -W -f=\'${Architecture}\n\' package | grep -qEx \'(amd64|all)\''),
     (Yum, 'rpm -q package'),
     (Dnf, 'rpm -q package'),
     (Brew, 'test -n "$(brew ls --versions package)"'),
@@ -451,7 +451,7 @@ def test_tools_check(tool_class, result):
 
 @pytest.mark.parametrize("tool_class, result", [
     (Apk, 'apk info package | grep "0.1"'),
-    (Apt, 'dpkg-query -W -f=\'${Architecture} ${Version}\' package | grep -qEx \'(amd64|all) 0.1\''),
+    (Apt, 'dpkg-query -W -f=\'${Architecture} ${Version}\n\' package | grep -qEx \'(amd64|all) 0.1\''),
     (Yum, 'rpm -q package-0.1'),
     (Dnf, 'rpm -q package-0.1'),
     (Brew, 'brew list --versions package | grep "0.1"'),


### PR DESCRIPTION
The current `check_command` for Apt at foreign architectures checks for `<package_name:<arch>`.
However, this selector doesn't find all packages.

The solution is to just check for the package name, dpkg-query will list the architecures and we check for the correct one.

When `dpkg-query` finds multiple matches, it printed that on the same line,
which broke the grep.

Docs: omit
Close #18569
Close https://github.com/conan-io/conan/issues/18862

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
