### PR TITLE
qbs: add optional support for cmake_file_name property

### DIFF
--- a/conan/tools/qbs/qbsdeps.py
+++ b/conan/tools/qbs/qbsdeps.py
@@ -55,10 +55,11 @@ class _QbsDepsModuleFile:
 class _QbsDepGenerator:
     """ Handles a single package, can create multiple modules in case of several components
     """
-    def __init__(self, conanfile, dep, build_bindirs):
+    def __init__(self, conanfile, dep, build_bindirs, use_cmake_file_name):
         self._conanfile = conanfile
         self._dep = dep
         self._build_bindirs = build_bindirs
+        self._use_cmake_file_name = use_cmake_file_name
 
     @property
     def content(self):
@@ -68,6 +69,8 @@ class _QbsDepGenerator:
         def _get_package_name(dep):
             # TODO: pkgconfig uses suffix, do we need it? see:
             # https://github.com/conan-io/conan/blob/develop2/conan/tools/gnu/pkgconfigdeps.py#L319
+            if self._use_cmake_file_name:
+                return dep.cpp_info.get_property("cmake_file_name") or dep.ref.name
             return dep.cpp_info.get_property("pkg_config_name") or dep.ref.name
 
         def _get_component_name(dep, comp_name):
@@ -166,6 +169,15 @@ class QbsDeps:
         :param conanfile: The current recipe object. Always use ``self``.
         """
         self._conanfile = conanfile
+        self._use_cmake_file_name = False
+
+    @property
+    def use_cmake_file_name(self):
+        return self._use_cmake_file_name
+
+    @use_cmake_file_name.setter
+    def use_cmake_file_name(self, value):
+        self._use_cmake_file_name = value
 
     @property
     def content(self):
@@ -186,7 +198,7 @@ class QbsDeps:
                 continue
 
             dep_build_bindirs = build_bindirs.get(dep.ref.name, [])
-            qbs_files.update(_QbsDepGenerator(self._conanfile, dep, dep_build_bindirs).content)
+            qbs_files.update(_QbsDepGenerator(self._conanfile, dep, dep_build_bindirs, self._use_cmake_file_name).content)
         return qbs_files
 
     def generate(self):

--- a/test/integration/toolchains/qbs/test_qbsdeps.py
+++ b/test/integration/toolchains/qbs/test_qbsdeps.py
@@ -104,6 +104,41 @@ def test_pkg_config_name():
     assert os.path.exists(module_path)
 
 
+def test_cmake_file_name():
+    # Checks we can override module name using the "test_cmake_file_name" property
+    conanfile = textwrap.dedent('''
+        from conan import ConanFile
+
+        class Recipe(ConanFile):
+            name = 'mylib'
+            version = '0.1'
+            def package_info(self):
+                self.cpp_info.set_property("cmake_file_name", "MyFirstLib")
+        ''')
+    client = TestClient()
+    client.save({'conanfile.py': conanfile})
+    client.run('create .')
+
+    client2 = TestClient(cache_folder=client.cache_folder)
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.qbs import QbsDeps
+
+        class ConsumerConan(ConanFile):
+            requires = "mylib/0.1"
+
+            def generate(self):
+                deps = QbsDeps(self)
+                deps.use_cmake_file_name = True
+                deps.generate()
+    """)
+    client2.save({"conanfile.py": conanfile})
+    client2.run("install .")
+
+    module_path = os.path.join(client2.current_folder, 'conan-qbs-deps', 'MyFirstLib.json')
+    assert os.path.exists(module_path)
+
+
 @pytest.mark.parametrize('host_os, arch, build_type', [
     ('Linux', 'x86_64', 'Debug'),
     ('Linux', 'x86_64', 'Release'),


### PR DESCRIPTION
As was requested by user migrating from Conan 1.x here https://bugreports.qt.io/projects/QBS/issues/QBS-1849.

Changelog: (Feature): Describe here your pull request
Docs: omitted

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
