### PR TITLE
fix listing prereleases

### DIFF
--- a/conan/api/model/list.py
+++ b/conan/api/model/list.py
@@ -358,10 +358,10 @@ class ListPattern:
         if self.version and self.version.startswith("[") and self.version.endswith("]"):
             return VersionRange(self.version[1:-1])
 
-    def filter_versions(self, refs):
+    def filter_versions(self, refs, resolve_prereleases=None):
         vrange = self._version_range
         if vrange:
-            refs = [r for r in refs if vrange.contains(r.version, None)]
+            refs = [r for r in refs if vrange.contains(r.version, resolve_prereleases)]
         return refs
 
     @property

--- a/conan/api/subapi/list.py
+++ b/conan/api/subapi/list.py
@@ -163,7 +163,8 @@ class ListAPI:
 
         return result
 
-    def select(self, pattern: ListPattern, package_query=None, remote: Remote = None, lru=None, profile=None) -> PackagesList:
+    def select(self, pattern: ListPattern, package_query=None, remote: Remote = None, lru=None,
+               profile=None) -> PackagesList:
         """For a given pattern, return a list of recipes and packages matching the provided filters.
 
         :parameter ListPattern pattern: Search criteria
@@ -192,7 +193,9 @@ class ListAPI:
         remote_name = "local cache" if not remote else remote.name
         if search_ref:
             refs = _search_recipes(app, search_ref, remote=remote)
-            refs = pattern.filter_versions(refs)
+            global_conf = self._conan_api._api_helpers.global_conf  # noqa
+            resolve_prereleases = global_conf.get("core.version_ranges:resolve_prereleases")
+            refs = pattern.filter_versions(refs, resolve_prereleases)
             pattern.check_refs(refs)
             out.info(f"Found {len(refs)} pkg/version recipes matching {search_ref} in {remote_name}")
         else:


### PR DESCRIPTION
Changelog: Bugfix: Command ``conan list`` with version-ranges can now listen to ``core.version_ranges:resolve_prereleases=True`` to list pre-releases.
Docs: Omit

Close https://github.com/conan-io/conan/issues/18863