### PR TITLE
improve error message for build-scripts with deps

### DIFF
--- a/conan/internal/model/requires.py
+++ b/conan/internal/model/requires.py
@@ -304,7 +304,9 @@ class Requirement:
             elif pkg_type is PackageType.HEADER:
                 downstream_require = Requirement(require.ref, headers=require.headers, libs=require.libs, run=require.run)
             else:
-                assert pkg_type == PackageType.UNKNOWN
+                if pkg_type != PackageType.UNKNOWN:
+                    raise ConanException(f"Package '{self.ref}' with type '{pkg_type}' cannot have "
+                                         f"a '{dep_pkg_type}' dependency to '{require.ref}'")
                 # TODO: This is undertested, changing it did not break tests
                 downstream_require = require.copy_requirement()
         elif dep_pkg_type is PackageType.HEADER:


### PR DESCRIPTION
Changelog: Fix: Improve the error message and avoid the traceback when a ``build-scripts`` package tries to depend on a ``library`` in the "host" context.
Docs: https://github.com/conan-io/docs/pull/4245

Close https://github.com/conan-io/conan/issues/18856
