### PR TITLE
Fix regression with system package manager tools

### DIFF
--- a/conan/__init__.py
+++ b/conan/__init__.py
@@ -2,5 +2,5 @@ from conan.internal.model.conan_file import ConanFile
 from conan.internal.model.workspace import Workspace
 from conan.internal.model.version import Version
 
-__version__ = '2.20.0'
+__version__ = '2.20.1'
 conan_version = Version(__version__)

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -228,7 +228,6 @@ class _SystemPackageManagerTool(object):
     def check_package(self, package, host_package=True):
         name, version, arch_separator, arch_name, _ = self._split_package_name(package, host_package)
         arch_package = arch_name or self._arch_names.get(self._arch or self._conanfile.settings_build.get_safe('arch'))
-
         package = self.full_package_name.format(name=name,
                                                 arch_separator=arch_separator,
                                                 arch_name=arch_name,

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -245,8 +245,8 @@ class Apt(_SystemPackageManagerTool):
     full_package_name = "{name}{arch_separator}{arch_name}{version_separator}{version}"
     install_command = "{sudo}{tool} install -y {recommends}{packages}"
     update_command = "{sudo}{tool} update"
-    check_command = "dpkg-query -W -f='${{Architecture}}' {package} | grep -qEx '({arch_package}|all)'"
-    check_version_command = "dpkg-query -W -f='${{Architecture}} ${{Version}}' {package} | grep -qEx '({arch_package}|all) {version}'"
+    check_command = "dpkg-query -W -f='${{Architecture}}\n' {package} | grep -qEx '({arch_package}|all)'"
+    check_version_command = "dpkg-query -W -f='${{Architecture}} ${{Version}}\n' {package} | grep -qEx '({arch_package}|all) {version}'"
 
     def __init__(self, conanfile, arch_names=None):
         """

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -228,15 +228,10 @@ class _SystemPackageManagerTool(object):
     def check_package(self, package, host_package=True):
         name, version, arch_separator, arch_name, _ = self._split_package_name(package, host_package)
         arch_package = arch_name or self._arch_names.get(self._arch or self._conanfile.settings_build.get_safe('arch'))
-        package = self.full_package_name.format(name=name,
-                                                arch_separator=arch_separator,
-                                                arch_name=arch_name,
-                                                version="",
-                                                version_separator="")
-        command = self.check_command.format(tool=self.tool_name, package=package, arch_package=arch_package)
+        command = self.check_command.format(tool=self.tool_name, package=name, arch_package=arch_package)
         if version:
             if self.check_version_command:
-                command = self.check_version_command.format(tool=self.tool_name, package=package, version=version, arch_package=arch_package)
+                command = self.check_version_command.format(tool=self.tool_name, package=name, version=version, arch_package=arch_package)
             else:
                 self._conanfile.output.warning(f"System requirements: \"{self.tool_name}\" doesn't support package versions,"
                                                f" \"{package}\" will be installed without a specific version.")

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -253,8 +253,8 @@ class Apt(_SystemPackageManagerTool):
     full_package_name = "{name}{arch_separator}{arch_name}{version_separator}{version}"
     install_command = "{sudo}{tool} install -y {recommends}{packages}"
     update_command = "{sudo}{tool} update"
-    check_command = "dpkg-query -W -f='${{Architecture}}\n' {base_name} | grep -qEx '({arch_package}|all)'"
-    check_version_command = "dpkg-query -W -f='${{Architecture}} ${{Version}}\n' {base_name} | grep -qEx '({arch_package}|all) {version}'"
+    check_command = r"dpkg-query -W -f='${{Architecture}}\n' {base_name} | grep -qEx '({arch_package}|all)'"
+    check_version_command = r"dpkg-query -W -f='${{Architecture}} ${{Version}}\n' {base_name} | grep -qEx '({arch_package}|all) {version}'"
 
     def __init__(self, conanfile, arch_names=None):
         """

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -228,10 +228,18 @@ class _SystemPackageManagerTool(object):
     def check_package(self, package, host_package=True):
         name, version, arch_separator, arch_name, _ = self._split_package_name(package, host_package)
         arch_package = arch_name or self._arch_names.get(self._arch or self._conanfile.settings_build.get_safe('arch'))
-        command = self.check_command.format(tool=self.tool_name, package=name, arch_package=arch_package)
+
+        package = self.full_package_name.format(name=name,
+                                                arch_separator=arch_separator,
+                                                arch_name=arch_name,
+                                                version="",
+                                                version_separator="")
+        command = self.check_command.format(tool=self.tool_name, package=package, arch_package=arch_package, base_name=name)
+ 
         if version:
             if self.check_version_command:
-                command = self.check_version_command.format(tool=self.tool_name, package=name, version=version, arch_package=arch_package)
+                command = self.check_version_command.format(tool=self.tool_name, package=package, version=version, arch_package=arch_package,
+                                                            base_name=name)
             else:
                 self._conanfile.output.warning(f"System requirements: \"{self.tool_name}\" doesn't support package versions,"
                                                f" \"{package}\" will be installed without a specific version.")
@@ -245,8 +253,8 @@ class Apt(_SystemPackageManagerTool):
     full_package_name = "{name}{arch_separator}{arch_name}{version_separator}{version}"
     install_command = "{sudo}{tool} install -y {recommends}{packages}"
     update_command = "{sudo}{tool} update"
-    check_command = "dpkg-query -W -f='${{Architecture}}\n' {package} | grep -qEx '({arch_package}|all)'"
-    check_version_command = "dpkg-query -W -f='${{Architecture}} ${{Version}}\n' {package} | grep -qEx '({arch_package}|all) {version}'"
+    check_command = "dpkg-query -W -f='${{Architecture}}\n' {base_name} | grep -qEx '({arch_package}|all)'"
+    check_version_command = "dpkg-query -W -f='${{Architecture}} ${{Version}}\n' {base_name} | grep -qEx '({arch_package}|all) {version}'"
 
     def __init__(self, conanfile, arch_names=None):
         """

--- a/test/integration/tools/system/package_manager_test.py
+++ b/test/integration/tools/system/package_manager_test.py
@@ -427,7 +427,7 @@ def test_tools_install_archless_with_version(tool_class, result):
 
 @pytest.mark.parametrize("tool_class, result", [
     (Apk, 'apk info -e package'),
-    (Apt, 'dpkg-query -W -f=\'${Architecture}\' package | grep -qEx \'(amd64|all)\''),
+    (Apt, 'dpkg-query -W -f=\'${Architecture}\n\' package | grep -qEx \'(amd64|all)\''),
     (Yum, 'rpm -q package'),
     (Dnf, 'rpm -q package'),
     (Brew, 'test -n "$(brew ls --versions package)"'),
@@ -451,7 +451,7 @@ def test_tools_check(tool_class, result):
 
 @pytest.mark.parametrize("tool_class, result", [
     (Apk, 'apk info package | grep "0.1"'),
-    (Apt, 'dpkg-query -W -f=\'${Architecture} ${Version}\' package | grep -qEx \'(amd64|all) 0.1\''),
+    (Apt, 'dpkg-query -W -f=\'${Architecture} ${Version}\n\' package | grep -qEx \'(amd64|all) 0.1\''),
     (Yum, 'rpm -q package-0.1'),
     (Dnf, 'rpm -q package-0.1'),
     (Brew, 'brew list --versions package | grep "0.1"'),

--- a/test/integration/tools/system/package_manager_test.py
+++ b/test/integration/tools/system/package_manager_test.py
@@ -427,7 +427,7 @@ def test_tools_install_archless_with_version(tool_class, result):
 
 @pytest.mark.parametrize("tool_class, result", [
     (Apk, 'apk info -e package'),
-    (Apt, 'dpkg-query -W -f=\'${Architecture}\n\' package | grep -qEx \'(amd64|all)\''),
+    (Apt, r"dpkg-query -W -f='${Architecture}\n' package | grep -qEx '(amd64|all)'"),
     (Yum, 'rpm -q package'),
     (Dnf, 'rpm -q package'),
     (Brew, 'test -n "$(brew ls --versions package)"'),
@@ -451,7 +451,7 @@ def test_tools_check(tool_class, result):
 
 @pytest.mark.parametrize("tool_class, result", [
     (Apk, 'apk info package | grep "0.1"'),
-    (Apt, 'dpkg-query -W -f=\'${Architecture} ${Version}\n\' package | grep -qEx \'(amd64|all) 0.1\''),
+    (Apt, r"dpkg-query -W -f='${Architecture} ${Version}\n' package | grep -qEx '(amd64|all) 0.1'"),
     (Yum, 'rpm -q package-0.1'),
     (Dnf, 'rpm -q package-0.1'),
     (Brew, 'brew list --versions package | grep "0.1"'),


### PR DESCRIPTION
Changelog: BugFix: Fix Apt not detecting the correct architecture in multiarch setups.
Changelog: BugFix: Apt correctly detects arch-independent (all) packages during cross-building to avoid unnecessary reinstalls.
Docs: Omit

The regression was introduced by https://github.com/conan-io/conan/pull/18517

Closes: #18862
Closes: #18569

For the #18569 it closes the second part of the issue