### PR TITLE
cleaning files and urls in package lists

### DIFF
--- a/conan/api/subapi/download.py
+++ b/conan/api/subapi/download.py
@@ -85,8 +85,12 @@ class DownloadAPI:
         def _download_pkglist(pkglist):
             for ref, recipe_bundle in pkglist.refs().items():
                 self.recipe(ref, remote, metadata)
-                for pref, _ in pkglist.prefs(ref, recipe_bundle).items():
+                recipe_bundle.pop("files", None)
+                recipe_bundle.pop("upload-urls", None)
+                for pref, pref_bundle in pkglist.prefs(ref, recipe_bundle).items():
                     self.package(pref, remote, metadata)
+                    pref_bundle.pop("files", None)
+                    pref_bundle.pop("upload-urls", None)
 
         t = time.time()
         parallel = self._conan_api.config.get("core.download:parallel", default=1, check_type=int)

--- a/conan/internal/api/uploader.py
+++ b/conan/internal/api/uploader.py
@@ -54,8 +54,6 @@ class UploadUpstreamChecker:
                 output.info(f"Recipe '{ref.repr_notime()}' already in server, skipping upload")
                 ref_bundle["upload"] = False
                 ref_bundle["force_upload"] = False
-                ref_bundle.pop("files", None)
-                ref_bundle.pop("upload-urls", None)
 
     def _check_upstream_package(self, pref, prev_bundle, remote, force):
         assert (pref.revision is not None), "Cannot upload a package without PREV"
@@ -78,8 +76,6 @@ class UploadUpstreamChecker:
                 output.info(f"Package '{pref.repr_notime()}' already in server, skipping upload")
                 prev_bundle["force_upload"] = False
                 prev_bundle["upload"] = False
-                prev_bundle.pop("files", None)
-                prev_bundle.pop("upload-urls", None)
 
 
 class PackagePreparator:
@@ -100,9 +96,14 @@ class PackagePreparator:
                                          "This isn't a remote URL, the build won't be reproducible\n"
                                          "Failing because conf 'core.scm:local_url!=allow'")
 
+            # Just in case it was defined from a previous run
+            bundle.pop("files", None)
+            bundle.pop("upload-urls", None)
             if bundle.get("upload"):
                 self._prepare_recipe(ref, bundle, conanfile, enabled_remotes)
             for pref, prev_bundle in pkg_list.prefs(ref, bundle).items():
+                prev_bundle.pop("files", None)  # If defined from a previous upload
+                prev_bundle.pop("upload-urls", None)
                 if prev_bundle.get("upload"):
                     self._prepare_package(pref, prev_bundle)
 

--- a/conan/internal/api/uploader.py
+++ b/conan/internal/api/uploader.py
@@ -54,6 +54,8 @@ class UploadUpstreamChecker:
                 output.info(f"Recipe '{ref.repr_notime()}' already in server, skipping upload")
                 ref_bundle["upload"] = False
                 ref_bundle["force_upload"] = False
+                ref_bundle.pop("files", None)
+                ref_bundle.pop("upload-urls", None)
 
     def _check_upstream_package(self, pref, prev_bundle, remote, force):
         assert (pref.revision is not None), "Cannot upload a package without PREV"
@@ -76,6 +78,8 @@ class UploadUpstreamChecker:
                 output.info(f"Package '{pref.repr_notime()}' already in server, skipping upload")
                 prev_bundle["force_upload"] = False
                 prev_bundle["upload"] = False
+                prev_bundle.pop("files", None)
+                prev_bundle.pop("upload-urls", None)
 
 
 class PackagePreparator:


### PR DESCRIPTION
Changelog: Fix: Cleaning ``files`` and ``upload-urls`` from "package lists" after a download or when skipping uploads.
Docs: Omit

Close https://github.com/conan-io/conan/issues/18877
