### PR TITLE
Remove checks for major version being an int in the version repr for requirements

### DIFF
--- a/conan/internal/model/info.py
+++ b/conan/internal/model/info.py
@@ -20,31 +20,20 @@ class _VersionRepr:
             return self.major()
 
     def major(self):
-        if not isinstance(self._version.major.value, int):
-            return str(self._version.major)
         return ".".join([str(self._version.major), 'Y', 'Z'])
 
     def minor(self):
-        if not isinstance(self._version.major.value, int):
-            return str(self._version.major)
-
         v0 = str(self._version.major)
         v1 = str(self._version.minor) if self._version.minor is not None else "0"
         return ".".join([v0, v1, 'Z'])
 
     def patch(self):
-        if not isinstance(self._version.major.value, int):
-            return str(self._version.major)
-
         v0 = str(self._version.major)
         v1 = str(self._version.minor) if self._version.minor is not None else "0"
         v2 = str(self._version.patch) if self._version.patch is not None else "0"
         return ".".join([v0, v1, v2])
 
     def pre(self):
-        if not isinstance(self._version.major.value, int):
-            return str(self._version.major)
-
         v0 = str(self._version.major)
         v1 = str(self._version.minor) if self._version.minor is not None else "0"
         v2 = str(self._version.patch) if self._version.patch is not None else "0"

--- a/test/integration/package_id/package_id_test.py
+++ b/test/integration/package_id/package_id_test.py
@@ -265,3 +265,19 @@ def test_package_id_nonsemver_dependency():
     c.run("create dep --version=cci.2.5")
     c.run("install --requires=app/0.1", assert_error=True)
     assert "Missing prebuilt package for 'app/0.1'" in c.out
+
+
+def test_package_id_nonsemver_dependency_prefixed_versions():
+    """ This used not to be a missing binary because the initial cci major
+    was triggering logic that ignored following versions """
+    c = TestClient(light=True)
+    c.save({"dep/conanfile.py": GenConanfile("dep"),
+           "conanfile.py": GenConanfile("app", "0.1")
+            .with_requirement("dep/[>=v1.0 <v2]", package_id_mode="minor_mode")})
+
+    c.run("create dep --version=v1.0")
+
+    c.run("create .")
+    c.run("create dep --version=v1.3")
+    c.run("install --requires=app/0.1", assert_error=True)
+    assert "Missing prebuilt package for 'app/0.1'" in c.out

--- a/test/integration/package_id/package_id_test.py
+++ b/test/integration/package_id/package_id_test.py
@@ -252,6 +252,8 @@ def test_explicit_implements():
 
 
 def test_package_id_nonsemver_dependency():
+    """ This used not to be a missing binary because the initial cci major
+    was triggering logic that ignored following versions """
     c = TestClient(light=True)
     c.save({"dep/conanfile.py": GenConanfile("dep"),
            "conanfile.py": GenConanfile("app", "0.1")

--- a/test/integration/package_id/package_id_test.py
+++ b/test/integration/package_id/package_id_test.py
@@ -249,3 +249,17 @@ def test_explicit_implements():
     pkgid4 = c.created_package_id("pkg/0.1")
     assert pkgid4 != pkgid
     assert pkgid3 != pkgid4
+
+
+def test_package_id_nonsemver_dependency():
+    c = TestClient(light=True)
+    c.save({"dep/conanfile.py": GenConanfile("dep"),
+           "conanfile.py": GenConanfile("app", "0.1")
+            .with_requirement("dep/[>=cci.1.0]", package_id_mode="minor_mode")})
+
+    c.run("create dep --version=cci.1.3")
+
+    c.run("create .")
+    c.run("create dep --version=cci.2.5")
+    c.run("install --requires=app/0.1", assert_error=True)
+    assert "Missing prebuilt package for 'app/0.1'" in c.out

--- a/test/unittests/model/versionrepr_test.py
+++ b/test/unittests/model/versionrepr_test.py
@@ -9,12 +9,23 @@ class TestVersionRepr:
     def test_text(self):
         v1 = Version("master+build2")
         vr = _VersionRepr(v1)
-        assert vr.major() == "master"
-        assert vr.minor() == "master"
-        assert vr.patch() == "master"
-        assert vr.pre() == "master"
+        assert vr.major() == "master.Y.Z"
+        assert vr.minor() == "master.0.Z"
+        assert vr.patch() == "master.0.0"
+        assert vr.pre() == "master.0.0"
         assert vr.build == "build2"
-        assert vr.stable() == "master"
+        assert vr.stable() == "master.Y.Z"
+
+    def test_text_cci(self):
+        v1 = Version("cci.2025.09.05-alpha1+build2")
+        vr = _VersionRepr(v1)
+        assert vr.major() == "cci.Y.Z"
+        assert vr.minor() == "cci.2025.Z"
+        # TODO: Check if this parsed 9 int of 09 is correct
+        assert vr.patch() == "cci.2025.9"
+        assert vr.pre() == "cci.2025.9-alpha1"
+        assert vr.build == "build2"
+        assert vr.stable() == "cci.Y.Z"
 
     def test_patch(self):
         v1 = Version("1.2.3-alpha1+build2")

--- a/test/unittests/model/versionrepr_test.py
+++ b/test/unittests/model/versionrepr_test.py
@@ -55,9 +55,11 @@ class TestVersionRepr:
         assert vr.build == "build2"
         assert vr.stable() == "0.2.3-alpha1+build2"
 
-        v1 = Version("+build2")
-        vr = _VersionRepr(v1)
-        assert vr.major() == ""
+        # FIXME: Think what this should even return,
+        #  or even if the version itself is valid at all
+        # v1 = Version("+build2")
+        # vr = _VersionRepr(v1)
+        # assert vr.major() == ".Y.Z"
 
     def test_build(self):
         v1 = Version("0.2.3-alpha1+build2")


### PR DESCRIPTION
Changelog: Fix: Version with non integer majors will no longer be trimmed in `conaninfo.txt`
Docs: Omit

This might be a breaking behaviour, and at the very least will create missing binaries for packages recipes that use these versions, as now the package id will contain minor/patch patterns
