### PR TITLE
Add `recipes_only` feature for remotes

### DIFF
--- a/conan/api/model/remote.py
+++ b/conan/api/model/remote.py
@@ -7,13 +7,13 @@ class Remote:
     should not be created directly, but obtained from the relevant ``RemotesAPI`` subapi methods.
     """
     def __init__(self, name, url, verify_ssl=True, disabled=False, allowed_packages=None,
-                 remote_type=None, allow_binary_downloads=True):
+                 remote_type=None, recipes_only=False):
         self.name = name  # Read only, is the key
         self.url = url
         self.verify_ssl = verify_ssl
         self.disabled = disabled
         self.allowed_packages = allowed_packages
-        self.allow_binary_downloads = allow_binary_downloads
+        self.recipes_only = recipes_only
         self.remote_type = remote_type
         self._caching = {}
 
@@ -27,8 +27,8 @@ class Remote:
         allowed_msg = ""
         if self.allowed_packages:
             allowed_msg = ", Allowed packages: {}".format(", ".join(self.allowed_packages))
-        if not self.allow_binary_downloads:
-            allowed_msg += ", No binary downloads"
+        if self.recipes_only:
+            allowed_msg += ", Recipes only"
         if self.remote_type == LOCAL_RECIPES_INDEX:
             return "{}: {} [{}, Enabled: {}{}]".format(self.name, self.url, LOCAL_RECIPES_INDEX,
                                                        not self.disabled, allowed_msg)

--- a/conan/api/model/remote.py
+++ b/conan/api/model/remote.py
@@ -7,12 +7,13 @@ class Remote:
     should not be created directly, but obtained from the relevant ``RemotesAPI`` subapi methods.
     """
     def __init__(self, name, url, verify_ssl=True, disabled=False, allowed_packages=None,
-                 remote_type=None):
+                 remote_type=None, allow_binary_downloads=True):
         self.name = name  # Read only, is the key
         self.url = url
         self.verify_ssl = verify_ssl
         self.disabled = disabled
         self.allowed_packages = allowed_packages
+        self.allow_binary_downloads = allow_binary_downloads
         self.remote_type = remote_type
         self._caching = {}
 
@@ -26,6 +27,8 @@ class Remote:
         allowed_msg = ""
         if self.allowed_packages:
             allowed_msg = ", Allowed packages: {}".format(", ".join(self.allowed_packages))
+        if not self.allow_binary_downloads:
+            allowed_msg += ", No binary downloads"
         if self.remote_type == LOCAL_RECIPES_INDEX:
             return "{}: {} [{}, Enabled: {}{}]".format(self.name, self.url, LOCAL_RECIPES_INDEX,
                                                        not self.disabled, allowed_msg)

--- a/conan/api/subapi/remotes.py
+++ b/conan/api/subapi/remotes.py
@@ -159,7 +159,7 @@ class RemotesAPI:
         return removed
 
     def update(self, remote_name: str, url=None, secure=None, disabled=None, index=None,
-               allowed_packages=None):
+               allowed_packages=None, allow_binary_downloads=None):
         """
         Update an existing remote
 
@@ -169,6 +169,7 @@ class RemotesAPI:
         :param disabled: optional disabled state
         :param index:  optional integer to change the order of the remote
         :param allowed_packages: optional list of packages allowed from this remote
+        :param allow_binary_downloads: optional boolean to allow binary downloads from this remote
         """
         remotes = _load(self._remotes_file)
         try:
@@ -186,6 +187,8 @@ class RemotesAPI:
             remote.disabled = disabled
         if allowed_packages is not None:
             remote.allowed_packages = allowed_packages
+        if allow_binary_downloads is not None:
+            remote.allow_binary_downloads = allow_binary_downloads
 
         if index is not None:
             remotes = [r for r in remotes if r.name != remote.name]
@@ -300,7 +303,8 @@ def _load(remotes_file):
     result = []
     for r in data.get("remotes", []):
         remote = Remote(r["name"], r["url"], r["verify_ssl"], r.get("disabled", False),
-                        r.get("allowed_packages"), r.get("remote_type"))
+                        r.get("allowed_packages"), r.get("remote_type"),
+                        r.get("allow_binary_downloads", True))
         result.append(remote)
     return result
 
@@ -308,7 +312,8 @@ def _load(remotes_file):
 def _save(remotes_file, remotes):
     remote_list = []
     for r in remotes:
-        remote = {"name": r.name, "url": r.url, "verify_ssl": r.verify_ssl}
+        remote = {"name": r.name, "url": r.url, "verify_ssl": r.verify_ssl,
+                  "allow_binary_downloads": r.allow_binary_downloads}
         if r.disabled:
             remote["disabled"] = True
         if r.allowed_packages:

--- a/conan/api/subapi/remotes.py
+++ b/conan/api/subapi/remotes.py
@@ -159,7 +159,7 @@ class RemotesAPI:
         return removed
 
     def update(self, remote_name: str, url=None, secure=None, disabled=None, index=None,
-               allowed_packages=None, allow_binary_downloads=None):
+               allowed_packages=None, recipes_only=None):
         """
         Update an existing remote
 
@@ -169,7 +169,8 @@ class RemotesAPI:
         :param disabled: optional disabled state
         :param index:  optional integer to change the order of the remote
         :param allowed_packages: optional list of packages allowed from this remote
-        :param allow_binary_downloads: optional boolean to allow binary downloads from this remote
+        :param recipes_only: optional boolean to only allow recipe downloads from this remote,
+            never package binaries
         """
         remotes = _load(self._remotes_file)
         try:
@@ -187,8 +188,8 @@ class RemotesAPI:
             remote.disabled = disabled
         if allowed_packages is not None:
             remote.allowed_packages = allowed_packages
-        if allow_binary_downloads is not None:
-            remote.allow_binary_downloads = allow_binary_downloads
+        if recipes_only is not None:
+            remote.recipes_only = recipes_only
 
         if index is not None:
             remotes = [r for r in remotes if r.name != remote.name]
@@ -304,7 +305,7 @@ def _load(remotes_file):
     for r in data.get("remotes", []):
         remote = Remote(r["name"], r["url"], r["verify_ssl"], r.get("disabled", False),
                         r.get("allowed_packages"), r.get("remote_type"),
-                        r.get("allow_binary_downloads", True))
+                        r.get("recipes_only", False))
         result.append(remote)
     return result
 
@@ -313,7 +314,7 @@ def _save(remotes_file, remotes):
     remote_list = []
     for r in remotes:
         remote = {"name": r.name, "url": r.url, "verify_ssl": r.verify_ssl,
-                  "allow_binary_downloads": r.allow_binary_downloads}
+                  "recipes_only": r.recipes_only}
         if r.disabled:
             remote["disabled"] = True
         if r.allowed_packages:

--- a/conan/api/subapi/remotes.py
+++ b/conan/api/subapi/remotes.py
@@ -313,14 +313,15 @@ def _load(remotes_file):
 def _save(remotes_file, remotes):
     remote_list = []
     for r in remotes:
-        remote = {"name": r.name, "url": r.url, "verify_ssl": r.verify_ssl,
-                  "recipes_only": r.recipes_only}
+        remote = {"name": r.name, "url": r.url, "verify_ssl": r.verify_ssl}
         if r.disabled:
             remote["disabled"] = True
         if r.allowed_packages:
             remote["allowed_packages"] = r.allowed_packages
         if r.remote_type:
             remote["remote_type"] = r.remote_type
+        if r.recipes_only:
+            remote["recipes_only"] = r.recipes_only
         remote_list.append(remote)
     # This atomic replace avoids a corrupted remotes.json file if this is killed during the process
     save(remotes_file + ".tmp", json.dumps({"remotes": remote_list}, indent=True))

--- a/conan/cli/commands/remote.py
+++ b/conan/cli/commands/remote.py
@@ -138,6 +138,7 @@ def remote_update(conan_api, parser, subparser, *args):
     if (args.url is None and args.secure is None and args.index is None and
         args.allowed_packages is None and args.recipes_only is None):
         subparser.error("Please add at least one argument to update")
+    args.recipes_only = None if args.recipes_only is None else args.recipes_only == "True"
     conan_api.remotes.update(args.remote, args.url, args.secure, index=args.index,
                              allowed_packages=args.allowed_packages,
                              recipes_only=args.recipes_only)

--- a/conan/cli/commands/remote.py
+++ b/conan/cli/commands/remote.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 import os
 from collections import OrderedDict
@@ -18,7 +19,7 @@ def _print_remotes_json(remotes):
              "verify_ssl": r.verify_ssl,
              "enabled": not r.disabled,
              "allowed_packages": r.allowed_packages,
-             "allow_binary_downloads": r.allow_binary_downloads,}
+             "recipes_only": r.recipes_only,}
             for r in remotes]
     cli_out_write(json.dumps(info, indent=4))
 
@@ -84,8 +85,9 @@ def remote_add(conan_api, parser, subparser, *args):
                                 "this remote")
     subparser.add_argument("-t", "--type", choices=[LOCAL_RECIPES_INDEX],
                            help="Define the remote type")
-    subparser.add_argument("-nbd", "--no-binary-downloads", default=False,
-                           help="Disallow binary downloads from this remote")
+    subparser.add_argument("--recipes-only", default=False,
+                           help="Disallow binary downloads from this remote, only recipes "
+                                "will be downloaded")
 
     subparser.set_defaults(secure=True)
     args = parser.parse_args(*args)
@@ -95,7 +97,7 @@ def remote_add(conan_api, parser, subparser, *args):
     url = url_folder if remote_type == LOCAL_RECIPES_INDEX else args.url
     r = Remote(args.name, url, args.secure, disabled=False, remote_type=remote_type,
                allowed_packages=args.allowed_packages,
-               allow_binary_downloads=not args.no_binary_downloads)
+               recipes_only=args.recipes_only)
     conan_api.remotes.add(r, force=args.force, index=args.index)
 
 
@@ -117,6 +119,16 @@ def remote_update(conan_api, parser, subparser, *args):
     """
     Update a remote.
     """
+    def get_bool_from_text(value):
+        if value is None:
+            return None
+        value = value.lower()
+        if value in ["1", "yes", "y", "true"]:
+            return True
+        if value in ["0", "no", "n", "false"]:
+            return False
+        raise argparse.ArgumentTypeError("%s is not a valid value" % value)
+
     subparser.add_argument("remote", help="Name of the remote to update")
     subparser.add_argument("--url", action=OnceArgument, help="New url for the remote")
     subparser.add_argument("--secure", dest="secure", action='store_true',
@@ -127,21 +139,18 @@ def remote_update(conan_api, parser, subparser, *args):
                            help="Insert the remote at a specific position in the remote list")
     subparser.add_argument("-ap", "--allowed-packages", action="append", default=None,
                            help="Add recipe reference pattern to the list of allowed packages for this remote")
-    subparser.add_argument("-abd", "--allow-binary-downloads", dest="allow_binaries",
-                           action="store_true",
-                           help="Allow binary downloads from this remote (default)")
-    subparser.add_argument("-nbd", "--no-binary-downloads", dest="allow_binaries",
-                           action="store_false",
-                           help="Disallow binary downloads from this remote")
-    subparser.set_defaults(allow_binaries=None)
+    subparser.add_argument("--recipes-only", type=get_bool_from_text, nargs="?", default=None,
+                           const=True,
+                           help="Disallow binary downloads from this remote, only recipes will be downloaded")
+
     subparser.set_defaults(secure=None)
     args = parser.parse_args(*args)
     if (args.url is None and args.secure is None and args.index is None and
-        args.allowed_packages is None and args.allow_binaries is None):
+        args.allowed_packages is None and args.recipes_only is None):
         subparser.error("Please add at least one argument to update")
     conan_api.remotes.update(args.remote, args.url, args.secure, index=args.index,
                              allowed_packages=args.allowed_packages,
-                             allow_binary_downloads=args.allow_binaries)
+                             recipes_only=args.recipes_only)
 
 
 @conan_subcommand()

--- a/conan/cli/commands/remote.py
+++ b/conan/cli/commands/remote.py
@@ -17,7 +17,8 @@ def _print_remotes_json(remotes):
              "url": r.url,
              "verify_ssl": r.verify_ssl,
              "enabled": not r.disabled,
-             "allowed_packages": r.allowed_packages,}
+             "allowed_packages": r.allowed_packages,
+             "allow_binary_downloads": r.allow_binary_downloads,}
             for r in remotes]
     cli_out_write(json.dumps(info, indent=4))
 
@@ -83,6 +84,8 @@ def remote_add(conan_api, parser, subparser, *args):
                                 "this remote")
     subparser.add_argument("-t", "--type", choices=[LOCAL_RECIPES_INDEX],
                            help="Define the remote type")
+    subparser.add_argument("-nbd", "--no-binary-downloads", default=False,
+                           help="Disallow binary downloads from this remote")
 
     subparser.set_defaults(secure=True)
     args = parser.parse_args(*args)
@@ -91,7 +94,8 @@ def remote_add(conan_api, parser, subparser, *args):
     remote_type = args.type or (LOCAL_RECIPES_INDEX if os.path.isdir(url_folder) else None)
     url = url_folder if remote_type == LOCAL_RECIPES_INDEX else args.url
     r = Remote(args.name, url, args.secure, disabled=False, remote_type=remote_type,
-               allowed_packages=args.allowed_packages)
+               allowed_packages=args.allowed_packages,
+               allow_binary_downloads=not args.no_binary_downloads)
     conan_api.remotes.add(r, force=args.force, index=args.index)
 
 
@@ -123,11 +127,21 @@ def remote_update(conan_api, parser, subparser, *args):
                            help="Insert the remote at a specific position in the remote list")
     subparser.add_argument("-ap", "--allowed-packages", action="append", default=None,
                            help="Add recipe reference pattern to the list of allowed packages for this remote")
+    subparser.add_argument("-abd", "--allow-binary-downloads", dest="allow_binaries",
+                           action="store_true",
+                           help="Allow binary downloads from this remote (default)")
+    subparser.add_argument("-nbd", "--no-binary-downloads", dest="allow_binaries",
+                           action="store_false",
+                           help="Disallow binary downloads from this remote")
+    subparser.set_defaults(allow_binaries=None)
     subparser.set_defaults(secure=None)
     args = parser.parse_args(*args)
-    if args.url is None and args.secure is None and args.index is None and args.allowed_packages is None:
+    if (args.url is None and args.secure is None and args.index is None and
+        args.allowed_packages is None and args.allow_binaries is None):
         subparser.error("Please add at least one argument to update")
-    conan_api.remotes.update(args.remote, args.url, args.secure, index=args.index, allowed_packages=args.allowed_packages)
+    conan_api.remotes.update(args.remote, args.url, args.secure, index=args.index,
+                             allowed_packages=args.allowed_packages,
+                             allow_binary_downloads=args.allow_binaries)
 
 
 @conan_subcommand()

--- a/conan/cli/commands/remote.py
+++ b/conan/cli/commands/remote.py
@@ -119,16 +119,6 @@ def remote_update(conan_api, parser, subparser, *args):
     """
     Update a remote.
     """
-    def get_bool_from_text(value):
-        if value is None:
-            return None
-        value = value.lower()
-        if value in ["1", "yes", "y", "true"]:
-            return True
-        if value in ["0", "no", "n", "false"]:
-            return False
-        raise argparse.ArgumentTypeError("%s is not a valid value" % value)
-
     subparser.add_argument("remote", help="Name of the remote to update")
     subparser.add_argument("--url", action=OnceArgument, help="New url for the remote")
     subparser.add_argument("--secure", dest="secure", action='store_true',
@@ -139,8 +129,8 @@ def remote_update(conan_api, parser, subparser, *args):
                            help="Insert the remote at a specific position in the remote list")
     subparser.add_argument("-ap", "--allowed-packages", action="append", default=None,
                            help="Add recipe reference pattern to the list of allowed packages for this remote")
-    subparser.add_argument("--recipes-only", type=get_bool_from_text, nargs="?", default=None,
-                           const=True,
+    subparser.add_argument("--recipes-only", default=None, const="True", nargs="?",
+                           choices=["True", "False"],
                            help="Disallow binary downloads from this remote, only recipes will be downloaded")
 
     subparser.set_defaults(secure=None)

--- a/conan/cli/commands/remote.py
+++ b/conan/cli/commands/remote.py
@@ -85,7 +85,7 @@ def remote_add(conan_api, parser, subparser, *args):
                                 "this remote")
     subparser.add_argument("-t", "--type", choices=[LOCAL_RECIPES_INDEX],
                            help="Define the remote type")
-    subparser.add_argument("--recipes-only", default=False,
+    subparser.add_argument("--recipes-only", action="store_true", default=False,
                            help="Disallow binary downloads from this remote, only recipes "
                                 "will be downloaded")
 

--- a/conan/internal/rest/remote_manager.py
+++ b/conan/internal/rest/remote_manager.py
@@ -166,6 +166,8 @@ class RemoteManager:
     def _get_package(self, layout, pref, remote, scoped_output, metadata):
         try:
             assert pref.revision is not None
+            if not remote.allow_binary_downloads:
+                raise NotFoundException(f"Remote '{remote.name}' doesn't allow binary downloads")
 
             download_pkg_folder = layout.download_package()
             # Download files to the pkg_tgz folder, not to the final one
@@ -206,6 +208,8 @@ class RemoteManager:
             return result
 
     def search_packages(self, remote, ref):
+        if not remote.allow_binary_downloads:
+            return {}
         packages = self._call_remote(remote, "search_packages", ref)
         # Avoid serializing conaninfo in server side
         packages = {PkgReference(ref, pid): load_binary_info(data["content"])
@@ -234,6 +238,8 @@ class RemoteManager:
 
     def get_package_revisions_references(self, pref, remote, headers=None) -> List[PkgReference]:
         assert pref.revision is None, "get_package_revisions_references of a reference with revision"
+        if not remote.allow_binary_downloads:
+            return []
         return self._call_remote(remote, "get_package_revisions_references", pref, headers=headers)
 
     def get_latest_recipe_reference(self, ref, remote):
@@ -242,6 +248,8 @@ class RemoteManager:
 
     def get_latest_package_reference(self, pref, remote, info=None) -> PkgReference:
         assert pref.revision is None, "get_latest_package_reference of a reference with revision"
+        if not remote.allow_binary_downloads:
+            raise NotFoundException(f"Remote '{remote.name}' doesn't allow binary downloads")
         # These headers are useful to know what configurations are being requested in the server
         headers = None
         if info:

--- a/conan/internal/rest/remote_manager.py
+++ b/conan/internal/rest/remote_manager.py
@@ -166,7 +166,7 @@ class RemoteManager:
     def _get_package(self, layout, pref, remote, scoped_output, metadata):
         try:
             assert pref.revision is not None
-            if not remote.allow_binary_downloads:
+            if remote.recipes_only:
                 raise NotFoundException(f"Remote '{remote.name}' doesn't allow binary downloads")
 
             download_pkg_folder = layout.download_package()
@@ -208,7 +208,7 @@ class RemoteManager:
             return result
 
     def search_packages(self, remote, ref):
-        if not remote.allow_binary_downloads:
+        if remote.recipes_only:
             return {}
         packages = self._call_remote(remote, "search_packages", ref)
         # Avoid serializing conaninfo in server side
@@ -238,7 +238,7 @@ class RemoteManager:
 
     def get_package_revisions_references(self, pref, remote, headers=None) -> List[PkgReference]:
         assert pref.revision is None, "get_package_revisions_references of a reference with revision"
-        if not remote.allow_binary_downloads:
+        if remote.recipes_only:
             return []
         return self._call_remote(remote, "get_package_revisions_references", pref, headers=headers)
 
@@ -248,7 +248,7 @@ class RemoteManager:
 
     def get_latest_package_reference(self, pref, remote, info=None) -> PkgReference:
         assert pref.revision is None, "get_latest_package_reference of a reference with revision"
-        if not remote.allow_binary_downloads:
+        if remote.recipes_only:
             raise NotFoundException(f"Remote '{remote.name}' doesn't allow binary downloads")
         # These headers are useful to know what configurations are being requested in the server
         headers = None

--- a/test/integration/remote/test_remote_disabled_binaries.py
+++ b/test/integration/remote/test_remote_disabled_binaries.py
@@ -1,0 +1,84 @@
+import json
+import os
+
+import pytest
+
+from conan.api.model import PkgReference
+from conan.internal.util.files import save
+from conan.test.assets.genconanfile import GenConanfile
+from conan.test.utils.tools import TestClient
+
+PKG_ID = "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+RREV = "a9ec2e5fbb166568d4670a9cd1ef4b26"
+
+
+@pytest.fixture(scope="module")
+def client():
+    tc = TestClient(light=True, default_server_user=True)
+    tc.save({"conanfile.py": GenConanfile("pkg")})
+    tc.run("create . --version=1.0")
+    assert RREV == tc.exported_recipe_revision()
+    assert PKG_ID == tc.created_package_id("pkg/1.0")
+    tc.run("upload * -r=default -c")
+    tc.run("remove * -c")
+    tc.run("remote update default -nbd")
+    return tc
+
+
+def test_graph_binary_analyze(client):
+    client.run("install --requires=pkg/1.0 -f=json", assert_error=True)
+    client.assert_listed_binary({"pkg/1.0": (PKG_ID, "Missing")})
+
+    client.run("graph explain --requires=pkg/1.0")
+    assert "ERROR: No package binaries exist" in client.out
+
+
+def test_list_packages(client):
+    client.run("list pkg/1.0:* -r=default -f=json", redirect_stdout="list.json")
+    result = json.loads(client.load("list.json"))
+    assert len(result["default"]["pkg/1.0"]["revisions"][RREV]["packages"]) == 0
+
+    client.run(f"list pkg/1.0:{PKG_ID} -r=default -f=json", redirect_stdout="list.json")
+    result = json.loads(client.load("list.json"))
+    assert "error" in result["default"]  # not found error
+
+
+def test_download_package(client):
+    client.run("download pkg/1.0:* -r=default -f=json", redirect_stdout="download.json")
+    result = json.loads(client.load("download.json"))
+    assert len(result["Local Cache"]["pkg/1.0"]["revisions"][RREV]["packages"]) == 0
+
+
+def test_remove_package(client):
+    client.run(f"remove pkg/1.0:{PKG_ID} -r=default -c -f=json", redirect_stdout="remove.json")
+    result = json.loads(client.load("remove.json"))
+    assert result["default"] == {}
+
+    client.run(f"remove pkg/1.0:* -r=default -c -f=json", redirect_stdout="remove.json")
+    result = json.loads(client.load("remove.json"))
+    assert result["default"] == {}
+
+    client.run(f"remove pkg/1.0 -r=default -c -f=json", redirect_stdout="remove.json")
+    result = json.loads(client.load("remove.json"))
+    assert "packages" not in result["default"]["pkg/1.0"]["revisions"][RREV]
+
+
+@pytest.mark.parametrize("pattern", ["*", "pkg/2.0", "pkg/2.0:*", f"pkg/2.0:{PKG_ID}"])
+def test_upload_still_works(client, pattern):
+    client.run("create . --version=2.0")
+    layout = client.created_layout()
+    save(os.path.join(layout.metadata(), "metadata.log"), "New hello")
+
+    client.run(f"upload {pattern} -r=default -c")
+
+    # Now check that the binary was in fact uploaded
+    client.run("remote update default -abd")
+    client.run("remove * -c")
+    client.run("list pkg/2.0:* -r=default -f=json", redirect_stdout="list.json")
+    result = json.loads(client.load("list.json"))
+    assert len(result["default"]["pkg/2.0"]["revisions"][RREV]["packages"]) == 1
+    assert PKG_ID in result["default"]["pkg/2.0"]["revisions"][RREV]["packages"]
+
+    client.run(f"download {pattern} -r=default -f=json --metadata=*", redirect_stdout="download.json")
+    pkg2_layout = client.get_latest_pkg_layout(PkgReference().loads(f"pkg/2.0#{RREV}:{PKG_ID}"))
+    assert os.path.exists(os.path.join(pkg2_layout.metadata(), "metadata.log"))

--- a/test/integration/remote/test_remote_recipes_only.py
+++ b/test/integration/remote/test_remote_recipes_only.py
@@ -21,7 +21,7 @@ def client():
     assert PKG_ID == tc.created_package_id("pkg/1.0")
     tc.run("upload * -r=default -c")
     tc.run("remove * -c")
-    tc.run("remote update default -nbd")
+    tc.run("remote update default --recipes-only")
     return tc
 
 
@@ -72,7 +72,7 @@ def test_upload_still_works(client, pattern):
     client.run(f"upload {pattern} -r=default -c")
 
     # Now check that the binary was in fact uploaded
-    client.run("remote update default -abd")
+    client.run("remote update default --recipes-only=False")
     client.run("remove * -c")
     client.run("list pkg/2.0:* -r=default -f=json", redirect_stdout="list.json")
     result = json.loads(client.load("list.json"))


### PR DESCRIPTION
Changelog: Feature: Add `recipes_only` field to remote to control whether a remote can be used to download binaries.
Docs: https://github.com/conan-io/docs/pull/4238

As suggested by @jcar87 in a discussion with the team