### PR TITLE
fix VCVars path with mixed slashes

### DIFF
--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -296,6 +296,7 @@ def _vcvars_path(version, vs_install_path):
         vcpath = os.path.join(vs_path, "VC/Auxiliary/Build/vcvarsall.bat")
     else:
         vcpath = os.path.join(vs_path, "VC/vcvarsall.bat")
+    vcpath = os.path.normpath(vcpath)
     return vcpath
 
 

--- a/test/integration/toolchains/microsoft/vcvars_test.py
+++ b/test/integration/toolchains/microsoft/vcvars_test.py
@@ -29,7 +29,7 @@ def test_vcvars_generator(scope):
                '-s compiler.cppstd=14 -s compiler.runtime=static')
 
     assert os.path.exists(os.path.join(client.current_folder, "conanvcvars.bat"))
-
+    assert r"VC\Auxiliary\Build\vcvarsall.bat" in client.load("conanvcvars.bat")
     bat_contents = client.load("conanbuild.bat")
     if scope in ("build", None):
         assert "conanvcvars.bat" in bat_contents


### PR DESCRIPTION
Changelog: Fix: Ensure ``VCVars`` generated ``conanvcvars.bat`` has normalized path with backward slash (Windows).
Docs: Omit

Close https://github.com/conan-io/conan/issues/18893
