### PR TITLE
Fix missing double quotes around arguments

### DIFF
--- a/conan/tools/microsoft/msbuild.py
+++ b/conan/tools/microsoft/msbuild.py
@@ -50,7 +50,7 @@ class MSBuild:
         :return: ``str`` msbuild command line.
         """
         # TODO: Enable output_binary_log via config
-        cmd = ('msbuild.exe "%s" -p:Configuration="%s" -p:Platform=%s'
+        cmd = ('msbuild.exe "%s" -p:Configuration="%s" -p:Platform="%s"'
                % (sln, self.build_type, self.platform))
 
         verbosity = msbuild_verbosity_cmd_line_arg(self._conanfile)
@@ -60,12 +60,12 @@ class MSBuild:
         maxcpucount = self._conanfile.conf.get("tools.microsoft.msbuild:max_cpu_count",
                                                check_type=int)
         if maxcpucount is not None:
-            cmd += f" -m:{maxcpucount}" if maxcpucount > 0 else " -m"
+            cmd += f' -m:"{maxcpucount}"' if maxcpucount > 0 else " -m"
 
         if targets:
             if not isinstance(targets, list):
                 raise ConanException("targets argument should be a list")
-            cmd += " -target:{}".format(";".join(targets))
+            cmd += ' -target:"{}"'.format(";".join(targets))
 
         return cmd
 

--- a/test/integration/toolchains/premake/test_premake.py
+++ b/test/integration/toolchains/premake/test_premake.py
@@ -138,4 +138,4 @@ def test_premake_msbuild_platform():
     tc.save({"conanfile.py": conanfile, "win": windows_profile})
     tc.run("build . -pr win")
     assert 'conanfile.premake5.lua" vs2022 --arch=x86_64!!' in tc.out
-    assert 'Running msbuild.exe "App.sln" -p:Configuration="Release" -p:Platform=Win64!!' in tc.out
+    assert 'Running msbuild.exe "App.sln" -p:Configuration="Release" -p:Platform="Win64"!!' in tc.out

--- a/test/unittests/tools/microsoft/test_msbuild.py
+++ b/test/unittests/tools/microsoft/test_msbuild.py
@@ -25,7 +25,7 @@ def test_msbuild_targets():
     msbuild = MSBuild(conanfile)
     cmd = msbuild.command('project.sln', targets=["static", "shared"])
 
-    assert '-target:static;shared' in cmd
+    assert '-target:"static;shared"' in cmd
 
 
 def test_msbuild_cpu_count():
@@ -40,12 +40,12 @@ def test_msbuild_cpu_count():
 
     msbuild = MSBuild(conanfile)
     cmd = msbuild.command('project.sln')
-    assert 'msbuild.exe "project.sln" -p:Configuration="Release" -p:Platform=x64 -m:23' == cmd
+    assert 'msbuild.exe "project.sln" -p:Configuration="Release" -p:Platform="x64" -m:"23"' == cmd
 
     c.loads("tools.microsoft.msbuild:max_cpu_count=0")
     conanfile.conf = c.get_conanfile_conf(None)
     cmd = msbuild.command('project.sln')
-    assert 'msbuild.exe "project.sln" -p:Configuration="Release" -p:Platform=x64 -m' == cmd
+    assert 'msbuild.exe "project.sln" -p:Configuration="Release" -p:Platform="x64" -m' == cmd
 
 
 def test_msbuild_toolset():


### PR DESCRIPTION
Changelog: Bugfix: Fix missing double quotes for MSBuild's commands.
Docs: Omit
Closes: https://github.com/conan-io/conan/issues/18910

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.

Hello! Could someone please write a simple test for this? Thanks in advance!