### PR TITLE
Make `auto_shared_fpic` always apply deletions even when methods are defined

### DIFF
--- a/conan/internal/methods.py
+++ b/conan/internal/methods.py
@@ -90,7 +90,7 @@ def run_configure_method(conanfile, down_options, profile_options, ref):
     if hasattr(conanfile, "config_options"):
         with conanfile_exception_formatter(conanfile, "config_options"):
             conanfile.config_options()
-    elif "auto_shared_fpic" in conanfile.implements:
+    if "auto_shared_fpic" in conanfile.implements:
         auto_shared_fpic_config_options(conanfile)
 
     auto_language(conanfile)  # default implementation removes `compiler.cstd`
@@ -102,7 +102,7 @@ def run_configure_method(conanfile, down_options, profile_options, ref):
     if hasattr(conanfile, "configure"):
         with conanfile_exception_formatter(conanfile, "configure"):
             conanfile.configure()
-    elif "auto_shared_fpic" in conanfile.implements:
+    if "auto_shared_fpic" in conanfile.implements:
         auto_shared_fpic_configure(conanfile)
 
     if initial_requires_count != len(conanfile.requires):

--- a/test/integration/options/test_configure_options.py
+++ b/test/integration/options/test_configure_options.py
@@ -57,25 +57,21 @@ class TestConfigureOptions:
 
     @parameterized.expand([
         ["Linux", False, False, False, [False, False, False]],
-        ["Linux", False, False, True, [False, False, True]],
+        ["Windows", False, False, False, [False, None, False]],
+        ["Windows", True, False, False, [True, None, False]],
+        ["Windows", False, False, True, [None, None, True]],
+        ["Linux", False, False, True, [None, None, True]],
+        ["Linux", True, True, False, [True, None, False]],
+        ["Linux", True, False, False, [True, None, False]],
+        ["Linux", True, True, True, [None, None, True]],
+        ["Linux", True, True, True, [None, None, True]],
         ["Linux", False, True, False, [False, True, False]],
-        ["Linux", False, True, True, [False, True, True]],
-        ["Linux", True, False, False, [True, False, False]],
-        ["Linux", True, False, True, [True, False, True]],
-        ["Linux", True, True, False, [True, True, False]],
-        ["Linux", True, True, True, [True, True, True]],
-        ["Windows", False, False, False, [False, False, False]],
-        ["Windows", False, False, True, [False, False, True]],
-        ["Windows", False, True, False, [False, True, False]],
-        ["Windows", False, True, True, [False, True, True]],
-        ["Windows", True, False, False, [True, False, False]],
-        ["Windows", True, False, True, [True, False, True]],
-        ["Windows", True, True, False, [True, True, False]],
-        ["Windows", True, True, True, [True, True, True]],
+        ["Linux", False, True, False, [False, True, False]],
     ])
     def test_optout(self, settings_os, shared, fpic, header_only, result):
         """
-        Test that options are not managed automatically when methods are defined even if implements = ["auto_shared_fpic", "auto_header_only"]
+        Test that options are managed automatically when implements = ["auto_shared_fpic", "auto_header_only"]
+        even if methods are defined.
         Check that header only package gets its unique package ID.
         """
         client = TestClient()


### PR DESCRIPTION
Changelog: Feature: Make `auto_shared_fpic` always apply deletions even when methods are defined
Docs: TODO

