### PR TITLE
Fix/mesontoolchain linker script

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -463,7 +463,7 @@ class MesonToolchain:
                                                 check_type=list)
         linker_scripts = self._conanfile_conf.get("tools.build:linker_scripts", default=[],
                                                   check_type=list)
-        linker_script_flags = ['-T"' + linker_script + '"' for linker_script in linker_scripts]
+        linker_script_flags = ['-T' + linker_script for linker_script in linker_scripts]
         defines = self._conanfile_conf.get("tools.build:defines", default=[], check_type=list)
         sys_root = [f"--sysroot={self._sys_root}"] if self._sys_root else [""]
         ld = (sharedlinkflags + exelinkflags + linker_script_flags + sys_root + self.extra_ldflags

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -230,7 +230,6 @@ def test_custom_arch_flag_via_toolchain():
     assert re.search(r"cpp_link_args =.+-mmy-flag.+", content)
 
 
-
 def test_linker_scripts_via_conf():
     profile = textwrap.dedent("""
         [settings]
@@ -256,8 +255,10 @@ def test_linker_scripts_via_conf():
 
     t.run("install . -pr:b=profile -pr=profile")
     content = t.load(MesonToolchain.native_filename)
-    assert "c_link_args = ['-flag0', '-other=val', '-m64', '-flag5', '-flag6', '-T\"/linker/scripts/flash.ld\"', '-T\"/linker/scripts/extra_data.ld\"']" in content
-    assert "cpp_link_args = ['-flag0', '-other=val', '-m64', '-flag5', '-flag6', '-T\"/linker/scripts/flash.ld\"', '-T\"/linker/scripts/extra_data.ld\"']" in content
+    assert ("c_link_args = ['-flag0', '-other=val', '-m64', '-flag5', '-flag6', "
+            "'-T/linker/scripts/flash.ld', '-T/linker/scripts/extra_data.ld']") in content
+    assert ("cpp_link_args = ['-flag0', '-other=val', '-m64', '-flag5', '-flag6', "
+            "'-T/linker/scripts/flash.ld', '-T/linker/scripts/extra_data.ld']") in content
 
 
 def test_correct_quotes():


### PR DESCRIPTION
Changelog: Bugfix: MesonToolchain no longer add quotes to ``linker_script`` definition.
Docs: Omit

Close https://github.com/conan-io/conan/issues/18535