### PR TITLE
Always run validate hooks even if no validate method exists

### DIFF
--- a/conan/internal/graph/compute_pid.py
+++ b/conan/internal/graph/compute_pid.py
@@ -72,17 +72,17 @@ def run_validate_package_id(conanfile, hook_manager=None):
                     # This 'cant_build' will be ignored if we don't have to build the node.
                     conanfile.info.cant_build = str(e)
 
-    if hasattr(conanfile, "validate"):
-        with conanfile_exception_formatter(conanfile, "validate"):
-            with conanfile_remove_attr(conanfile, ['cpp_info'], "validate"):
-                try:
-                    if hook_manager:
-                        hook_manager.execute("pre_validate", conanfile=conanfile)
+    with conanfile_exception_formatter(conanfile, "validate"):
+        with conanfile_remove_attr(conanfile, ['cpp_info'], "validate"):
+            try:
+                if hook_manager:
+                    hook_manager.execute("pre_validate", conanfile=conanfile)
+                if hasattr(conanfile, "validate"):
                     conanfile.validate()
-                    if hook_manager:
-                        hook_manager.execute("post_validate", conanfile=conanfile)
-                except ConanInvalidConfiguration as e:
-                    conanfile.info.invalid = str(e)
+                if hook_manager:
+                    hook_manager.execute("post_validate", conanfile=conanfile)
+            except ConanInvalidConfiguration as e:
+                conanfile.info.invalid = str(e)
 
     # Once we are done, call package_id() to narrow and change possible values
     if hasattr(conanfile, "package_id"):

--- a/test/integration/extensions/hooks/hook_test.py
+++ b/test/integration/extensions/hooks/hook_test.py
@@ -88,10 +88,14 @@ class TestHooks:
         assert f"conanfile.py (pkg/0.1): {hook_msg} post_source(): Hello" in c.out
 
         c.run("install .")
+        assert f"conanfile.py (pkg/0.1): {hook_msg} pre_validate(): Hello" in c.out
+        assert f"conanfile.py (pkg/0.1): {hook_msg} post_validate(): Hello" in c.out
         assert f"conanfile.py (pkg/0.1): {hook_msg} pre_generate(): Hello" in c.out
         assert f"conanfile.py (pkg/0.1): {hook_msg} post_generate(): Hello" in c.out
 
         c.run("build .")
+        assert f"conanfile.py (pkg/0.1): {hook_msg} pre_validate(): Hello" in c.out
+        assert f"conanfile.py (pkg/0.1): {hook_msg} post_validate(): Hello" in c.out
         assert f"conanfile.py (pkg/0.1): {hook_msg} pre_build(): Hello" in c.out
         assert f"conanfile.py (pkg/0.1): {hook_msg} post_build(): Hello" in c.out
         assert f"conanfile.py (pkg/0.1): {hook_msg} pre_generate(): Hello" in c.out
@@ -108,6 +112,8 @@ class TestHooks:
         assert f"conanfile.py (pkg/0.1): {hook_msg} post_package(): Hello" in c.out
 
         c.run("create . ")
+        assert f"pkg/0.1: {hook_msg} pre_validate(): Hello" in c.out
+        assert f"pkg/0.1: {hook_msg} post_validate(): Hello" in c.out
         assert f"pkg/0.1: {hook_msg} pre_export(): Hello" in c.out
         assert f"pkg/0.1: {hook_msg} post_export(): Hello" in c.out
         assert f"pkg/0.1: {hook_msg} pre_source(): Hello" in c.out


### PR DESCRIPTION
Changelog: Fix: Always run `validate` hooks even if recipe does not define `validate()` method.
Docs: Omit

To first discuss with the team, because the current logic was probably implemented for a reason, even though this new behaviour seems to be useful in CI contexts like CCI
Closes https://github.com/conan-io/conan/issues/18926