### PR TITLE
Move test_requires to build_requirements in tests

### DIFF
--- a/test/functional/toolchains/microsoft/test_msbuilddeps.py
+++ b/test/functional/toolchains/microsoft/test_msbuilddeps.py
@@ -833,7 +833,7 @@ def check_build_vs_project_with_test_requires(vs_version):
             settings = "os", "build_type", "compiler", "arch"
             generators = "MSBuildDeps", "MSBuildToolchain"
 
-            def requirements(self):
+            def build_requirements(self):
                 self.test_requires("mydep.pkg.team/0.1")
 
             def build(self):

--- a/test/integration/graph/test_test_requires.py
+++ b/test/integration/graph/test_test_requires.py
@@ -35,8 +35,10 @@ class TestTestRequiresDiamond:
             from conan import ConanFile
             class Pkg(ConanFile):
                 def requirements(self):
+                    # Best practice is to declare test_requires in the build_requirements() method,
+                    # but this ensures it is also possible to declare them in requirements(),
+                    # as has historically been allowed.
                     self.test_requires("gtest/1.0")
-                def build_requirements(self):
                     self.requires("zlib/1.0")
             """)
         c = TestClient(light=True)

--- a/test/integration/graph/test_test_requires.py
+++ b/test/integration/graph/test_test_requires.py
@@ -36,6 +36,7 @@ class TestTestRequiresDiamond:
             class Pkg(ConanFile):
                 def requirements(self):
                     self.test_requires("gtest/1.0")
+                def build_requirements(self):
                     self.requires("zlib/1.0")
             """)
         c = TestClient(light=True)
@@ -70,8 +71,9 @@ class TestTestRequiresDiamond:
         game = textwrap.dedent("""
            from conan import ConanFile
            class Pkg(ConanFile):
-               def requirements(self):
+               def build_requirements(self):
                    self.test_requires("gtest/1.0")
+               def requirements(self):
                    self.requires("engine/1.0")
            """)
         c.save({"zlib/conanfile.py": GenConanfile("zlib", "1.0"),
@@ -94,6 +96,7 @@ class TestTestRequiresDiamond:
            class Pkg(ConanFile):
                def requirements(self):
                    self.test_requires("gtest/1.0", force=True)
+               def build_requirements(self):
                    self.test_requires("rapidcheck/1.0")
            """)
         c.save({"gtest/conanfile.py": GenConanfile("gtest"),
@@ -214,8 +217,9 @@ def test_requires_transitive_diamond_components_order():
             name = "libc"
             version = "0.1"
 
-            def requirements(self):
+            def build_requirements(self):
                 self.test_requires("liba/1.0")
+            def requirements(self):
                 self.requires("libb/1.0")
 
             def package_info(self):

--- a/test/integration/graph/test_test_requires.py
+++ b/test/integration/graph/test_test_requires.py
@@ -94,9 +94,8 @@ class TestTestRequiresDiamond:
         game = textwrap.dedent("""
            from conan import ConanFile
            class Pkg(ConanFile):
-               def requirements(self):
-                   self.test_requires("gtest/1.0", force=True)
                def build_requirements(self):
+                   self.test_requires("gtest/1.0", force=True)
                    self.test_requires("rapidcheck/1.0")
            """)
         c.save({"gtest/conanfile.py": GenConanfile("gtest"),


### PR DESCRIPTION
Changelog: Fix: Move `test_requires` to `build_requirements` method in tests.
Docs: Omit
