### PR TITLE
Move macOS bitcode flag testing to integration test

### DIFF
--- a/.github/workflows/osx-tests.yml
+++ b/.github/workflows/osx-tests.yml
@@ -158,6 +158,7 @@ jobs:
           sudo xcode-select -s /Applications/Xcode_16.4.app
           xcodebuild -version
           xcrun --sdk macosx --show-sdk-version
+          clang --version
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5

--- a/test/functional/toolchains/cmake/test_cmake_toolchain_xcode_flags.py
+++ b/test/functional/toolchains/cmake/test_cmake_toolchain_xcode_flags.py
@@ -16,6 +16,7 @@ def _add_message_status_flags(client):
         cmakelists_file.write('message(STATUS "CONAN_OBJCXX_FLAGS: ${CONAN_OBJCXX_FLAGS}")\n')
 
 
+@pytest.mark.skip(reason="Bitcode is deprecated on Xcode >= 14")
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
 @pytest.mark.parametrize("op_system,os_version,sdk,arch", [
     ("watchOS", "8.1", "watchos", "armv7k"),

--- a/test/functional/toolchains/cmake/test_cmake_toolchain_xcode_flags.py
+++ b/test/functional/toolchains/cmake/test_cmake_toolchain_xcode_flags.py
@@ -16,7 +16,6 @@ def _add_message_status_flags(client):
         cmakelists_file.write('message(STATUS "CONAN_OBJCXX_FLAGS: ${CONAN_OBJCXX_FLAGS}")\n')
 
 
-@pytest.mark.skip(reason="Bitcode is deprecated on Xcode >= 14")
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
 @pytest.mark.parametrize("op_system,os_version,sdk,arch", [
     ("watchOS", "8.1", "watchos", "armv7k"),
@@ -31,7 +30,6 @@ def test_cmake_apple_bitcode_arc_and_visibility_flags_enabled(op_system, os_vers
         os.sdk={}
         arch={}
         [conf]
-        tools.apple:enable_bitcode=True
         tools.apple:enable_arc=True
         tools.apple:enable_visibility=True
     """.format(op_system, os_version, sdk, arch))
@@ -42,10 +40,6 @@ def test_cmake_apple_bitcode_arc_and_visibility_flags_enabled(op_system, os_vers
     _add_message_status_flags(client)
     client.run("install . --profile:build=default --profile:host=host")
     toolchain = client.load(os.path.join("build", "Release", "generators", "conan_toolchain.cmake"))
-    # bitcode
-    assert 'set(CMAKE_XCODE_ATTRIBUTE_ENABLE_BITCODE "YES")' in toolchain
-    assert 'set(CMAKE_XCODE_ATTRIBUTE_BITCODE_GENERATION_MODE "bitcode")' in toolchain
-    assert 'set(BITCODE "-fembed-bitcode")' in toolchain
     # arc
     assert 'set(FOBJC_ARC "-fobjc-arc")' in toolchain
     assert 'set(CMAKE_XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC "YES")' in toolchain
@@ -55,10 +49,10 @@ def test_cmake_apple_bitcode_arc_and_visibility_flags_enabled(op_system, os_vers
 
     client.run("create . --profile:build=default --profile:host=host -tf=")
     # flags
-    assert "-- CONAN_C_FLAGS:  -fembed-bitcode -fvisibility=default" in client.out
-    assert "-- CONAN_CXX_FLAGS:  -fembed-bitcode -fvisibility=default" in client.out
-    assert "-- CONAN_OBJC_FLAGS:  -fembed-bitcode -fvisibility=default -fobjc-arc" in client.out
-    assert "-- CONAN_OBJCXX_FLAGS:  -fembed-bitcode -fvisibility=default -fobjc-arc" in client.out
+    assert "-- CONAN_C_FLAGS:   -fvisibility=default" in client.out
+    assert "-- CONAN_CXX_FLAGS:   -fvisibility=default" in client.out
+    assert "-- CONAN_OBJC_FLAGS:   -fvisibility=default -fobjc-arc" in client.out
+    assert "-- CONAN_OBJCXX_FLAGS:   -fvisibility=default -fobjc-arc" in client.out
     assert "[100%] Built target hello" in client.out
 
 

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -523,6 +523,31 @@ def test_extra_flags_via_conf():
     assert 'add_compile_definitions( "D1" "D2")' in toolchain
 
 
+def test_bitcode_enable_flag():
+    profile = textwrap.dedent("""
+        [settings]
+        os=Macos
+        arch=armv8
+        compiler=apple-clang
+        compiler.version=17
+        compiler.libcxx=libc++
+        build_type=Release
+
+        [conf]
+        tools.apple:enable_bitcode=True
+        """)
+
+    client = TestClient(path_with_spaces=False)
+
+    conanfile = GenConanfile().with_settings("os", "arch", "compiler", "build_type") \
+                              .with_generator("CMakeToolchain")
+    client.save({"conanfile.py": conanfile,
+                 "profile": profile})
+    client.run("install . --profile:build=profile --profile:host=profile")
+    toolchain = client.load("conan_toolchain.cmake")
+    assert 'set(BITCODE "-fembed-bitcode")' in toolchain
+
+
 def test_cmake_presets_binary_dir_available():
     client = TestClient(path_with_spaces=False)
     conanfile = textwrap.dedent("""


### PR DESCRIPTION
Changelog: Fix: Move macOS bitcode flag testing to integration test.
Docs: Omit

clang 17 does not accept the bitcode flag any more. I have moved the testing of the conf to integration testing just to check that the flag is set correctly in the toolchain but it will make the CI fail if we try to pass it to the clang installed for functional tests.

Check deprecation warnings about bitcode flag in Xcode releases:
- https://developer.apple.com/documentation/xcode-release-notes/xcode-14-release-notes
- https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes