### PR TITLE
workspace add updates reference

### DIFF
--- a/conan/internal/model/workspace.py
+++ b/conan/internal/model/workspace.py
@@ -48,10 +48,13 @@ class Workspace:
         if output_folder:
             editable["output_folder"] = self._conan_rel_path(output_folder)
         packages = self.conan_data.setdefault("packages", [])
-        if any(p["path"] == path for p in packages):
-            self.output.warning(f"Package {path} already exists, skipping")
-            return
-        packages.append(editable)
+        for p in packages:
+            if p["path"] == path:
+                self.output.warning(f"Package {path} already exists, updating its reference")
+                p["ref"] = editable["ref"]
+                break
+        else:
+            packages.append(editable)
         save(os.path.join(self.folder, WORKSPACE_YML), yaml.dump(self.conan_data))
 
     def remove(self, path):

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -119,6 +119,22 @@ class TestAddRemove:
         assert "dep1/0.1" in c.out
         assert "dep2" not in c.out
 
+    def test_add_modified(self):
+        # https://github.com/conan-io/conan/issues/18942
+        c = TestClient(light=True)
+        c.save({"conanws.yml": "",
+                "dep1/conanfile.py": GenConanfile("dep1", "0.1")})
+        c.run("workspace add dep1")
+        assert "Reference 'dep1/0.1' added to workspace" in c.out
+        c.run("workspace info")
+        assert "dep1/0.1" in c.out
+        c.save({"dep1/conanfile.py": GenConanfile("dep1", "0.2")})
+        c.run("workspace add dep1")
+        assert "Package dep1 already exists, updating its reference" in c.out
+        assert "Reference 'dep1/0.2' added to workspace" in c.out
+        c.run("workspace info")
+        assert "dep1/0.2" in c.out
+
     @pytest.mark.parametrize("api", [False, True])
     def test_dynamic_editables(self, api):
         c = TestClient(light=True)

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -134,6 +134,7 @@ class TestAddRemove:
         assert "Reference 'dep1/0.2' added to workspace" in c.out
         c.run("workspace info")
         assert "dep1/0.2" in c.out
+        assert "dep1/0.1" not in c.out
 
     @pytest.mark.parametrize("api", [False, True])
     def test_dynamic_editables(self, api):


### PR DESCRIPTION
Changelog: Fix: ``workspace add`` can update the package version of an existing package in the workspace.
Docs: Omit

Close https://github.com/conan-io/conan/issues/18942
