### PR TITLE
refactor, move http requester to private helpers

### DIFF
--- a/conan/api/subapi/config.py
+++ b/conan/api/subapi/config.py
@@ -42,7 +42,7 @@ class ConfigAPI:
         """
         from conan.internal.api.config.config_installer import configuration_install
         cache_folder = self._conan_api.cache_folder
-        requester = self._conan_api.remotes.requester
+        requester = self._helpers.requester
         configuration_install(cache_folder, requester, path_or_url, verify_ssl,
                               config_type=config_type, args=args,
                               source_folder=source_folder, target_folder=target_folder)
@@ -103,7 +103,7 @@ class ConfigAPI:
 
         from conan.internal.api.config.config_installer import configuration_install
         cache_folder = self._conan_api.cache_folder
-        requester = self._conan_api.remotes.requester
+        requester = self._helpers.requester
         configuration_install(cache_folder, requester, uri=pkg.conanfile.package_folder,
                               verify_ssl=False, config_type="dir",
                               ignore=["conaninfo.txt", "conanmanifest.txt"])

--- a/conan/api/subapi/remotes.py
+++ b/conan/api/subapi/remotes.py
@@ -8,7 +8,6 @@ from conan.api.model import Remote, LOCAL_RECIPES_INDEX
 from conan.api.output import ConanOutput
 from conan.internal.cache.home_paths import HomePaths
 from conan.internal.conan_app import ConanBasicApp
-from conan.internal.rest.conan_requester import ConanRequester
 from conan.internal.rest.remote_credentials import RemoteCredentials
 from conan.internal.rest.rest_client_local_recipe_index import add_local_recipes_index_remote, \
     remove_local_recipes_index_remote
@@ -35,11 +34,6 @@ class RemotesAPI:
         self._api_helpers = api_helpers
         self._home_folder = conan_api.home_folder
         self._remotes_file = HomePaths(self._home_folder).remotes_path
-        # Wraps an http_requester to inject proxies, certs, etc
-        self._requester = ConanRequester(api_helpers.global_conf, self._home_folder)
-
-    def reinit(self):
-        self._requester = ConanRequester(self._api_helpers.global_conf, self._home_folder)
 
     def list(self, pattern=None, only_enabled=True):
         """
@@ -281,10 +275,6 @@ class RemotesAPI:
         app.remote_manager.check_credentials(remote, force)
         user, token, _ = localdb.get_login(remote.url)
         return user
-
-    @property
-    def requester(self):
-        return self._requester
 
 
 def _load(remotes_file):

--- a/conan/api/subapi/upload.py
+++ b/conan/api/subapi/upload.py
@@ -155,7 +155,7 @@ class UploadAPI:
             output.info("No backup sources files to upload")
             return
 
-        requester = self._conan_api.remotes.requester
+        requester = self._api_helpers.requester
         uploader = FileUploader(requester, verify=True, config=config, source_credentials=True)
         # TODO: For Artifactory, we can list all files once and check from there instead
         #  of 1 request per file, but this is more general

--- a/conan/internal/api/audit/providers.py
+++ b/conan/internal/api/audit/providers.py
@@ -16,7 +16,7 @@ class ConanCenterProvider:
         self.url = provider_data["url"]
         self.type = provider_data["type"]
         self._token = provider_data.get("token")
-        self._session = conan_api.remotes.requester
+        self._session = conan_api._api_helpers.requester  # noqa
         self._query_url = urljoin(self.url, "api/v1/query")
 
     def get_cves(self, refs):
@@ -111,7 +111,7 @@ class PrivateProvider:
         self.url = provider_data["url"]
         self.type = provider_data["type"]
         self._token = provider_data.get("token")
-        self._session = conan_api.remotes.requester
+        self._session = conan_api._api_helpers.requester  # noqa
         self._query_url = urljoin(self.url, "catalog/api/v0/public/graphql")
 
     def get_cves(self, refs):

--- a/conan/internal/conan_app.py
+++ b/conan/internal/conan_app.py
@@ -51,8 +51,8 @@ class ConanBasicApp:
         self.cache = PkgCache(self.cache_folder, global_conf)
         # Wraps RestApiClient to add authentication support (same interface)
         localdb = LocalDB(cache_folder)
-        auth_manager = ConanApiAuthManager(conan_api.remotes.requester, cache_folder, localdb,
-                                           global_conf)
+        requester = conan_api._api_helpers.requester  # noqa
+        auth_manager = ConanApiAuthManager(requester, cache_folder, localdb, global_conf)
         # Handle remote connections
         self.remote_manager = RemoteManager(self.cache, auth_manager, cache_folder)
         global_editables = conan_api.local.editable_packages
@@ -72,8 +72,8 @@ class ConanApp(ConanBasicApp):
 
         self.pyreq_loader = PyRequireLoader(self, self._global_conf)
         cmd_wrap = CmdWrapper(HomePaths(self.cache_folder).wrapper_path)
-        conanfile_helpers = ConanFileHelpers(conan_api.remotes.requester, cmd_wrap,
-                                             self._global_conf, self.cache, self.cache_folder)
+        requester = conan_api._api_helpers.requester  # noqa
+        conanfile_helpers = ConanFileHelpers(requester, cmd_wrap, self._global_conf, self.cache, self.cache_folder)
         self.loader = ConanFileLoader(self.pyreq_loader, conanfile_helpers)
 
 

--- a/test/integration/command/test_audit.py
+++ b/test/integration/command/test_audit.py
@@ -56,7 +56,7 @@ _sbom_zlib_1_2_11 = """
 
 @contextmanager
 def proxy_response(status, data, retry_after=60):
-    with patch("conan.api.conan_api.RemotesAPI.requester") as conanRequesterMock:
+    with patch("conan.api.conan_api.ConanAPI._ApiHelpers.requester") as conanRequesterMock:
         return_status = MagicMock()
         return_status.status_code = status
         return_status.json = MagicMock(return_value=data)
@@ -350,7 +350,7 @@ def test_audit_provider_env_credentials_with_proxy(monkeypatch):
         return response
 
     with environment_update({"CONAN_AUDIT_PROVIDER_TOKEN_CONANCENTER": "env_token_value"}):
-        with patch("conan.api.conan_api.RemotesAPI.requester",
+        with patch("conan.api.conan_api.ConanAPI._ApiHelpers.requester",
                    new_callable=MagicMock) as requester_mock:
             requester_mock.post = fake_post
             tc.run("audit list zlib/1.2.11")

--- a/test/unittests/client/rest/requester_test.py
+++ b/test/unittests/client/rest/requester_test.py
@@ -14,4 +14,4 @@ def test_requester_reinit():
     conan_api = ConanAPI(tmp_folder)
     save(os.path.join(home_path.global_conf_path), "core.net.http:timeout=(10, 20)")
     conan_api.reinit()
-    assert conan_api.remotes.requester._timeout == (10, 20)
+    assert conan_api._api_helpers.requester._timeout == (10, 20)


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

@AbrilRBS this was pending, or there were some reason we wanted the requester to be public in the RemotesAPI?
