### PR TITLE
Sketch locked show in graph summary

### DIFF
--- a/conan/cli/printers/graph.py
+++ b/conan/cli/printers/graph.py
@@ -16,16 +16,16 @@ def print_graph_basic(graph):
     for node in graph.nodes:
         if hasattr(node.conanfile, "python_requires"):
             for _, r in node.conanfile.python_requires.items():
-                python_requires[r.ref] = r.recipe, r.remote
+                python_requires[r.ref] = r.recipe, r.remote, r.locked
         if node.recipe in ("Consumer", "Cli"):
             continue
         if node.context == "build":
-            build_requires[node.ref] = node.recipe, node.remote
+            build_requires[node.ref] = node.recipe, node.remote, node.locked
         else:
             if node.test:
-                test_requires[node.ref] = node.recipe, node.remote
+                test_requires[node.ref] = node.recipe, node.remote, node.locked
             else:
-                requires[node.ref] = node.recipe, node.remote
+                requires[node.ref] = node.recipe, node.remote, node.locked
         if node.conanfile.deprecated:
             deprecated[node.ref] = node.conanfile.deprecated
 
@@ -37,10 +37,13 @@ def print_graph_basic(graph):
         if not reqs_to_print:
             return
         output.info(title, Color.BRIGHT_YELLOW)
-        for ref_, (recipe, remote) in sorted(reqs_to_print.items()):
+        for ref_, (recipe, remote, is_locked) in sorted(reqs_to_print.items()):
             if remote is not None:
                 recipe = "{} ({})".format(recipe, remote.name)
-            output.info("    {} - {}".format(ref_.repr_notime(), recipe), Color.BRIGHT_CYAN)
+            info = ref_.repr_notime()
+            if is_locked:
+                info = f"{info} (Locked)"
+            output.info("    {} - {}".format(info, recipe), Color.BRIGHT_CYAN)
 
     _format_requires("Requirements", requires)
     _format_requires("Test requirements", test_requires)

--- a/conan/internal/graph/graph.py
+++ b/conan/internal/graph/graph.py
@@ -71,6 +71,7 @@ class Node:
         self.is_conf = False
         self.replaced_requires = {}  # To track the replaced requires for self.edges[old-ref]
         self.skipped_build_requires = False
+        self.locked = False
 
     @property
     def dependencies(self):

--- a/conan/internal/graph/graph_builder.py
+++ b/conan/internal/graph/graph_builder.py
@@ -372,9 +372,10 @@ class DepsGraphBuilder:
 
         resolved = self._resolved_system(node, require, profile_build, profile_host,
                                          self._resolve_prereleases)
+        locked = False
         if graph_lock is not None:
             # Here is when the ranges and revisions are resolved
-            graph_lock.resolve_locked(node, require, self._resolve_prereleases)
+            locked = graph_lock.resolve_locked(node, require, self._resolve_prereleases)
 
         if resolved is None:
             try:
@@ -399,6 +400,7 @@ class DepsGraphBuilder:
         new_node = Node(new_ref, dep_conanfile, context=context, test=require.test or node.test)
         new_node.recipe = recipe_status
         new_node.remote = remote
+        new_node.locked = locked
 
         down_options = self._compute_down_options(node, require, new_ref)
 

--- a/conan/internal/graph/python_requires.py
+++ b/conan/internal/graph/python_requires.py
@@ -13,6 +13,7 @@ class PyRequire:
         self.path = path
         self.recipe = recipe_status
         self.remote = remote
+        self.locked = False
 
     def serialize(self):
         return {"remote": self.remote.name if self.remote is not None else None,
@@ -96,7 +97,7 @@ class PyRequireLoader(object):
         for py_requires_ref in py_requires_refs:
             py_requires_ref = RecipeReference.loads(py_requires_ref)
             requirement = Requirement(py_requires_ref)
-            resolved_ref = self._resolve_ref(requirement, graph_lock, remotes, update)
+            resolved_ref, locked = self._resolve_ref(requirement, graph_lock, remotes, update)
             try:
                 py_require = self._cached_py_requires[resolved_ref]
             except KeyError:
@@ -104,6 +105,7 @@ class PyRequireLoader(object):
                                                              remotes, update, check_update)
                 conanfile, module, new_ref, path, recipe_status, remote = pyreq_conanfile
                 py_require = PyRequire(module, conanfile, new_ref, path, recipe_status, remote)
+                py_require.locked = locked
                 self._cached_py_requires[resolved_ref] = py_require
             result.add_pyrequire(py_require)
         return result
@@ -112,12 +114,13 @@ class PyRequireLoader(object):
         if requirement.alias:
             raise ConanException("python-requires 'alias' are not supported in Conan 2.0. "
                                  "Please use version ranges instead")
+        locked = False
         if graph_lock:
-            graph_lock.resolve_locked_pyrequires(requirement, self._resolve_prereleases)
+            locked = graph_lock.resolve_locked_pyrequires(requirement, self._resolve_prereleases)
         # If the lock hasn't resolved the range, and it hasn't failed (it is partial), resolve it
         self._range_resolver.resolve(requirement, "python_requires", remotes, update)
         ref = requirement.ref
-        return ref
+        return ref, locked
 
     def _load_pyreq_conanfile(self, loader, graph_lock, ref, remotes, update, check_update):
         try:

--- a/conan/internal/model/lockfile.py
+++ b/conan/internal/model/lockfile.py
@@ -286,7 +286,7 @@ class Lockfile(object):
             locked_refs = self._requires.refs()
             kind = "requires"
         try:
-            self._resolve(require, locked_refs, resolve_prereleases, kind)
+            return self._resolve(require, locked_refs, resolve_prereleases, kind)
         except ConanException:
             overrides = self._overrides.get(require.ref)
             if overrides is not None and len(overrides) > 1:
@@ -327,23 +327,28 @@ class Lockfile(object):
             for m in matches:
                 if version_range.contains(m.version, resolve_prereleases):
                     require.ref = m
-                    break
+                    return True
+            if self.partial:
+                return False
             else:
-                if not self.partial:
-                    raise ConanException(f"Requirement '{ref}' not in lockfile '{kind}'")
+                raise ConanException(f"Requirement '{ref}' not in lockfile '{kind}'")
         else:
             ref = require.ref
             if ref.revision is None:
                 for m in matches:
                     if m.version == ref.version:
                         require.ref = m
-                        break
+                        return True
                 else:
-                    if not self.partial:
+                    if self.partial:
+                        return False
+                    else:
                         raise ConanException(f"Requirement '{ref}' not in lockfile '{kind}'")
             else:
                 if ref not in matches and not self.partial:
                     raise ConanException(f"Requirement '{repr(ref)}' not in lockfile '{kind}'")
+                else:
+                    return True
 
     def replace_alias(self, require, alias):
         locked_alias = self._alias.get(alias)
@@ -355,4 +360,4 @@ class Lockfile(object):
 
     def resolve_locked_pyrequires(self, require, resolve_prereleases=None):
         locked_refs = self._python_requires.refs()  # CHANGE
-        self._resolve(require, locked_refs, resolve_prereleases, "python_requires")
+        return self._resolve(require, locked_refs, resolve_prereleases, "python_requires")

--- a/test/integration/lockfile/test_lock_pyrequires.py
+++ b/test/integration/lockfile/test_lock_pyrequires.py
@@ -25,13 +25,14 @@ def test_transitive_py_requires():
                  "consumer/conanfile.py": consumer})
 
     client.run("export dep --name=dep --version=0.1 --user=user --channel=channel")
+    rrev = client.exported_recipe_revision()
     client.run("export pkg --name=pkg --version=0.1 --user=user --channel=channel")
     client.run("lock create consumer/conanfile.py")
 
     client.run("export dep --name=dep --version=0.2 --user=user --channel=channel")
 
     client.run("install consumer/conanfile.py")
-    assert "dep/0.1@user/channel" in client.out
+    assert f"dep/0.1@user/channel#{rrev} (Locked)" in client.out
     assert "dep/0.2" not in client.out
 
     os.remove(os.path.join(client.current_folder, "consumer/conan.lock"))

--- a/test/integration/lockfile/test_lock_requires.py
+++ b/test/integration/lockfile/test_lock_requires.py
@@ -19,13 +19,14 @@ def test_conanfile_txt_deps_ranges(requires):
     client.save({"pkg/conanfile.py": GenConanfile(),
                  "consumer/conanfile.txt": f"[{requires}]\npkg/[>0.0]@user/testing"})
     client.run("create pkg --name=pkg --version=0.1 --user=user --channel=testing")
+    rrev = client.exported_recipe_revision()
     client.run("lock create consumer/conanfile.txt")
     assert "pkg/0.1@user/testing#" in client.out
 
     client.run("create pkg --name=pkg --version=0.2 --user=user --channel=testing")
 
     client.run("install consumer/conanfile.txt")
-    assert "pkg/0.1@user/testing#" in client.out
+    assert f"pkg/0.1@user/testing#{rrev} (Locked)" in client.out
     assert "pkg/0.2" not in client.out
 
     os.remove(os.path.join(client.current_folder, "consumer/conan.lock"))


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

While working one the "Advanced versioning and lockfiles" tutorial, I realized that there's no explicit output that a certain reference was locked from the lockfile, so it made the explaining part a bit harder that it would have been otherwise.

To discuss with the team if we even want this output, me finding it useful might not warrant adding more logging like this
