### PR TITLE
Add `--context={build,host}` filter to `conan audit scan`

### DIFF
--- a/conan/api/subapi/audit.py
+++ b/conan/api/subapi/audit.py
@@ -3,6 +3,7 @@ import json
 import os
 import base64
 
+from conan.api.output import ConanOutput
 from conan.internal.api.audit.providers import ConanCenterProvider, PrivateProvider
 from conan.errors import ConanException
 from conan.internal.api.remotes.encrypt import encode, decode

--- a/conan/api/subapi/audit.py
+++ b/conan/api/subapi/audit.py
@@ -28,12 +28,15 @@ class AuditAPI:
         }
 
     @staticmethod
-    def scan(deps_graph, provider):
+    def scan(deps_graph, provider, context="all"):
         """
         Scan a given recipe for vulnerabilities in its dependencies.
         """
+        is_all = context == "all"
         refs = sorted(set(RecipeReference.loads(f"{node.ref.name}/{node.ref.version}")
-                          for node in deps_graph.nodes[1:]), key=lambda ref: ref.name)
+                          for node in deps_graph.nodes[1:]
+                          if is_all or node.context == context),
+                      key=lambda ref: ref.name)
         return provider.get_cves(refs)
 
     @staticmethod

--- a/conan/api/subapi/audit.py
+++ b/conan/api/subapi/audit.py
@@ -28,14 +28,13 @@ class AuditAPI:
         }
 
     @staticmethod
-    def scan(deps_graph, provider, context="both"):
+    def scan(deps_graph, provider, context=None):
         """
         Scan a given recipe for vulnerabilities in its dependencies.
         """
-        report_both_context = context == "both"
         refs = sorted(set(RecipeReference.loads(f"{node.ref.name}/{node.ref.version}")
                           for node in deps_graph.nodes[1:]
-                          if report_both_context or node.context == context),
+                          if context is None or node.context == context),
                       key=lambda ref: ref.name)
         return provider.get_cves(refs)
 

--- a/conan/api/subapi/audit.py
+++ b/conan/api/subapi/audit.py
@@ -28,14 +28,14 @@ class AuditAPI:
         }
 
     @staticmethod
-    def scan(deps_graph, provider, context="all"):
+    def scan(deps_graph, provider, context="both"):
         """
         Scan a given recipe for vulnerabilities in its dependencies.
         """
-        is_all = context == "all"
+        report_both_context = context == "both"
         refs = sorted(set(RecipeReference.loads(f"{node.ref.name}/{node.ref.version}")
                           for node in deps_graph.nodes[1:]
-                          if is_all or node.context == context),
+                          if report_both_context or node.context == context),
                       key=lambda ref: ref.name)
         return provider.get_cves(refs)
 

--- a/conan/cli/commands/audit.py
+++ b/conan/cli/commands/audit.py
@@ -60,8 +60,9 @@ def audit_scan(conan_api: ConanAPI, parser, subparser, *args) -> dict:
                            help="Set threshold for severity level to raise an error. "
                                 "By default raises an error for any critical CVSS (9.0 or higher). "
                                 " Use 100.0 to disable it.")
-    subparser.add_argument("--context", help="Context to scan, by default both contexts are scanned",
-                           choices=["host", "build", "both"], default="both")
+    subparser.add_argument("--context", help="Context to scan, by default both contexts are scanned "
+                                             "if not specified",
+                           choices=["host", "build"], default=None)
 
     _add_provider_arg(subparser)
     args = parser.parse_args(*args)

--- a/conan/cli/commands/audit.py
+++ b/conan/cli/commands/audit.py
@@ -60,6 +60,8 @@ def audit_scan(conan_api: ConanAPI, parser, subparser, *args) -> dict:
                            help="Set threshold for severity level to raise an error. "
                                 "By default raises an error for any critical CVSS (9.0 or higher). "
                                 " Use 100.0 to disable it.")
+    subparser.add_argument("--context", help="Context to scan, by default both contexts are scanned",
+                           choices=["host", "build", "all"], default="all")
 
     _add_provider_arg(subparser)
     args = parser.parse_args(*args)
@@ -97,7 +99,7 @@ def audit_scan(conan_api: ConanAPI, parser, subparser, *args) -> dict:
 
     provider = conan_api.audit.get_provider(args.provider or CONAN_CENTER_AUDIT_PROVIDER_NAME)
 
-    scan_result = conan_api.audit.scan(deps_graph, provider)
+    scan_result = conan_api.audit.scan(deps_graph, provider, args.context)
     _parse_error_threshold(scan_result, args.severity_level)
     return scan_result
 

--- a/conan/cli/commands/audit.py
+++ b/conan/cli/commands/audit.py
@@ -61,7 +61,7 @@ def audit_scan(conan_api: ConanAPI, parser, subparser, *args) -> dict:
                                 "By default raises an error for any critical CVSS (9.0 or higher). "
                                 " Use 100.0 to disable it.")
     subparser.add_argument("--context", help="Context to scan, by default both contexts are scanned",
-                           choices=["host", "build", "all"], default="all")
+                           choices=["host", "build", "both"], default="both")
 
     _add_provider_arg(subparser)
     args = parser.parse_args(*args)

--- a/test/integration/command/test_audit.py
+++ b/test/integration/command/test_audit.py
@@ -475,7 +475,7 @@ def test_parse_error_crash_when_no_edges():
 
 
 @pytest.mark.parametrize("package_context", ["build", "host"])
-@pytest.mark.parametrize("filter_context", ["build", "host", "all"])
+@pytest.mark.parametrize("filter_context", ["build", "host", "both"])
 def test_audit_scan_context_filter(package_context, filter_context):
     successful_response = {
         "data": {
@@ -525,7 +525,7 @@ def test_audit_scan_context_filter(package_context, filter_context):
 
     with proxy_response(200, successful_response):
         tc.run(f"audit scan --{requires}=zlib/1.2.11 --context={filter_context}")
-        if filter_context == "all" or filter_context == package_context:
+        if filter_context == "both" or filter_context == package_context:
             assert "zlib/1.2.11 1 vulnerability found" in tc.out
         else:
             assert "Total vulnerabilities found: 0" in tc.out

--- a/test/integration/command/test_audit.py
+++ b/test/integration/command/test_audit.py
@@ -472,3 +472,60 @@ def test_parse_error_crash_when_no_edges():
     assert "conan_error" in scan_result
     assert "zlib/1.2.11" in scan_result["conan_error"]
     assert "7.0" in scan_result["conan_error"]
+
+
+@pytest.mark.parametrize("package_context", ["build", "host"])
+@pytest.mark.parametrize("filter_context", ["build", "host", "all"])
+def test_audit_scan_context_filter(package_context, filter_context):
+    successful_response = {
+        "data": {
+            "query": {
+                "vulnerabilities": {
+                    "totalCount": 1,
+                    "edges": [
+                        {
+                            "node": {
+                                "name": "CVE-2023-45853",
+                                "description": "Zip vulnerability",
+                                "severity": "Critical",
+                                "cvss": {
+                                    "preferredBaseScore": 8.9
+                                },
+                                "aliases": [
+                                    "CVE-2023-45853",
+                                    "JFSA-2023-000272529"
+                                ],
+                                "advisories": [
+                                    {
+                                        "name": "CVE-2023-45853"
+                                    },
+                                    {
+                                        "name": "JFSA-2023-000272529"
+                                    }
+                                ],
+                                "references": [
+                                    "https://pypi.org/project/pyminizip/#history",
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "error": None
+    }
+
+    tc = TestClient(light=True)
+
+    tc.save({"conanfile.py": GenConanfile("zlib", "1.2.11")})
+    tc.run("export .")
+    tc.run("audit provider auth conancenter --token=valid_token")
+
+    requires = "requires" if package_context == "host" else "tool-requires"
+
+    with proxy_response(200, successful_response):
+        tc.run(f"audit scan --{requires}=zlib/1.2.11 --context={filter_context}")
+        if filter_context == "all" or filter_context == package_context:
+            assert "zlib/1.2.11 1 vulnerability found" in tc.out
+        else:
+            assert "Total vulnerabilities found: 0" in tc.out

--- a/test/integration/command/test_audit.py
+++ b/test/integration/command/test_audit.py
@@ -477,44 +477,6 @@ def test_parse_error_crash_when_no_edges():
 @pytest.mark.parametrize("package_context", ["build", "host"])
 @pytest.mark.parametrize("filter_context", ["build", "host", None])
 def test_audit_scan_context_filter(package_context, filter_context):
-    successful_response = {
-        "data": {
-            "query": {
-                "vulnerabilities": {
-                    "totalCount": 1,
-                    "edges": [
-                        {
-                            "node": {
-                                "name": "CVE-2023-45853",
-                                "description": "Zip vulnerability",
-                                "severity": "Critical",
-                                "cvss": {
-                                    "preferredBaseScore": 8.9
-                                },
-                                "aliases": [
-                                    "CVE-2023-45853",
-                                    "JFSA-2023-000272529"
-                                ],
-                                "advisories": [
-                                    {
-                                        "name": "CVE-2023-45853"
-                                    },
-                                    {
-                                        "name": "JFSA-2023-000272529"
-                                    }
-                                ],
-                                "references": [
-                                    "https://pypi.org/project/pyminizip/#history",
-                                ]
-                            }
-                        }
-                    ]
-                }
-            }
-        },
-        "error": None
-    }
-
     tc = TestClient(light=True)
 
     tc.save({"conanfile.py": GenConanfile("zlib", "1.2.11")})
@@ -524,9 +486,9 @@ def test_audit_scan_context_filter(package_context, filter_context):
     requires = "requires" if package_context == "host" else "tool-requires"
     context = "" if filter_context is None else f"--context={filter_context}"
 
-    with proxy_response(200, successful_response):
+    with proxy_response(200, {}):
         tc.run(f"audit scan --{requires}=zlib/1.2.11 {context}")
         if filter_context is None or filter_context == package_context:
-            assert "zlib/1.2.11 1 vulnerability found" in tc.out
+            assert "Requesting vulnerability info for: zlib/1.2.11" in tc.out
         else:
-            assert "Total vulnerabilities found: 0" in tc.out
+            assert "Requesting vulnerability info for: zlib/1.2.11" not in tc.out

--- a/test/integration/command/test_audit.py
+++ b/test/integration/command/test_audit.py
@@ -475,7 +475,7 @@ def test_parse_error_crash_when_no_edges():
 
 
 @pytest.mark.parametrize("package_context", ["build", "host"])
-@pytest.mark.parametrize("filter_context", ["build", "host", "both"])
+@pytest.mark.parametrize("filter_context", ["build", "host", None])
 def test_audit_scan_context_filter(package_context, filter_context):
     successful_response = {
         "data": {
@@ -522,10 +522,11 @@ def test_audit_scan_context_filter(package_context, filter_context):
     tc.run("audit provider auth conancenter --token=valid_token")
 
     requires = "requires" if package_context == "host" else "tool-requires"
+    context = "" if filter_context is None else f"--context={filter_context}"
 
     with proxy_response(200, successful_response):
-        tc.run(f"audit scan --{requires}=zlib/1.2.11 --context={filter_context}")
-        if filter_context == "both" or filter_context == package_context:
+        tc.run(f"audit scan --{requires}=zlib/1.2.11 {context}")
+        if filter_context is None or filter_context == package_context:
             assert "zlib/1.2.11 1 vulnerability found" in tc.out
         else:
             assert "Total vulnerabilities found: 0" in tc.out


### PR DESCRIPTION
Changelog: Feature: Add `--context={build,host}` filter to `conan audit scan`.
Docs: https://github.com/conan-io/docs/pull/4239

Closes https://github.com/conan-io/conan/issues/18937