### PR TITLE
allowing different --ca-path per remote

### DIFF
--- a/conan/cli/commands/remote.py
+++ b/conan/cli/commands/remote.py
@@ -1,4 +1,3 @@
-import argparse
 import json
 import os
 from collections import OrderedDict
@@ -74,8 +73,11 @@ def remote_add(conan_api, parser, subparser, *args):
     """
     subparser.add_argument("name", help="Name of the remote to add")
     subparser.add_argument("url", help="Url of the remote")
-    subparser.add_argument("--insecure", dest="secure", action='store_false',
-                           help="Allow insecure server connections when using SSL")
+    group = subparser.add_mutually_exclusive_group()
+    group.add_argument("--insecure", dest="secure", action='store_false',
+                       help="Allow insecure server connections when using SSL")
+    group.add_argument("--ca-path", dest="secure",
+                       help="Connect with this remote with SSL with this certificate")
     subparser.add_argument("--index", action=OnceArgument, type=int,
                            help="Insert the remote at a specific position in the remote list")
     subparser.add_argument("-f", "--force", action='store_true',
@@ -121,10 +123,13 @@ def remote_update(conan_api, parser, subparser, *args):
     """
     subparser.add_argument("remote", help="Name of the remote to update")
     subparser.add_argument("--url", action=OnceArgument, help="New url for the remote")
-    subparser.add_argument("--secure", dest="secure", action='store_true',
-                           help="Don't allow insecure server connections when using SSL")
-    subparser.add_argument("--insecure", dest="secure", action='store_false',
-                           help="Allow insecure server connections when using SSL")
+    group = subparser.add_mutually_exclusive_group()
+    group.add_argument("--secure", dest="secure", action='store_true',
+                       help = "Don't allow insecure server connections when using SSL")
+    group.add_argument("--insecure", dest="secure", action='store_false',
+                       help = "Allow insecure server connections when using SSL")
+    group.add_argument("--ca-path", dest="secure",
+                       help="Connect with this remote with SSL with this certificate")
     subparser.add_argument("--index", action=OnceArgument, type=int,
                            help="Insert the remote at a specific position in the remote list")
     subparser.add_argument("-ap", "--allowed-packages", action="append", default=None,

--- a/test/integration/command/remote/remote_verify_ssl_test.py
+++ b/test/integration/command/remote/remote_verify_ssl_test.py
@@ -1,62 +1,81 @@
-import requests
-from requests.models import Response
-
-from conan.test.utils.tools import TestClient
-
-resp = Response()
-resp._content = b'{"results": []}'
-resp.status_code = 200
-resp.headers = {"Content-Type": "application/json", "X-Conan-Server-Capabilities": "revisions"}
+from conan.test.utils.tools import TestClient, TestRequester, TestServer
 
 
-class RequesterMockFalse:
-    expected = False
+def requester(expected):
+    class CheckVerifyRequester(TestRequester):
 
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def get(self, url, *args, **kwargs):  # noqa
-        assert kwargs["verify"] is self.expected
-        return resp
-
-    def Session(self):  # noqa
-        return self
-
-    @property
-    def codes(self):
-        return requests.codes
-
-    def mount(self, *args, **kwargs):
-        pass
-
-
-class RequesterMockTrue(RequesterMockFalse):
-    expected = True
+        def get(self, *args, **kwargs):
+            verify = kwargs["verify"]
+            assert verify == expected
+            return super(CheckVerifyRequester, self).get(*args, **kwargs)
+    return CheckVerifyRequester
 
 
 class TestVerifySSL:
 
     def test_verify_ssl(self):
-        c = TestClient(requester_class=RequesterMockTrue)
-        c.run("remote add myremote https://localhost --insecure")
+        server = TestServer()
+        c = TestClient(servers={"default": server})
+        c.run("remote remove default") # to remove from file, not from testing client
+
+        c.run(f"remote add myremote {server.fake_url} --insecure")
         c.run("remote list")
         assert "Verify SSL: False" in c.out
 
-        c.run("remote update myremote --url https://localhost --secure")
+        c.run(f"remote update myremote --secure")
         c.run("remote list")
         assert "Verify SSL: True" in c.out
 
         c.run("remote remove myremote")
-        c.run("remote add myremote https://localhost")
+        c.run(f"remote add myremote {server.fake_url}")
         c.run("remote list")
         assert "Verify SSL: True" in c.out
 
         # Verify that SSL is checked in requests
+        c.requester_class = requester(True)
         c.run("search op* -r myremote")
         assert "WARN: There are no matching recipe references" in c.out
 
         # Verify that SSL is not checked in requests
-        c = TestClient(requester_class=RequesterMockFalse)
-        c.run("remote add myremote https://localhost --insecure")
+        c.requester_class = requester(False)
+        c.run(f"remote update myremote --insecure")
         c.run("search op* -r myremote")
         assert "WARN: There are no matching recipe references" in c.out
+
+    def test_verify_certificate_per_remote(self):
+        server1 = TestServer()
+        server2 = TestServer()
+        cert1 = "my/path/cert1"
+        cert2 = "other/path/cert2"
+        c = TestClient(servers={"server1": server1, "server2": server2})
+        c.run("remote remove *") # to remove from file, not from testing client
+
+        c.run(f"remote add server1 {server1.fake_url} --ca-path={cert1}")
+        c.run(f"remote add server2 {server2.fake_url} --ca-path={cert2}")
+        c.run("remote list")
+        assert f"Verify SSL: {cert1}" in c.out
+        assert f"Verify SSL: {cert2}" in c.out
+
+        # Verify that SSL is checked in requests
+        c.requester_class = requester(cert1)
+        c.run("search op* -r server1")
+        assert "WARN: There are no matching recipe references" in c.out
+
+        c.requester_class = requester(cert2)
+        c.run("search op* -r server2")
+        assert "WARN: There are no matching recipe references" in c.out
+        c.run(f"remote update server1 --ca-path={cert2}")
+        c.run("search op* -r server2")
+        assert "WARN: There are no matching recipe references" in c.out
+
+    def test_verify_error_secure(self):
+        c = TestClient()
+        c.run(f"remote add server1 http://someurl --insecure=path1", assert_error=True)
+        assert "argument --insecure: ignored explicit argument" in c.out
+        c.run(f"remote add server1 http://someurl --ca-path", assert_error=True)
+        assert "argument --ca-path: expected one argument" in c.out
+        c.run(f"remote add server1 http://someurl --ca-path=path1 --ca-path=path2")
+        # This WONT ERROR, but take the latest value (argparse limitations)
+        c.run("remote list")
+        assert f"Verify SSL: path2" in c.out
+


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

Close https://github.com/conan-io/conan/issues/18967

Notes:

- argparse quite of a nightmare to introduce optionality over the ``--secure`` argument, used ``--ca-path`` extra arg
- argparse quite of a nightmare to allow to force just 1 value. Gave up, will do just the last value passed

While developing it, my concerns increased a bit, I am not sure Conan should have to manage the certificates per remote, maybe the certificates should be aggregated in the same folder and always point to it via ``conf``? Need to follow up in the ticket
