### PR TITLE
Fix for depending on all components of [replace_requires] package

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -236,6 +236,9 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
                     # dependencies, maybe it has been filtered out by traits => Skip
                     pass
                 else:
+                    if dep_name == component_name:
+                        # Depends on all components in `dep_name` package
+                        component_name = req.ref.name.split("/")[0]
                     component_name = self.get_component_alias(req, component_name)
                     ret.append(component_name)
         elif transitive_reqs:

--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -226,6 +226,9 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
                     except KeyError:  # The transitive dep might have been skipped
                         pass
                     else:
+                        if required_pkg == required_comp:
+                            # Depends on all components in `required_pkg` package
+                            required_comp = req.ref.name.split("/")[0]
                         public_comp_deps.append(self.get_component_alias(req, required_comp))
                 else:  # Points to a component of same package
                     public_comp_deps.append(self.get_component_alias(self.conanfile, required_comp))

--- a/test/integration/graph/test_replace_requires.py
+++ b/test/integration/graph/test_replace_requires.py
@@ -216,7 +216,7 @@ def test_replace_requires_consumer_references(name, version):
     if name == "zlib-ng":
         # CMakeDeps can not be used to consume replaced requires for different packages
         # only CMakeConfigDeps has this capability
-        c.run("install --requires=app/0.1 -pr=profile -g CMakeDeps", assert_error=True)
+        c.run("install --requires=app/0.1 -pr=profile -g CMakeDeps")
 
 
 def test_replace_requires_consumer_references_error_multiple():


### PR DESCRIPTION
Changelog: Bugfix: Fix for depending on all components of [replace_requires] package
Docs: https://github.com/conan-io/docs/pull/XXXX

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.



@AbrilRBS IDK how dirty or acceptable this change is but it fixes #18986 