### PR TITLE
SBOM - Add the `namespace`, `pref` and `qualifiers` to the purl

### DIFF
--- a/conan/tools/sbom/cyclonedx.py
+++ b/conan/tools/sbom/cyclonedx.py
@@ -1,7 +1,7 @@
 from conan import conan_version
 
 
-def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, qualifiers=None, **kwargs):
+def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, namespace=None, qualifiers=None, **kwargs):
     """
     (Experimental) Generate cyclone 1.4 SBOM with JSON format
 
@@ -14,6 +14,7 @@ def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, qualif
         name (str, optional): Custom name for the metadata field.
         add_build (bool, optional, default=False): Include build dependencies.
         add_tests (bool, optional, default=False): Include test dependencies.
+        namespace (str, optional): Custom namespace show in PURL.
         qualifiers (list[str], optional): Qualifiers show in PURL.
 
     Returns:
@@ -46,14 +47,14 @@ def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, qualif
     dependencies = []
     if has_special_root_node:
         deps = {"ref": special_id,
-                "dependsOn": [_calculate_bomref(d.dst, qualifiers) for d in graph.root.edges
+                "dependsOn": [_calculate_bomref(d.dst, namespace, qualifiers) for d in graph.root.edges
                               if should_add_node(d.dst, add_build, add_tests)]}
         dependencies.append(deps)
     for c in nodes:
-        deps = {"ref": _calculate_bomref(c, qualifiers)}
+        deps = {"ref": _calculate_bomref(c, namespace, qualifiers)}
         dep = [d for d in c.edges if should_add_node(d.dst, add_build, add_tests)]
 
-        depends_on = [_calculate_bomref(d.dst, qualifiers) for d in dep
+        depends_on = [_calculate_bomref(d.dst, namespace, qualifiers) for d in dep
                       if should_add_node(d.dst, add_build, add_tests)]
         if depends_on:
             deps["dependsOn"] = depends_on
@@ -62,7 +63,7 @@ def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, qualif
     sbom_cyclonedx_1_4 = {
         **({"components": [{
             "author": node.conanfile.author or "Unknown",
-            "bom-ref": _calculate_bomref(node, qualifiers),
+            "bom-ref": _calculate_bomref(node, namespace, qualifiers),
             "description": node.conanfile.description,
             **({"externalReferences": [{
                 "type": "website",
@@ -70,7 +71,7 @@ def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, qualif
             }]} if node.conanfile.homepage else {}),
             **({"licenses": _calculate_licenses(node)} if node.conanfile.license else {}),
             "name": node.name,
-            "purl": _calculate_bomref(node, qualifiers),
+            "purl": _calculate_bomref(node, namespace, qualifiers),
             "type": "application" if node.conanfile.package_type == "application" else "library",
             "version": str(node.ref.version),
         } for node in nodes]} if nodes else {}),
@@ -78,7 +79,7 @@ def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, qualif
         "metadata": {
             "component": {
                 "author": conanfile.author or "Unknown",
-                "bom-ref": special_id if has_special_root_node else _calculate_bomref(conanfile, qualifiers),
+                "bom-ref": special_id if has_special_root_node else _calculate_bomref(conanfile, namespace, qualifiers),
                 "name": name if name else name_default,
                 "type": "application" if conanfile.package_type == "application" else "library",
             },
@@ -99,7 +100,7 @@ def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, qualif
     return sbom_cyclonedx_1_4
 
 
-def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, qualifiers=None, **kwargs):
+def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, namespace=None, qualifiers=None, **kwargs):
     """
     (Experimental) Generate cyclone 1.6 SBOM with JSON format
 
@@ -112,6 +113,7 @@ def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, qualif
         name (str, optional): Custom name for the metadata field.
         add_build (bool, optional, default=False): Include build dependencies.
         add_tests (bool, optional, default=False): Include test dependencies.
+        namespace (str, optional): Custom namespace show in PURL.
         qualifiers (list[str], optional): Qualifiers show in PURL.
 
     Returns:
@@ -144,15 +146,15 @@ def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, qualif
     dependencies = []
     if has_special_root_node:
         deps = {"ref": special_id,
-                "dependsOn": [_calculate_bomref(d.dst, qualifiers)
+                "dependsOn": [_calculate_bomref(d.dst, namespace, qualifiers)
                               for d in graph.root.edges
                               if should_add_node(d.dst, add_build, add_tests)]}
         dependencies.append(deps)
     for c in nodes:
-        deps = {"ref": _calculate_bomref(c, qualifiers)}
+        deps = {"ref": _calculate_bomref(c, namespace, qualifiers)}
         dep = [d for d in c.edges if should_add_node(d.dst, add_build, add_tests)]
 
-        depends_on = [_calculate_bomref(d.dst, qualifiers) for d in dep
+        depends_on = [_calculate_bomref(d.dst, namespace, qualifiers) for d in dep
                       if should_add_node(d.dst, add_build, add_tests)]
         if depends_on:
             deps["dependsOn"] = depends_on
@@ -161,7 +163,7 @@ def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, qualif
     sbom_cyclonedx_1_6 = {
         **({"components": [{
             **({"authors": [{"name": node.conanfile.author}]} if node.conanfile.author else {}),
-            "bom-ref": _calculate_bomref(node, qualifiers),
+            "bom-ref": _calculate_bomref(node, namespace, qualifiers),
             "description": node.conanfile.description,
             **({"externalReferences": [{
                 "type": "website",
@@ -169,7 +171,7 @@ def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, qualif
             }]} if node.conanfile.homepage else {}),
             **({"licenses": _calculate_licenses(node)} if node.conanfile.license else {}),
             "name": node.name,
-            "purl": _calculate_bomref(node, qualifiers),
+            "purl": _calculate_bomref(node, namespace, qualifiers),
             "type": "application" if node.conanfile.package_type == "application" else "library",
             "version": str(node.ref.version),
         } for node in nodes]} if nodes else {}),
@@ -177,7 +179,7 @@ def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, qualif
         "metadata": {
             "component": {
                 **({"authors": [{"name": conanfile.author}]} if conanfile.author else {}),
-                "bom-ref": special_id if has_special_root_node else _calculate_bomref(conanfile, qualifiers),
+                "bom-ref": special_id if has_special_root_node else _calculate_bomref(conanfile, namespace, qualifiers),
                 "name": name if name else name_default,
                 "type": "application" if conanfile.package_type == "application" else "library"
             },
@@ -215,13 +217,14 @@ def _calculate_licenses(component):
     ]
 
 
-def _calculate_bomref(component, qualifiers):
+def _calculate_bomref(component, namespace, qualifiers):
+    namespace = f"{namespace}/" if namespace else ""
     user = f"&user={component.ref.user}" if component.ref.user else ""
     channel = f"&channel={component.ref.channel}" if component.ref.channel else ""
     purl_qualifier = ""
     if hasattr(component, "conanfile"):
         purl_qualifier = "".join(f"&{qualifier}={component.conanfile.settings.get_safe(qualifier)}" for qualifier in qualifiers)
-    return (f"pkg:conan/{component.name}@{component.ref.version}"
+    return (f"pkg:conan/{namespace}{component.name}@{component.ref.version}"
             f"?rref={component.ref.revision}&pref={component.pref.package_id}"
             f"{user}{channel}{purl_qualifier}")
 

--- a/conan/tools/sbom/cyclonedx.py
+++ b/conan/tools/sbom/cyclonedx.py
@@ -1,7 +1,7 @@
 from conan import conan_version
 
 
-def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, **kwargs):
+def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, qualifiers=None, **kwargs):
     """
     (Experimental) Generate cyclone 1.4 SBOM with JSON format
 
@@ -14,6 +14,7 @@ def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, **kwar
         name (str, optional): Custom name for the metadata field.
         add_build (bool, optional, default=False): Include build dependencies.
         add_tests (bool, optional, default=False): Include test dependencies.
+        qualifiers (list[str], optional): Qualifiers show in PURL.
 
     Returns:
         The generated CycloneDX 1.4 document as a string.
@@ -28,6 +29,7 @@ def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, **kwar
     import time
     from datetime import datetime, timezone
     graph = conanfile.subgraph
+    qualifiers = qualifiers or []
 
     has_special_root_node = not (getattr(graph.root.ref, "name", False)
                                  and getattr(graph.root.ref, "version", False)
@@ -44,14 +46,14 @@ def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, **kwar
     dependencies = []
     if has_special_root_node:
         deps = {"ref": special_id,
-                "dependsOn": [_calculate_bomref(d.dst) for d in graph.root.edges
+                "dependsOn": [_calculate_bomref(d.dst, qualifiers) for d in graph.root.edges
                               if should_add_node(d.dst, add_build, add_tests)]}
         dependencies.append(deps)
     for c in nodes:
-        deps = {"ref": _calculate_bomref(c)}
+        deps = {"ref": _calculate_bomref(c, qualifiers)}
         dep = [d for d in c.edges if should_add_node(d.dst, add_build, add_tests)]
 
-        depends_on = [_calculate_bomref(d.dst) for d in dep
+        depends_on = [_calculate_bomref(d.dst, qualifiers) for d in dep
                       if should_add_node(d.dst, add_build, add_tests)]
         if depends_on:
             deps["dependsOn"] = depends_on
@@ -60,7 +62,7 @@ def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, **kwar
     sbom_cyclonedx_1_4 = {
         **({"components": [{
             "author": node.conanfile.author or "Unknown",
-            "bom-ref": _calculate_bomref(node),
+            "bom-ref": _calculate_bomref(node, qualifiers),
             "description": node.conanfile.description,
             **({"externalReferences": [{
                 "type": "website",
@@ -68,7 +70,7 @@ def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, **kwar
             }]} if node.conanfile.homepage else {}),
             **({"licenses": _calculate_licenses(node)} if node.conanfile.license else {}),
             "name": node.name,
-            "purl": f"pkg:conan/{node.name}@{node.ref.version}",
+            "purl": _calculate_bomref(node, qualifiers),
             "type": "application" if node.conanfile.package_type == "application" else "library",
             "version": str(node.ref.version),
         } for node in nodes]} if nodes else {}),
@@ -76,7 +78,7 @@ def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, **kwar
         "metadata": {
             "component": {
                 "author": conanfile.author or "Unknown",
-                "bom-ref": special_id if has_special_root_node else _calculate_bomref(conanfile),
+                "bom-ref": special_id if has_special_root_node else _calculate_bomref(conanfile, qualifiers),
                 "name": name if name else name_default,
                 "type": "application" if conanfile.package_type == "application" else "library",
             },
@@ -97,7 +99,7 @@ def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, **kwar
     return sbom_cyclonedx_1_4
 
 
-def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, **kwargs):
+def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, qualifiers=None, **kwargs):
     """
     (Experimental) Generate cyclone 1.6 SBOM with JSON format
 
@@ -110,6 +112,7 @@ def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, **kwar
         name (str, optional): Custom name for the metadata field.
         add_build (bool, optional, default=False): Include build dependencies.
         add_tests (bool, optional, default=False): Include test dependencies.
+        qualifiers (list[str], optional): Qualifiers show in PURL.
 
     Returns:
         The generated CycloneDX 1.6 document as a string.
@@ -124,6 +127,7 @@ def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, **kwar
     import time
     from datetime import datetime, timezone
     graph = conanfile.subgraph
+    qualifiers = qualifiers or []
 
     has_special_root_node = not (getattr(graph.root.ref, "name", False)
                                  and getattr(graph.root.ref, "version", False)
@@ -140,15 +144,15 @@ def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, **kwar
     dependencies = []
     if has_special_root_node:
         deps = {"ref": special_id,
-                "dependsOn": [_calculate_bomref(d.dst)
+                "dependsOn": [_calculate_bomref(d.dst, qualifiers)
                               for d in graph.root.edges
                               if should_add_node(d.dst, add_build, add_tests)]}
         dependencies.append(deps)
     for c in nodes:
-        deps = {"ref": _calculate_bomref(c)}
+        deps = {"ref": _calculate_bomref(c, qualifiers)}
         dep = [d for d in c.edges if should_add_node(d.dst, add_build, add_tests)]
 
-        depends_on = [_calculate_bomref(d.dst) for d in dep
+        depends_on = [_calculate_bomref(d.dst, qualifiers) for d in dep
                       if should_add_node(d.dst, add_build, add_tests)]
         if depends_on:
             deps["dependsOn"] = depends_on
@@ -157,7 +161,7 @@ def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, **kwar
     sbom_cyclonedx_1_6 = {
         **({"components": [{
             **({"authors": [{"name": node.conanfile.author}]} if node.conanfile.author else {}),
-            "bom-ref": _calculate_bomref(node),
+            "bom-ref": _calculate_bomref(node, qualifiers),
             "description": node.conanfile.description,
             **({"externalReferences": [{
                 "type": "website",
@@ -165,7 +169,7 @@ def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, **kwar
             }]} if node.conanfile.homepage else {}),
             **({"licenses": _calculate_licenses(node)} if node.conanfile.license else {}),
             "name": node.name,
-            "purl": f"pkg:conan/{node.name}@{node.ref.version}",
+            "purl": _calculate_bomref(node, qualifiers),
             "type": "application" if node.conanfile.package_type == "application" else "library",
             "version": str(node.ref.version),
         } for node in nodes]} if nodes else {}),
@@ -173,7 +177,7 @@ def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, **kwar
         "metadata": {
             "component": {
                 **({"authors": [{"name": conanfile.author}]} if conanfile.author else {}),
-                "bom-ref": special_id if has_special_root_node else _calculate_bomref(conanfile),
+                "bom-ref": special_id if has_special_root_node else _calculate_bomref(conanfile, qualifiers),
                 "name": name if name else name_default,
                 "type": "application" if conanfile.package_type == "application" else "library"
             },
@@ -211,10 +215,14 @@ def _calculate_licenses(component):
     ]
 
 
-def _calculate_bomref(component):
+def _calculate_bomref(component, qualifiers):
     user = f"&user={component.ref.user}" if component.ref.user else ""
     channel = f"&channel={component.ref.channel}" if component.ref.channel else ""
-    return f"pkg:conan/{component.name}@{component.ref.version}?rref={component.ref.revision}{user}{channel}"
+    _settings = dict(component.conanfile.settings_build.values_list) if hasattr(component, "conanfile") else {}
+    purl_qualifier = "".join(f"&{qualifier}={_settings.get(qualifier)}" for qualifier in qualifiers)
+    return (f"pkg:conan/{component.name}@{component.ref.version}"
+            f"?rref={component.ref.revision}&pref={component.pref.package_id}"
+            f"{user}{channel}{purl_qualifier}")
 
 
 def should_add_node(node, add_build, add_tests):

--- a/conan/tools/sbom/cyclonedx.py
+++ b/conan/tools/sbom/cyclonedx.py
@@ -218,8 +218,9 @@ def _calculate_licenses(component):
 def _calculate_bomref(component, qualifiers):
     user = f"&user={component.ref.user}" if component.ref.user else ""
     channel = f"&channel={component.ref.channel}" if component.ref.channel else ""
-    _settings = dict(component.conanfile.settings_build.values_list) if hasattr(component, "conanfile") else {}
-    purl_qualifier = "".join(f"&{qualifier}={_settings.get(qualifier)}" for qualifier in qualifiers)
+    purl_qualifier = ""
+    if hasattr(component, "conanfile"):
+        purl_qualifier = "".join(f"&{qualifier}={component.conanfile.settings.get_safe(qualifier)}" for qualifier in qualifiers)
     return (f"pkg:conan/{component.name}@{component.ref.version}"
             f"?rref={component.ref.revision}&pref={component.pref.package_id}"
             f"{user}{channel}{purl_qualifier}")

--- a/test/functional/sbom/test_cyclonedx.py
+++ b/test/functional/sbom/test_cyclonedx.py
@@ -291,8 +291,10 @@ class TestCyclonedx:
         assert os.path.exists(os.path.join(tc.current_folder, "sbom", "sbom.cdx.json"))
         assert f'"name": "{result}"' in tc.load(os.path.join(tc.current_folder, "sbom", "sbom.cdx.json"))
 
-    @pytest.mark.parametrize("qualifiers", [None, ["os", "arch"]])
-    def test_cyclonedx_check_content(self, cyclone_version, qualifiers):
+    @pytest.mark.parametrize("options", [{}, {"qualifiers": ["os", "arch"]}, {"namespace": "CustomNamespace"}])
+    def test_cyclonedx_check_content(self, cyclone_version, options):
+        qualifiers = options.get("qualifiers", None)
+        namespace = options.get("namespace", None)
         _sbom_hook_post_package = textwrap.dedent("""
         import json
         import os
@@ -301,7 +303,7 @@ class TestCyclonedx:
         from conan.tools.sbom import {cyclone_version}
 
         def post_package(conanfile):
-            sbom_cyclonedx= {cyclone_version}(conanfile, qualifiers={qualifiers})
+            sbom_cyclonedx= {cyclone_version}(conanfile, namespace={namespace}, qualifiers={qualifiers})
             metadata_folder = conanfile.package_metadata_folder
             file_name = "sbom.cdx.json"
             with open(os.path.join(metadata_folder, file_name), 'w') as f:
@@ -310,7 +312,10 @@ class TestCyclonedx:
         """)
         tc = TestClient()
         hook_path = os.path.join(tc.paths.hooks_path, "hook_sbom.py")
-        save(hook_path, _sbom_hook_post_package.format(cyclone_version=cyclone_version, qualifiers=qualifiers))
+        save(hook_path, _sbom_hook_post_package.format(
+            cyclone_version=cyclone_version,
+            namespace=f"'{namespace}'" if namespace else None,
+            qualifiers=qualifiers))
         conanfile_bar = textwrap.dedent("""
                 from conan import ConanFile
                 class HelloConan(ConanFile):
@@ -359,8 +364,10 @@ class TestCyclonedx:
             assert content_json["components"][0]["type"] == 'application'
         if qualifiers:
             assert all(q in content_json["components"][0]["purl"] for q in qualifiers)
+        elif namespace:
+            assert f"pkg:conan/CustomNamespace/foo@1.0?rref={foo_rrev}&pref=" in content_json["components"][0]["purl"]
         else:
-            assert f"pkg:conan/foo@1.0?rref={foo_rrev}&pref=" in content_json["components"][0]["purl"]
+            assert f"pkg:conan/foo@1.0?rref={foo_rrev}&pref=" in content_json["components"][0][ "purl"]
 
     @pytest.mark.parametrize("user, channel, user_dep, channel_dep", [("user", None, "user_dep", None), ("user", "channel", "user_dep", "channel_dep")])
     def test_sbom_user_path(self, hook_setup_post_package_tl, user, channel, user_dep, channel_dep):

--- a/test/functional/sbom/test_cyclonedx.py
+++ b/test/functional/sbom/test_cyclonedx.py
@@ -1,5 +1,6 @@
 import textwrap
 import json
+from symbol import pass_stmt
 
 import pytest
 
@@ -291,7 +292,8 @@ class TestCyclonedx:
         assert os.path.exists(os.path.join(tc.current_folder, "sbom", "sbom.cdx.json"))
         assert f'"name": "{result}"' in tc.load(os.path.join(tc.current_folder, "sbom", "sbom.cdx.json"))
 
-    def test_cyclonedx_check_content(self, cyclone_version):
+    @pytest.mark.parametrize("qualifiers", [None, ["os", "arch"]])
+    def test_cyclonedx_check_content(self, cyclone_version, qualifiers):
         _sbom_hook_post_package = textwrap.dedent("""
         import json
         import os
@@ -300,7 +302,7 @@ class TestCyclonedx:
         from conan.tools.sbom import {cyclone_version}
 
         def post_package(conanfile):
-            sbom_cyclonedx= {cyclone_version}(conanfile)
+            sbom_cyclonedx= {cyclone_version}(conanfile, qualifiers={qualifiers})
             metadata_folder = conanfile.package_metadata_folder
             file_name = "sbom.cdx.json"
             with open(os.path.join(metadata_folder, file_name), 'w') as f:
@@ -309,7 +311,7 @@ class TestCyclonedx:
         """)
         tc = TestClient()
         hook_path = os.path.join(tc.paths.hooks_path, "hook_sbom.py")
-        save(hook_path, _sbom_hook_post_package.format(cyclone_version=cyclone_version))
+        save(hook_path, _sbom_hook_post_package.format(cyclone_version=cyclone_version, qualifiers=qualifiers))
         conanfile_bar = textwrap.dedent("""
                 from conan import ConanFile
                 class HelloConan(ConanFile):
@@ -353,6 +355,10 @@ class TestCyclonedx:
             assert not content_json["components"][0].get("author")
             assert content_json["components"][0]["authors"][0]["name"] == 'conan-dev'
             assert content_json["components"][0]["type"] == 'application'
+        if qualifiers:
+            assert all(q in content_json["components"][0]["purl"] for q in qualifiers)
+        else:
+            assert "pkg:conan/foo@1.0?rref=ec5797d63ec2eab8056fb3087fcd5039&pref=" in content_json["components"][0]["purl"]
 
     @pytest.mark.parametrize("user, channel, user_dep, channel_dep", [("user", None, "user_dep", None), ("user", "channel", "user_dep", "channel_dep")])
     def test_sbom_user_path(self, hook_setup_post_package_tl, user, channel, user_dep, channel_dep):

--- a/test/functional/sbom/test_cyclonedx.py
+++ b/test/functional/sbom/test_cyclonedx.py
@@ -319,6 +319,7 @@ class TestCyclonedx:
                     version = '1.0'
                     author = 'conan-dev'
                     package_type = 'application'
+                    settings = 'os', 'arch', 'compiler', 'build_type'
             """)
 
         conanfile_foo = textwrap.dedent("""
@@ -328,6 +329,7 @@ class TestCyclonedx:
                 version = '1.0'
                 author = 'conan-dev'
                 package_type = 'application'
+                settings = 'os', 'arch', 'compiler', 'build_type'
 
                 def requirements(self):
                     self.requires("bar/1.0")
@@ -336,6 +338,7 @@ class TestCyclonedx:
         tc.run("create .")
         tc.save({"conanfile.py": conanfile_foo})
         tc.run("create .")
+        foo_rrev = tc.exported_recipe_revision()
 
         create_layout = tc.created_layout()
         cyclone_path = os.path.join(create_layout.metadata(), "sbom.cdx.json")
@@ -358,7 +361,7 @@ class TestCyclonedx:
         if qualifiers:
             assert all(q in content_json["components"][0]["purl"] for q in qualifiers)
         else:
-            assert "pkg:conan/foo@1.0?rref=ec5797d63ec2eab8056fb3087fcd5039&pref=" in content_json["components"][0]["purl"]
+            assert f"pkg:conan/foo@1.0?rref={foo_rrev}&pref=" in content_json["components"][0]["purl"]
 
     @pytest.mark.parametrize("user, channel, user_dep, channel_dep", [("user", None, "user_dep", None), ("user", "channel", "user_dep", "channel_dep")])
     def test_sbom_user_path(self, hook_setup_post_package_tl, user, channel, user_dep, channel_dep):

--- a/test/functional/sbom/test_cyclonedx.py
+++ b/test/functional/sbom/test_cyclonedx.py
@@ -1,6 +1,5 @@
 import textwrap
 import json
-from symbol import pass_stmt
 
 import pytest
 


### PR DESCRIPTION
Changelog: Fix: Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

Add the `pref` and `qualifiers` to the purl
Add `namespace` support to the purl

close: https://github.com/conan-io/conan/issues/18971
close: https://github.com/conan-io/conan/issues/19246

blocked by: https://github.com/package-url/purl-spec/issues/705