### PR TITLE
feat: export recipe in the ConanFileInterface

### DIFF
--- a/conan/__init__.py
+++ b/conan/__init__.py
@@ -4,3 +4,5 @@ from conan.internal.model.version import Version
 
 __version__ = '2.21.0-dev'
 conan_version = Version(__version__)
+
+__all__ = ["ConanFile", "Version", "Workspace", "__version__", "conan_version"]

--- a/conan/__init__.py
+++ b/conan/__init__.py
@@ -4,5 +4,3 @@ from conan.internal.model.version import Version
 
 __version__ = '2.21.0-dev'
 conan_version = Version(__version__)
-
-__all__ = ["ConanFile", "Version", "Workspace", "__version__", "conan_version"]

--- a/conan/internal/model/conanfile_interface.py
+++ b/conan/internal/model/conanfile_interface.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 from conan.internal.graph.graph import CONTEXT_BUILD
 
+
 class ConanFileInterface:
     """ this is just a protective wrapper to give consumers
     a limited view of conanfile dependencies, "read" only,

--- a/conan/internal/model/conanfile_interface.py
+++ b/conan/internal/model/conanfile_interface.py
@@ -1,7 +1,11 @@
+import typing
 from pathlib import Path
 
 from conan.internal.graph.graph import CONTEXT_BUILD, RECIPE_EDITABLE, RECIPE_PLATFORM
-from conan.internal.model.conan_file import ConanFile
+
+if typing.TYPE_CHECKING:
+    # Avoid circular import
+    from conan.internal.model.conan_file import ConanFile
 
 
 class ConanFileInterface:
@@ -12,7 +16,7 @@ class ConanFileInterface:
     def __str__(self):
         return str(self._conanfile)
 
-    def __init__(self, conanfile: ConanFile):
+    def __init__(self, conanfile: "ConanFile"):
         self._conanfile = conanfile
 
     def __eq__(self, other):

--- a/conan/internal/model/conanfile_interface.py
+++ b/conan/internal/model/conanfile_interface.py
@@ -1,5 +1,7 @@
 from pathlib import Path
-from conan.internal.graph.graph import CONTEXT_BUILD
+
+from conan.internal.graph.graph import CONTEXT_BUILD, RECIPE_EDITABLE, RECIPE_PLATFORM
+from conan.internal.model.conan_file import ConanFile
 
 
 class ConanFileInterface:
@@ -10,7 +12,7 @@ class ConanFileInterface:
     def __str__(self):
         return str(self._conanfile)
 
-    def __init__(self, conanfile):
+    def __init__(self, conanfile: ConanFile):
         self._conanfile = conanfile
 
     def __eq__(self, other):
@@ -142,3 +144,15 @@ class ConanFileInterface:
     @property
     def extension_properties(self):
         return getattr(self._conanfile, "extension_properties", {})
+
+    @property
+    def recipe(self) -> str:
+        return self._conanfile._conan_node.recipe
+
+    @property
+    def is_editable(self) -> bool:
+        return self.recipe == RECIPE_EDITABLE
+
+    @property
+    def is_platform(self) -> bool:
+        return self.recipe == RECIPE_PLATFORM

--- a/conan/internal/model/conanfile_interface.py
+++ b/conan/internal/model/conanfile_interface.py
@@ -1,12 +1,6 @@
-import typing
 from pathlib import Path
 
 from conan.internal.graph.graph import CONTEXT_BUILD, RECIPE_EDITABLE, RECIPE_PLATFORM
-
-if typing.TYPE_CHECKING:
-    # Avoid circular import
-    from conan.internal.model.conan_file import ConanFile
-
 
 class ConanFileInterface:
     """ this is just a protective wrapper to give consumers
@@ -16,7 +10,7 @@ class ConanFileInterface:
     def __str__(self):
         return str(self._conanfile)
 
-    def __init__(self, conanfile: "ConanFile"):
+    def __init__(self, conanfile):
         self._conanfile = conanfile
 
     def __eq__(self, other):

--- a/conan/internal/model/conanfile_interface.py
+++ b/conan/internal/model/conanfile_interface.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from conan.internal.graph.graph import CONTEXT_BUILD, RECIPE_EDITABLE, RECIPE_PLATFORM
+from conan.internal.graph.graph import CONTEXT_BUILD
 
 class ConanFileInterface:
     """ this is just a protective wrapper to give consumers
@@ -147,12 +147,5 @@ class ConanFileInterface:
     def recipe(self) -> str:
         return self._conanfile._conan_node.recipe
 
-    @property
-    def is_editable(self) -> bool:
-        return self.recipe == RECIPE_EDITABLE
-
-    @property
-    def is_platform(self) -> bool:
-        return self.recipe == RECIPE_PLATFORM
     def conf(self):
         return self._conanfile.conf

--- a/conan/internal/model/conanfile_interface.py
+++ b/conan/internal/model/conanfile_interface.py
@@ -149,5 +149,6 @@ class ConanFileInterface:
         # IMPORTANT: this should be used only for "informational" purposes, see GH#18996.
         return self._conanfile._conan_node.recipe
 
+    @property
     def conf(self):
         return self._conanfile.conf

--- a/conan/internal/model/conanfile_interface.py
+++ b/conan/internal/model/conanfile_interface.py
@@ -146,6 +146,7 @@ class ConanFileInterface:
 
     @property
     def recipe(self) -> str:
+        # IMPORTANT: this should be used only for "informational" purposes, see GH#18996.
         return self._conanfile._conan_node.recipe
 
     def conf(self):

--- a/conan/internal/model/dependencies.py
+++ b/conan/internal/model/dependencies.py
@@ -1,7 +1,8 @@
 from collections import OrderedDict
 
-from conan.errors import ConanException
 from conan.api.model import RecipeReference
+from conan.errors import ConanException
+from conan.internal.graph.graph import RECIPE_PLATFORM
 from conan.internal.model.conanfile_interface import ConanFileInterface
 
 
@@ -116,7 +117,7 @@ class ConanFileDependencies(UserRequirementsDict):
 
         data = OrderedDict((k, v) for k, v in self._data.items() if filter_fn(k))
         if remove_system:
-            data = OrderedDict((k, v) for k, v in data.items() if not v.is_platform)
+            data = OrderedDict((k, v) for k, v in data.items() if v.recipe != RECIPE_PLATFORM)
         return ConanFileDependencies(data, require_filter)
 
     def transitive_requires(self, other):

--- a/conan/internal/model/dependencies.py
+++ b/conan/internal/model/dependencies.py
@@ -1,6 +1,5 @@
 from collections import OrderedDict
 
-from conan.internal.graph.graph import RECIPE_PLATFORM
 from conan.errors import ConanException
 from conan.api.model import RecipeReference
 from conan.internal.model.conanfile_interface import ConanFileInterface
@@ -117,9 +116,7 @@ class ConanFileDependencies(UserRequirementsDict):
 
         data = OrderedDict((k, v) for k, v in self._data.items() if filter_fn(k))
         if remove_system:
-            data = OrderedDict((k, v) for k, v in data.items()
-                               # TODO: Make "recipe" part of ConanFileInterface model
-                               if v._conanfile._conan_node.recipe != RECIPE_PLATFORM)
+            data = OrderedDict((k, v) for k, v in data.items() if not v.is_platform)
         return ConanFileDependencies(data, require_filter)
 
     def transitive_requires(self, other):

--- a/test/integration/graph/test_dependencies_visit.py
+++ b/test/integration/graph/test_dependencies_visit.py
@@ -255,11 +255,15 @@ def test_dependency_interface():
         class User(ConanFile):
             requires = "dep/1.0"
             def generate(self):
-                self.output.info("HOME: {}".format(self.dependencies["dep"].homepage))
-                self.output.info("URL: {}".format(self.dependencies["dep"].url))
-                self.output.info("LICENSE: {}".format(self.dependencies["dep"].license))
-                self.output.info("RECIPE: {}".format(self.dependencies["dep"].recipe_folder))
-                self.output.info("CONANDATA: {}".format(self.dependencies["dep"].conan_data))
+                dep = self.dependencies["dep"]
+                self.output.info("HOME: {}".format(dep.homepage))
+                self.output.info("URL: {}".format(dep.url))
+                self.output.info("LICENSE: {}".format(dep.license))
+                self.output.info("RECIPE FOLDER: {}".format(dep.recipe_folder))
+                self.output.info("CONANDATA: {}".format(dep.conan_data))
+                self.output.info("RECIPE: {}".format(dep.recipe))
+                self.output.info("IS_EDITABLE: {}".format(dep.is_editable))
+                self.output.info("IS_PLATFORM: {}".format(dep.is_platform))
 
             """)
     c.save({"dep/conanfile.py": conanfile,
@@ -270,8 +274,11 @@ def test_dependency_interface():
     assert "conanfile.py: HOME: myhome" in c.out
     assert "conanfile.py: URL: myurl" in c.out
     assert "conanfile.py: LICENSE: MIT" in c.out
-    assert "conanfile.py: RECIPE:" in c.out
+    assert "conanfile.py: RECIPE FOLDER:" in c.out
     assert "conanfile.py: CONANDATA: {}" in c.out
+    assert "conanfile.py: RECIPE: Cache" in c.out
+    assert "conanfile.py: IS_EDITABLE: False" in c.out
+    assert "conanfile.py: IS_PLATFORM: False" in c.out
 
 
 def test_dependency_interface_validate():

--- a/test/integration/graph/test_dependencies_visit.py
+++ b/test/integration/graph/test_dependencies_visit.py
@@ -262,8 +262,6 @@ def test_dependency_interface():
                 self.output.info("RECIPE FOLDER: {}".format(dep.recipe_folder))
                 self.output.info("CONANDATA: {}".format(dep.conan_data))
                 self.output.info("RECIPE: {}".format(dep.recipe))
-                self.output.info("IS_EDITABLE: {}".format(dep.is_editable))
-                self.output.info("IS_PLATFORM: {}".format(dep.is_platform))
 
             """)
     c.save({"dep/conanfile.py": conanfile,
@@ -277,8 +275,6 @@ def test_dependency_interface():
     assert "conanfile.py: RECIPE FOLDER:" in c.out
     assert "conanfile.py: CONANDATA: {}" in c.out
     assert "conanfile.py: RECIPE: Cache" in c.out
-    assert "conanfile.py: IS_EDITABLE: False" in c.out
-    assert "conanfile.py: IS_PLATFORM: False" in c.out
 
 
 def test_dependency_interface_validate():


### PR DESCRIPTION
Changelog: Feature: Expose `recipe` in the `ConanFileInterface` for information purpose only.
Docs: https://github.com/conan-io/docs/pull/4264

closes https://github.com/conan-io/conan/issues/18996
- ~~explicit exports using the `__all__` variable~~

Some additional context: currently there is no easy way for a generator to know if a dependency is editable, platform, ...
This PR exposes the recipe via the `ConanFileInterface` so users don't have to use private method to have the info.


~~For the `__all__` keywords, this makes it explicit what Conan exports and avoid "unused import" warnings with linters.~~

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
