### PR TITLE
Update `CMakeDeps` `set_property()` docstring with new `cmake_extra_variables` property

### DIFF
--- a/conan/tools/cmake/cmakedeps/cmakedeps.py
+++ b/conan/tools/cmake/cmakedeps/cmakedeps.py
@@ -39,7 +39,7 @@ class CMakeDeps(object):
 
     def generate(self):
         """
-        This method will save the generated files to the conanfile.generators_folder
+        This method will save the generated files to the ``conanfile.generators_folder`` folder
         """
         check_duplicated_generator(self, self._conanfile)
 
@@ -135,10 +135,10 @@ class CMakeDeps(object):
     def set_property(self, dep, prop, value, build_context=False):
         """
         Using this method you can overwrite the :ref:`property<CMakeDeps Properties>` values set by
-        the Conan recipes from the consumer. This can be done for `cmake_file_name`, `cmake_target_name`,
-        `cmake_find_mode`, `cmake_module_file_name`, `cmake_module_target_name`, `cmake_additional_variables_prefixes`,
-        `cmake_config_version_compat`, `system_package_version`,
-        `cmake_build_modules`, `nosoname`, and `cmake_target_aliases`.
+        the Conan recipes from the consumer. This can be done for ``cmake_file_name``, ``cmake_target_name``,
+        ``cmake_find_mode``, ``cmake_module_file_name``, ``cmake_module_target_name``, ``cmake_additional_variables_prefixes``,
+        ``cmake_config_version_compat``, ``system_package_version``,
+        ``cmake_build_modules``, ``nosoname``, ``cmake_target_aliases`` and ``cmake_extra_variables``.
 
         :param dep: Name of the dependency to set the :ref:`property<CMakeDeps Properties>`. For
          components use the syntax: ``dep_name::component_name``.
@@ -167,7 +167,7 @@ class CMakeDeps(object):
                 else dep.cpp_info.components[comp_name].get_property(prop, check_type=check_type)
 
     def get_cmake_package_name(self, dep, module_mode=None):
-        """Get the name of the file for the find_package(XXX)"""
+        """Get the name of the file for the ``find_package(XXX)`` call"""
         # This is used by CMakeDeps to determine:
         # - The filename to generate (XXX-config.cmake or FindXXX.cmake)
         # - The name of the defined XXX_DIR variables
@@ -182,7 +182,7 @@ class CMakeDeps(object):
     def get_find_mode(self, dep):
         """
         :param dep: requirement
-        :return: "none" or "config" or "module" or "both" or "config" when not set
+        :return: One of ``"none"``, ``"config"``, ``"module"`` or ``"both"``. Defaults to ``"config"`` when not set
         """
         tmp = self.get_property("cmake_find_mode", dep)
         if tmp is None:


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Missed this in the initial PR https://github.com/conan-io/conan/pull/18822


<img width="808" height="747" alt="Captura de pantalla 2025-09-29 a las 13 04 34" src="https://github.com/user-attachments/assets/2291a5c7-ea9a-4c77-a1a9-5d113f39a3ed" />
