### PR TITLE
Improve performance for huge diffs in `conan report diff` HTML output

### DIFF
--- a/conan/cli/formatters/report/diff.py
+++ b/conan/cli/formatters/report/diff.py
@@ -66,7 +66,7 @@ def _render_diff(content, template, template_folder, **kwargs):
         for folder in bits[:-1]:
             cur = cur["folders"].setdefault(folder, {"folders": {}, "files": {}})
         cur["files"][bits[-1]] = {"filename": file, "is_new": "(new)" in replaced_path,
-                                  "is_deleted": "+++ /dev/null" in content[file],
+                                  "is_deleted": "+++ /dev/null" in content[file][:10],
                                   "relative_path": replaced_path}
 
     def flatten_empty_folders(current_node):

--- a/conan/cli/formatters/report/diff.py
+++ b/conan/cli/formatters/report/diff.py
@@ -49,9 +49,6 @@ def _render_diff(content, template, template_folder, **kwargs):
         # Calculate base64 of the filename
         return base64.b64encode(filename.encode(), altchars=b'-_').decode()
 
-    def _get_diff_filename(line):
-        return _get_filenames(line, kwargs["src_prefix"], kwargs["dst_prefix"])[0]
-
     def _remove_prefixes(line):
         return line.replace(kwargs["src_prefix"][:-1], "").replace(kwargs["dst_prefix"][:-1], "")
 
@@ -113,8 +110,6 @@ def _render_diff(content, template, template_folder, **kwargs):
                            replace_paths=_replace_paths,
                            replace_cache_paths=_replace_cache_paths,
                            remove_prefixes=_remove_prefixes,
-                           get_diff_filename=_get_diff_filename,
-                           get_line_numbers=_get_line_numbers,
                            **kwargs)
 
 

--- a/conan/cli/formatters/report/diff.py
+++ b/conan/cli/formatters/report/diff.py
@@ -66,7 +66,9 @@ def _render_diff(content, template, template_folder, **kwargs):
         for folder in bits[:-1]:
             cur = cur["folders"].setdefault(folder, {"folders": {}, "files": {}})
         cur["files"][bits[-1]] = {"filename": file, "is_new": "(new)" in replaced_path,
-                                  "is_deleted": "+++ /dev/null" in content[file][:10],
+                                  "is_deleted": "+++ /dev/null" in content[file][:10]
+                                                or any("deleted file mode" in line
+                                                       for line in content[file][:10]),
                                   "relative_path": replaced_path}
 
     def flatten_empty_folders(current_node):

--- a/conan/cli/formatters/report/diff.py
+++ b/conan/cli/formatters/report/diff.py
@@ -1,7 +1,6 @@
 import json
 import os
 import base64
-import re
 
 from jinja2 import Template
 

--- a/conan/cli/formatters/report/diff.py
+++ b/conan/cli/formatters/report/diff.py
@@ -66,6 +66,7 @@ def _render_diff(content, template, template_folder, **kwargs):
         for folder in bits[:-1]:
             cur = cur["folders"].setdefault(folder, {"folders": {}, "files": {}})
         cur["files"][bits[-1]] = {"filename": file, "is_new": "(new)" in replaced_path,
+                                  "is_deleted": "+++ /dev/null" in content[file],
                                   "relative_path": replaced_path}
 
     def flatten_empty_folders(current_node):

--- a/conan/cli/formatters/report/diff.py
+++ b/conan/cli/formatters/report/diff.py
@@ -58,13 +58,6 @@ def _render_diff(content, template, template_folder, **kwargs):
     def _replace_paths(line):
         return _remove_prefixes(_replace_cache_paths(line))
 
-    def _get_line_numbers(line):
-        match = re.search(r"@@ -(\d+),\d+ \+(\d+),\d+ @@", line)
-        if not match:
-            return 0, 0
-        old, new = match.groups()
-        return int(old), int(new)
-
     per_folder = {"folders": {}, "files": {}}
     for file in content:
         replaced_path = _replace_paths(file)

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -536,7 +536,11 @@ diff_html = r"""
                     const [lines, new_count, old_count] = makeDiffLines(data[path]);
                     const diffLines = elem.querySelector(".diff-lines")
 
-                    //diffLines.style.height = "auto";
+                    // If we're scrolling up, new lines are added to the top, so we need to
+                    // preserve the scroll position relative to the bottom of the new content
+                    const prevRect = elem.getBoundingClientRect();
+
+
                     diffLines.appendChild(lines);
 
                     if (new_count !== 0 || old_count !== 0) {
@@ -546,6 +550,13 @@ diff_html = r"""
                     if (elem.getAttribute("data-is-linked") === "true") {
                         // We need to scroll to the element again now that its height has changed
                         elem.scrollIntoView({block: "start", inline: "nearest", behavior: "instant"});
+                    } else {
+                        if (prevRect.top < 0) {
+                            const prevBottom = prevRect.bottom;
+                            const newBottom = elem.getBoundingClientRect().bottom;
+                            const container = document.querySelector('.container');
+                            container.scroll(0, container.scrollTop + (newBottom - prevBottom));
+                        }
                     }
 
                     observer.unobserve(elem);
@@ -563,10 +574,10 @@ diff_html = r"""
             const observer = new IntersectionObserver(intersectionCallback, options);
 
             document.addEventListener("DOMContentLoaded", (e) => {
+                setDataIsLinked(null);
                 document.querySelectorAll('.diff-container').forEach((section) => {
                     observer.observe(section);
                 });
-                setDataIsLinked(null);
             });
 
             function debounce(func, delay) {
@@ -663,6 +674,10 @@ diff_html = r"""
                 document.querySelectorAll('.diff-container').forEach((section) => {
                     if (section.id === hash) {
                         section.setAttribute("data-is-linked", "true");
+                        if (!event) {
+                            // Scroll to the linked element on page load
+                            section.scrollIntoView({block: "start", inline: "nearest", behavior: "instant"});
+                        }
                     } else {
                         section.setAttribute("data-is-linked", "false");
                     }

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -677,7 +677,6 @@ diff_html = r"""
                     <div class="search-area">
                         <input type="search" class="search-field" id="search-include" placeholder="Include search..." oninput="onIncludeSearchInput(event)" />
                         <input type="search" class="search-field" id="search-exclude" placeholder="Exclude search..." oninput="onExcludeSearchInput(event)" />
-                        <a href="#">Top</a>
                         <span id="searching_icon" style="display:none">...</span>
                         <p>Showing <b id="file-count">{{ content|length }}</b> out of <b>{{ content|length }}</b> files</p>
                     </div>

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -47,7 +47,6 @@ diff_html = r"""
         </div>
     {%- endfor %}
 {% endmacro %}
-<!DOCTYPE html>
 <html lang="en">
     <head>
         <meta charset="utf-8">
@@ -295,12 +294,6 @@ diff_html = r"""
 
             .diff-header {
                 padding: 0px 5px 5px 5px;
-            }
-
-            .diff-subheader {
-                display: flex;
-                justify-content: space-between;
-                align-items: center;
             }
 
             .filename {
@@ -695,10 +688,8 @@ diff_html = r"""
                 <span id="empty_search" style="display:none">No results found</span>
             </div>
             <div class='content'>
-                <div class="diff-header"><div class="diff-header">
+                <div class="diff-header">
                     <h2>Diff Report Between <b class="del">{{ old_reference.repr_notime() }}</b> And <b class="add">{{ new_reference.repr_notime() }}</b></h2>
-                    <div class="diff-subheader">
-                    </div>
                 </div>
                 <span id="empty_result" style="display:none">No matches</span>
                 {{ render_diff_folder(per_folder) }}

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -15,7 +15,7 @@ diff_html = r"""
         <li class="file file-{{ "deleted" if file_info["is_deleted"] else (
                                 "new" if file_info["is_new"] else "old") }}"
             data-path="{{ file_info["relative_path"] }}">
-            <a href="#diff_{{- safe_filename(file_info["filename"]) -}}" class="side-link">
+            <a href="#diff_{{- safe_filename(file_info["filename"]) -}}" onclick="setDataIsLinked(event)" class="side-link">
                 {{ name }}
             </a>
         </li>
@@ -92,7 +92,7 @@ diff_html = r"""
             }
 
             .file-list li ul {
-                border-left: 2px solid #ddd;
+                border-left: 1px solid #ddd;
                 margin-left: 3px;
             }
 
@@ -106,29 +106,52 @@ diff_html = r"""
 
             .folder > summary {
                 cursor: pointer;
+                list-style: none;
             }
 
             .folder > summary:hover {
                 background-color: #e0e0e033;
             }
 
+            .folder:not(:open) > summary:before {
+                content: "\1F4C1";
+                display: inline-block;
+                margin-right: 3px;
+            }
+
+            .folder:open > summary:before {
+                content: "\1F4C2";
+                display: inline-block;
+                margin-right: 3px;
+            }
+
             details.folder ul:hover {
-                background-color: #e0e0e033;
-                border-left: 2px solid #00000066;
+                border-left: 1px solid #00000066;
             }
 
             .sidebar li {
-                line-height: 1.5;
+                line-height: 1.8;
                 list-style: none;
                 list-style-position: inside;
+                user-select: none;
             }
 
             .sidebar li a {
                 text-decoration: none;
+                padding: 5px;
+                color: black;
             }
 
             .sidebar li a:hover {
-                text-decoration: underline;
+                text-decoration: none;
+                border-radius: 5px;
+                background-color: #e0e0e0;
+                padding: 5px;
+                color: black;
+            }
+
+            .sidebar li a:visited {
+                color: black;
             }
 
             .side-link {
@@ -151,7 +174,7 @@ diff_html = r"""
 
             .sidebar li.file-old:before {
                 content: "\00B1";
-                color: black;
+                color: gray;
             }
 
             .sidebar li.file-deleted:before {
@@ -162,12 +185,20 @@ diff_html = r"""
 
             /* --- Diff View Components --- */
 
+            .diff-container {
+                scroll-margin-top: 10px;
+            }
+
             .diff-content {
                 padding-bottom: 7px;
                 border: 1px solid black;
                 border-radius: 7px;
-                margin-bottom: 10;
+                margin-bottom: 10px;
                 background-color: white;
+            }
+
+            .diff-container[data-is-linked="true"] .diff-content {
+                border: 2px solid #0078d7;
             }
 
             details.diff-details summary.diff-summary {
@@ -251,8 +282,13 @@ diff_html = r"""
                 display: inline-block;
             }
 
+            .diff-lines {
+                line-break: anywhere;
+            }
+
             .line-number {
                 width: 4ch;
+                min-width: 4ch;
                 display: inline-block;
                 text-align: center;
                 user-select: none;
@@ -263,13 +299,25 @@ diff_html = r"""
             }
 
             .add {
-                background-color: #76ffbbBB;
+                background-color: #cbfcd9;
                 color: black;
             }
 
             .del {
-                background-color: #fdb9c1BB;
+                background-color: #ffebe9;
                 color: black;
+            }
+
+            .add,
+            .del,
+            .context-line {
+                height: 100%;
+            }
+
+            .diff-line {
+                display: flex;
+                box-sizing: border-box;
+                line-height: 1.5em;
             }
 
             .line-number.add {
@@ -278,6 +326,11 @@ diff_html = r"""
 
             .line-number.del {
                 background-color: #fdb9c1;
+            }
+
+            .line-number.add,
+            .line-number.del {
+                height: auto;
             }
 
             /* --- Utility & Page States --- */
@@ -320,6 +373,8 @@ diff_html = r"""
                 for (let i = 0; i < lines.length; i++) {
                     const line = lines[i];
                     let spanLine = document.createElement("span");
+                    const lineDiv = document.createElement("div");
+                    lineDiv.className = "diff-line";
                     let shouldAddLine = true;
                     if (line.startsWith("+++")) {
                         seen_header = true;
@@ -360,7 +415,7 @@ diff_html = r"""
                         const lineNumberSpan = document.createElement("span");
                         lineNumberSpan.className = "line-number add";
                         lineNumberSpan.textContent = new_line_index;
-                        currentDetails.appendChild(lineNumberSpan);
+                        lineDiv.appendChild(lineNumberSpan);
 
                         new_line_index += 1;
                         new_line_count += 1;
@@ -371,7 +426,7 @@ diff_html = r"""
                         const lineNumberSpan = document.createElement("span");
                         lineNumberSpan.className = "line-number del";
                         lineNumberSpan.textContent = old_line_index;
-                        currentDetails.appendChild(lineNumberSpan);
+                        lineDiv.appendChild(lineNumberSpan);
 
                         old_line_index += 1;
                         old_line_count += 1;
@@ -389,14 +444,16 @@ diff_html = r"""
                         const lineNumberSpan = document.createElement("span");
                         lineNumberSpan.className = "line-number context-line";
                         lineNumberSpan.textContent = new_line_index;
-                        currentDetails.appendChild(lineNumberSpan);
+                        lineDiv.appendChild(lineNumberSpan);
 
                         new_line_index += 1;
                         old_line_index += 1;
                     }
                     if (shouldAddLine) {
-                        currentDetails.appendChild(spanLine);
-                        currentDetails.appendChild(document.createElement("br"));
+                        lineDiv.appendChild(spanLine);
+
+                        currentDetails.appendChild(lineDiv);
+                        //currentDetails.appendChild(document.createElement("br"));
                     }
                 }
                 if (!seen_header) {
@@ -419,7 +476,10 @@ diff_html = r"""
                     let elem = entry.target;
                     const path = elem.dataset.path;
                     const [lines, new_count, old_count] = makeDiffLines(data[path]);
-                    elem.querySelector(".diff-lines").appendChild(lines);
+                    const diffLines = elem.querySelector(".diff-lines")
+
+                    //diffLines.style.height = "auto";
+                    diffLines.appendChild(lines);
 
                     if (new_count !== 0 || old_count !== 0) {
                         elem.querySelector(".changes-count-container").appendChild(createChangesCountElement(new_count, old_count));
@@ -443,6 +503,7 @@ diff_html = r"""
                 document.querySelectorAll('.diff-container').forEach((section) => {
                     observer.observe(section);
                 });
+                setDataIsLinked(null);
             });
 
             function debounce(func, delay) {
@@ -524,7 +585,7 @@ diff_html = r"""
 
             const debouncedOnSearchInput = debounce(onSearchInput, 300);
 
-             async function onExcludeSearchInput(event) {
+            async function onExcludeSearchInput(event) {
                 excludeSearchQuery = event.currentTarget.value.toLowerCase();
                 debouncedOnSearchInput(event);
             }
@@ -533,6 +594,17 @@ diff_html = r"""
                 includeSearchQuery = event.currentTarget.value.toLowerCase();
                 debouncedOnSearchInput(event);
             }
+
+            function setDataIsLinked(event) {
+                const hash = event ? event.currentTarget.getAttribute("href").substring(1) : window.location.hash.substring(1);
+                document.querySelectorAll('.diff-container').forEach((section) => {
+                    if (section.id === hash) {
+                        section.setAttribute("data-is-linked", "true");
+                    } else {
+                        section.setAttribute("data-is-linked", "false");
+                    }
+                });
+            }
         </script>
     </head>
     <body>
@@ -540,8 +612,8 @@ diff_html = r"""
             <div class='sidebar'>
                 <div id="sidebar-contents">
                     <div class="search-area">
-                        <input type="text" class="search-field" id="search-include" placeholder="Include search..." oninput="onIncludeSearchInput(event)" />
-                        <input type="text" class="search-field" id="search-exclude" placeholder="Exclude search..." oninput="onExcludeSearchInput(event)" />
+                        <input type="search" class="search-field" id="search-include" placeholder="Include search..." oninput="onIncludeSearchInput(event)" />
+                        <input type="search" class="search-field" id="search-exclude" placeholder="Exclude search..." oninput="onExcludeSearchInput(event)" />
                         <span id="searching_icon" style="display:none">...</span>
                         <p>Showing <b id="file-count">{{ content|length }}</b> out of <b>{{ content|length }}</b> files</p>
                     </div>
@@ -568,7 +640,8 @@ diff_html = r"""
                                     </b>
                                     <div class="changes-count-container"></div>
                                 </summary>
-                                <div class="diff-lines"></div>
+                                <div class="diff-lines">
+                                </div>
                             </details>
                         </div>
                     </div>

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -1,12 +1,12 @@
 diff_html = r"""
-{% macro render_folder(folder, folder_info) %}
+{% macro render_sidebar_folder(folder, folder_info) %}
     {%- for name, sub_folder_info in folder_info["folders"].items() %}
         {% set folder_name = folder + "/" + name %}
         <li>
             <details open class="folder">
                 <summary>{{ name }}</summary>
                 <ul>
-                    {{ render_folder(folder_name, sub_folder_info) }}
+                    {{ render_sidebar_folder(folder_name, sub_folder_info) }}
                 </ul>
             </details>
         </li>
@@ -15,12 +15,39 @@ diff_html = r"""
         <li class="file file-{{ "deleted" if file_info["is_deleted"] else (
                                 "new" if file_info["is_new"] else "old") }}"
             data-path="{{ file_info["relative_path"] }}">
-            <a href="#diff_{{- safe_filename(file_info["filename"]) -}}" onclick="setDataIsLinked(event)" class="side-link">
+            <a href="#diff_{{- safe_filename(file_info["filename"]) -}}"
+                onclick="setDataIsLinked(event)" draggable="false"
+                class="side-link">
                 {{ name }}
             </a>
         </li>
     {%- endfor %}
 {% endmacro %}
+
+{% macro render_diff_folder(folder_info) %}
+    {%- for name, sub_folder_info in folder_info["folders"].items() %}
+        {{ render_diff_folder(sub_folder_info) }}
+    {%- endfor %}
+    {%- for name, file_info in folder_info["files"].items() %}
+        {% set filename = file_info["filename"] %}
+
+        <div id="diff_{{ safe_filename(filename) }}" data-path="{{ filename }}" class="diff-container">
+            <div class="diff-content">
+                <details open class="diff-details">
+                    <summary class="diff-summary">
+                        <b id="diff_{{ safe_filename(filename) }}_filename" class="filename" data-replaced-paths="">
+                            <span>{{ replace_cache_paths(filename) | replace("(old)/", "") | replace("(new)/", "") }}</span>
+                        </b>
+                        <div class="changes-count-container"></div>
+                    </summary>
+                    <div class="diff-lines">
+                    </div>
+                </details>
+            </div>
+        </div>
+    {%- endfor %}
+{% endmacro %}
+<!DOCTYPE html>
 <html lang="en">
     <head>
         <meta charset="utf-8">
@@ -306,7 +333,7 @@ diff_html = r"""
                 list-style: none;
                 background-color: var(--context-chunk-header-bgColor);
                 color: var(--context-chunk-header-color);
-                line-height: 1.5;
+                line-height: 2;
                 cursor: pointer;
             }
 
@@ -657,11 +684,12 @@ diff_html = r"""
                     <div class="search-area">
                         <input type="search" class="search-field" id="search-include" placeholder="Include search..." oninput="onIncludeSearchInput(event)" />
                         <input type="search" class="search-field" id="search-exclude" placeholder="Exclude search..." oninput="onExcludeSearchInput(event)" />
+                        <a href="#">Top</a>
                         <span id="searching_icon" style="display:none">...</span>
                         <p>Showing <b id="file-count">{{ content|length }}</b> out of <b>{{ content|length }}</b> files</p>
                     </div>
                     <ul class="file-list">
-                        {{ render_folder("", per_folder) }}
+                        {{ render_sidebar_folder("", per_folder) }}
                     </ul>
                 </div>
                 <span id="empty_search" style="display:none">No results found</span>
@@ -673,22 +701,7 @@ diff_html = r"""
                     </div>
                 </div>
                 <span id="empty_result" style="display:none">No matches</span>
-                {%- for filename, lines in content.items() -%}
-                    <div id="diff_{{ safe_filename(filename) }}" data-path="{{ filename }}" class="diff-container">
-                        <div class="diff-content">
-                            <details open class="diff-details">
-                                <summary class="diff-summary">
-                                    <b id="diff_{{ safe_filename(filename) }}_filename" class="filename" data-replaced-paths="">
-                                        <span>{{ replace_cache_paths(filename) | replace("(old)/", "") | replace("(new)/", "") }}</span>
-                                    </b>
-                                    <div class="changes-count-container"></div>
-                                </summary>
-                                <div class="diff-lines">
-                                </div>
-                            </details>
-                        </div>
-                    </div>
-                {%- endfor -%}
+                {{ render_diff_folder(per_folder) }}
             </div>
         </div>
     </body>

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -485,6 +485,11 @@ diff_html = r"""
                         elem.querySelector(".changes-count-container").appendChild(createChangesCountElement(new_count, old_count));
                     }
 
+                    if (elem.getAttribute("data-is-linked") === "true") {
+                        // We need to scroll to the element again now that its height has changed
+                        elem.scrollIntoView({block: "start", inline: "nearest", behavior: "instant"});
+                    }
+
                     observer.unobserve(elem);
                 }
               });

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -26,12 +26,50 @@ diff_html = r"""
         <meta charset="utf-8">
         <title>Diff report for {{ old_reference }} - {{ new_reference }}</title>
         <style>
+            /* --- Colors --- */
+            :root {
+                --body-bgColor: #f8f8f8;
+                --sidebar-bgColor: #f4f4f466;
+                --sidebar-borderColor: #ccc;
+                --sidebar-contents-bgColor: #f4f4f4;
+                --content-bgColor: #f8f8f8;
+                --search-area-borderColor: #ccc;
+                --search-field-borderColor: #ccc;
+                --file-list-borderColor: #ddd;
+                --folder-summary-hover-bgColor: #e0e0e033;
+                --folder-ul-hover-borderColor: #00000066;
+                --sidebar-li-a-hover-bgColor: #e0e0e0;
+                --sidebar-link-color: black;
+                --sidebar-link-hover-color: var(--sidebar-link-color);
+                --sidebar-link-visited-color: var(--sidebar-link-color);
+                --sidebar-file-new-color: green;
+                --sidebar-file-old-color: gray;
+                --sidebar-file-deleted-color: red;
+                --diff-content-borderColor: black;
+                --diff-content-bgColor: white;
+                --diff-container-linked-borderColor: #0078d7;
+                --diff-summary-borderColor: #ccc;
+                --diff-summary-bgColor: #f8f8f8;
+                --diff-summary-hover-bgColor: #f0f0f0;
+                --new-lines-count-color: green;
+                --old-lines-count-color: black;
+                --context-line-color: #888;
+                --context-chunk-header-bgColor: #cef8ff;
+                --context-chunk-header-color: var(--context-line-color);
+                --added-line-bgColor: #cbfcd9;
+                --added-line-color: black;
+                --deleted-line-bgColor: #ffebe9;
+                --deleted-line-color: black;
+                --line-number-added-bgColor: #76ffbb;
+                --line-number-deleted-bgColor: #fdb9c1;
+            }
+
             /* --- Global Styles --- */
 
             body {
                 font-family: monospace;
                 margin: 0px;
-                background-color: #f8f8f8;
+                background-color: var(--body-bgColor);
             }
 
             /* --- Main Layout --- */
@@ -48,8 +86,8 @@ diff_html = r"""
                 max-width: 33%;
                 padding: 10px;
                 overflow: scroll;
-                background: #f4f4f466;
-                border-right: 1px solid #ccc;
+                background: var(--sidebar-bgColor);
+                border-right: 1px solid var(--sidebar-borderColor);
                 resize: horizontal;
                 position: sticky;
                 top: 0;
@@ -57,25 +95,25 @@ diff_html = r"""
 
             .content {
                 padding: 20px;
-                background: #f8f8f8;
+                background: var(--content-bgColor);
                 width: 100%;
             }
 
             /* --- Sidebar & File Tree --- */
 
             #sidebar-contents {
-                background: #f4f4f4;
+                background: var(--sidebar-contents-bgColor);
                 border-radius: 7px;
                 overflow-y: hidden;
                 padding-top: 5px;
             }
 
             .search-area {
-                border-bottom: 1px solid #ccc;
+                border-bottom: 1px solid var(--search-area-borderColor);
             }
 
             .search-field {
-                border: 1px solid #ccc;
+                border: 1px solid var(--search-field-borderColor);
                 border-radius: 5px;
                 padding: 5px;
                 margin: 5px;
@@ -92,7 +130,7 @@ diff_html = r"""
             }
 
             .file-list li ul {
-                border-left: 1px solid #ddd;
+                border-left: 1px solid var(--file-list-borderColor);
                 margin-left: 3px;
             }
 
@@ -110,7 +148,7 @@ diff_html = r"""
             }
 
             .folder > summary:hover {
-                background-color: #e0e0e033;
+                background-color: var(--folder-summary-hover-bgColor);
             }
 
             .folder:not(:open) > summary:before {
@@ -126,7 +164,7 @@ diff_html = r"""
             }
 
             details.folder ul:hover {
-                border-left: 1px solid #00000066;
+                border-left: 1px solid var(--folder-ul-hover-borderColor);
             }
 
             .sidebar li {
@@ -139,19 +177,19 @@ diff_html = r"""
             .sidebar li a {
                 text-decoration: none;
                 padding: 5px;
-                color: black;
+                color: var(--sidebar-link-color);
             }
 
             .sidebar li a:hover {
                 text-decoration: none;
                 border-radius: 5px;
-                background-color: #e0e0e0;
+                background-color: var(--sidebar-li-a-hover-bgColor);
                 padding: 5px;
-                color: black;
+                color: var(--sidebar-link-hover-color);
             }
 
             .sidebar li a:visited {
-                color: black;
+                color: var(--sidebar-link-visited-color);
             }
 
             .side-link {
@@ -168,18 +206,18 @@ diff_html = r"""
 
             .sidebar li.file-new:before {
                 content: "+";
-                color: green;
+                color: var(--sidebar-file-new-color);
                 font-weight: bold;
             }
 
             .sidebar li.file-old:before {
                 content: "\00B1";
-                color: gray;
+                color: var(--sidebar-file-old-color);
             }
 
             .sidebar li.file-deleted:before {
                 content: "-";
-                color: red;
+                color: var(--sidebar-file-deleted-color);
                 font-weight: bold;
             }
 
@@ -191,14 +229,14 @@ diff_html = r"""
 
             .diff-content {
                 padding-bottom: 7px;
-                border: 1px solid black;
+                border: 1px solid var(--diff-content-borderColor);
                 border-radius: 7px;
                 margin-bottom: 10px;
-                background-color: white;
+                background-color: var(--diff-content-bgColor);
             }
 
             .diff-container[data-is-linked="true"] .diff-content {
-                border: 2px solid #0078d7;
+                border: 2px solid var(--diff-container-linked-borderColor);
             }
 
             details.diff-details summary.diff-summary {
@@ -206,16 +244,16 @@ diff_html = r"""
                 display: flex;
                 justify-content: space-between;
                 align-items: center;
-                border-bottom: 1px solid #ccc;
+                border-bottom: 1px solid var(--diff-summary-borderColor);
                 padding: 5px 0px;
                 position: sticky;
                 top: 0;
-                background-color: #f8f8f8;
+                background-color: var(--diff-summary-bgColor);
                 border-radius: 7px 7px 0px 0px;
             }
 
             details.diff-details summary.diff-summary:hover {
-                background-color: #f0f0f0;
+                background-color: var(--diff-summary-hover-bgColor);
             }
 
             details:open .diff-summary .filename:before {
@@ -249,12 +287,12 @@ diff_html = r"""
             }
 
             .new-lines-count {
-                color: green;
+                color: var(--new-lines-count-color);
                 font-weight: bold;
             }
 
             .old-lines-count {
-                color: black;
+                color: var(--old-lines-count-color);
                 font-weight: bold;
             }
 
@@ -266,8 +304,8 @@ diff_html = r"""
 
             .context-chunk-header {
                 list-style: none;
-                background-color: #cef8ff;
-                color: #888;
+                background-color: var(--context-chunk-header-bgColor);
+                color: var(--context-chunk-header-color);
                 line-height: 1.5;
                 cursor: pointer;
             }
@@ -295,17 +333,17 @@ diff_html = r"""
             }
 
             .context-line {
-                color: #888;
+                color: var(--context-line-color);
             }
 
             .add {
-                background-color: #cbfcd9;
-                color: black;
+                background-color: var(--added-line-bgColor);
+                color: var(--added-line-color);
             }
 
             .del {
-                background-color: #ffebe9;
-                color: black;
+                background-color: var(--deleted-line-bgColor);
+                color: var(--deleted-line-color);
             }
 
             .add,
@@ -321,11 +359,11 @@ diff_html = r"""
             }
 
             .line-number.add {
-                background-color: #76ffbb;
+                background-color: var(--line-number-added-bgColor);
             }
 
             .line-number.del {
-                background-color: #fdb9c1;
+                background-color: var(--line-number-deleted-bgColor);
             }
 
             .line-number.add,

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -24,7 +24,7 @@ diff_html = r"""
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>{{ old_reference }} - {{ new_reference }}</title>
+        <title>Diff report for {{ old_reference }} - {{ new_reference }}</title>
         <style>
             body { font-family: monospace; margin: 0px; }
             .container { display: flex; height: 100%; }
@@ -93,7 +93,7 @@ diff_html = r"""
             }
 
             .diff-content {
-                padding: 0px 0px 3px 3px;
+                padding-bottom: 7px;
                 border: 1px solid black;
                 border-radius: 7px;
                 margin-bottom: 10;
@@ -115,9 +115,9 @@ diff_html = r"""
                 text-align: center;
                 user-select: none;
             }
-            hr { margin-left: -3px;}
             .filename {
                 font-size: 1.2em;
+                padding-left: 10px;
             }
             .diff-summary {
                 display: flex;
@@ -138,6 +138,7 @@ diff_html = r"""
                 list-style: none;
                 background-color: #cef8ff;
                 color: #888;
+                line-height: 1.5;
             }
 
             details:open .context-chunk-header .line-number:before {

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -12,7 +12,8 @@ diff_html = r"""
         </li>
     {%- endfor %}
     {%- for name, file_info in folder_info["files"].items() %}
-        <li class="file-{{ "new" if file_info["is_new"] else "old" }}"
+        <li class="file-{{ "deleted" if file_info["is_deleted"] else (
+                            "new" if file_info["is_new"] else "old") }}"
             data-path="{{ file_info["relative_path"] }}">
             <a href="#diff_{{- safe_filename(file_info["filename"]) -}}" class="side-link">
                 {{ name }}
@@ -51,6 +52,8 @@ diff_html = r"""
             .sidebar li.file-new:before { content: "+"; color: green; font-weight: bold; }
             .sidebar li.file-old { list-style: none; padding-left: 0;  }
             .sidebar li.file-old:before { content: "\00B1"; color: black; }
+            .sidebar li.file-deleted { list-style: none; padding-left: 0; }
+            .sidebar li.file-deleted:before { content: "-"; color: red; font-weight: bold; }
             .sidebar li a {
                 text-decoration: none;
             }

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -26,12 +26,22 @@ diff_html = r"""
         <meta charset="utf-8">
         <title>Diff report for {{ old_reference }} - {{ new_reference }}</title>
         <style>
-            body { font-family: monospace; margin: 0px; background-color: #f8f8f8; }
+            /* --- Global Styles --- */
+
+            body {
+                font-family: monospace;
+                margin: 0px;
+                background-color: #f8f8f8;
+            }
+
+            /* --- Main Layout --- */
+
             .container {
                 display: flex;
                 height: 100%;
                 overflow: scroll;
             }
+
             .sidebar {
                 width: 17%;
                 min-width: 10%;
@@ -44,80 +54,113 @@ diff_html = r"""
                 position: sticky;
                 top: 0;
             }
+
+            .content {
+                padding: 20px;
+                background: #f8f8f8;
+                width: 100%;
+            }
+
+            /* --- Sidebar & File Tree --- */
+
             #sidebar-contents {
                 background: #f4f4f4;
                 border-radius: 7px;
                 overflow-y: hidden;
                 padding-top: 5px;
             }
-            details.folder {
-                text-wrap: nowrap;
+
+            .search-area {
+                border-bottom: 1px solid #ccc;
             }
 
-            .sidebar li { line-height: 1.5; list-style: none; list-style-position: inside; }
-            .sidebar li.file-new { list-style: none; padding-left: 0; }
-            .sidebar li.file-new:before { content: "+"; color: green; font-weight: bold; }
-            .sidebar li.file-old { list-style: none; padding-left: 0;  }
-            .sidebar li.file-old:before { content: "\00B1"; color: black; }
-            .sidebar li.file-deleted { list-style: none; padding-left: 0; }
-            .sidebar li.file-deleted:before { content: "-"; color: red; font-weight: bold; }
-            .sidebar li a {
-                text-decoration: none;
+            .search-field {
+                border: 1px solid #ccc;
+                border-radius: 5px;
+                padding: 5px;
+                margin: 5px;
             }
-            .sidebar li a:hover {
-                text-decoration: underline;
-            }
-            .side-link {
-                text-wrap: nowrap;
-            }
+
             .file-list {
                 padding-left: 10px;
                 width: 100%;
                 overflow-x: clip;
             }
+
             .file-list ul li {
                 width: 100%;
             }
+
             .file-list li ul {
                 border-left: 2px solid #ddd;
                 margin-left: 3px;
             }
-            li ul { padding-left: 1ch; }
-            .content {
-                padding: 20px;
-                background: #f8f8f8;
-                //overflow-y: scroll;
-                width: 100%;
-            }
-            .content span {
-                white-space: pre-wrap;
-            }
-            .add { background-color: #76ffbbBB; color: black; }
-            .del { background-color: #fdb9c1BB; color: black; }
 
-            .line-number.add { background-color: #76ffbb; }
-            .line-number.del { background-color: #fdb9c1; }
+            li ul {
+                padding-left: 1ch;
+            }
 
-            .new-lines-count { color: green; font-weight: bold; }
-            .old-lines-count { color: black; font-weight: bold; }
-            .changes-count-container {
-                font-size: 0.9em;
-                padding-right: 10px;
+            details.folder {
+                text-wrap: nowrap;
             }
 
             .folder > summary {
                 cursor: pointer;
             }
 
-            /*.folder:open > summary:before {
-                content: "\1F4C2";
+            .folder > summary:hover {
+                background-color: #e0e0e033;
             }
 
-            .folder:not(:open) > summary:before {
-                content: "\1F4C1";
-            }*/
+            details.folder ul:hover {
+                background-color: #e0e0e033;
+                border-left: 2px solid #00000066;
+            }
 
-            .folder > summary:hover { background-color: #e0e0e033; }
+            .sidebar li {
+                line-height: 1.5;
+                list-style: none;
+                list-style-position: inside;
+            }
+
+            .sidebar li a {
+                text-decoration: none;
+            }
+
+            .sidebar li a:hover {
+                text-decoration: underline;
+            }
+
+            .side-link {
+                text-wrap: nowrap;
+            }
+
+            /* File Status Indicators */
+            .sidebar li.file-new,
+            .sidebar li.file-old,
+            .sidebar li.file-deleted {
+                list-style: none;
+                padding-left: 0;
+            }
+
+            .sidebar li.file-new:before {
+                content: "+";
+                color: green;
+                font-weight: bold;
+            }
+
+            .sidebar li.file-old:before {
+                content: "\00B1";
+                color: black;
+            }
+
+            .sidebar li.file-deleted:before {
+                content: "-";
+                color: red;
+                font-weight: bold;
+            }
+
+            /* --- Diff View Components --- */
 
             .diff-content {
                 padding-bottom: 7px;
@@ -126,10 +169,7 @@ diff_html = r"""
                 margin-bottom: 10;
                 background-color: white;
             }
-            details.folder ul:hover {
-                background-color: #e0e0e033;
-                border-left: 2px solid #00000066;
-            }
+
             details.diff-details summary.diff-summary {
                 cursor: pointer;
                 display: flex;
@@ -142,29 +182,55 @@ diff_html = r"""
                 background-color: #f8f8f8;
                 border-radius: 7px 7px 0px 0px;
             }
+
             details.diff-details summary.diff-summary:hover {
                 background-color: #e0e0e033;
             }
-            .context-line { color: #888; }
-            .line-number {
-                width: 4ch;
+
+            details:open .diff-summary filename:before {
+                content: "\25BC";
                 display: inline-block;
-                text-align: center;
-                user-select: none;
             }
+
+            details:not(:open) .diff-summary filename:before {
+                content: "\25B6";
+                display: inline-block;
+            }
+
+            .diff-header {
+                padding: 0px 5px 5px 5px;
+            }
+
+            .diff-subheader {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+            }
+
             .filename {
                 font-size: 1.2em;
                 padding-left: 10px;
             }
 
-
-            details:open .diff-summary b:before {
-                content: "\25BC";
-                display: inline-block;
+            .changes-count-container {
+                font-size: 0.9em;
+                padding-right: 10px;
             }
-            details:not(:open) .diff-summary b:before {
-                content: "\25B6";
-                display: inline-block;
+
+            .new-lines-count {
+                color: green;
+                font-weight: bold;
+            }
+
+            .old-lines-count {
+                color: black;
+                font-weight: bold;
+            }
+
+            /* --- Diff Line Styles --- */
+
+            .content span {
+                white-space: pre-wrap;
             }
 
             .context-chunk-header {
@@ -184,6 +250,37 @@ diff_html = r"""
                 display: inline-block;
             }
 
+            .line-number {
+                width: 4ch;
+                display: inline-block;
+                text-align: center;
+                user-select: none;
+            }
+
+            .context-line {
+                color: #888;
+            }
+
+            .add {
+                background-color: #76ffbbBB;
+                color: black;
+            }
+
+            .del {
+                background-color: #fdb9c1BB;
+                color: black;
+            }
+
+            .line-number.add {
+                background-color: #76ffbb;
+            }
+
+            .line-number.del {
+                background-color: #fdb9c1;
+            }
+
+            /* --- Utility & Page States --- */
+
             #empty_result {
                 justify-content: center;
                 align-items: center;
@@ -191,27 +288,6 @@ diff_html = r"""
                 font-weight: bold;
                 font-size: 4em;
                 text-align: center;
-            }
-
-            .diff-header {
-                padding: 0px 5px 5px 5px;
-            }
-
-            .diff-subheader {
-                display: flex;
-                justify-content: space-between;
-                align-items: center;
-            }
-
-            .search-field {
-                border: 1px solid #ccc;
-                border-radius: 5px;
-                padding: 5px;
-                margin: 5px;
-            }
-
-            .search-area {
-                border-bottom: 1px solid #ccc;
             }
         </style>
         <script>
@@ -445,7 +521,7 @@ diff_html = r"""
 
             }
 
-            const debouncedOnSearchInput = debounce(onSearchInput, 500);
+            const debouncedOnSearchInput = debounce(onSearchInput, 300);
 
              async function onExcludeSearchInput(event) {
                 excludeSearchQuery = event.currentTarget.value.toLowerCase();

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -83,6 +83,106 @@ diff_html = r"""
             }
         </style>
         <script>
+
+            const data = {{ content | tojson | safe }};
+
+            function extractLineNumbers(hunkHeader) {
+                const regex = /@@ -(\d+),\d+ \+(\d+),\d+ @@/;
+                const match = hunkHeader.match(regex);
+                if (!match) {
+                    return [0, 0];
+                }
+                return [parseInt(match[1]), parseInt(match[2])];
+            }
+
+
+            function makeDiffLines(lines) {
+                const element = document.createElement("div");
+                let seen_header = false;
+                let new_line_number = 0;
+                let old_line_number = 0;
+                for (let i = 1; i < lines.length; i++) {
+                    const line = lines[i];
+                    let spanLine = document.createElement("span");
+                    if (line.startsWith("+++")) {
+                        seen_header = true;
+                        spanLine.className = "add";
+                        spanLine.textContent = line;
+                    } else if (line.startsWith("---")) {
+                        spanLine.className = "del";
+                        spanLine.textContent = line;
+                    } else if (line.startsWith("@@")) {
+                        const lineNumbers = extractLineNumbers(line);
+                        old_line_number = lineNumbers[0];
+                        new_line_number = lineNumbers[1];
+                        spanLine.className = "context-header";
+                        spanLine.textContent = line;
+                    } else if (line.startsWith("+")) {
+                        spanLine.className = "add";
+                        spanLine.textContent = line;
+
+                        const lineNumberSpan = document.createElement("span");
+                        lineNumberSpan.className = "line-number";
+                        lineNumberSpan.textContent = new_line_number;
+                        element.appendChild(lineNumberSpan);
+
+                        new_line_number += 1;
+                    } else if (line.startsWith("-")) {
+                        spanLine.className = "del";
+                        spanLine.textContent = line;
+
+                        const lineNumberSpan = document.createElement("span");
+                        lineNumberSpan.className = "line-number";
+                        lineNumberSpan.textContent = old_line_number;
+                        element.appendChild(lineNumberSpan);
+
+                        old_line_number += 1;
+                    } else {
+                        if (seen_header) {
+                            const lineNumberSpan = document.createElement("span");
+                            lineNumberSpan.className = "line-number";
+                            lineNumberSpan.textContent = new_line_number;
+                            element.appendChild(lineNumberSpan);
+                        }
+                        spanLine.className = "context";
+                        spanLine.textContent = line;
+                        new_line_number += 1;
+                        old_line_number += 1;
+                    }
+                    element.appendChild(spanLine);
+                    element.appendChild(document.createElement("br"));
+                }
+                return element;
+            }
+
+
+            functino intersectionCallback(entries) {
+              entries.forEach((entry) => {
+                if (entry.isIntersecting) {
+                    let elem = entry.target;
+                    const path = elem.dataset.path;
+                    elem.querySelector(".diff-lines").appendChild(makeDiffLines(data[path]));
+                    observer.unobserve(elem);
+                }
+              });
+            }
+
+            const options = {
+                root: document.querySelector('.content'),
+                rootMargin: "0px",
+                scrollMargin: "0px",
+                threshold: 0.05,
+            };
+
+            const observer = new IntersectionObserver(intersectionCallback, options);
+
+
+            document.addEventListener("DOMContentLoaded", (e) => {
+                document.querySelectorAll('.diff-content').forEach((section) => {
+                    observer.observe(section);
+                });
+            });
+
             function debounce(func, delay) {
                 let timeout;
                 return function(...args) {
@@ -195,52 +295,19 @@ diff_html = r"""
                     </span>
                 </div>
                 <span id="empty_result" style="display:none">No matches</span>
-                <div><!--placeholder-->
                 {%- for filename, lines in content.items() -%}
+                    <div id="diff_{{ safe_filename(filename) }}" data-path="{{ filename }}" class="diff-content">
+
+                        {% set firstLine = lines[0] if lines else "" %}
+                        <h3 id="diff_{{ safe_filename(filename) }}_filename" class="filename" data-replaced-paths="{{ replace_cache_paths(filename) }}">
+                            {{ remove_prefixes(firstLine) }}
+                        </h3>
+                        <div class="diff-lines">
+                        </div>
+                        <hr/>
                     </div>
-                    {% set ns = namespace() %}
-                    {% set ns.old_line_number = 0 %}
-                    {% set ns.new_line_number = 0 %}
-                    {% set ns.seen_header = false %}
-                    <div id="diff_{{ safe_filename(filename) }}" class="diff-content">
-                    {%- for line in lines -%}
-                        {%- if loop.first -%}
-                            <hr/>
-                            <h3 id="diff_{{ safe_filename(filename) }}_filename" class="filename" data-replaced-paths="{{ replace_cache_paths(filename) }}">{{ remove_prefixes(line) }}</h3>
-                        {%- elif line.startswith('+++') %}
-                            {% set ns.seen_header = true %}
-                            <span class="add">{{ replace_paths(line) }}</span>
-                            <br/>
-                        {%- elif line.startswith('@@') %}
-                            {% set lines = get_line_numbers(line) %}
-                            {% set ns.old_line_number = lines[0] %}
-                            {% set ns.new_line_number = lines[1] %}
-                            <span class="context-header">{{ line }}</span>
-                            <br/>
-                        {%- elif line.startswith('---') %}
-                            <span class="del">{{ replace_paths(line) }}</span>
-                            <br/>
-                        {%- elif line.startswith('+') %}
-                            <span class="line-number">{{ ns.new_line_number }}</span><span class="add">{{ line }}</span>
-                            <br/>
-                            {% set ns.new_line_number = ns.new_line_number + 1 %}
-                        {%- elif line.startswith('-') %}
-                            <span class="line-number">{{ ns.old_line_number }}</span><span class="del">{{ line }}</span>
-                            <br/>
-                            {% set ns.old_line_number = ns.old_line_number + 1 %}
-                        {%- else %}
-                            {% if ns.seen_header %}
-                                <span class="line-number">{{ ns.new_line_number }}</span>
-                            {% endif %}
-                            <span class="context">{{ line }}</span>
-                            <br/>
-                            {% set ns.new_line_number = ns.new_line_number + 1 %}
-                            {% set ns.old_line_number = ns.old_line_number + 1 %}
-                        {%- endif %}
-                    {%- endfor -%}
                 {%- endfor -%}
-                <hr/>
-                </div>
+
             </div>
         </div>
     </body>

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -50,7 +50,7 @@ diff_html = r"""
             .sidebar li.file-new { list-style: none; padding-left: 0; }
             .sidebar li.file-new:before { content: "+"; color: green; font-weight: bold; }
             .sidebar li.file-old { list-style: none; padding-left: 0;  }
-            .sidebar li.file-old:before { content: "*"; color: black; }
+            .sidebar li.file-old:before { content: "\00B1"; color: black; }
             .sidebar li a {
                 text-decoration: none;
             }
@@ -285,7 +285,7 @@ diff_html = r"""
                     const [lines, new_count, old_count] = makeDiffLines(data[path]);
                     elem.querySelector(".diff-lines").appendChild(lines);
 
-                    if (new_count !== 0 && old_count !== 0) {
+                    if (new_count !== 0 || old_count !== 0) {
                         elem.querySelector(".changes-count-container").appendChild(createChangesCountElement(new_count, old_count));
                     }
 
@@ -302,7 +302,6 @@ diff_html = r"""
             };
 
             const observer = new IntersectionObserver(intersectionCallback, options);
-
 
             document.addEventListener("DOMContentLoaded", (e) => {
                 document.querySelectorAll('.diff-container').forEach((section) => {
@@ -393,15 +392,14 @@ diff_html = r"""
         <div class='container'>
             <div class='sidebar'>
                 <div id="sidebar-contents">
-                    <h2>File list:</h2>
                     <input type="text" id="search-include" placeholder="Include search..." oninput="onIncludeSearchInput(event)" />
                     <input type="text" id="search-exclude" placeholder="Exclude search..." oninput="onExcludeSearchInput(event)" />
                     <span id="searching_icon" style="display:none">...</span>
                     <ul class="file-list">
                         {{ render_folder("", per_folder) }}
                     </ul>
-                    <span id="empty_search" style="display:none">No results found</span>
                 </div>
+                <span id="empty_search" style="display:none">No results found</span>
             </div>
             <div class='content'>
                 <div class="diff-header">
@@ -429,7 +427,6 @@ diff_html = r"""
                                 <hr/>
                                 <div class="diff-lines"></div>
                             </details>
-
                         </div>
                     </div>
                 {%- endfor -%}

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -3,7 +3,7 @@ diff_html = r"""
     {%- for name, sub_folder_info in folder_info["folders"].items() %}
         {% set folder_name = folder + "/" + name %}
         <li>
-            <details open>
+            <details open class="folder">
                 <summary>{{ name }}</summary>
                 <ul>
                     {{ render_folder(folder_name, sub_folder_info) }}
@@ -28,21 +28,35 @@ diff_html = r"""
             body { font-family: monospace; margin: 0px; }
             .container { display: flex; height: 100%; }
             .sidebar {
-                min-width: 17%;
+                width: 17%;
+                min-width: 10%;
                 max-width: 20%;
                 padding: 10px;
-                overflow-y: scroll;
-                background: #f4f4f4;
+                overflow: scroll;
+                background: #f4f4f466;
                 border-right: 1px solid #ccc;
+                resize: horizontal;
             }
-            details {
+            #sidebar-contents {
+                background: #f4f4f4;
+                border-radius: 7px;
+                //border: 1px solid #ccc;
+            }
+            details.folder {
                 text-wrap: nowrap;
             }
+
             .sidebar li { line-height: 1.5; list-style: none; list-style-position: inside; }
             .sidebar li.file-new { list-style: none; padding-left: 0; }
-            .sidebar li.file-new:before { content: "+"; color: green; }
+            .sidebar li.file-new:before { content: "+"; color: green; font-weight: bold; }
             .sidebar li.file-old { list-style: none; padding-left: 0;  }
             .sidebar li.file-old:before { content: "*"; color: black; }
+            .sidebar li a {
+                text-decoration: none;
+            }
+            .sidebar li a:hover {
+                text-decoration: underline;
+            }
             .side-link {
                 text-wrap: nowrap;
             }
@@ -56,22 +70,31 @@ diff_html = r"""
                 padding: 20px;
                 background: #fff;
                 overflow-y: scroll;
-                width: auto;
+                width: 100%;
             }
             .content span {
                 white-space: pre-wrap;
             }
-            .diff-header {
-                background-color: #f0f0f0;
-            }
             .add { background-color: #76ffbb; }
             .del { background-color: #fdb9c1; }
             .context, .context-header, .diff-content { background-color: #f8f8f8; }
+            .diff-content {
+                padding: 0px 0px 3px 3px;
+                border: 1px solid black;
+                border-radius: 7px;
+                margin-bottom: 10;
+                box-shadow: 6px 6px #00808022;
+             }
+            details.folder ul:hover {
+                background-color: #e0e0e033;
+                border-left: 2px solid #00000066;
+            }
+            details.diff-details summary { cursor: pointer; margin-top: 5px; }
             .context-header { color: gray; }
             .line-number { width: 4ch; display: inline-block; text-align: left; color: #888; user-select: none; }
-            .filename { background-color: #f0f0f0; }
-            a:visited {
-                color: blue;
+            hr { margin-left: -3px;}
+            .filename {
+                font-size: 1.2em;
             }
             #empty_result {
                 justify-content: center;
@@ -85,6 +108,9 @@ diff_html = r"""
         <script>
 
             const data = {{ content | tojson | safe }};
+
+            const oldPattern = "{{ src_prefix[:-1] }}{{ old_cache_path }}";
+            const newPattern = "{{ dst_prefix[:-1] }}{{ new_cache_path }}";
 
             function extractLineNumbers(hunkHeader) {
                 const regex = /@@ -(\d+),\d+ \+(\d+),\d+ @@/;
@@ -101,16 +127,16 @@ diff_html = r"""
                 let seen_header = false;
                 let new_line_number = 0;
                 let old_line_number = 0;
-                for (let i = 1; i < lines.length; i++) {
+                for (let i = 0; i < lines.length; i++) {
                     const line = lines[i];
                     let spanLine = document.createElement("span");
                     if (line.startsWith("+++")) {
                         seen_header = true;
                         spanLine.className = "add";
-                        spanLine.textContent = line;
+                        spanLine.textContent = line.replace(newPattern, "(new)");
                     } else if (line.startsWith("---")) {
                         spanLine.className = "del";
-                        spanLine.textContent = line;
+                        spanLine.textContent = line.replace(oldPattern, "(old)");
                     } else if (line.startsWith("@@")) {
                         const lineNumbers = extractLineNumbers(line);
                         old_line_number = lineNumbers[0];
@@ -138,14 +164,19 @@ diff_html = r"""
 
                         old_line_number += 1;
                     } else {
+                        const lineNumberSpan = document.createElement("span");
+                        lineNumberSpan.className = "line-number";
                         if (seen_header) {
-                            const lineNumberSpan = document.createElement("span");
-                            lineNumberSpan.className = "line-number";
                             lineNumberSpan.textContent = new_line_number;
-                            element.appendChild(lineNumberSpan);
+                            spanLine.className = "context";
+                            spanLine.textContent = line;
+                        } else {
+                            spanLine.textContent = line.replace(oldPattern, "(old)").replace(newPattern, "(new)");
+                            spanLine.className = "context-header";
                         }
-                        spanLine.className = "context";
-                        spanLine.textContent = line;
+                        element.appendChild(lineNumberSpan);
+
+
                         new_line_number += 1;
                         old_line_number += 1;
                     }
@@ -178,7 +209,7 @@ diff_html = r"""
 
 
             document.addEventListener("DOMContentLoaded", (e) => {
-                document.querySelectorAll('.diff-content').forEach((section) => {
+                document.querySelectorAll('.diff-container').forEach((section) => {
                     observer.observe(section);
                 });
             });
@@ -198,12 +229,14 @@ diff_html = r"""
 
             async function onSearchInput(event) {
                 const sidebar = document.querySelectorAll(".sidebar li");
-                const content = document.querySelectorAll(".content .diff-content");
+                const fileList = document.querySelector(".file-list");
+                const content = document.querySelectorAll(".content .diff-container .diff-content");
                 const searchingIcon = document.getElementById("searching_icon");
 
                 searchingIcon.style.display = "inline-block";
 
                 let emptySearch = true;
+                let includedFiles = 0;
 
                 sidebar.forEach(async function(item) {
                     const text = item.dataset.path.toLowerCase();
@@ -217,6 +250,7 @@ diff_html = r"""
                             item.style.display = "none";
                             contentItem.style.display = "none";
                         } else {
+                            includedFiles += 1;
                             item.style.display = "list-item";
                             contentItem.style.display = "block";
                             emptySearch = false;
@@ -234,10 +268,16 @@ diff_html = r"""
                 if (emptySearch) {
                     emptySearchTag.style.display = "block";
                     emptyResultTag.style.display = "block";
+                    fileList.style.display = "none";
                 } else {
                     emptySearchTag.style.display = "none";
                     emptyResultTag.style.display = "none";
+                    fileList.style.display = "block";
                 }
+
+                const fileCountTag = document.getElementById("file-count");
+                fileCountTag.textContent = includedFiles;
+
             }
 
             const debouncedOnSearchInput = debounce(onSearchInput, 500);
@@ -278,33 +318,37 @@ diff_html = r"""
                     <span id="searching_icon" style="display:none">...</span>
                     <ul class="file-list">
                         {{ render_folder("", per_folder) }}
-                        <span id="empty_search" style="display:none">No results found</span>
                     </ul>
+                    <span id="empty_search" style="display:none">No results found</span>
                 </div>
             </div>
             <div class='content'>
                 <div class="diff-header">
-                    <h2>Diff Report:</h2>
-                    <p>Total files: <b>{{ content|length }}</b></p>
+                    <h2>Diff Report Between <b>{{ old_reference.repr_notime() }}</b> And <b>{{ new_reference.repr_notime() }}</b></h2>
+                    <p>Showing a total of <b id="file-count">{{ content|length }}</b> files</p>
                     <span class="del" style="white-space: nowrap;">
-                        --- (old) belongs to <b>{{ old_reference.repr_notime() }}</b> reference
+                        --- (old) belongs to the <b>{{ old_reference.repr_notime() }}</b> reference
                     </span>
                     <br/>
                     <span class="add" style="white-space: nowrap;">
-                        +++ (new) belongs to <b>{{ new_reference.repr_notime() }}</b> reference
+                        +++ (new) belongs to the <b>{{ new_reference.repr_notime() }}</b> reference
                     </span>
                 </div>
                 <span id="empty_result" style="display:none">No matches</span>
                 {%- for filename, lines in content.items() -%}
-                    <div id="diff_{{ safe_filename(filename) }}" data-path="{{ filename }}" class="diff-content">
+                    <div id="diff_{{ safe_filename(filename) }}" data-path="{{ filename }}" class="diff-container">
+                        <div class="diff-content">
+                            <details open class="diff-details">
+                                <summary>
+                                    <b id="diff_{{ safe_filename(filename) }}_filename" class="filename" data-replaced-paths="">
+                                        {{ replace_cache_paths(filename) | replace("(old)/", "") | replace("(new)/", "") }}
+                                    </b>
+                                    <hr/>
+                                </summary>
+                                <div class="diff-lines"></div>
+                            </details>
 
-                        {% set firstLine = lines[0] if lines else "" %}
-                        <h3 id="diff_{{ safe_filename(filename) }}_filename" class="filename" data-replaced-paths="{{ replace_cache_paths(filename) }}">
-                            {{ remove_prefixes(firstLine) }}
-                        </h3>
-                        <div class="diff-lines">
                         </div>
-                        <hr/>
                     </div>
                 {%- endfor -%}
 

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -42,6 +42,7 @@ diff_html = r"""
                 background: #f4f4f4;
                 border-radius: 7px;
                 overflow-y: hidden;
+                padding-top: 5px;
             }
             details.folder {
                 text-wrap: nowrap;

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -30,7 +30,7 @@ diff_html = r"""
             .sidebar {
                 width: 17%;
                 min-width: 10%;
-                max-width: 20%;
+                max-width: 33%;
                 padding: 10px;
                 overflow: scroll;
                 background: #f4f4f466;
@@ -75,8 +75,8 @@ diff_html = r"""
             .content span {
                 white-space: pre-wrap;
             }
-            .add { background-color: #76ffbb; }
-            .del { background-color: #fdb9c1; }
+            .add { background-color: #76ffbbEE; }
+            .del { background-color: #fdb9c1EE; }
             .context, .context-header, .diff-content { background-color: #f8f8f8; }
             .diff-content {
                 padding: 0px 0px 3px 3px;
@@ -291,26 +291,11 @@ diff_html = r"""
                 includeSearchQuery = event.currentTarget.value.toLowerCase();
                 debouncedOnSearchInput(event);
             }
-
-            function toggleSidebar() {
-                const contents = document.querySelector('#sidebar-contents');
-                const sidebar = document.querySelector('.sidebar');
-                if (contents.style.display === 'none') {
-                    contents.style.display = 'initial';
-                    sidebar.style.minWidth = '17%';
-                    event.srcElement.textContent = 'Hide';
-                } else {
-                    contents.style.display = 'none';
-                    sidebar.style.minWidth = 'unset';
-                    event.srcElement.textContent = 'Show';
-                }
-            }
         </script>
     </head>
     <body>
         <div class='container'>
             <div class='sidebar'>
-                <button onclick="toggleSidebar()">Hide</button>
                 <div id="sidebar-contents">
                     <h2>File list:</h2>
                     <input type="text" id="search-include" placeholder="Include search..." oninput="onIncludeSearchInput(event)" />

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -238,6 +238,7 @@ diff_html = r"""
                 background-color: #cef8ff;
                 color: #888;
                 line-height: 1.5;
+                cursor: pointer;
             }
 
             details:open .context-chunk-header .line-number:before {

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -26,8 +26,12 @@ diff_html = r"""
         <meta charset="utf-8">
         <title>Diff report for {{ old_reference }} - {{ new_reference }}</title>
         <style>
-            body { font-family: monospace; margin: 0px; }
-            .container { display: flex; height: 100%; }
+            body { font-family: monospace; margin: 0px; background-color: #f8f8f8; }
+            .container {
+                display: flex;
+                height: 100%;
+                overflow: scroll;
+            }
             .sidebar {
                 width: 17%;
                 min-width: 10%;
@@ -37,6 +41,8 @@ diff_html = r"""
                 background: #f4f4f466;
                 border-right: 1px solid #ccc;
                 resize: horizontal;
+                position: sticky;
+                top: 0;
             }
             #sidebar-contents {
                 background: #f4f4f4;
@@ -64,7 +70,14 @@ diff_html = r"""
             .side-link {
                 text-wrap: nowrap;
             }
-            .file-list { padding-left: 10px; }
+            .file-list {
+                padding-left: 10px;
+                width: 100%;
+                overflow-x: clip;
+            }
+            .file-list ul li {
+                width: 100%;
+            }
             .file-list li ul {
                 border-left: 2px solid #ddd;
                 margin-left: 3px;
@@ -73,7 +86,7 @@ diff_html = r"""
             .content {
                 padding: 20px;
                 background: #f8f8f8;
-                overflow-y: scroll;
+                //overflow-y: scroll;
                 width: 100%;
             }
             .content span {
@@ -92,6 +105,20 @@ diff_html = r"""
                 padding-right: 10px;
             }
 
+            .folder > summary {
+                cursor: pointer;
+            }
+
+            /*.folder:open > summary:before {
+                content: "\1F4C2";
+            }
+
+            .folder:not(:open) > summary:before {
+                content: "\1F4C1";
+            }*/
+
+            .folder > summary:hover { background-color: #e0e0e033; }
+
             .diff-content {
                 padding-bottom: 7px;
                 border: 1px solid black;
@@ -103,12 +130,22 @@ diff_html = r"""
                 background-color: #e0e0e033;
                 border-left: 2px solid #00000066;
             }
-            details.diff-details summary {
+            details.diff-details summary.diff-summary {
                 cursor: pointer;
-                margin-top: 5px;
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                border-bottom: 1px solid #ccc;
+                padding: 5px 0px;
+                position: sticky;
+                top: 0;
+                background-color: #f8f8f8;
+                border-radius: 7px 7px 0px 0px;
+            }
+            details.diff-details summary.diff-summary:hover {
+                background-color: #e0e0e033;
             }
             .context-line { color: #888; }
-            .diff-details summary:hover { background-color: #e0e0e033; }
             .line-number {
                 width: 4ch;
                 display: inline-block;
@@ -119,11 +156,7 @@ diff_html = r"""
                 font-size: 1.2em;
                 padding-left: 10px;
             }
-            .diff-summary {
-                display: flex;
-                justify-content: space-between;
-                align-items: center;
-            }
+
 
             details:open .diff-summary b:before {
                 content: "\25BC";
@@ -158,6 +191,27 @@ diff_html = r"""
                 font-weight: bold;
                 font-size: 4em;
                 text-align: center;
+            }
+
+            .diff-header {
+                padding: 0px 5px 5px 5px;
+            }
+
+            .diff-subheader {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+            }
+
+            .search-field {
+                border: 1px solid #ccc;
+                border-radius: 5px;
+                padding: 5px;
+                margin: 5px;
+            }
+
+            .search-area {
+                border-bottom: 1px solid #ccc;
             }
         </style>
         <script>
@@ -408,9 +462,12 @@ diff_html = r"""
         <div class='container'>
             <div class='sidebar'>
                 <div id="sidebar-contents">
-                    <input type="text" id="search-include" placeholder="Include search..." oninput="onIncludeSearchInput(event)" />
-                    <input type="text" id="search-exclude" placeholder="Exclude search..." oninput="onExcludeSearchInput(event)" />
-                    <span id="searching_icon" style="display:none">...</span>
+                    <div class="search-area">
+                        <input type="text" class="search-field" id="search-include" placeholder="Include search..." oninput="onIncludeSearchInput(event)" />
+                        <input type="text" class="search-field" id="search-exclude" placeholder="Exclude search..." oninput="onExcludeSearchInput(event)" />
+                        <span id="searching_icon" style="display:none">...</span>
+                        <p>Showing <b id="file-count">{{ content|length }}</b> out of <b>{{ content|length }}</b> files</p>
+                    </div>
                     <ul class="file-list">
                         {{ render_folder("", per_folder) }}
                     </ul>
@@ -418,16 +475,10 @@ diff_html = r"""
                 <span id="empty_search" style="display:none">No results found</span>
             </div>
             <div class='content'>
-                <div class="diff-header">
-                    <h2>Diff Report Between <b>{{ old_reference.repr_notime() }}</b> And <b>{{ new_reference.repr_notime() }}</b></h2>
-                    <p>Showing a total of <b id="file-count">{{ content|length }}</b> files</p>
-                    <span class="del" style="white-space: nowrap;">
-                        --- (old) belongs to the <b>{{ old_reference.repr_notime() }}</b> reference
-                    </span>
-                    <br/>
-                    <span class="add" style="white-space: nowrap;">
-                        +++ (new) belongs to the <b>{{ new_reference.repr_notime() }}</b> reference
-                    </span>
+                <div class="diff-header"><div class="diff-header">
+                    <h2>Diff Report Between <b class="del">{{ old_reference.repr_notime() }}</b> And <b class="add">{{ new_reference.repr_notime() }}</b></h2>
+                    <div class="diff-subheader">
+                    </div>
                 </div>
                 <span id="empty_result" style="display:none">No matches</span>
                 {%- for filename, lines in content.items() -%}
@@ -440,7 +491,6 @@ diff_html = r"""
                                     </b>
                                     <div class="changes-count-container"></div>
                                 </summary>
-                                <hr/>
                                 <div class="diff-lines"></div>
                             </details>
                         </div>

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -156,7 +156,7 @@ diff_html = r"""
             }
 
 
-            functino intersectionCallback(entries) {
+            function intersectionCallback(entries) {
               entries.forEach((entry) => {
                 if (entry.isIntersecting) {
                     let elem = entry.target;

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -40,7 +40,7 @@ diff_html = r"""
             #sidebar-contents {
                 background: #f4f4f4;
                 border-radius: 7px;
-                //border: 1px solid #ccc;
+                overflow-y: hidden;
             }
             details.folder {
                 text-wrap: nowrap;
@@ -68,34 +68,84 @@ diff_html = r"""
             li ul { padding-left: 1ch; }
             .content {
                 padding: 20px;
-                background: #fff;
+                background: #f8f8f8;
                 overflow-y: scroll;
                 width: 100%;
             }
             .content span {
                 white-space: pre-wrap;
             }
-            .add { background-color: #76ffbbEE; }
-            .del { background-color: #fdb9c1EE; }
-            .context, .context-header, .diff-content { background-color: #f8f8f8; }
+            .add { background-color: #76ffbbBB; color: black; }
+            .del { background-color: #fdb9c1BB; color: black; }
+
+            .line-number.add { background-color: #76ffbb; }
+            .line-number.del { background-color: #fdb9c1; }
+
+            .new-lines-count { color: green; font-weight: bold; }
+            .old-lines-count { color: black; font-weight: bold; }
+            .changes-count-container {
+                font-size: 0.9em;
+                padding-right: 10px;
+            }
+
             .diff-content {
                 padding: 0px 0px 3px 3px;
                 border: 1px solid black;
                 border-radius: 7px;
                 margin-bottom: 10;
-                box-shadow: 6px 6px #00808022;
-             }
+                background-color: white;
+            }
             details.folder ul:hover {
                 background-color: #e0e0e033;
                 border-left: 2px solid #00000066;
             }
-            details.diff-details summary { cursor: pointer; margin-top: 5px; }
-            .context-header { color: gray; }
-            .line-number { width: 4ch; display: inline-block; text-align: left; color: #888; user-select: none; }
+            details.diff-details summary {
+                cursor: pointer;
+                margin-top: 5px;
+            }
+            .context-line { color: #888; }
+            .diff-details summary:hover { background-color: #e0e0e033; }
+            .line-number {
+                width: 4ch;
+                display: inline-block;
+                text-align: center;
+                user-select: none;
+            }
             hr { margin-left: -3px;}
             .filename {
                 font-size: 1.2em;
             }
+            .diff-summary {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+            }
+
+            details:open .diff-summary b:before {
+                content: "\25BC";
+                display: inline-block;
+            }
+            details:not(:open) .diff-summary b:before {
+                content: "\25B6";
+                display: inline-block;
+            }
+
+            .context-chunk-header {
+                list-style: none;
+                background-color: #cef8ff;
+                color: #888;
+            }
+
+            details:open .context-chunk-header .line-number:before {
+                content: "\25BC";
+                display: inline-block;
+            }
+
+            details:not(:open) .context-chunk-header .line-number:before {
+                content: "\25B6";
+                display: inline-block;
+            }
+
             #empty_result {
                 justify-content: center;
                 align-items: center;
@@ -125,65 +175,105 @@ diff_html = r"""
             function makeDiffLines(lines) {
                 const element = document.createElement("div");
                 let seen_header = false;
-                let new_line_number = 0;
-                let old_line_number = 0;
+                let new_line_index = 0;
+                let old_line_index = 0;
+                let new_line_count = 0;
+                let old_line_count = 0;
+                const headerDiv = document.createElement("div");
+                let currentDetails = null;
                 for (let i = 0; i < lines.length; i++) {
                     const line = lines[i];
                     let spanLine = document.createElement("span");
+                    let shouldAddLine = true;
                     if (line.startsWith("+++")) {
                         seen_header = true;
                         spanLine.className = "add";
                         spanLine.textContent = line.replace(newPattern, "(new)");
+                        headerDiv.appendChild(spanLine);
+                        continue;
                     } else if (line.startsWith("---")) {
                         spanLine.className = "del";
                         spanLine.textContent = line.replace(oldPattern, "(old)");
+                        headerDiv.appendChild(spanLine);
+                        continue;
                     } else if (line.startsWith("@@")) {
+                        currentDetails = document.createElement("details");
+                        currentDetails.open = true;
+
+                        const summary = document.createElement("summary");
+                        summary.className = "context-chunk-header";
+                        const summaryArrow = document.createElement("span");
+                        summaryArrow.className = "line-number";
+                        const summaryText = document.createElement("span");
+                        summaryText.textContent = line;
+
+                        summary.appendChild(summaryArrow);
+                        summary.appendChild(summaryText);
+
+                        currentDetails.appendChild(summary);
+                        element.appendChild(currentDetails);
+                        shouldAddLine = false;
+
                         const lineNumbers = extractLineNumbers(line);
-                        old_line_number = lineNumbers[0];
-                        new_line_number = lineNumbers[1];
-                        spanLine.className = "context-header";
-                        spanLine.textContent = line;
+                        old_line_index = lineNumbers[0];
+                        new_line_index = lineNumbers[1];
                     } else if (line.startsWith("+")) {
                         spanLine.className = "add";
                         spanLine.textContent = line;
 
                         const lineNumberSpan = document.createElement("span");
-                        lineNumberSpan.className = "line-number";
-                        lineNumberSpan.textContent = new_line_number;
-                        element.appendChild(lineNumberSpan);
+                        lineNumberSpan.className = "line-number add";
+                        lineNumberSpan.textContent = new_line_index;
+                        currentDetails.appendChild(lineNumberSpan);
 
-                        new_line_number += 1;
+                        new_line_index += 1;
+                        new_line_count += 1;
                     } else if (line.startsWith("-")) {
                         spanLine.className = "del";
                         spanLine.textContent = line;
 
                         const lineNumberSpan = document.createElement("span");
-                        lineNumberSpan.className = "line-number";
-                        lineNumberSpan.textContent = old_line_number;
-                        element.appendChild(lineNumberSpan);
+                        lineNumberSpan.className = "line-number del";
+                        lineNumberSpan.textContent = old_line_index;
+                        currentDetails.appendChild(lineNumberSpan);
 
-                        old_line_number += 1;
+                        old_line_index += 1;
+                        old_line_count += 1;
                     } else {
-                        const lineNumberSpan = document.createElement("span");
-                        lineNumberSpan.className = "line-number";
-                        if (seen_header) {
-                            lineNumberSpan.textContent = new_line_number;
-                            spanLine.className = "context";
-                            spanLine.textContent = line;
-                        } else {
+                        spanLine.className = "context-line";
+                        if (!seen_header) {
                             spanLine.textContent = line.replace(oldPattern, "(old)").replace(newPattern, "(new)");
-                            spanLine.className = "context-header";
+                            headerDiv.appendChild(spanLine);
+                            headerDiv.appendChild(document.createElement("br"));
+                            continue;
+                        } else {
+                            spanLine.textContent = line;
                         }
-                        element.appendChild(lineNumberSpan);
 
+                        const lineNumberSpan = document.createElement("span");
+                        lineNumberSpan.className = "line-number context-line";
+                        lineNumberSpan.textContent = new_line_index;
+                        currentDetails.appendChild(lineNumberSpan);
 
-                        new_line_number += 1;
-                        old_line_number += 1;
+                        new_line_index += 1;
+                        old_line_index += 1;
                     }
-                    element.appendChild(spanLine);
-                    element.appendChild(document.createElement("br"));
+                    if (shouldAddLine) {
+                        currentDetails.appendChild(spanLine);
+                        currentDetails.appendChild(document.createElement("br"));
+                    }
                 }
-                return element;
+                if (!seen_header) {
+                    element.appendChild(headerDiv);
+                }
+                return [element, new_line_count, old_line_count];
+            }
+
+            function createChangesCountElement(new_count, old_count) {
+                const changes = document.createElement("span");
+                changes.className = "changes-count";
+                changes.innerHTML = `<span class="new-lines-count">+${new_count}</span> <span class="old-lines-count">-${old_count}</span>`;
+                return changes;
             }
 
 
@@ -192,7 +282,11 @@ diff_html = r"""
                 if (entry.isIntersecting) {
                     let elem = entry.target;
                     const path = elem.dataset.path;
-                    elem.querySelector(".diff-lines").appendChild(makeDiffLines(data[path]));
+                    const [lines, new_count, old_count] = makeDiffLines(data[path]);
+
+                    elem.querySelector(".diff-lines").appendChild(lines);
+                    elem.querySelector(".changes-count-container").appendChild(createChangesCountElement(new_count, old_count));
+
                     observer.unobserve(elem);
                 }
               });
@@ -324,19 +418,19 @@ diff_html = r"""
                     <div id="diff_{{ safe_filename(filename) }}" data-path="{{ filename }}" class="diff-container">
                         <div class="diff-content">
                             <details open class="diff-details">
-                                <summary>
+                                <summary class="diff-summary">
                                     <b id="diff_{{ safe_filename(filename) }}_filename" class="filename" data-replaced-paths="">
-                                        {{ replace_cache_paths(filename) | replace("(old)/", "") | replace("(new)/", "") }}
+                                        <span>{{ replace_cache_paths(filename) | replace("(old)/", "") | replace("(new)/", "") }}</span>
                                     </b>
-                                    <hr/>
+                                    <div class="changes-count-container"></div>
                                 </summary>
+                                <hr/>
                                 <div class="diff-lines"></div>
                             </details>
 
                         </div>
                     </div>
                 {%- endfor -%}
-
             </div>
         </div>
     </body>

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -184,15 +184,15 @@ diff_html = r"""
             }
 
             details.diff-details summary.diff-summary:hover {
-                background-color: #e0e0e033;
+                background-color: #f0f0f0;
             }
 
-            details:open .diff-summary filename:before {
+            details:open .diff-summary .filename:before {
                 content: "\25BC";
                 display: inline-block;
             }
 
-            details:not(:open) .diff-summary filename:before {
+            details:not(:open) .diff-summary .filename:before {
                 content: "\25B6";
                 display: inline-block;
             }

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -12,8 +12,8 @@ diff_html = r"""
         </li>
     {%- endfor %}
     {%- for name, file_info in folder_info["files"].items() %}
-        <li class="file-{{ "deleted" if file_info["is_deleted"] else (
-                            "new" if file_info["is_new"] else "old") }}"
+        <li class="file file-{{ "deleted" if file_info["is_deleted"] else (
+                                "new" if file_info["is_new"] else "old") }}"
             data-path="{{ file_info["relative_path"] }}">
             <a href="#diff_{{- safe_filename(file_info["filename"]) -}}" class="side-link">
                 {{ name }}
@@ -376,6 +376,17 @@ diff_html = r"""
 
                 const fileCountTag = document.getElementById("file-count");
                 fileCountTag.textContent = includedFiles;
+
+                const allDetails = document.querySelectorAll(".sidebar details.folder");
+                allDetails.forEach(function(details) {
+                    details.style.display = "none";
+                    details.querySelectorAll("li.file").forEach(function(li) {
+                        if (li.style.display !== "none") {
+                            details.style.display = "block";
+                            return;
+                        }
+                    });
+                });
 
             }
 

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -283,9 +283,11 @@ diff_html = r"""
                     let elem = entry.target;
                     const path = elem.dataset.path;
                     const [lines, new_count, old_count] = makeDiffLines(data[path]);
-
                     elem.querySelector(".diff-lines").appendChild(lines);
-                    elem.querySelector(".changes-count-container").appendChild(createChangesCountElement(new_count, old_count));
+
+                    if (new_count !== 0 && old_count !== 0) {
+                        elem.querySelector(".changes-count-container").appendChild(createChangesCountElement(new_count, old_count));
+                    }
 
                     observer.unobserve(elem);
                 }

--- a/test/functional/command/report_test.py
+++ b/test/functional/command/report_test.py
@@ -111,6 +111,7 @@ def test_compare_paths(fixture_client, old_args, new_args, formatter):
     elif "html" in formatter:
         output_html = tc.load("output.html")
         # We have patch information
-        assert "(new)/es/patches/patch.patch" in output_html
+        assert "(old)/es/patches/patch.patch" in output_html
+        assert "(new)/s/new-file-for-v2.txt" in output_html
         # We have exports information
         assert "(old)/e/v1.txt" in output_html


### PR DESCRIPTION
Changelog: Fix: Improve support for huge diffs in `conan report diff` HTML output.
Docs: https://github.com/conan-io/docs/pull/4279

My weekend project of learning about the [`Intersection Observer API`](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)

Still needs some tests, but this works great locally for big diffs that prior to this would struggle to work properly.


There is an issue with upwards scrolling unloaded content, but other than that, this looks almost ready