### PR TITLE
improving error when workspace badly defined for super-install

### DIFF
--- a/conan/api/subapi/workspace.py
+++ b/conan/api/subapi/workspace.py
@@ -303,6 +303,13 @@ class WorkspaceAPI:
         conanfile.workspace_packages_options = {}
         for node in deps_graph.nodes[1:]:  # Exclude the current root
             if node.recipe != RECIPE_EDITABLE:
+                # sanity check, a pacakge in the cache cannot have dependencies to the workspace
+                deps_edit = [d.node for d in node.transitive_deps.values()
+                             if d.node.recipe == RECIPE_EDITABLE]
+                if deps_edit:
+                    raise ConanException(f"Workspace definition error. Package {node} in the "
+                                         f"Conan cache has dependencies to packages "
+                                         f"in the workspace: {deps_edit}")
                 result.add_node(node)
                 continue
             conanfile.workspace_packages_options[node.ref] = node.conanfile.options.serialize()

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -703,6 +703,21 @@ class TestMeta:
         c.run("workspace super-install -of=build -o *:myoption=1")
         assert "project Conanfile: Generating with opt dep/0.1:myoption=1!!!!" in c.out
 
+    def test_intermediate_non_editable(self):
+        c = TestClient(light=True)
+
+        c.save({"liba/conanfile.py": GenConanfile("liba", "0.1"),
+                "libb/conanfile.py": GenConanfile("libb", "0.1").with_requires("liba/0.1"),
+                "libc/conanfile.py": GenConanfile("libc", "0.1").with_requires("libb/0.1")})
+
+        c.run("workspace init")
+        c.run("workspace add liba")
+        c.run("export libb")
+        c.run("workspace add libc")
+        c.run("workspace super-install", assert_error=True)
+        assert ("Workspace definition error. Package libb/0.1 in the Conan cache "
+                "has dependencies to packages in the workspace: [liba/0.1]") in c.out
+
 
 def test_workspace_with_local_recipes_index():
     c3i_folder = temp_folder()


### PR DESCRIPTION
Changelog: Fix: Improve the error message when a workspace ``super-install`` defines intermediate packages in the cache depending on workspace packages.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19009