### PR TITLE
Add new `tools.gnu:disable_flags` conf variable

### DIFF
--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -104,7 +104,7 @@ BUILT_IN_CONFS = {
     "tools.graph:skip_build": "(Experimental) Do not expand build/tool_requires",
     "tools.graph:skip_test": "(Experimental) Do not expand test_requires. If building it might need 'tools.build:skip_test=True'",
     "tools.gnu:make_program": "Indicate path to make program",
-    "tools.gnu:disable_flags": "Disable the automatic addition of flags to some build systems. Value is a list with possible values: 'libcxx', ",
+    "tools.gnu:disable_flags": "Disable the automatic addition of flags to some build systems. List of possible values: ['arch', 'arch_link', 'libcxx', 'build_type', 'build_type_link', 'threads','cppstd', 'cstd']",
     "tools.gnu:define_libcxx11_abi": "Force definition of GLIBCXX_USE_CXX11_ABI=1 for libstdc++11",
     "tools.gnu:pkg_config": "Path to pkg-config executable used by PkgConfig build helper",
     "tools.gnu:build_triplet": "Custom build triplet to pass to Autotools scripts",

--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -104,6 +104,7 @@ BUILT_IN_CONFS = {
     "tools.graph:skip_build": "(Experimental) Do not expand build/tool_requires",
     "tools.graph:skip_test": "(Experimental) Do not expand test_requires. If building it might need 'tools.build:skip_test=True'",
     "tools.gnu:make_program": "Indicate path to make program",
+    "tools.gnu:disable_stdlib_flag": "Disable the addition of '-stdlib=xxx' flags in builds",
     "tools.gnu:define_libcxx11_abi": "Force definition of GLIBCXX_USE_CXX11_ABI=1 for libstdc++11",
     "tools.gnu:pkg_config": "Path to pkg-config executable used by PkgConfig build helper",
     "tools.gnu:build_triplet": "Custom build triplet to pass to Autotools scripts",

--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -104,7 +104,7 @@ BUILT_IN_CONFS = {
     "tools.graph:skip_build": "(Experimental) Do not expand build/tool_requires",
     "tools.graph:skip_test": "(Experimental) Do not expand test_requires. If building it might need 'tools.build:skip_test=True'",
     "tools.gnu:make_program": "Indicate path to make program",
-    "tools.gnu:disable_stdlib_flag": "Disable the addition of '-stdlib=xxx' flags in builds",
+    "tools.gnu:disable_flags": "Disable the automatic addition of flags to some build systems. Value is a list with possible values: 'libcxx', ",
     "tools.gnu:define_libcxx11_abi": "Force definition of GLIBCXX_USE_CXX11_ABI=1 for libstdc++11",
     "tools.gnu:pkg_config": "Path to pkg-config executable used by PkgConfig build helper",
     "tools.gnu:build_triplet": "Custom build triplet to pass to Autotools scripts",

--- a/conan/tools/build/flags.py
+++ b/conan/tools/build/flags.py
@@ -3,13 +3,9 @@ from conan.internal.model.version import Version
 
 
 def disable_flag(conanfile, flag):
-    disable_flags = conanfile.conf.get("tools.gnu:disable_flags")
+    disable_flags = conanfile.conf.get("tools.gnu:disable_flags", check_type=list)
     if disable_flags is None:
         return False
-    if disable_flags == "all":
-        return True
-    if not isinstance(disable_flags, list):
-        raise ConanException(f"tools.gnu:disable_flags must be 'all' or list, not '{disable_flags}'")
     valid = ["arch", "arch_link", "libcxx", "build_type", "build_type_link", "threads",
              "cppstd", "cstd"]
     for v in disable_flags:
@@ -246,7 +242,7 @@ def llvm_clang_front(conanfile):
     compilers = conanfile.conf.get("tools.build:compiler_executables", default={})
     if "clang-cl" in compilers.get("c", "") or "clang-cl" in compilers.get("cpp", ""):
         return "clang-cl"  # The MSVC-compatible front
-    return "clang" # The GNU-compatible front
+    return "clang"  # The GNU-compatible front
 
 
 def cppstd_flag(conanfile) -> str:

--- a/conan/tools/build/flags.py
+++ b/conan/tools/build/flags.py
@@ -90,6 +90,8 @@ def libcxx_flags(conanfile):
     libcxx = conanfile.settings.get_safe("compiler.libcxx")
     if not libcxx:
         return None, None
+    if conanfile.conf.get("tools.gnu:disable_stdlib_flag", check_type=bool):
+        return None, None
     compiler = conanfile.settings.get_safe("compiler")
     lib = stdlib11 = None
     if compiler == "apple-clang":

--- a/conan/tools/build/flags.py
+++ b/conan/tools/build/flags.py
@@ -1,4 +1,21 @@
+from conan.errors import ConanException
 from conan.internal.model.version import Version
+
+
+def disable_flag(conanfile, flag):
+    disable_flags = conanfile.conf.get("tools.gnu:disable_flags")
+    if disable_flags is None:
+        return False
+    if disable_flags == "all":
+        return True
+    if not isinstance(disable_flags, list):
+        raise ConanException(f"tools.gnu:disable_flags must be 'all' or list, not '{disable_flags}'")
+    valid = ["arch", "arch_link", "libcxx", "build_type", "build_type_link", "threads",
+             "cppstd", "cstd"]
+    for v in disable_flags:
+        if v not in valid:
+            raise ConanException(f"tools.gnu:disable_flags value '{v}', must be one of: {valid}")
+    return flag in disable_flags
 
 
 def architecture_flag(conanfile):
@@ -6,6 +23,8 @@ def architecture_flag(conanfile):
     returns flags specific to the target architecture and compiler
     Used by CMakeToolchain and AutotoolsToolchain
     """
+    if disable_flag(conanfile, "arch"):
+        return ""
     settings = conanfile.settings
     from conan.tools.apple.apple import _to_apple_arch
     compiler = settings.get_safe("compiler")
@@ -76,6 +95,8 @@ def architecture_link_flag(conanfile):
     """
     returns exclusively linker flags specific to the target architecture and compiler
     """
+    if disable_flag(conanfile, "arch_link"):
+        return ""
     compiler = conanfile.settings.get_safe("compiler")
     arch = conanfile.settings.get_safe("arch")
     if compiler == "emcc":
@@ -90,7 +111,7 @@ def libcxx_flags(conanfile):
     libcxx = conanfile.settings.get_safe("compiler.libcxx")
     if not libcxx:
         return None, None
-    if conanfile.conf.get("tools.gnu:disable_stdlib_flag", check_type=bool):
+    if disable_flag(conanfile, "libcxx"):
         return None, None
     compiler = conanfile.settings.get_safe("compiler")
     lib = stdlib11 = None
@@ -146,6 +167,8 @@ def build_type_flags(conanfile):
     (-s, -g, /Zi, etc.)
     Used only by AutotoolsToolchain
     """
+    if disable_flag(conanfile, "build_type"):
+        return []
     settings = conanfile.settings
     compiler = settings.get_safe("compiler")
     build_type = settings.get_safe("build_type")
@@ -197,10 +220,13 @@ def build_type_flags(conanfile):
             return flags
     return []
 
+
 def threads_flags(conanfile):
     """
     returns flags specific to the threading model used by the compiler
     """
+    if disable_flag(conanfile, "threads"):
+        return []
     compiler = conanfile.settings.get_safe("compiler")
     threads = conanfile.settings.get_safe("compiler.threads")
     if compiler == "emcc":
@@ -209,6 +235,7 @@ def threads_flags(conanfile):
         elif threads == "wasm_workers":
             return ["-sWASM_WORKERS=1"]
     return []
+
 
 def llvm_clang_front(conanfile):
     # Only Windows clang with MSVC backend (LLVM/Clang, not MSYS2 clang)
@@ -241,6 +268,9 @@ def cppstd_flag(conanfile) -> str:
     cppstd = conanfile.settings.get_safe("compiler.cppstd")
 
     if not compiler or not compiler_version or not cppstd:
+        return ""
+
+    if disable_flag(conanfile, "cppstd"):
         return ""
 
     func = {"gcc": _cppstd_gcc,
@@ -578,6 +608,9 @@ def cstd_flag(conanfile) -> str:
     cstd = conanfile.settings.get_safe("compiler.cstd")
 
     if not compiler or not compiler_version or not cstd:
+        return ""
+
+    if disable_flag(conanfile, "cstd"):
         return ""
 
     func = {"gcc": _cstd_gcc,

--- a/conan/tools/meson/helpers.py
+++ b/conan/tools/meson/helpers.py
@@ -1,5 +1,5 @@
 from conan.api.output import ConanOutput
-from conan.tools.build.flags import cppstd_msvc_flag
+from conan.tools.build.flags import cppstd_msvc_flag, disable_flag
 from conan.internal.model.options import _PackageOption
 
 # https://mesonbuild.com/Reference-tables.html#operating-system-names
@@ -107,15 +107,17 @@ def to_meson_value(value):
     return value
 
 
-def to_cppstd_flag(compiler, compiler_version, cppstd):
+def to_cppstd_flag(conanfile, compiler, compiler_version, cppstd):
     """Gets a valid cppstd flag.
-
+    :param conanfile: ``ConanFile`` instance.
     :param compiler: ``str`` compiler name.
     :param compiler_version: ``str`` compiler version.
     :param cppstd: ``str`` cppstd version.
     :return: ``str`` cppstd flag.
     """
     if cppstd is None:
+        return None
+    if disable_flag(conanfile, "cppstd"):
         return None
     if compiler == "msvc":
         # Meson's logic with 'vc++X' vs 'c++X' is possibly a little outdated.
@@ -127,10 +129,11 @@ def to_cppstd_flag(compiler, compiler_version, cppstd):
         return f"gnu++{cppstd[3:]}" if cppstd.startswith("gnu") else f"c++{cppstd}"
 
 
-def to_cstd_flag(cstd):
+def to_cstd_flag(conanfile, cstd):
     """Gets a valid cstd flag.
     """
     if cstd is None:
         return None
-    else:
-        return cstd if cstd.startswith("gnu") else f"c{cstd}"
+    if disable_flag(conanfile, "cppstd"):
+        return None
+    return cstd if cstd.startswith("gnu") else f"c{cstd}"

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -201,9 +201,9 @@ class MesonToolchain:
         cppstd = self._conanfile.settings.get_safe("compiler.cppstd")
         cstd = self._conanfile.settings.get_safe("compiler.cstd")
         #: C++ language standard to use. Defined by ``to_cppstd_flag()`` by default.
-        self.cpp_std = to_cppstd_flag(compiler, compiler_version, cppstd)
+        self.cpp_std = to_cppstd_flag(self._conanfile, compiler, compiler_version, cppstd)
         #: C language standard to use. Defined by ``to_cstd_flag()`` by default.
-        self.c_std = to_cstd_flag(cstd)
+        self.c_std = to_cstd_flag(self._conanfile, cstd)
         #: VS runtime library to use. Defined by ``msvc_runtime_flag()`` by default.
         self.b_vscrt = None
         if compiler in ("msvc", "clang"):

--- a/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -266,14 +266,6 @@ def test_disable_libcxx():
     assert be.build_type_flags == []
     assert be.cppstd == ""
     assert be.cstd == ""
-    # Disable all
-    conanfile.conf.define("tools.gnu:disable_flags", "all")
-    be = AutotoolsToolchain(conanfile)
-    assert be.libcxx is None
-    assert be.arch_flag == ""
-    assert be.build_type_flags == []
-    assert be.cppstd == ""
-    assert be.cstd == ""
 
 
 def test_cxx11_abi_define():
@@ -337,6 +329,7 @@ def test_architecture_flag(config):
     assert expected in env["CFLAGS"]
     assert expected in env["LDFLAGS"]
     assert "-debug" not in env["LDFLAGS"]
+
 
 @pytest.mark.parametrize("config", [
     ("gcc", "x86_64", ""),

--- a/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -232,14 +232,48 @@ def test_disable_libcxx():
          "compiler": "clang",
          "compiler.libcxx": "libc++",
          "compiler.version": "7.1",
-         "compiler.cppstd": "17"})
+         "compiler.cppstd": "17",
+         "compiler.cstd": "99"})
     conanfile.settings_build = conanfile.settings
-    conanfile.conf.define("tools.gnu:disable_stdlib_flag", True)
+    # Disable just one
+    conanfile.conf.define("tools.gnu:disable_flags", ["libcxx"])
     be = AutotoolsToolchain(conanfile)
     assert be.libcxx is None
-    conanfile.conf.define("tools.gnu:disable_stdlib_flag", False)
+    assert be.arch_flag == "-m32"
+    assert be.build_type_flags == ['-O3']
+    assert be.cppstd == "-std=c++17"
+    assert be.cstd == "-std=c99"
+    # Disable two
+    conanfile.conf.define("tools.gnu:disable_flags", ["libcxx", "cppstd"])
     be = AutotoolsToolchain(conanfile)
-    assert be.libcxx == "-stdlib=libc++"
+    assert be.libcxx is None
+    assert be.arch_flag == "-m32"
+    assert be.build_type_flags == ['-O3']
+    assert be.cppstd == ""
+    assert be.cstd == "-std=c99"
+    # Error value
+    conanfile.conf.define("tools.gnu:disable_flags", ["other"])
+    try:
+        AutotoolsToolchain(conanfile)
+    except ConanException as e:
+        assert "tools.gnu:disable_flags value 'other', must be one of:" in str(e)
+    conanfile.conf.define("tools.gnu:disable_flags",
+                          ["arch", "arch_link", "libcxx", "build_type",
+                           "build_type_link", "threads", "cppstd", "cstd"])
+    be = AutotoolsToolchain(conanfile)
+    assert be.libcxx is None
+    assert be.arch_flag == ""
+    assert be.build_type_flags == []
+    assert be.cppstd == ""
+    assert be.cstd == ""
+    # Disable all
+    conanfile.conf.define("tools.gnu:disable_flags", "all")
+    be = AutotoolsToolchain(conanfile)
+    assert be.libcxx is None
+    assert be.arch_flag == ""
+    assert be.build_type_flags == []
+    assert be.cppstd == ""
+    assert be.cstd == ""
 
 
 def test_cxx11_abi_define():

--- a/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
+++ b/test/unittests/client/toolchain/autotools/autotools_toolchain_test.py
@@ -223,6 +223,25 @@ def test_libcxx(config):
         assert expected_flag in env["CXXFLAGS"]
 
 
+def test_disable_libcxx():
+    conanfile = ConanFileMock()
+    conanfile.settings = MockSettings(
+        {"os": "Linux",
+         "build_type": "Release",
+         "arch": "x86",
+         "compiler": "clang",
+         "compiler.libcxx": "libc++",
+         "compiler.version": "7.1",
+         "compiler.cppstd": "17"})
+    conanfile.settings_build = conanfile.settings
+    conanfile.conf.define("tools.gnu:disable_stdlib_flag", True)
+    be = AutotoolsToolchain(conanfile)
+    assert be.libcxx is None
+    conanfile.conf.define("tools.gnu:disable_stdlib_flag", False)
+    be = AutotoolsToolchain(conanfile)
+    assert be.libcxx == "-stdlib=libc++"
+
+
 def test_cxx11_abi_define():
     conanfile = ConanFileMock()
     conanfile.settings = MockSettings(

--- a/test/unittests/tools/meson/test_meson.py
+++ b/test/unittests/tools/meson/test_meson.py
@@ -50,7 +50,7 @@ def test_meson_subsystem_helper(apple_sdk, subsystem):
     (None, None)
 ])
 def test_meson_to_cstd_flag(cstd, expected):
-    assert to_cstd_flag(cstd) == expected
+    assert to_cstd_flag(ConanFileMock(), cstd) == expected
 
 
 @pytest.mark.parametrize("compiler, compiler_version, cppstd, expected", [
@@ -64,7 +64,7 @@ def test_meson_to_cstd_flag(cstd, expected):
     (None, None, None, None)
 ])
 def test_meson_to_cppstd_flag(compiler, compiler_version, cppstd, expected):
-    assert to_cppstd_flag(compiler, compiler_version, cppstd) == expected
+    assert to_cppstd_flag(ConanFileMock(), compiler, compiler_version, cppstd) == expected
 
 
 def test_meson_install_strip():


### PR DESCRIPTION
Changelog: Feature: New ``tools.gnu:disable_flags`` configuration to allow disabling the injection of some build system flags.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19006

Very preliminary, can't guarantee to merge it, just for exploration