### PR TITLE
add njobs to cmake test presets

### DIFF
--- a/conan/tools/build/cpu.py
+++ b/conan/tools/build/cpu.py
@@ -22,10 +22,7 @@ def build_jobs(conanfile):
     :param conanfile: The current recipe object. Always use ``self``.
     :return: ``int`` with the number of jobs
     """
-    njobs = conanfile.conf.get("tools.build:jobs",
-                               default=_cpu_count(),
-                               check_type=int)
-    return njobs
+    return conanfile.conf.get("tools.build:jobs", default=_cpu_count(), check_type=int)
 
 
 def _cpu_count():

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -224,6 +224,9 @@ class _CMakePresets:
     @staticmethod
     def _test_preset_fields(conanfile, multiconfig, preset_prefix, runenv):
         ret = _CMakePresets._common_preset_fields(conanfile, multiconfig, preset_prefix)
+        build_preset_jobs = build_jobs(conanfile)
+        if build_preset_jobs:
+            ret.setdefault("execution", {})["jobs"] = build_preset_jobs
         if runenv:
             ret["environment"] = runenv
         return ret

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -1396,9 +1396,11 @@ def test_presets_njobs():
     c.run('install . -g CMakeToolchain -c tools.build:jobs=42')
     presets = json.loads(c.load("CMakePresets.json"))
     assert presets["buildPresets"][0]["jobs"] == 42
+    assert presets["testPresets"][0]["execution"]["jobs"] == 42
     c.run('install . -g CMakeToolchain -c tools.build:jobs=0')
     presets = json.loads(c.load("CMakePresets.json"))
     assert "jobs" not in presets["buildPresets"][0]
+    assert "execution" not in presets["testPresets"][0]
 
 
 def test_add_cmakeexe_to_presets():


### PR DESCRIPTION
Changelog: Fix: Add ``execution["jobs"]`` to the generated CMake ``testPresets`` with same logic and value as ``buildPresets``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19020
