### PR TITLE
Avoid referencing  xcconfig from skipped dependencies required in components in XcodeDeps

### DIFF
--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -257,7 +257,6 @@ class XcodeDeps(object):
 
             include_components_names = []
             if dep.cpp_info.has_components:
-                # Filter out skipped dependencies from external requirements
                 available_deps = self._conanfile.dependencies.filter({"build": False, "skip": False})
                 available_dep_names = [_format_name(dep.ref.name) for _, dep in available_deps.items()]
 

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -257,6 +257,9 @@ class XcodeDeps(object):
 
             include_components_names = []
             if dep.cpp_info.has_components:
+                # Filter out skipped dependencies from external requirements
+                available_deps = self._conanfile.dependencies.filter({"build": False, "skip": False})
+                available_dep_names = [_format_name(dep.ref.name) for _, dep in available_deps.items()]
 
                 sorted_components = dep.cpp_info.get_sorted_components().items()
                 for comp_name, comp_cpp_info in sorted_components:
@@ -266,7 +269,8 @@ class XcodeDeps(object):
                     #           "list of names from required components from other packages")
                     def _get_component_requires(component):
                         requires_external = [(req.split("::")[0], req.split("::")[1]) for req in
-                                             component.requires if "::" in req]
+                                             component.requires if "::" in req
+                                             if req.split("::")[0] in available_dep_names]
                         requires_internal = [dep.cpp_info.components.get(req) for req in
                                              component.requires if "::" not in req]
                         return requires_internal, requires_external

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -256,9 +256,10 @@ class XcodeDeps(object):
             dep_name = _format_name(dep.ref.name)
 
             include_components_names = []
+            transitive_requires = [r for r, _ in
+                                   get_transitive_requires(self._conanfile, dep).items()]
             if dep.cpp_info.has_components:
-                available_deps = self._conanfile.dependencies.filter({"build": False, "skip": False})
-                available_dep_names = [_format_name(dep.ref.name) for _, dep in available_deps.items()]
+                transitive_dep_names = [_format_name(dep.ref.name) for dep in transitive_requires]
 
                 sorted_components = dep.cpp_info.get_sorted_components().items()
                 for comp_name, comp_cpp_info in sorted_components:
@@ -269,7 +270,7 @@ class XcodeDeps(object):
                     def _get_component_requires(component):
                         requires_external = [(req.split("::")[0], req.split("::")[1]) for req in
                                              component.requires if "::" in req
-                                             and req.split("::")[0] in available_dep_names]
+                                             and req.split("::")[0] in transitive_dep_names]
                         requires_internal = [dep.cpp_info.components.get(req) for req in
                                              component.requires if "::" not in req]
                         return requires_internal, requires_external
@@ -304,7 +305,6 @@ class XcodeDeps(object):
                     result.update(component_content)
             else:
                 public_deps = []
-                transitive_requires = [r for r, _ in get_transitive_requires(self._conanfile, dep).items()]
                 for r, d in dep.dependencies.direct_host.items():
                     if r not in transitive_requires:
                         continue

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -269,7 +269,7 @@ class XcodeDeps(object):
                     def _get_component_requires(component):
                         requires_external = [(req.split("::")[0], req.split("::")[1]) for req in
                                              component.requires if "::" in req
-                                             if req.split("::")[0] in available_dep_names]
+                                             and req.split("::")[0] in available_dep_names]
                         requires_internal = [dep.cpp_info.components.get(req) for req in
                                              component.requires if "::" not in req]
                         return requires_internal, requires_external

--- a/test/integration/toolchains/apple/test_xcodedeps.py
+++ b/test/integration/toolchains/apple/test_xcodedeps.py
@@ -633,3 +633,11 @@ def test_dont_add_skipped_xcconfigs_when_required_by_components():
     conandeps = client.load("conan_regular_lib_component.xcconfig")
     assert '#include "conan_header_skip.xcconfig"' not in conandeps
     assert '#include "conan_header_transitive.xcconfig"' in conandeps
+
+    # Verify that header_skip xcconfig files are NOT generated (skipped dependency)
+    skip_files = [f for f in os.listdir(client.current_folder) if 'header_skip' in f and f.endswith('.xcconfig')]
+    assert len(skip_files) == 0, f"Header skip files should not be generated: {skip_files}"
+
+    # Verify that header_transitive xcconfig files ARE generated (transitive dependency)
+    transitive_files = [f for f in os.listdir(client.current_folder) if 'header_transitive' in f and f.endswith('.xcconfig')]
+    assert len(transitive_files) > 0, f"Header transitive files should be generated: {transitive_files}"

--- a/test/integration/toolchains/apple/test_xcodedeps.py
+++ b/test/integration/toolchains/apple/test_xcodedeps.py
@@ -593,16 +593,17 @@ def test_dont_add_skipped_xcconfigs_when_required_by_components():
             version = '1.0'
             settings = 'os', 'compiler', 'arch', 'build_type'
             def requirements(self):
-                self.requires('header_library/1.0')
+                self.requires('header_skip/1.0')
+                self.requires('header_transitive/1.0', transitive_headers=True)
             def package_info(self):
-                self.cpp_info.libs = ["regular_lib"]
-                self.cpp_info.components['component'].requires = ['header_library::header_library']
+                self.cpp_info.components['component'].requires = ['header_skip::header_skip',
+                                                                  'header_transitive::header_transitive']
         """)
 
-    header_lib = textwrap.dedent("""
+    header_transitive = textwrap.dedent("""
         from conan import ConanFile
         class PkgUsesComponent(ConanFile):
-            name = 'header_library'
+            name = 'header_transitive'
             version = '1.0'
             settings = 'os', 'compiler', 'arch', 'build_type'
             package_type = 'header-library'
@@ -610,11 +611,25 @@ def test_dont_add_skipped_xcconfigs_when_required_by_components():
                 self.cpp_info.includedirs = ["include"]
         """)
 
-    client.save({"header.py": header_lib,
+    header_skip = textwrap.dedent("""
+        from conan import ConanFile
+        class PkgUsesComponent(ConanFile):
+            name = 'header_skip'
+            version = '1.0'
+            settings = 'os', 'compiler', 'arch', 'build_type'
+            package_type = 'header-library'
+            def package_info(self):
+                self.cpp_info.includedirs = ["include"]
+        """)
+
+    client.save({"header_transitive.py": header_transitive,
+                 "header_skip.py": header_skip,
                  "regular_lib.py": regular_lib})
-    client.run("create header.py")
+    client.run("create header_transitive.py")
+    client.run("create header_skip.py")
     client.run("create regular_lib.py")
     client.run("install --requires=regular_lib/1.0 -g XcodeDeps")
 
     conandeps = client.load("conan_regular_lib_component.xcconfig")
-    assert '#include "conan_header_library.xcconfig"' not in conandeps
+    assert '#include "conan_header_skip.xcconfig"' not in conandeps
+    assert '#include "conan_header_transitive.xcconfig"' in conandeps

--- a/test/integration/toolchains/apple/test_xcodedeps.py
+++ b/test/integration/toolchains/apple/test_xcodedeps.py
@@ -582,3 +582,39 @@ def test_correctly_handle_transitive_components():
     conan_uses_xcconfig = client.load("conan_uses_components_uses_components.xcconfig")
     assert '#include "conan_has_components_first.xcconfig"' in conan_uses_xcconfig
     assert '#include "conan_has_components_second.xcconfig"' not in conan_uses_xcconfig
+
+
+def test_dont_add_skipped_xcconfigs_when_required_by_components():
+    client = TestClient()
+    regular_lib = textwrap.dedent("""
+        from conan import ConanFile
+        class PkgWithComponents(ConanFile):
+            name = 'regular_lib'
+            version = '1.0'
+            settings = 'os', 'compiler', 'arch', 'build_type'
+            def requirements(self):
+                self.requires('header_library/1.0')
+            def package_info(self):
+                self.cpp_info.libs = ["regular_lib"]
+                self.cpp_info.components['component'].requires = ['header_library::header_library']
+        """)
+
+    header_lib = textwrap.dedent("""
+        from conan import ConanFile
+        class PkgUsesComponent(ConanFile):
+            name = 'header_library'
+            version = '1.0'
+            settings = 'os', 'compiler', 'arch', 'build_type'
+            package_type = 'header-library'
+            def package_info(self):
+                self.cpp_info.includedirs = ["include"]
+        """)
+
+    client.save({"header.py": header_lib,
+                 "regular_lib.py": regular_lib})
+    client.run("create header.py")
+    client.run("create regular_lib.py")
+    client.run("install --requires=regular_lib/1.0 -g XcodeDeps")
+
+    conandeps = client.load("conan_regular_lib_component.xcconfig")
+    assert '#include "conan_header_library.xcconfig"' not in conandeps


### PR DESCRIPTION
Changelog: Fix: Avoid referencing xcconfig from skipped dependencies required in components in XcodeDeps.
Docs: Omit

When a package with components had a `components['component'].requires` to a skipped package it was generating a reference to a non-existing `xcconfig` file that should have not been added as the file does not exist because the package was skipped. 