### PR TITLE
Fixed bug in VS2026 support

### DIFF
--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -249,7 +249,8 @@ class CMakeToolchain:
                        '14': '14 2015',
                        '15': '15 2017',
                        '16': '16 2019',
-                       '17': '17 2022'}
+                       '17': '17 2022',
+                       '18': '18 2026'}
 
         if compiler == "msvc":
             if compiler_version is None:

--- a/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -245,7 +245,7 @@ def test_osx_deployment_target(conanfile_apple):
 def conanfile_msvc():
     c = ConanFile(None)
     c.settings = Settings({"os": ["Windows"],
-                           "compiler": {"msvc": {"version": ["193", "194"], "cppstd": ["20"],
+                           "compiler": {"msvc": {"version": ["193", "194", "195"], "cppstd": ["20"],
                                                  "update": [None, 8, 9]}},
                            "build_type": ["Release"],
                            "arch": ["x86"]})
@@ -270,6 +270,13 @@ def test_toolset(conanfile_msvc):
     assert 'set(CMAKE_GENERATOR_TOOLSET "v143" CACHE STRING "" FORCE)' in toolchain.content
     assert 'Visual Studio 17 2022' in toolchain.generator
     assert 'CMAKE_CXX_STANDARD 20' in toolchain.content
+
+
+def test_toolset_latest_generator(conanfile_msvc):
+    conanfile_msvc.settings.compiler.version="195"
+    toolchain = CMakeToolchain(conanfile_msvc)
+    assert 'set(CMAKE_GENERATOR_TOOLSET "v145" CACHE STRING "" FORCE)' in toolchain.content
+    assert 'Visual Studio 18 2026' in toolchain.generator
 
 
 def test_toolset_update_version(conanfile_msvc):


### PR DESCRIPTION
Changelog: Fix: Add VS2026 CMake generator mapping.
Docs: Omit

Related to https://github.com/conan-io/conan/pull/18948/

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
