### PR TITLE
initial proposal for pkg-list from build-order

### DIFF
--- a/conan/api/model/list.py
+++ b/conan/api/model/list.py
@@ -98,6 +98,9 @@ class MultiPackagesList:
         try:
             base_context = context.split("-")[0] if context else None
             graph = json.loads(load(graphfile))
+            if "order_by" in graph:  # This is a "build-order" json, not a graph
+                return MultiPackagesList._define_build_order(graph, graph_binaries)
+
             # Check if input json is a graph file
             if "graph" not in graph:
                 raise ConanException(
@@ -189,6 +192,38 @@ class MultiPackagesList:
             if any(b == "*" or b == binary for b in binaries):
                 cache_list.add_ref(ref)  # Binary listed forces recipe listed
                 cache_list.add_pref(pref, node["info"])
+        return pkglist
+
+    @staticmethod
+    def _define_build_order(build_order, graph_binaries=None):
+        pkglist = MultiPackagesList()
+        cache_list = PackagesList()
+        if graph_binaries is None:
+            binaries = ["*"]
+        else:
+            binaries = [b.lower() for b in graph_binaries or []]
+
+        pkglist.lists["Local Cache"] = cache_list
+        order_by = build_order.get("order_by")
+        if order_by not in ("configuration", "recipe"):
+            raise ConanException(f"Invalid order_by value: {order_by}")
+
+        for level in build_order["order"]:
+            for node in level:
+                ref = node["ref"]
+                ref = RecipeReference.loads(ref)
+                pnodes = [node] if order_by == "configuration" else \
+                    [p for lev in node["packages"] for p in lev]
+                for pnode in pnodes:
+                    pref = PkgReference(ref, pnode["package_id"], pnode["prev"])
+                    binary = pnode["binary"]
+                    if binary in (BINARY_SKIP, BINARY_INVALID, BINARY_MISSING):
+                        continue
+                    binary = binary.lower()
+                    if any(b == "*" or b == binary for b in binaries):
+                        cache_list.add_ref(ref)  # Binary listed forces recipe listed
+                        cache_list.add_pref(pref, pnode["info"])
+
         return pkglist
 
 

--- a/test/integration/command/list/test_combined_pkglist_flows.py
+++ b/test/integration/command/list/test_combined_pkglist_flows.py
@@ -487,3 +487,42 @@ class TestListGraphContext:
         tc.run("list --graph=graph_context.json --graph-context=build-only --format=json",
                assert_error=True)
         assert "Note that the graph file should not be filtered" in tc.out
+
+
+class TestBuildOrderToPkgList:
+    @pytest.mark.parametrize("order_by", ["recipe", "configuration"])
+    def test_build_order_to_list(self, order_by):
+        c = TestClient(light=True)
+        c.save({"zlib/conanfile.py": GenConanfile("zlib", "1.0"),
+                "app/conanfile.py": GenConanfile("app", "1.0").with_requires("zlib/1.0")})
+        c.run("export zlib")
+        c.run("export app")
+
+        c.run("graph build-order --requires=app/1.0 "
+              f"--order-by={order_by} --build=missing --format=json", redirect_stdout="bo.json")
+        c.run("list --graph=bo.json --format=json")
+        pkglist = json.loads(c.stdout)
+        pkgs = pkglist["Local Cache"]
+        zlib_pkgs = pkgs["zlib/1.0"]["revisions"]["c570d63921c5f2070567da4bf64ff261"]["packages"]
+        assert zlib_pkgs == {"da39a3ee5e6b4b0d3255bfef95601890afd80709": {"info": {}}}
+        app_pkgs = pkgs["app/1.0"]["revisions"]["0fa1ff1b90576bb782600e56df642e19"]["packages"]
+        assert app_pkgs == {"594ed0eb2e9dfcc60607438924c35871514e6c2a":
+            {"info": {"requires": ["zlib/1.Y.Z"]}}}
+
+    @pytest.mark.parametrize("order_by", ["recipe", "configuration"])
+    def test_build_order_to_list_only_build(self, order_by):
+        c = TestClient(light=True)
+        c.save({"zlib/conanfile.py": GenConanfile("zlib", "1.0"),
+                "app/conanfile.py": GenConanfile("app", "1.0").with_requires("zlib/1.0")})
+        c.run("create zlib")
+        c.run("export app")
+
+        c.run("graph build-order --requires=app/1.0 "
+              f"--order-by={order_by} --build=missing --format=json", redirect_stdout="bo.json")
+        c.run("list --graph=bo.json --graph-binaries=build --format=json")
+        pkglist = json.loads(c.stdout)
+        pkgs = pkglist["Local Cache"]
+        assert "zlib/1.0" not in pkgs
+        app_pkgs = pkgs["app/1.0"]["revisions"]["0fa1ff1b90576bb782600e56df642e19"]["packages"]
+        assert app_pkgs == {"594ed0eb2e9dfcc60607438924c35871514e6c2a":
+                                {"info": {"requires": ["zlib/1.Y.Z"]}}}


### PR DESCRIPTION
Changelog: Feature: Create a pkg-list from a "build-order" json file
Docs: https://github.com/conan-io/docs/pull/XXXX

Close https://github.com/conan-io/conan/issues/18962

This is a draft just to think about it, no guarantees. In fact, I see some problematic things:

- As the packages haven't been built, the origin that I am assiging is package list is the "Local Cache". But this will not be correct, it needs to be a package list referenced to the remote containing the uploaded artifacts, but that doesn't happen until the upload.
- It is not possible to filter by context host/build, as there is not full information about it in the graph build-order
- It is not possible to filter by ``--graph-recipes``, for the same reason, the graph build-order does not contain information about the recipes origins, because it is intended for a distributed build.