### PR TITLE
pyinstaller support added to PipEnv

### DIFF
--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -129,7 +129,7 @@ BUILT_IN_CONFS = {
     "tools.system.package_manager:mode": "Mode for package_manager tools: 'check', 'report', 'report-installed' or 'install'",
     "tools.system.package_manager:sudo": "Use 'sudo' when invoking the package manager tools in Linux (False by default)",
     "tools.system.package_manager:sudo_askpass": "Use the '-A' argument if using sudo in Linux to invoke the system package manager (False by default)",
-    "tools.system.pip_manager:python_interpreter": "Path to the Python interpreter to be used to create the virtualenv",
+    "tools.system.pipenv:python_interpreter": "Path to the Python interpreter to be used to create the virtualenv",
     "tools.apple:sdk_path": "Path to the SDK to be used",
     "tools.apple:enable_bitcode": "(boolean) Enable/Disable Bitcode Apple Clang flags",
     "tools.apple:enable_arc": "(boolean) Enable/Disable ARC Apple Clang flags",

--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -129,6 +129,7 @@ BUILT_IN_CONFS = {
     "tools.system.package_manager:mode": "Mode for package_manager tools: 'check', 'report', 'report-installed' or 'install'",
     "tools.system.package_manager:sudo": "Use 'sudo' when invoking the package manager tools in Linux (False by default)",
     "tools.system.package_manager:sudo_askpass": "Use the '-A' argument if using sudo in Linux to invoke the system package manager (False by default)",
+    "tools.system.pip_manager:python_interpreter": "Path to the Python interpreter to be used to create the virtualenv",
     "tools.apple:sdk_path": "Path to the SDK to be used",
     "tools.apple:enable_bitcode": "(boolean) Enable/Disable Bitcode Apple Clang flags",
     "tools.apple:enable_arc": "(boolean) Enable/Disable ARC Apple Clang flags",

--- a/conan/tools/system/pip_manager.py
+++ b/conan/tools/system/pip_manager.py
@@ -27,7 +27,7 @@ class PipEnv:
 
     def _create_venv(self):
         python_interpreter = self._conanfile.conf.get(
-            "tools.system.pip_manager:python_interpreter",
+            "tools.system.pipenv:python_interpreter",
             default=shutil.which('python') if platform.system() == "Windows" else shutil.which('python3'))
         if not python_interpreter:
             raise ConanException("PipEnv could not find a Python executable path.")

--- a/conan/tools/system/pip_manager.py
+++ b/conan/tools/system/pip_manager.py
@@ -1,7 +1,6 @@
 import platform
 import os
 import shutil
-import sys
 
 from conan.tools.build import cmd_args_to_string
 from conan.tools.env.environment import Environment
@@ -26,9 +25,9 @@ class PipEnv:
         env.vars(self._conanfile).save_script(self.env_name)
 
     def _create_venv(self):
-        python_interpreter = self._conanfile.conf.get(
-            "tools.system.pipenv:python_interpreter",
-            default=shutil.which('python') if platform.system() == "Windows" else shutil.which('python3'))
+        default_python = shutil.which('python') if platform.system() == "Windows" else shutil.which('python3')
+        python_interpreter = self._conanfile.conf.get("tools.system.pipenv:python_interpreter",
+                                                      default=os.path.realpath(default_python) if default_python else None)
         if not python_interpreter:
             raise ConanException("PipEnv could not find a Python executable path.")
 

--- a/conan/tools/system/pip_manager.py
+++ b/conan/tools/system/pip_manager.py
@@ -24,10 +24,13 @@ class PipEnv:
         env.prepend_path("PATH", self.bin_dir)
         env.vars(self._conanfile).save_script(self.env_name)
 
-    def _create_venv(self):
+    @staticmethod
+    def _default_python():
         default_python = shutil.which('python') if platform.system() == "Windows" else shutil.which('python3')
-        python_interpreter = self._conanfile.conf.get("tools.system.pipenv:python_interpreter",
-                                                      default=os.path.realpath(default_python) if default_python else None)
+        return os.path.realpath(default_python) if default_python else None
+
+    def _create_venv(self):
+        python_interpreter = self._conanfile.conf.get("tools.system.pipenv:python_interpreter") or self._default_python()
         if not python_interpreter:
             raise ConanException("PipEnv could not find a Python executable path."
                                  "Please set 'tools.system.pipenv:python_interpreter' to '</your/python/full/path>' "

--- a/conan/tools/system/pip_manager.py
+++ b/conan/tools/system/pip_manager.py
@@ -29,7 +29,10 @@ class PipEnv:
         python_interpreter = self._conanfile.conf.get("tools.system.pipenv:python_interpreter",
                                                       default=os.path.realpath(default_python) if default_python else None)
         if not python_interpreter:
-            raise ConanException("PipEnv could not find a Python executable path.")
+            raise ConanException("PipEnv could not find a Python executable path."
+                                 "Please set 'tools.system.pipenv:python_interpreter' to '</your/python/full/path>' "
+                                 "in the [conf] section of the profile, or in the command line using "
+                                 "'-c tools.system.pipenv:python_interpreter=</your/python/full/path>'")
 
         try:
             self._conanfile.run(cmd_args_to_string([python_interpreter, '-m', 'venv', self._env_dir]))

--- a/conan/tools/system/pip_manager.py
+++ b/conan/tools/system/pip_manager.py
@@ -32,15 +32,14 @@ class PipEnv:
     def _create_venv(self):
         python_interpreter = self._conanfile.conf.get("tools.system.pipenv:python_interpreter") or self._default_python()
         if not python_interpreter:
-            raise ConanException("PipEnv could not find a Python executable path."
-                                 "Please set 'tools.system.pipenv:python_interpreter' to '</your/python/full/path>' "
-                                 "in the [conf] section of the profile, or in the command line using "
-                                 "'-c tools.system.pipenv:python_interpreter=</your/python/full/path>'")
+            raise ConanException("PipEnv could not find a Python executable path. "
+                                 "Please, install Python system-wide or set the 'tools.system.pipenv:python_interpreter' "
+                                 "conf to the full path of a Python executable")
 
         try:
             self._conanfile.run(cmd_args_to_string([python_interpreter, '-m', 'venv', self._env_dir]))
-        except ConanException:
-            raise ConanException("PipEnv could not create a Python virtual environment.")
+        except ConanException as e:
+            raise ConanException(f"PipEnv could not create a Python virtual environment using '{python_interpreter}': {e}")
 
     def install(self, packages, pip_args=None):
         """

--- a/conan/tools/system/pip_manager.py
+++ b/conan/tools/system/pip_manager.py
@@ -43,7 +43,10 @@ class PipEnv:
             python_executable = sys.executable
 
         if not python_executable:
-            python_executable = shutil.which('python3') or shutil.which('python')
+            if platform.system() == "Windows":
+                python_executable = shutil.which('python')
+            else:
+                python_executable = shutil.which('python3')
             if not python_executable:
                 raise ConanException("PipEnv could not find a Python executable path.")
 

--- a/conan/tools/system/pip_manager.py
+++ b/conan/tools/system/pip_manager.py
@@ -49,8 +49,10 @@ class PipEnv:
                 python_executable = shutil.which('python3')
             if not python_executable:
                 raise ConanException("PipEnv could not find a Python executable path.")
-
-        self._conanfile.run(cmd_args_to_string([python_executable, '-m', 'venv', self._env_dir]))
+        try:
+            self._conanfile.run(cmd_args_to_string([python_executable, '-m', 'venv', self._env_dir]))
+        except ConanException:
+            raise ConanException("PipEnv could not create a Python virtual environment.")
 
     def install(self, packages, pip_args=None):
         """

--- a/conan/tools/system/pip_manager.py
+++ b/conan/tools/system/pip_manager.py
@@ -26,9 +26,10 @@ class PipEnv:
         env.vars(self._conanfile).save_script(self.env_name)
 
     def _create_venv(self):
-        print("=" * 20)
         python_executable = None
-        if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+
+        # https://pyinstaller.org/en/stable/runtime-information.html#run-time-information
+        if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):  # Conan is bundled
             if platform.system() == "Windows":
                 candidate_names = ['python.exe', 'pythonw.exe']
             else:
@@ -40,22 +41,14 @@ class PipEnv:
                 if os.path.exists(expected_path):
                     python_executable = expected_path
                     break
-            if not python_executable:
-                if platform.system() == "Windows":
-                    system_py = shutil.which('python')
-                else:
-                    system_py = shutil.which('python3') or shutil.which('python')
-                if system_py:
-                    python_executable = system_py
-        else:
+        else:  # Conan is running from source
             python_executable = sys.executable
-        print("=" * 20)
-        print(python_executable)
-        print(getattr(sys, 'frozen', False))
-        print(getattr(sys, '_MEIPASS', False))
-        print("=" * 20)
+
         if not python_executable:
-            raise ConanException("PipEnv could not find a Python executable path.")
+            python_executable = shutil.which('python3') or shutil.which('python')
+            if not python_executable:
+                raise ConanException("PipEnv could not find a Python executable path.")
+
         self._conanfile.run(cmd_args_to_string([python_executable, '-m', 'venv', self._env_dir]))
 
     def install(self, packages, pip_args=None):

--- a/conan/tools/system/pip_manager.py
+++ b/conan/tools/system/pip_manager.py
@@ -34,10 +34,8 @@ class PipEnv:
                 candidate_names = ['python.exe', 'pythonw.exe']
             else:
                 candidate_names = ['python', 'python3']
-
             for name in candidate_names:
                 expected_path = os.path.join(sys._MEIPASS, name)
-                print(expected_path)
                 if os.path.exists(expected_path):
                     python_executable = expected_path
                     break

--- a/conan/tools/system/pip_manager.py
+++ b/conan/tools/system/pip_manager.py
@@ -26,29 +26,12 @@ class PipEnv:
         env.vars(self._conanfile).save_script(self.env_name)
 
     def _create_venv(self):
-        python_executable = None
-
-        # https://pyinstaller.org/en/stable/runtime-information.html#run-time-information
-        if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):  # Conan is bundled
-            if platform.system() == "Windows":
-                candidate_names = ['python.exe', 'pythonw.exe']
-            else:
-                candidate_names = ['python', 'python3']
-            for name in candidate_names:
-                expected_path = os.path.join(sys._MEIPASS, name)
-                if os.path.exists(expected_path):
-                    python_executable = expected_path
-                    break
-        else:  # Conan is running from source
-            python_executable = sys.executable
-
+        if platform.system() == "Windows":
+            python_executable = shutil.which('python')
+        else:
+            python_executable = shutil.which('python3')
         if not python_executable:
-            if platform.system() == "Windows":
-                python_executable = shutil.which('python')
-            else:
-                python_executable = shutil.which('python3')
-            if not python_executable:
-                raise ConanException("PipEnv could not find a Python executable path.")
+            raise ConanException("PipEnv could not find a Python executable path.")
         try:
             self._conanfile.run(cmd_args_to_string([python_executable, '-m', 'venv', self._env_dir]))
         except ConanException:

--- a/conan/tools/system/pip_manager.py
+++ b/conan/tools/system/pip_manager.py
@@ -26,14 +26,14 @@ class PipEnv:
         env.vars(self._conanfile).save_script(self.env_name)
 
     def _create_venv(self):
-        if platform.system() == "Windows":
-            python_executable = shutil.which('python')
-        else:
-            python_executable = shutil.which('python3')
-        if not python_executable:
+        python_interpreter = self._conanfile.conf.get(
+            "tools.system.pip_manager:python_interpreter",
+            default=shutil.which('python') if platform.system() == "Windows" else shutil.which('python3'))
+        if not python_interpreter:
             raise ConanException("PipEnv could not find a Python executable path.")
+
         try:
-            self._conanfile.run(cmd_args_to_string([python_executable, '-m', 'venv', self._env_dir]))
+            self._conanfile.run(cmd_args_to_string([python_interpreter, '-m', 'venv', self._env_dir]))
         except ConanException:
             raise ConanException("PipEnv could not create a Python virtual environment.")
 

--- a/conan/tools/system/pip_manager.py
+++ b/conan/tools/system/pip_manager.py
@@ -1,9 +1,11 @@
-import venv
 import platform
 import os
+import shutil
+import sys
 
 from conan.tools.build import cmd_args_to_string
 from conan.tools.env.environment import Environment
+from conan.errors import ConanException
 
 
 class PipEnv:
@@ -23,6 +25,39 @@ class PipEnv:
         env.prepend_path("PATH", self.bin_dir)
         env.vars(self._conanfile).save_script(self.env_name)
 
+    def _create_venv(self):
+        print("=" * 20)
+        python_executable = None
+        if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+            if platform.system() == "Windows":
+                candidate_names = ['python.exe', 'pythonw.exe']
+            else:
+                candidate_names = ['python', 'python3']
+
+            for name in candidate_names:
+                expected_path = os.path.join(sys._MEIPASS, name)
+                print(expected_path)
+                if os.path.exists(expected_path):
+                    python_executable = expected_path
+                    break
+            if not python_executable:
+                if platform.system() == "Windows":
+                    system_py = shutil.which('python')
+                else:
+                    system_py = shutil.which('python3') or shutil.which('python')
+                if system_py:
+                    python_executable = system_py
+        else:
+            python_executable = sys.executable
+        print("=" * 20)
+        print(python_executable)
+        print(getattr(sys, 'frozen', False))
+        print(getattr(sys, '_MEIPASS', False))
+        print("=" * 20)
+        if not python_executable:
+            raise ConanException("PipEnv could not find a Python executable path.")
+        self._conanfile.run(cmd_args_to_string([python_executable, '-m', 'venv', self._env_dir]))
+
     def install(self, packages, pip_args=None):
         """
         Will try to install the list of pip packages passed as a parameter.
@@ -34,7 +69,7 @@ class PipEnv:
         :return: the return code of the executed pip command.
         """
 
-        venv.EnvBuilder(clear=True, with_pip=True).create(self._env_dir)
+        self._create_venv()
         args = [self._python_exe, "-m", "pip", "install", "--disable-pip-version-check"]
         if pip_args:
             args += list(pip_args)

--- a/test/integration/tools/system/pip_manager_test.py
+++ b/test/integration/tools/system/pip_manager_test.py
@@ -10,7 +10,6 @@ from conan.test.utils.mocks import ConanFileMock
 def test_pipenv_conf(mock_shutil_which):
     conanfile = ConanFileMock()
     conanfile.settings = Settings()
-    mock_shutil_which.side_effect = Exception()
     conanfile.conf.define("tools.system.pipenv:python_interpreter", "/python/interpreter/from/config")
     result = "/python/interpreter/from/config -m venv"
     pipenv = PipEnv(conanfile, "testenv")
@@ -20,6 +19,7 @@ def test_pipenv_conf(mock_shutil_which):
         return 100
     conanfile.run = fake_run
     pipenv._create_venv()
+    mock_shutil_which.assert_not_called()
 
 
 @patch('shutil.which')

--- a/test/integration/tools/system/pip_manager_test.py
+++ b/test/integration/tools/system/pip_manager_test.py
@@ -30,9 +30,7 @@ def test_pipenv_error_message(mock_shutil_which):
     with pytest.raises(ConanException) as exc_info:
         pipenv = PipEnv(conanfile, "testenv")
         pipenv._create_venv()
-    assert exc_info.value.args[0] == "PipEnv could not find a Python executable path. " \
-                                     "Please, install Python system-wide or set the 'tools.system.pipenv:python_interpreter' " \
-                                     "conf to the full path of a Python executable"
+    assert "PipEnv could not find a Python executable path." in exc_info.value.args[0]
 
 
 def test_pipenv_creation_error_message():
@@ -46,4 +44,4 @@ def test_pipenv_creation_error_message():
     conanfile.run = fake_run
     with pytest.raises(ConanException) as exc_info:
         pipenv._create_venv()
-    assert exc_info.value.args[0] == "PipEnv could not create a Python virtual environment using '/python/interpreter/from/config': fake error message"
+    assert "using '/python/interpreter/from/config': fake error message" in exc_info.value.args[0]

--- a/test/integration/tools/system/pip_manager_test.py
+++ b/test/integration/tools/system/pip_manager_test.py
@@ -8,10 +8,12 @@ from conan.internal.model.settings import Settings
 from conan.test.utils.mocks import ConanFileMock
 
 
-def test_pipenv_conf():
+@patch('shutil.which')
+def test_pipenv_conf(mock_shutil_which):
     # https://github.com/conan-io/conan/issues/11661
     conanfile = ConanFileMock()
     conanfile.settings = Settings()
+    mock_shutil_which.side_effect = Exception()
     conanfile.conf.define("tools.system.pipenv:python_interpreter", "/python/interpreter/from/config")
     result = "/python/interpreter/from/config -m venv"
     pipenv = PipEnv(conanfile, "testenv")

--- a/test/integration/tools/system/pip_manager_test.py
+++ b/test/integration/tools/system/pip_manager_test.py
@@ -30,7 +30,7 @@ def test_pipenv_error_message(mock_shutil_which):
     with pytest.raises(ConanException) as exc_info:
         pipenv = PipEnv(conanfile, "testenv")
         pipenv._create_venv()
-    assert "PipEnv could not find a Python executable path." in exc_info.value.args[0]
+    assert "install Python system-wide or set the 'tools.system.pipenv:python_interpreter' conf" in exc_info.value.args[0]
 
 
 def test_pipenv_creation_error_message():

--- a/test/integration/tools/system/pip_manager_test.py
+++ b/test/integration/tools/system/pip_manager_test.py
@@ -1,0 +1,38 @@
+from conan.tools.system import PipEnv
+from unittest.mock import patch
+import mock
+import pytest
+from unittest.mock import PropertyMock
+from conan.errors import ConanException
+from conan.internal.model.settings import Settings
+from conan.test.utils.mocks import ConanFileMock
+
+
+def test_pipenv_conf():
+    # https://github.com/conan-io/conan/issues/11661
+    conanfile = ConanFileMock()
+    conanfile.settings = Settings()
+    conanfile.conf.define("tools.system.pipenv:python_interpreter", "/python/interpreter/from/config")
+    result = "/python/interpreter/from/config -m venv"
+    pipenv = PipEnv(conanfile, "testenv")
+
+    def fake_run(command, win_bash=False, subsystem=None, env=None, ignore_errors=False, quiet=False):
+        assert result in command
+        return 100
+    conanfile.run = fake_run
+    pipenv._create_venv()
+
+
+@patch('shutil.which')
+def test_pipenv_error_message(mock_shutil_which):
+    # https://github.com/conan-io/conan/issues/11661
+    conanfile = ConanFileMock()
+    conanfile.settings = Settings()
+    mock_shutil_which.return_value = None
+    with pytest.raises(ConanException) as exc_info:
+        pipenv = PipEnv(conanfile, "testenv")
+        pipenv._create_venv()
+    assert exc_info.value.args[0] == "PipEnv could not find a Python executable path." \
+                                     "Please set 'tools.system.pipenv:python_interpreter' to '</your/python/full/path>' " \
+                                     "in the [conf] section of the profile, or in the command line using " \
+                                     "'-c tools.system.pipenv:python_interpreter=</your/python/full/path>'"

--- a/test/integration/tools/system/pip_manager_test.py
+++ b/test/integration/tools/system/pip_manager_test.py
@@ -1,8 +1,6 @@
 from conan.tools.system import PipEnv
 from unittest.mock import patch
-import mock
 import pytest
-from unittest.mock import PropertyMock
 from conan.errors import ConanException
 from conan.internal.model.settings import Settings
 from conan.test.utils.mocks import ConanFileMock
@@ -10,7 +8,6 @@ from conan.test.utils.mocks import ConanFileMock
 
 @patch('shutil.which')
 def test_pipenv_conf(mock_shutil_which):
-    # https://github.com/conan-io/conan/issues/11661
     conanfile = ConanFileMock()
     conanfile.settings = Settings()
     mock_shutil_which.side_effect = Exception()
@@ -27,14 +24,26 @@ def test_pipenv_conf(mock_shutil_which):
 
 @patch('shutil.which')
 def test_pipenv_error_message(mock_shutil_which):
-    # https://github.com/conan-io/conan/issues/11661
     conanfile = ConanFileMock()
     conanfile.settings = Settings()
     mock_shutil_which.return_value = None
     with pytest.raises(ConanException) as exc_info:
         pipenv = PipEnv(conanfile, "testenv")
         pipenv._create_venv()
-    assert exc_info.value.args[0] == "PipEnv could not find a Python executable path." \
-                                     "Please set 'tools.system.pipenv:python_interpreter' to '</your/python/full/path>' " \
-                                     "in the [conf] section of the profile, or in the command line using " \
-                                     "'-c tools.system.pipenv:python_interpreter=</your/python/full/path>'"
+    assert exc_info.value.args[0] == "PipEnv could not find a Python executable path. " \
+                                     "Please, install Python system-wide or set the 'tools.system.pipenv:python_interpreter' " \
+                                     "conf to the full path of a Python executable"
+
+
+def test_pipenv_creation_error_message():
+    conanfile = ConanFileMock()
+    conanfile.settings = Settings()
+    conanfile.conf.define("tools.system.pipenv:python_interpreter", "/python/interpreter/from/config")
+    pipenv = PipEnv(conanfile, "testenv")
+
+    def fake_run(command, win_bash=False, subsystem=None, env=None, ignore_errors=False, quiet=False):
+        raise ConanException("fake error message")
+    conanfile.run = fake_run
+    with pytest.raises(ConanException) as exc_info:
+        pipenv._create_venv()
+    assert exc_info.value.args[0] == "PipEnv could not create a Python virtual environment using '/python/interpreter/from/config': fake error message"


### PR DESCRIPTION
Changelog: Fix: Improved Python virtual environment creation in ``PipEnv`` by using the system-installed interpreter or a user-defined one via ``tools.system.pipenv:python_interpreter``.
Docs: https://github.com/conan-io/docs/pull/4291

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
