### PR TITLE
allow nullifying settings from profiles and command line

### DIFF
--- a/conan/internal/api/profile/profile_loader.py
+++ b/conan/internal/api/profile/profile_loader.py
@@ -348,6 +348,8 @@ class _ProfileValueParser(object):
             result_name, result_value = item.split("=", 1)
             result_name = result_name.strip()
             result_value = _unquote(result_value)
+            if result_value == "@None@":
+                result_value = None
             return packagename, result_name, result_value
 
         package_settings = OrderedDict()
@@ -388,6 +390,8 @@ def _profile_parse_args(settings, options, conf):
         package_items = defaultdict(list)
         tuples = _get_tuples_list_from_extender_arg(items)
         for name, value in tuples:
+            if value == "@None@":
+                value = None
             if ":" in name:  # Scoped items
                 tmp = name.split(":", 1)
                 ref_name = tmp[0]

--- a/conan/internal/api/profile/profile_loader.py
+++ b/conan/internal/api/profile/profile_loader.py
@@ -348,7 +348,7 @@ class _ProfileValueParser(object):
             result_name, result_value = item.split("=", 1)
             result_name = result_name.strip()
             result_value = _unquote(result_value)
-            if result_value == "@None@":
+            if result_value == "~":  # Can be used to undefine an already defined setting
                 result_value = None
             return packagename, result_name, result_value
 
@@ -390,7 +390,7 @@ def _profile_parse_args(settings, options, conf):
         package_items = defaultdict(list)
         tuples = _get_tuples_list_from_extender_arg(items)
         for name, value in tuples:
-            if value == "@None@":
+            if value == "~":  # Can be used to undefine an already defined setting
                 value = None
             if ":" in name:  # Scoped items
                 tmp = name.split(":", 1)

--- a/test/integration/configuration/profile_test.py
+++ b/test/integration/configuration/profile_test.py
@@ -6,7 +6,6 @@ from collections import OrderedDict
 from textwrap import dedent
 
 import pytest
-from parameterized import parameterized
 
 from conan.internal.paths import CONANFILE
 from conan.test.assets.genconanfile import GenConanfile
@@ -645,3 +644,33 @@ def test_compose_numeric_values_scoped_pkg():
 
     tc.run("create . -pr=profile")
     assert "user.var.value: 10" in tc.out
+
+
+def test_nullify_settings():
+    c = TestClient()
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        class Pkg(ConanFile):
+            settings = "build_type"
+            def configure(self):
+                if not self.settings.build_type:
+                    self.output.info("BUILD TYPE NOT DEFINED!!!")
+                else:
+                    self.output.info(f"I am a {self.settings.build_type} pkg!!!")
+        """)
+    c.save({"conanfile.py": conanfile,
+            "profile": "[settings]\nbuild_type=Release\npkg1/*:build_type=@None@"})
+    c.run("create . --name=pkg1 --version=0.1")
+    c.run("create . --name=pkg2 --version=0.1")
+    c.run("create . --name=pkg3 --version=0.1")
+    c.save({"conanfile.py": GenConanfile().with_requires("pkg1/0.1", "pkg2/0.1", "pkg3/0.1")})
+
+    c.run("graph info . -s build_type=Release -s pkg1/*:build_type=@None@")
+    assert "pkg1/0.1: BUILD TYPE NOT DEFINED!!!" in c.out
+    assert "pkg2/0.1: I am a Release pkg!!!" in c.out
+    assert "pkg3/0.1: I am a Release pkg!!!" in c.out
+
+    c.run("graph info . -pr=profile")
+    assert "pkg1/0.1: BUILD TYPE NOT DEFINED!!!" in c.out
+    assert "pkg2/0.1: I am a Release pkg!!!" in c.out
+    assert "pkg3/0.1: I am a Release pkg!!!" in c.out

--- a/test/integration/configuration/profile_test.py
+++ b/test/integration/configuration/profile_test.py
@@ -659,13 +659,13 @@ def test_nullify_settings():
                     self.output.info(f"I am a {self.settings.build_type} pkg!!!")
         """)
     c.save({"conanfile.py": conanfile,
-            "profile": "[settings]\nbuild_type=Release\npkg1/*:build_type=@None@"})
+            "profile": "[settings]\nbuild_type=Release\npkg1/*:build_type=~"})
     c.run("create . --name=pkg1 --version=0.1")
     c.run("create . --name=pkg2 --version=0.1")
     c.run("create . --name=pkg3 --version=0.1")
     c.save({"conanfile.py": GenConanfile().with_requires("pkg1/0.1", "pkg2/0.1", "pkg3/0.1")})
 
-    c.run("graph info . -s build_type=Release -s pkg1/*:build_type=@None@")
+    c.run("graph info . -s build_type=Release -s pkg1/*:build_type=~")
     assert "pkg1/0.1: BUILD TYPE NOT DEFINED!!!" in c.out
     assert "pkg2/0.1: I am a Release pkg!!!" in c.out
     assert "pkg3/0.1: I am a Release pkg!!!" in c.out


### PR DESCRIPTION
Changelog: Feature: Allow nullifying settings from profiles and command line.
Docs: https://github.com/conan-io/docs/pull/4285

Close https://github.com/conan-io/conan/issues/18968
Related to https://github.com/conan-io/conan/pull/19031

We have agreed to use the already existing negation syntax ``~`` as value.

At the moment we will not implement the same for options, as options are already per-package, we didn't find a case for it, so we will better wait for users requests for it.



