### PR TITLE
Fix conflict with recipe-revision and test with <host_version> and user/channel

### DIFF
--- a/conan/internal/graph/graph_builder.py
+++ b/conan/internal/graph/graph_builder.py
@@ -1,5 +1,3 @@
-import copy
-
 from collections import deque
 
 from conan.internal.cache.conan_reference_layout import BasicLayout
@@ -135,6 +133,7 @@ class DepsGraphBuilder:
     @staticmethod
     def _conflicting_version(require, node,
                              prev_require, prev_node, prev_ref, base_previous, resolve_prereleases):
+        # As we are closing a diamond, there can be conflicts. This will raise if so
         version_range = require.version_range
         prev_version_range = prev_require.version_range if prev_node is None else None
         if version_range:
@@ -154,27 +153,11 @@ class DepsGraphBuilder:
                     raise GraphConflictError(node, require, prev_node, prev_require, base_previous)
         elif prev_version_range is not None:
             if require.ref.user != prev_require.ref.user or \
-                    require.ref.channel != prev_require.ref.channel:
-                raise GraphConflictError(node, require, prev_node, prev_require, base_previous)
-            if not prev_version_range.contains(require.ref.version, resolve_prereleases):
+                    require.ref.channel != prev_require.ref.channel or \
+                    not prev_version_range.contains(require.ref.version, resolve_prereleases):
                 raise GraphConflictError(node, require, prev_node, prev_require, base_previous)
         else:
-            def _conflicting_refs(ref1, ref2):
-                ref1_norev = copy.copy(ref1)
-                ref1_norev.revision = None
-                ref2_norev = copy.copy(ref2)
-                ref2_norev.revision = None
-                if ref2_norev != ref1_norev:
-                    return True
-                # Computed node, if is Editable, has revision=None
-                # If new_ref.revision is None we cannot assume any conflict, user hasn't specified
-                # a revision, so it's ok any previous_ref
-                if ref1.revision and ref2.revision and ref1.revision != ref2.revision:
-                    return True
-
-            # As we are closing a diamond, there can be conflicts. This will raise if so
-            conflict = _conflicting_refs(prev_ref, require.ref)
-            if conflict:  # It is possible to get conflict from alias, try to resolve it
+            if prev_ref != require.ref:
                 raise GraphConflictError(node, require, prev_node, prev_require, base_previous)
             # If there is no conflict, then the incomplete require without revision can be updated
             # with the previous revision to avoid the later conflict

--- a/conan/internal/graph/graph_builder.py
+++ b/conan/internal/graph/graph_builder.py
@@ -176,6 +176,10 @@ class DepsGraphBuilder:
             conflict = _conflicting_refs(prev_ref, require.ref)
             if conflict:  # It is possible to get conflict from alias, try to resolve it
                 raise GraphConflictError(node, require, prev_node, prev_require, base_previous)
+            # If there is no conflict, then the incomplete require without revision can be updated
+            # with the previous revision to avoid the later conflict
+            if prev_ref.revision is not None and require.ref.revision is None:
+                require.ref.revision = prev_ref.revision
 
     @staticmethod
     def _prepare_node(node, profile_host, profile_build, down_options, define_consumers=False):

--- a/test/integration/build_requires/build_requires_test.py
+++ b/test/integration/build_requires/build_requires_test.py
@@ -565,6 +565,54 @@ class TestBuildTrackHost:
         else:
             assert "pkg/0.1: Package '39f6a091994d2d080081ea888d75ef65c1d04c8d' created" in c.out
 
+    def test_user_channel_error(self):
+        lib = textwrap.dedent("""
+           from conan import ConanFile
+           class LibWithToolConan(ConanFile):
+               name = "lib_with_tool"
+               package_type = "static-library"
+               settings = "os", "arch"
+               # {}
+           """)
+        c = TestClient(default_server_user=True)
+        c.save({"conanfile.py": lib.format(1)})
+        c.run("create . --version 1.0.0 --user foobar")
+        c.save({"conanfile.py": lib.format(2)})
+        c.run("create . --version 1.1.0 --user foobar")
+        rev1 = c.exported_recipe_revision()
+        c.save({"conanfile.py": lib.format(3)})
+        c.run("create . --version 1.1.0 --user foobar")
+        rev2 = c.exported_recipe_revision()
+        assert rev1 != rev2
+
+        c.run(f"upload lib_with_tool/1.1.0@foobar#{rev2} -r=default")
+        c.run(f"remove lib_with_tool/1.1.0@foobar#{rev2} -c")
+
+        dep = textwrap.dedent("""
+           from conan import ConanFile
+           class DepLibConan(ConanFile):
+               name = "dep_lib"
+
+               package_type = "static-library"
+               settings = "os", "arch"
+
+               def build_requirements(self):
+                   self.tool_requires("lib_with_tool/<host_version>@foobar")
+
+               def requirements(self):
+                   self.requires("lib_with_tool/[>=1]@foobar")
+           """)
+        c.save({"conanfile.py": dep}, clean_first=True)
+        c.run("create . --version=1.0.0 --user=foobar")
+
+        conanfile = textwrap.dedent(f"""
+            [requires]
+            dep_lib/1.0.0@foobar
+            lib_with_tool/1.1.0@foobar#{rev2}
+            """)
+        c.save({"conanfile.txt": conanfile}, clean_first=True)
+        c.run("install .")
+
 
 def test_build_missing_build_requires():
     c = TestClient(light=True)

--- a/test/integration/build_requires/build_requires_test.py
+++ b/test/integration/build_requires/build_requires_test.py
@@ -600,7 +600,7 @@ class TestBuildTrackHost:
                    self.tool_requires("lib_with_tool/<host_version>@foobar")
 
                def requirements(self):
-                   self.requires("lib_with_tool/[>=1]@foobar")
+                   self.requires("lib_with_tool/1.1.0@foobar")
            """)
         c.save({"conanfile.py": dep}, clean_first=True)
         c.run("create . --version=1.0.0 --user=foobar")
@@ -612,6 +612,7 @@ class TestBuildTrackHost:
             """)
         c.save({"conanfile.txt": conanfile}, clean_first=True)
         c.run("install .")
+        # No longer produces a conflict
 
 
 def test_build_missing_build_requires():


### PR DESCRIPTION
Changelog: Bugfix: Solve unexpected conflict when pinning a ``recipe-revision`` directly in a conanfile that is not the latest, and having other dependencies resolving first to the latest recipe revision.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19029