### PR TITLE
Add new environment variable CONAN_DEFAULT_BUILD_PROFILE for default build profile

### DIFF
--- a/conan/api/subapi/profiles.py
+++ b/conan/api/subapi/profiles.py
@@ -43,7 +43,7 @@ class ProfilesAPI:
         :return: the path to the default "build" profile, either in the cache or as
             defined by the user in configuration
         """
-        default_profile = os.environ.get("CONAN_DEFAULT_PROFILE")
+        default_profile = os.environ.get("CONAN_DEFAULT_PROFILE_BUILD")
         if default_profile is None:
             global_conf = self._api_helpers.global_conf
             default_profile = global_conf.get("core:default_build_profile",

--- a/conan/api/subapi/profiles.py
+++ b/conan/api/subapi/profiles.py
@@ -43,8 +43,11 @@ class ProfilesAPI:
         :return: the path to the default "build" profile, either in the cache or as
             defined by the user in configuration
         """
-        global_conf = self._api_helpers.global_conf
-        default_profile = global_conf.get("core:default_build_profile", default=DEFAULT_PROFILE_NAME)
+        default_profile = os.environ.get("CONAN_DEFAULT_PROFILE")
+        if default_profile is None:
+            global_conf = self._api_helpers.global_conf
+            default_profile = global_conf.get("core:default_build_profile",
+                                              default=DEFAULT_PROFILE_NAME)
         default_profile = os.path.join(self._home_paths.profiles_path, default_profile)
         if not os.path.exists(default_profile):
             msg = ("The default build profile '{}' doesn't exist.\n"

--- a/conan/api/subapi/profiles.py
+++ b/conan/api/subapi/profiles.py
@@ -43,7 +43,7 @@ class ProfilesAPI:
         :return: the path to the default "build" profile, either in the cache or as
             defined by the user in configuration
         """
-        default_profile = os.environ.get("CONAN_DEFAULT_PROFILE_BUILD")
+        default_profile = os.environ.get("CONAN_DEFAULT_BUILD_PROFILE")
         if default_profile is None:
             global_conf = self._api_helpers.global_conf
             default_profile = global_conf.get("core:default_build_profile",

--- a/conan/cli/commands/profile.py
+++ b/conan/cli/commands/profile.py
@@ -10,10 +10,10 @@ from conan.errors import ConanException
 
 def _print_profiles(profiles):
     if "host" in profiles:
-        cli_out_write("Host profile:")
+        ConanOutput().info("Host profile:")
         cli_out_write(profiles["host"].dumps())
     if "build" in profiles:
-        cli_out_write("Build profile:")
+        ConanOutput().info("Build profile:")
         cli_out_write(profiles["build"].dumps())
 
 

--- a/conan/cli/commands/profile.py
+++ b/conan/cli/commands/profile.py
@@ -10,10 +10,10 @@ from conan.errors import ConanException
 
 def _print_profiles(profiles):
     if "host" in profiles:
-        ConanOutput().info("Host profile:")
+        cli_out_write("Host profile:")
         cli_out_write(profiles["host"].dumps())
     if "build" in profiles:
-        ConanOutput().info("Build profile:")
+        cli_out_write("Build profile:")
         cli_out_write(profiles["build"].dumps())
 
 

--- a/test/integration/configuration/default_profile_test.py
+++ b/test/integration/configuration/default_profile_test.py
@@ -145,24 +145,13 @@ class MyConanfile(ConanFile):
 
     def test_default_profile(self):
         c = TestClient()
-        c.save_home({"profiles/default": "broken\nprofile\n"})  # Broken one would fail if used
-
         # Test with a profile set using and environment variable
         tmp = temp_folder()
         profile = os.path.join(tmp, 'myprofile')
         save(profile, "[settings]\nos=FreeBSD\n")
-        with environment_update({'CONAN_DEFAULT_PROFILE': profile}):
+        with environment_update({'CONAN_DEFAULT_PROFILE_BUILD': profile}):
             c.run("profile show")
-            expected = textwrap.dedent("""\
-                Host profile:
-                [settings]
-                os=FreeBSD
-
-                Build profile:
-                [settings]
-                os=FreeBSD
-                """)
-            assert expected in c.out
+            assert "os=FreeBSD" in c.out  # build profiles
 
 
 def test_conf_default_two_profiles():

--- a/test/integration/configuration/default_profile_test.py
+++ b/test/integration/configuration/default_profile_test.py
@@ -149,7 +149,7 @@ class MyConanfile(ConanFile):
         tmp = temp_folder()
         profile = os.path.join(tmp, 'myprofile')
         save(profile, "[settings]\nos=FreeBSD\n")
-        with environment_update({'CONAN_DEFAULT_PROFILE_BUILD': profile}):
+        with environment_update({'CONAN_DEFAULT_BUILD_PROFILE': profile}):
             c.run("profile show")
             assert "os=FreeBSD" in c.out  # build profiles
 

--- a/test/integration/configuration/default_profile_test.py
+++ b/test/integration/configuration/default_profile_test.py
@@ -143,6 +143,27 @@ class MyConanfile(ConanFile):
                        assert_error=True)
             assert "You need to create a default profile" in client.out
 
+    def test_default_profile(self):
+        c = TestClient()
+        c.save_home({"profiles/default": "broken\nprofile\n"})  # Broken one would fail if used
+
+        # Test with a profile set using and environment variable
+        tmp = temp_folder()
+        profile = os.path.join(tmp, 'myprofile')
+        save(profile, "[settings]\nos=FreeBSD\n")
+        with environment_update({'CONAN_DEFAULT_PROFILE': profile}):
+            c.run("profile show")
+            expected = textwrap.dedent("""\
+                Host profile:
+                [settings]
+                os=FreeBSD
+
+                Build profile:
+                [settings]
+                os=FreeBSD
+                """)
+            assert expected in c.out
+
 
 def test_conf_default_two_profiles():
     client = TestClient()


### PR DESCRIPTION
Changelog: Feature: Add new environment variable `CONAN_DEFAULT_BUILD_PROFILE` for default build profile.
Docs: https://github.com/conan-io/docs/pull/4284

Close https://github.com/conan-io/conan/issues/19039