### PR TITLE
Add newline to the lockfile

### DIFF
--- a/conan/internal/model/lockfile.py
+++ b/conan/internal/model/lockfile.py
@@ -176,7 +176,7 @@ class Lockfile(object):
         return json.dumps(self.serialize(), indent=4)
 
     def save(self, path):
-        save(path, self.dumps())
+        save(path, self.dumps() + "\n")
 
     def merge(self, other):
         """


### PR DESCRIPTION
Changelog: Fix: Add missing final newline when saving lockfiles to disk.
Docs: Omit


Not having a newline in the end of file is not nice, and many code editors add it automatically, while some don't.
It also doesn't look nice in GitHub PRs.


- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
