### PR TITLE
fix: 🐛 Fix unittests to support Python 3.14

### DIFF
--- a/test/unittests/tools/files/test_downloads.py
+++ b/test/unittests/tools/files/test_downloads.py
@@ -156,7 +156,8 @@ class TestDownload:
         file_location = os.path.join(temp_folder(), "file.txt")
         save(file_location, "this is some content")
 
-        file_url = f"file:///{file_location.lstrip("/")}"
+        file_location = file_location.lstrip("/")
+        file_url = f"file:///{file_location}"
         file_md5 = "736db904ad222bf88ee6b8d103fceb8e"
 
         dest = os.path.join(temp_folder(), "downloaded_file.txt")

--- a/test/unittests/tools/files/test_downloads.py
+++ b/test/unittests/tools/files/test_downloads.py
@@ -156,7 +156,7 @@ class TestDownload:
         file_location = os.path.join(temp_folder(), "file.txt")
         save(file_location, "this is some content")
 
-        file_url = f"file://{file_location}"
+        file_url = f"file:///{file_location.lstrip("/")}"
         file_md5 = "736db904ad222bf88ee6b8d103fceb8e"
 
         dest = os.path.join(temp_folder(), "downloaded_file.txt")

--- a/test/unittests/tools/files/test_downloads.py
+++ b/test/unittests/tools/files/test_downloads.py
@@ -156,7 +156,7 @@ class TestDownload:
         file_location = os.path.join(temp_folder(), "file.txt")
         save(file_location, "this is some content")
 
-        file_url = f"file:///{file_location}"
+        file_url = f"file://{file_location}"
         file_md5 = "736db904ad222bf88ee6b8d103fceb8e"
 
         dest = os.path.join(temp_folder(), "downloaded_file.txt")


### PR DESCRIPTION
In Python 3.14, the behavior of `urllib.request.url2pathname()` has been tightened. Previously, it was more permissive and would allow `file://` URIs with extra slashes. Now, only local file URIs are supported (i.e. with at most three slashes), such as: `file:///my/absolute/path`

What’s happening in our tests:

We are constructing URIs like `file:///{file_location}`, where `{file_location}` is already an absolute path. That ends up producing something like:

`file:////private/var/.../file.txt`

Because of the extra slash, Python 3.14 rejects it. During URI parsing, it splits out file: + //, then sees a non-empty “authority” part, and since that authority is not localhost, it errors out.

---

#### Extra information

Python <3.14 `requests` version:
```py
    def url2pathname(pathname):
        """OS-specific conversion from a relative URL of the 'file' scheme
        to a file system path; not recommended for general use."""
        breakpoint()
        if pathname[:3] == '///':
            # URL has an empty authority section, so the path begins on the
            # third character.
            pathname = pathname[2:]
        elif pathname[:12] == '//localhost/':
            # Skip past 'localhost' authority.
            pathname = pathname[11:]
        encoding = sys.getfilesystemencoding()
        errors = sys.getfilesystemencodeerrors()
        return unquote(pathname, encoding=encoding, errors=errors)
```

Python 3.14 `requests` version:

```py
def url2pathname(url, *, require_scheme=False, resolve_host=False):
    """Convert the given file URL to a local file system path.

    The 'file:' scheme prefix must be omitted unless *require_scheme*
    is set to true.

    The URL authority may be resolved with gethostbyname() if
    *resolve_host* is set to true.
    """
    if not require_scheme:
        url = 'file:' + url
    scheme, authority, url = urlsplit(url)[:3]  # Discard query and fragment.
    if scheme != 'file':
        raise URLError("URL is missing a 'file:' scheme")
    if os.name == 'nt':
        if authority[1:2] == ':':
            # e.g. file://c:/file.txt
            url = authority + url
        elif not _is_local_authority(authority, resolve_host):
            # e.g. file://server/share/file.txt
            url = '//' + authority + url
        elif url[:3] == '///':
            # e.g. file://///server/share/file.txt
            url = url[1:]
        else:
            if url[:1] == '/' and url[2:3] in (':', '|'):
                # Skip past extra slash before DOS drive in URL path.
                url = url[1:]
            if url[1:2] == '|':
                # Older URLs use a pipe after a drive letter
                url = url[:1] + ':' + url[2:]
        url = url.replace('/', '\\')
    elif not _is_local_authority(authority, resolve_host):
        raise URLError("file:// scheme is supported only on localhost")
    encoding = sys.getfilesystemencoding()
    errors = sys.getfilesystemencodeerrors()
    return unquote(url, encoding=encoding, errors=errors)
```


Changelog: omit
Docs: omit
