### PR TITLE
Fix CMakeConfigDeps case when a regular library requires an application

### DIFF
--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -87,6 +87,8 @@ class TargetConfigurationTemplate2:
                                    f"'{required_pkg}::{required_comp}' but component "
                                    f"'{required_comp}' not found in {required_pkg}")
                             raise ConanException(msg)
+                        if dep.package_type is PackageType.APP:
+                            continue  # It doesn't make sense to link a package that is an App
                         comp = None
                         default_target = f"{dep.ref.name}::{dep.ref.name}"  # replace_requires
                         link = pkg_type is not PackageType.SHARED

--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -93,6 +93,8 @@ class TargetConfigurationTemplate2:
                         default_target = f"{dep.ref.name}::{dep.ref.name}"  # replace_requires
                         link = pkg_type is not PackageType.SHARED
                     else:
+                        if dep_comp.type is PackageType.APP or dep_comp.exe:
+                            continue  # It doesn't make sense to link a package that is an App
                         comp = required_comp
                         default_target = f"{required_pkg}::{required_comp}"
                         link = not (pkg_type is PackageType.SHARED and

--- a/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
@@ -485,6 +485,43 @@ class TestRequiresToApp:
         # The libtool shouldn't depend on the automake::automake target
         assert "automake::automake" not in targets
 
+    def test_requires_from_library_component_to_app_component(self):
+        c = TestClient()
+        automake = textwrap.dedent("""
+            from conan import ConanFile
+            class Dependent(ConanFile):
+                name = "automake"
+                version = "0.1"
+
+                def package_info(self):
+                    self.cpp_info.components["myapp"].exe = "myapp"
+                    self.cpp_info.components["myapp"].location = "path/to/myapp"
+                    self.cpp_info.components["mylibapp"].type = "header-library"
+            """)
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            class Pkg(ConanFile):
+                name = "libtool"
+                version = "0.1"
+                package_type = "static-library"
+
+                def requirements(self):
+                    self.requires('automake/0.1')
+                def package_info(self):
+                    self.cpp_info.components["mycomp"].requires = ["automake::myapp"]
+            """)
+
+        c.save({"automake/conanfile.py": automake,
+                "libtool/conanfile.py": conanfile})
+        c.run("create automake")
+        c.run("create libtool")
+        c.run("install --requires=libtool/0.1 -g CMakeDeps "
+              f"-c tools.cmake.cmakedeps:new={new_value}")
+        targets = c.load("libtool-Targets-release.cmake")
+        # The libtool shouldn't depend on the automake::automake target
+        assert "automake::myapp" not in targets
+        assert "automake::automake" not in targets
+
 
 
 def test_alias_cmakedeps_set_property():

--- a/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
@@ -388,103 +388,103 @@ def test_cmake_find_mode_deprecated():
     assert "CMakeConfigDeps does not support module find mode"
 
 
-def test_requires_to_application():
-    c = TestClient()
-    automake = textwrap.dedent("""
-        from conan import ConanFile
-        class Dependent(ConanFile):
-            name = "automake"
-            version = "0.1"
-            package_type = "application"
-        """)
+class TestRequiresToApp:
+    def test_requires_to_application(self):
+        c = TestClient()
+        automake = GenConanfile("automake", "0.1").with_package_type("application")
+        conanfile = (GenConanfile("libtool", "0.1").with_package_type("static-library")
+                                                   .with_requirement("automake/0.1"))
+        test_package = textwrap.dedent("""
+            from conan import ConanFile
+            from conan.tools.cmake import CMake
 
-    conanfile = textwrap.dedent("""
-        from conan import ConanFile
-        class Pkg(ConanFile):
-            name = "libtool"
-            version = "0.1"
-            package_type = "static-library"
+            class TestPkg(ConanFile):
+                settings = "os", "compiler", "arch", "build_type"
+                generators = "CMakeDeps", "CMakeToolchain"
 
-            def requirements(self):
-                self.requires('automake/0.1')
-        """)
-    test_package = textwrap.dedent("""
-        from conan import ConanFile
-        from conan.tools.cmake import CMake
+                def requirements(self):
+                    self.requires(self.tested_reference_str)
 
-        class TestPkg(ConanFile):
-            settings = "os", "compiler", "arch", "build_type"
-            generators = "CMakeDeps", "CMakeToolchain"
+                def test(self):
+                    pass
+            """)
 
-            def requirements(self):
-                self.requires(self.tested_reference_str)
+        c.save({"automake/conanfile.py": automake,
+                "libtool/conanfile.py": conanfile,
+                "libtool/test_package/conanfile.py": test_package})
+        c.run("create automake")
+        c.run(f"create libtool -c tools.cmake.cmakedeps:new={new_value}")
+        targets = c.load("libtool/test_package/libtool-Targets-release.cmake")
+        # The libtool shouldn't depend on the automake::automake target
+        assert "automake::automake" not in targets
 
-            def test(self):
-                pass
-        """)
+    def test_requires_to_application_component(self):
+        c = TestClient()
+        automake = textwrap.dedent("""
+            from conan import ConanFile
+            class Dependent(ConanFile):
+                name = "automake"
+                version = "0.1"
+                package_type = "application"
 
-    c.save({"automake/conanfile.py": automake,
-            "libtool/conanfile.py": conanfile,
-            "libtool/test_package/conanfile.py": test_package})
-    c.run("create automake")
-    c.run(f"create libtool -c tools.cmake.cmakedeps:new={new_value}")
-    targets = c.load("libtool/test_package/libtool-Targets-release.cmake")
-    # The libtool shouldn't depend on the automake::automake target
-    assert "automake::automake" not in targets
+                def package_info(self):
+                    self.cpp_info.components["myapp"].exe = "myapp"
+                    self.cpp_info.components["myapp"].location = "path/to/myapp"
+                    self.cpp_info.components["mylibapp"].type = "header-library"
+            """)
 
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            class Pkg(ConanFile):
+                name = "libtool"
+                version = "0.1"
+                package_type = "static-library"
 
-def test_requires_to_application_component():
-    c = TestClient()
-    automake = textwrap.dedent("""
-        from conan import ConanFile
-        class Dependent(ConanFile):
-            name = "automake"
-            version = "0.1"
-            package_type = "application"
+                def requirements(self):
+                    self.requires('automake/0.1')
+                def package_info(self):
+                    self.cpp_info.requires = ["automake::mylibapp"]
+            """)
 
-            def package_info(self):
-                self.cpp_info.components["myapp"].exe = "myapp"
-                self.cpp_info.components["myapp"].location = "path/to/myapp"
-                self.cpp_info.components["mylibapp"].type = "header-library"
-        """)
+        c.save({"automake/conanfile.py": automake,
+                "libtool/conanfile.py": conanfile})
+        c.run("create automake")
 
-    conanfile = textwrap.dedent("""
-        from conan import ConanFile
-        class Pkg(ConanFile):
-            name = "libtool"
-            version = "0.1"
-            package_type = "static-library"
+        c.run("create libtool")
+        c.run("install --requires=libtool/0.1 -g CMakeDeps "
+              f"-c tools.cmake.cmakedeps:new={new_value}")
+        targets = c.load("libtool-Targets-release.cmake")
+        # The libtool shouldn't depend on the automake::automake target
+        assert "automake::automake" not in targets
+        assert "# Requirement automake::mylibapp => Full link: True" in targets
+        assert "$<$<CONFIG:RELEASE>:automake::mylibapp>" in targets
 
-            def requirements(self):
-                self.requires('automake/0.1')
-            def package_info(self):
-                self.cpp_info.requires = ["automake::mylibapp"]
-        """)
-    test_package = textwrap.dedent("""
-        from conan import ConanFile
-        from conan.tools.cmake import CMake
+    def test_requires_from_library_component(self):
+        c = TestClient()
+        automake = GenConanfile("automake", "0.1").with_package_type("application")
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            class Pkg(ConanFile):
+                name = "libtool"
+                version = "0.1"
+                package_type = "static-library"
 
-        class TestPkg(ConanFile):
-            settings = "os", "compiler", "arch", "build_type"
-            generators = "CMakeDeps", "CMakeToolchain"
+                def requirements(self):
+                    self.requires('automake/0.1')
+                def package_info(self):
+                    self.cpp_info.components["mycomp"].requires = ["automake::automake"]
+            """)
 
-            def requirements(self):
-                self.requires(self.tested_reference_str)
+        c.save({"automake/conanfile.py": automake,
+                "libtool/conanfile.py": conanfile})
+        c.run("create automake")
+        c.run("create libtool")
+        c.run("install --requires=libtool/0.1 -g CMakeDeps "
+              f"-c tools.cmake.cmakedeps:new={new_value}")
+        targets = c.load("libtool-Targets-release.cmake")
+        # The libtool shouldn't depend on the automake::automake target
+        assert "automake::automake" not in targets
 
-            def test(self):
-                pass
-        """)
-
-    c.save({"automake/conanfile.py": automake,
-            "libtool/conanfile.py": conanfile,
-            "libtool/test_package/conanfile.py": test_package})
-    c.run("create automake")
-    c.run(f"create libtool -c tools.cmake.cmakedeps:new={new_value}")
-    targets = c.load("libtool/test_package/libtool-Targets-release.cmake")
-    # The libtool shouldn't depend on the automake::automake target
-    assert "automake::automake" not in targets
-    assert "# Requirement automake::mylibapp => Full link: True" in targets
-    assert "$<$<CONFIG:RELEASE>:automake::mylibapp>" in targets
 
 
 def test_alias_cmakedeps_set_property():


### PR DESCRIPTION
Changelog: Fix: Fix ``CMakeConfigDeps`` when a regular library ``requires()`` an application, using components.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19042