### PR TITLE
[BazelDeps] glob() compatible with bazel 8.x

### DIFF
--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -64,7 +64,9 @@ class _BazelDepBuildGenerator:
             {% for header in obj["headers"] %}
             {{ header }},
             {% endfor %}
-        ]),
+        ],
+        allow_empty = True
+        ),
         {% endif %}
         {% if obj["includes"] %}
         includes = [

--- a/test/functional/toolchains/google/test_bazel.py
+++ b/test/functional/toolchains/google/test_bazel.py
@@ -3,6 +3,7 @@ import textwrap
 
 import pytest
 
+from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.test_files import temp_folder
 from conan.test.utils.tools import TestClient
 
@@ -341,3 +342,44 @@ def test_transitive_libs_consuming_7x(shared, bazel_output_root_dir):
         client.run(f"create . -o '*:shared={shared}'")
         assert "mysecondlib() First define MY_VALUE and other define 2" in client.out
         assert "myfirstlib/1.2.11: Hello World Release!"
+
+
+@pytest.mark.tool("bazel", "8.0.0")
+def test_empty_bazel_query():
+    """
+    Test that following a simple steps using the BazelDeps and running
+    a global `bazel query //...` runs OK (bazel >= 8.0)
+
+    Issue related: https://github.com/conan-io/conan/issues/18743
+    """
+    zlib = GenConanfile("zlib", "0.1")
+    consumer = textwrap.dedent("""
+    from conan import ConanFile
+    from conan.tools.google import BazelDeps, bazel_layout
+
+    class App(ConanFile):
+        settings = "os", "arch", "compiler", "build_type"
+        requires = "zlib/0.1"
+
+        def layout(self):
+            bazel_layout(self)
+
+        def generate(self):
+            bz = BazelDeps(self)
+            bz.generate()
+    """)
+    module = textwrap.dedent("""\
+    load_conan_dependencies = use_extension("//conan:conan_deps_module_extension.bzl", "conan_extension")
+    use_repo(load_conan_dependencies, "zlib")
+    """)
+    client = TestClient()
+    client.save({
+        "zlib/conanfile.py": zlib,
+        "consumer/conanfile.py": consumer,
+        "consumer/MODULE.bazel": module,
+    })
+    client.run("create zlib")
+    client.run("install consumer")
+    with client.chdir("consumer"):
+        client.run_command("bazel query //...")
+    assert "INFO: Empty results" in client.out

--- a/test/functional/toolchains/google/test_bazel.py
+++ b/test/functional/toolchains/google/test_bazel.py
@@ -382,4 +382,5 @@ def test_empty_bazel_query():
     client.run("install consumer")
     with client.chdir("consumer"):
         client.run_command("bazel query //...")
-    assert "INFO: Empty results" in client.out
+    assert "//conan/zlib:zlib" in client.out
+    assert "//conan/zlib:zlib_binaries" in client.out

--- a/test/integration/toolchains/google/test_bazeldeps.py
+++ b/test/integration/toolchains/google/test_bazeldeps.py
@@ -67,7 +67,9 @@ def test_bazel_relative_paths():
         name = "dep",
         hdrs = glob([
             "include/**",
-        ]),
+        ],
+        allow_empty = True
+        ),
         includes = [
             "include",
         ],
@@ -168,7 +170,9 @@ def test_bazeldeps_and_tool_requires():
         name = "dep",
         hdrs = glob([
             "include/**",
-        ]),
+        ],
+        allow_empty = True
+        ),
         includes = [
             "include",
         ],
@@ -273,7 +277,9 @@ def test_pkg_with_public_deps_and_component_requires():
         name = "third",
         hdrs = glob([
             "include/**",
-        ]),
+        ],
+        allow_empty = True
+        ),
         includes = [
             "include",
         ],
@@ -291,7 +297,9 @@ def test_pkg_with_public_deps_and_component_requires():
         name = "second-mycomponent",
         hdrs = glob([
             "include/**",
-        ]),
+        ],
+        allow_empty = True
+        ),
         includes = [
             "include",
         ],
@@ -306,7 +314,9 @@ def test_pkg_with_public_deps_and_component_requires():
         name = "second-myfirstcomp",
         hdrs = glob([
             "include/**",
-        ]),
+        ],
+        allow_empty = True
+        ),
         includes = [
             "include",
         ],
@@ -322,7 +332,9 @@ def test_pkg_with_public_deps_and_component_requires():
         name = "second",
         hdrs = glob([
             "include/**",
-        ]),
+        ],
+        allow_empty = True
+        ),
         includes = [
             "include",
         ],
@@ -349,7 +361,9 @@ def test_pkg_with_public_deps_and_component_requires():
         name = "myfirstlib-cmp1",
         hdrs = glob([
             "include/**",
-        ]),
+        ],
+        allow_empty = True
+        ),
         includes = [
             "include",
         ],
@@ -365,7 +379,9 @@ def test_pkg_with_public_deps_and_component_requires():
         name = "myfirstlib",
         hdrs = glob([
             "include/**",
-        ]),
+        ],
+        allow_empty = True
+        ),
         includes = [
             "include",
         ],
@@ -451,7 +467,9 @@ def test_pkg_with_public_deps_and_component_requires_2():
         name = "pkg",
         hdrs = glob([
             "include/**",
-        ]),
+        ],
+        allow_empty = True
+        ),
         includes = [
             "include",
         ],
@@ -482,7 +500,9 @@ def test_pkg_with_public_deps_and_component_requires_2():
         name = "component1",
         hdrs = glob([
             "include/**",
-        ]),
+        ],
+        allow_empty = True
+        ),
         includes = [
             "include",
         ],
@@ -497,7 +517,9 @@ def test_pkg_with_public_deps_and_component_requires_2():
         name = "fancy_name-cmp2",
         hdrs = glob([
             "include/**",
-        ]),
+        ],
+        allow_empty = True
+        ),
         includes = [
             "include",
         ],
@@ -512,7 +534,9 @@ def test_pkg_with_public_deps_and_component_requires_2():
         name = "component3",
         hdrs = glob([
             "include/**",
-        ]),
+        ],
+        allow_empty = True
+        ),
         includes = [
             "include",
         ],
@@ -528,7 +552,9 @@ def test_pkg_with_public_deps_and_component_requires_2():
         name = "fancy_name",
         hdrs = glob([
             "include/**",
-        ]),
+        ],
+        allow_empty = True
+        ),
         includes = [
             "include",
         ],
@@ -591,7 +617,9 @@ def test_pkgconfigdeps_with_test_requires():
         name = "{0}",
         hdrs = glob([
             "include/**",
-        ]),
+        ],
+        allow_empty = True
+        ),
         includes = [
             "include",
         ],
@@ -667,7 +695,9 @@ def test_with_editable_layout():
             name = "dep",
             hdrs = glob([
                 "include/**",
-            ]),
+            ],
+            allow_empty = True
+            ),
             includes = [
                 "include",
             ],
@@ -765,7 +795,9 @@ def test_tool_requires():
         name = "component1",
         hdrs = glob([
             "include/**",
-        ]),
+        ],
+        allow_empty = True
+        ),
         includes = [
             "include",
         ],
@@ -780,7 +812,9 @@ def test_tool_requires():
         name = "libother-cmp2",
         hdrs = glob([
             "include/**",
-        ]),
+        ],
+        allow_empty = True
+        ),
         includes = [
             "include",
         ],
@@ -795,7 +829,9 @@ def test_tool_requires():
         name = "component3",
         hdrs = glob([
             "include/**",
-        ]),
+        ],
+        allow_empty = True
+        ),
         includes = [
             "include",
         ],
@@ -811,7 +847,9 @@ def test_tool_requires():
         name = "libother",
         hdrs = glob([
             "include/**",
-        ]),
+        ],
+        allow_empty = True
+        ),
         includes = [
             "include",
         ],
@@ -1248,7 +1286,9 @@ def test_pkg_with_duplicated_component_requires():
         name = "mylib-myfirstcomp",
         hdrs = glob([
             "include/**",
-        ]),
+        ],
+        allow_empty = True
+        ),
         includes = [
             "include",
         ],
@@ -1289,7 +1329,9 @@ def test_apple_frameworks_and_frameworkdirs():
         name = "mylib",
         hdrs = glob([
             "include/**",
-        ]),
+        ],
+        allow_empty = True
+        ),
         includes = [
             "include",
         ],


### PR DESCRIPTION
Changelog: Fix: Explicitly set ``allow_empty=True`` in ``glob()`` function in ``BazelDeps`` (Bazel 8.x compatible).
Docs: omit
Closes: https://github.com/conan-io/conan/issues/18743
Original PR: https://github.com/conan-io/conan/pull/17444 (I most likely missed this glob)


**Rationale**

This bug appears only when Bazel tries to evaluate the generated packages themselves, for instance:

```bash
bazel query //...
```

Or similar commands that pass through all visible packages recursively.

Most Conan + Bazel users don’t do that as they typically import the dependencies indirectly.
However, starting in Bazel 7 and especially 8:

* Stricter enforcement of `allow_empty = False` in `glob()`.
* More robust detection of local vs. external package roots.

So what may have been silently ignored or warned in Bazel 6 now fails hard in Bazel 8.x.

For the record, another possible solution:

* Using `<pkg>.BUILD` (works fine, just not "official" solution).
