### PR TITLE
Sanitize XcodeDeps variable names to use only valid xcconfig characters

### DIFF
--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -1,4 +1,5 @@
 import os
+import re
 import textwrap
 from collections import OrderedDict
 
@@ -20,8 +21,7 @@ GLOBAL_XCCONFIG_FILENAME = "conan_config.xcconfig"
 
 
 def _format_name(name):
-    name = name.replace(".", "_").replace("-", "_")
-    return name.lower()
+    return re.sub(r'[^A-Za-z0-9_]', '_', name).lower()
 
 
 def _xcconfig_settings_filename(settings, configuration):

--- a/test/functional/toolchains/apple/test_xcodedeps_components.py
+++ b/test/functional/toolchains/apple/test_xcodedeps_components.py
@@ -107,10 +107,10 @@ def test_xcodedeps_components():
         self.cpp_info.components["core"].includedirs.append("include")
         self.cpp_info.components["core"].libdirs.append("lib")
 
-        self.cpp_info.components["client-test"].libs = ["client"]
-        self.cpp_info.components["client-test"].includedirs.append("include")
-        self.cpp_info.components["client-test"].libdirs.append("lib")
-        self.cpp_info.components["client-test"].requires.extend(["core", "tcp::tcp"])
+        self.cpp_info.components["client-test++"].libs = ["client"]
+        self.cpp_info.components["client-test++"].includedirs.append("include")
+        self.cpp_info.components["client-test++"].libdirs.append("lib")
+        self.cpp_info.components["client-test++"].requires.extend(["core", "tcp::tcp"])
 
         self.cpp_info.components["server"].libs = ["server"]
         self.cpp_info.components["server"].includedirs.append("include")
@@ -138,7 +138,7 @@ def test_xcodedeps_components():
         self.cpp_info.libs = ["chat"]
         self.cpp_info.includedirs.append("include")
         self.cpp_info.libdirs.append("lib")
-        self.cpp_info.requires.append("network::client-test")
+        self.cpp_info.requires.append("network::client-test++")
     """
 
     cmakelists_chat = textwrap.dedent("""
@@ -150,7 +150,7 @@ def test_xcodedeps_components():
         add_library(chat src/chat.cpp include/chat.h)
         target_include_directories(chat PUBLIC include)
         set_target_properties(chat PROPERTIES PUBLIC_HEADER "include/chat.h")
-        target_link_libraries(chat network::client-test)
+        target_link_libraries(chat network::client-test++)
         install(TARGETS chat)
         """)
 
@@ -188,7 +188,7 @@ def test_xcodedeps_components():
     client.run("install --requires=chat/1.0@ -g XcodeDeps --output-folder=conan "
                "-s build_type=Debug --build=missing")
     chat_xcconfig = client.load(os.path.join("conan", "conan_chat_chat.xcconfig"))
-    assert '#include "conan_network_client_test.xcconfig"' in chat_xcconfig
+    assert '#include "conan_network_client_test__.xcconfig"' in chat_xcconfig
     assert '#include "conan_network_server.xcconfig"' not in chat_xcconfig
     assert '#include "conan_network_network.xcconfig"' not in chat_xcconfig
     host_arch = client.get_default_host_profile().settings['arch']


### PR DESCRIPTION
Changelog: Fix: Sanitize XcodeDeps file and variable names to use only valid xcconfig characters.
Docs: Omit

Closes: https://github.com/conan-io/conan/issues/19064