### PR TITLE
raise error if lru without rrev pattern

### DIFF
--- a/conan/api/subapi/list.py
+++ b/conan/api/subapi/list.py
@@ -178,11 +178,16 @@ class ListAPI:
             It can be a string like ``"2d"`` (2 days) or ``"3h"`` (3 hours).
         :parameter Profile profile: Profile to filter the packages by settings and options.
         """
+        # TODO: Implement better error forwarding for "list" command that captures Exceptions
         if package_query and pattern.package_id and "*" not in pattern.package_id:
             raise ConanException("Cannot specify '-p' package queries, "
                                  "if 'package_id' is not a pattern")
         if remote and lru:
             raise ConanException("'--lru' cannot be used in remotes, only in cache")
+
+        if lru and not pattern.rrev:
+            raise ConanException("'--lru' must be used with recipe revision pattern, "
+                                 "use '#<rrev-pattern>' argument")
 
         select_bundle = PackagesList()
         # Avoid doing a ``search`` of recipes if it is an exact ref and it will be used later

--- a/conan/api/subapi/list.py
+++ b/conan/api/subapi/list.py
@@ -185,10 +185,6 @@ class ListAPI:
         if remote and lru:
             raise ConanException("'--lru' cannot be used in remotes, only in cache")
 
-        if lru and not pattern.rrev:
-            raise ConanException("'--lru' must be used with recipe revision pattern, "
-                                 "use '#<rrev-pattern>' argument")
-
         select_bundle = PackagesList()
         # Avoid doing a ``search`` of recipes if it is an exact ref and it will be used later
         search_ref = pattern.search_ref

--- a/conan/cli/commands/list.py
+++ b/conan/cli/commands/list.py
@@ -264,6 +264,9 @@ def list(conan_api: ConanAPI, parser, *args):
                                            args.filter_settings or args.filter_options):
             raise ConanException("--package-query and --filter-xxx can only be done for binaries, "
                                  "a 'pkgname/version:*' pattern is necessary")
+        if args.lru and not ref_pattern.rrev:
+            raise ConanException("'--lru' must be used with recipe revision pattern, "
+                                 "use '#<rrev-pattern>' argument")
         # If neither remote nor cache are defined, show results only from cache
         pkglist = MultiPackagesList()
         profile = conan_api.profiles.get_profile(args.filter_profile or [],

--- a/conan/cli/commands/list.py
+++ b/conan/cli/commands/list.py
@@ -264,9 +264,13 @@ def list(conan_api: ConanAPI, parser, *args):
                                            args.filter_settings or args.filter_options):
             raise ConanException("--package-query and --filter-xxx can only be done for binaries, "
                                  "a 'pkgname/version:*' pattern is necessary")
-        if args.lru and not ref_pattern.rrev:
-            raise ConanException("'--lru' must be used with recipe revision pattern, "
-                                 "use '#<rrev-pattern>' argument")
+        if args.lru:
+            if not ref_pattern.rrev and not ref_pattern.package_id:  # If package_id => #latest
+                raise ConanException("'--lru' must be used with recipe revision pattern, "
+                                     "use 'pkg/version#*' argument")
+            if ref_pattern.package_id and not ref_pattern.prev:
+                raise ConanException("'--lru' must be used with package revision pattern, "
+                                     "use 'pkg/version:*#*' argument")
         # If neither remote nor cache are defined, show results only from cache
         pkglist = MultiPackagesList()
         profile = conan_api.profiles.get_profile(args.filter_profile or [],

--- a/test/integration/command/list/test_list_lru.py
+++ b/test/integration/command/list/test_list_lru.py
@@ -52,6 +52,16 @@ class TestLRU:
         assert "da39a3ee5e6b4b0d3255bfef95601890afd80709" not in c.out
         assert "dep" not in c.out
 
+    def test_lru_just_created(self):
+        c = TestClient()
+        c.save({"conanfile.py": GenConanfile("pkg", "0.1")})
+        c.run("create .")
+        # Removing recipes (+ its binaries) that recipes haven't been used
+        c.run("list * --lru=1d", assert_error=True)
+        assert "'--lru' must be used with recipe revision pattern" in c.out
+        c.run("list *#* --lru=1d")
+        assert "pkg/0.1" not in c.out
+
     def test_update_lru_when_used_as_dependency(self):
         """Show that using a recipe as a dependency will update its LRU"""
         c = TestClient()

--- a/test/integration/command/list/test_list_lru.py
+++ b/test/integration/command/list/test_list_lru.py
@@ -56,11 +56,18 @@ class TestLRU:
         c = TestClient()
         c.save({"conanfile.py": GenConanfile("pkg", "0.1")})
         c.run("create .")
-        # Removing recipes (+ its binaries) that recipes haven't been used
         c.run("list * --lru=1d", assert_error=True)
         assert "'--lru' must be used with recipe revision pattern" in c.out
         c.run("list *#* --lru=1d")
         assert "pkg/0.1" not in c.out
+        # What if no revision, but package id is passed
+        c.run("list pkg/0.1:* --lru=1d", assert_error=True)
+        assert "'--lru' must be used with package revision pattern" in c.out
+        # Doesn't fail, but packages is empty
+        c.run("list pkg/0.1:*#* --lru=1d --format=json")
+        pkgs = json.loads(c.stdout)
+        rev = pkgs["Local Cache"]["pkg/0.1"]["revisions"]["485dad6cb11e2fa99d9afbe44a57a164"]
+        assert rev["packages"] == {}
 
     def test_update_lru_when_used_as_dependency(self):
         """Show that using a recipe as a dependency will update its LRU"""


### PR DESCRIPTION
Changelog: Fix: Raise an error if ``conan list * --lru=xx``, recommending the ``#<rev-pattern>`` argument.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19071