### PR TITLE
Reintroduce `settings_yml` to config subapi as an interface

### DIFF
--- a/conan/api/conan_api.py
+++ b/conan/api/conan_api.py
@@ -96,6 +96,7 @@ class ConanAPI:
         """
         self._api_helpers.reinit()
         self.local.reinit()
+        self.config.reinit()
 
     def migrate(self):
         # Migration system
@@ -142,30 +143,8 @@ class ConanAPI:
 
         @property
         def settings_yml(self):
-            """ Get the contents of the settings.yml and user_settings.yml files,
-                which define the possible values for settings."""
-
-            class SettingsInterface:
-                def __init__(self, settings):
-                    self._settings = settings
-
-                def possible_values(self):
-                    """ returns a dict with the possible values for each setting """
-                    return self._settings.possible_values()
-
-                @property
-                def fields(self):
-                    """ returns a dict with the fields of each setting """
-                    return self._settings.fields
-
-                def __getattr__(self, item):
-                    return SettingsInterface(getattr(self._settings, item))
-
-                def __str__(self):
-                    return str(self._settings)
-
             if self._settings_yml is None:
-                self._settings_yml = SettingsInterface(load_settings_yml(self._conan_api.home_folder))
+                self._settings_yml = load_settings_yml(self._conan_api.home_folder)
             return self._settings_yml
 
         @property

--- a/conan/api/conan_api.py
+++ b/conan/api/conan_api.py
@@ -96,7 +96,6 @@ class ConanAPI:
         """
         self._api_helpers.reinit()
         self.local.reinit()
-        self.config.reinit()
 
     def migrate(self):
         # Migration system

--- a/conan/api/conan_api.py
+++ b/conan/api/conan_api.py
@@ -96,6 +96,7 @@ class ConanAPI:
         """
         self._api_helpers.reinit()
         self.local.reinit()
+        self.config.reinit()
 
     def migrate(self):
         # Migration system

--- a/conan/api/conan_api.py
+++ b/conan/api/conan_api.py
@@ -96,7 +96,6 @@ class ConanAPI:
         """
         self._api_helpers.reinit()
         self.local.reinit()
-        self.config.reinit()
 
     def migrate(self):
         # Migration system
@@ -113,6 +112,7 @@ class ConanAPI:
             self.hook_manager = HookManager(HomePaths(self._conan_api.home_folder).hooks_path)
             # Wraps an http_requester to inject proxies, certs, etc
             self._requester = ConanRequester(self.global_conf, self._conan_api.home_folder)
+            self._settings_yml = None
 
         def set_core_confs(self, core_confs):
             confs = ConfDefinition()
@@ -138,10 +138,35 @@ class ConanAPI:
             self._init_global_conf()
             self.hook_manager.reinit()
             self._requester = ConanRequester(self.global_conf, self._conan_api.home_folder)
+            self._settings_yml = None
 
         @property
         def settings_yml(self):
-            return load_settings_yml(self._conan_api.home_folder)
+            """ Get the contents of the settings.yml and user_settings.yml files,
+                which define the possible values for settings."""
+
+            class SettingsInterface:
+                def __init__(self, settings):
+                    self._settings = settings
+
+                def possible_values(self):
+                    """ returns a dict with the possible values for each setting """
+                    return self._settings.possible_values()
+
+                @property
+                def fields(self):
+                    """ returns a dict with the fields of each setting """
+                    return self._settings.fields
+
+                def __getattr__(self, item):
+                    return SettingsInterface(getattr(self._settings, item))
+
+                def __str__(self):
+                    return str(self._settings)
+
+            if self._settings_yml is None:
+                self._settings_yml = SettingsInterface(load_settings_yml(self._conan_api.home_folder))
+            return self._settings_yml
 
         @property
         def requester(self):

--- a/conan/api/subapi/config.py
+++ b/conan/api/subapi/config.py
@@ -154,9 +154,20 @@ class ConfigAPI:
     @property
     def settings_yml(self):
         """ Get the contents of the settings.yml and user_settings.yml files,
-            which define the possible values for settings."""
+            which define the possible values for settings.
 
-        class SettingsInterface:
+            Note that this is different from the settings present in a conanfile,
+            which represent the actual values for a specific package, while this
+            property represents the possible values for each setting.
+
+            :returns: A read-only object representing the settings scheme, with a
+                ``possible_values()`` method that returns a dictionary with the possible values for each setting,
+                and a ``fields`` property that returns an ordered list with the fields of each setting.
+                Note that it's possible to access nested settings using attribute access,
+                such as ``settings_yml.compiler.possible_values()``.
+        """
+
+        class SettingsYmlInterface:
             def __init__(self, settings):
                 self._settings = settings
 
@@ -170,9 +181,9 @@ class ConfigAPI:
                 return self._settings.fields
 
             def __getattr__(self, item):
-                return SettingsInterface(getattr(self._settings, item))
+                return SettingsYmlInterface(getattr(self._settings, item))
 
             def __str__(self):
                 return str(self._settings)
 
-        return SettingsInterface(self._helpers.settings_yml)
+        return SettingsYmlInterface(self._helpers.settings_yml)

--- a/conan/api/subapi/config.py
+++ b/conan/api/subapi/config.py
@@ -25,7 +25,6 @@ class ConfigAPI:
     def __init__(self, conan_api, helpers):
         self._conan_api = conan_api
         self._helpers = helpers
-        self._settings_yml = None
 
     def home(self):
         """ return the current Conan home folder containing the configuration files like
@@ -176,9 +175,4 @@ class ConfigAPI:
             def __str__(self):
                 return str(self._settings)
 
-        if self._settings_yml is None:
-            self._settings_yml = SettingsInterface(self._helpers.settings_yml)
-        return self._settings_yml
-
-    def reinit(self):
-        self._settings_yml = None
+        return SettingsInterface(self._helpers.settings_yml)

--- a/conan/api/subapi/config.py
+++ b/conan/api/subapi/config.py
@@ -12,7 +12,6 @@ from conan.errors import ConanException
 from conan.internal.model.conf import BUILT_IN_CONFS
 from conan.internal.model.pkg_type import PackageType
 from conan.api.model import RecipeReference, PkgReference
-from conan.internal.model.settings import load_settings_yml
 from conan.internal.util.files import load, save, rmdir, remove
 
 

--- a/conan/api/subapi/config.py
+++ b/conan/api/subapi/config.py
@@ -26,6 +26,7 @@ class ConfigAPI:
     def __init__(self, conan_api, helpers):
         self._conan_api = conan_api
         self._helpers = helpers
+        self._settings_yml = None
 
     def home(self):
         """ return the current Conan home folder containing the configuration files like
@@ -155,5 +156,30 @@ class ConfigAPI:
     @property
     def settings_yml(self):
         """ Get the contents of the settings.yml and user_settings.yml files,
-                 which define the possible values for settings."""
-        return self._helpers.settings_yml
+            which define the possible values for settings."""
+
+        class SettingsInterface:
+            def __init__(self, settings):
+                self._settings = settings
+
+            def possible_values(self):
+                """ returns a dict with the possible values for each setting """
+                return self._settings.possible_values()
+
+            @property
+            def fields(self):
+                """ returns a dict with the fields of each setting """
+                return self._settings.fields
+
+            def __getattr__(self, item):
+                return SettingsInterface(getattr(self._settings, item))
+
+            def __str__(self):
+                return str(self._settings)
+
+        if self._settings_yml is None:
+            self._settings_yml = SettingsInterface(self._helpers.settings_yml)
+        return self._settings_yml
+
+    def reinit(self):
+        self._settings_yml = None

--- a/conan/api/subapi/config.py
+++ b/conan/api/subapi/config.py
@@ -26,7 +26,6 @@ class ConfigAPI:
     def __init__(self, conan_api, helpers):
         self._conan_api = conan_api
         self._helpers = helpers
-        self._settings_yml = None
 
     def home(self):
         """ return the current Conan home folder containing the configuration files like
@@ -154,31 +153,7 @@ class ConfigAPI:
         self._conan_api.migrate()
 
     @property
-    def settings_definitions(self):
+    def settings_yml(self):
         """ Get the contents of the settings.yml and user_settings.yml files,
-         which define the possible values for settings."""
-        class SettingsInterface:
-            def __init__(self, settings):
-                self._settings = settings
-
-            def possible_values(self):
-                """ returns a dict with the possible values for each setting """
-                return self._settings.possible_values()
-
-            @property
-            def fields(self):
-                """ returns a dict with the fields of each setting """
-                return self._settings.fields
-
-            def __getattr__(self, item):
-                return SettingsInterface(getattr(self._settings, item))
-
-            def __str__(self):
-                return str(self._settings)
-
-        if self._settings_yml is None:
-            self._settings_yml = SettingsInterface(load_settings_yml(self.home()))
-        return self._settings_yml
-
-    def reinit(self):
-        self._settings_yml = None
+                 which define the possible values for settings."""
+        return self._helpers.settings_yml

--- a/conan/api/subapi/config.py
+++ b/conan/api/subapi/config.py
@@ -12,6 +12,7 @@ from conan.errors import ConanException
 from conan.internal.model.conf import BUILT_IN_CONFS
 from conan.internal.model.pkg_type import PackageType
 from conan.api.model import RecipeReference, PkgReference
+from conan.internal.model.settings import load_settings_yml
 from conan.internal.util.files import load, save, rmdir, remove
 
 
@@ -25,6 +26,7 @@ class ConfigAPI:
     def __init__(self, conan_api, helpers):
         self._conan_api = conan_api
         self._helpers = helpers
+        self._settings_yml = None
 
     def home(self):
         """ return the current Conan home folder containing the configuration files like
@@ -150,3 +152,33 @@ class ConfigAPI:
         self._conan_api.reinit()
         # CHECK: This also generates a remotes.json that is not there after a conan profile show?
         self._conan_api.migrate()
+
+    @property
+    def settings_definitions(self):
+        """ Get the contents of the settings.yml and user_settings.yml files,
+         which define the possible values for settings."""
+        class SettingsInterface:
+            def __init__(self, settings):
+                self._settings = settings
+
+            def possible_values(self):
+                """ returns a dict with the possible values for each setting """
+                return self._settings.possible_values()
+
+            @property
+            def fields(self):
+                """ returns a dict with the fields of each setting """
+                return self._settings.fields
+
+            def __getattr__(self, item):
+                return SettingsInterface(getattr(self._settings, item))
+
+            def __str__(self):
+                return str(self._settings)
+
+        if self._settings_yml is None:
+            self._settings_yml = SettingsInterface(load_settings_yml(self.home()))
+        return self._settings_yml
+
+    def reinit(self):
+        self._settings_yml = None

--- a/test/integration/command/custom_commands_test.py
+++ b/test/integration/command/custom_commands_test.py
@@ -488,3 +488,28 @@ class TestCommandsRemoteCaching:
         c.run("mycache")
         # Does not break unexpectedly, caching is working
         assert "WARN: Cache invalidated, as expected: Invalid URL 'broken" in c.out
+
+
+def test_custom_command_settings_access():
+    tc = TestClient()
+    mycommand = textwrap.dedent("""
+        from conan.cli.command import conan_command
+        from conan.api.output import ConanOutput
+
+        @conan_command(group="custom commands")
+        def mycommand(conan_api, parser, *args, **kwargs):
+            \"""
+            test
+            \"""
+            settings = conan_api.config.settings_definitions
+            ConanOutput().info(f"settings.fields: {settings.fields}")
+            ConanOutput().info(f"settings.possible_values(): {settings.possible_values()}")
+            ConanOutput().info(f"settings.compiler: {settings.compiler}")
+            ConanOutput().info(f"settings.compiler.possible_values(): {settings.compiler.possible_values()}")
+        """)
+    command_file_path = os.path.join('extensions', 'commands', 'cmd_mycommand.py')
+    tc.save_home({f"{command_file_path}": mycommand})
+    tc.run("mycommand")
+    assert "settings.fields: ['arch', 'build_type', 'compiler', 'os']" in tc.out
+    # No values here, but as it does not fail, the interface is working fine
+    assert "settings.compiler: None" in tc.out

--- a/test/integration/command/custom_commands_test.py
+++ b/test/integration/command/custom_commands_test.py
@@ -501,7 +501,7 @@ def test_custom_command_settings_access():
             \"""
             test
             \"""
-            settings = conan_api.config.settings_definitions
+            settings = conan_api.config.settings_yml
             ConanOutput().info(f"settings.fields: {settings.fields}")
             ConanOutput().info(f"settings.possible_values(): {settings.possible_values()}")
             ConanOutput().info(f"settings.compiler: {settings.compiler}")


### PR DESCRIPTION
Changelog: Fix: Reintroduce `settings.yml` access to `config` Sub-API.
Docs: Omit

This new approach creates an interface to avoid users having access to non-scheme related methods, as this object won't have the settings values filled.

Maybe the name can be changed, and the interface location can be changed

Closes https://github.com/conan-io/conan/issues/19059