### PR TITLE
better CMakeConfigDeps message for missing component type

### DIFF
--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -648,7 +648,7 @@ class _Component:
                                  "cannot deduce locations")
         # fully defined by user in conanfile, nothing to do.
         if self._location or self._link_location:
-            if self._type not in [PackageType.SHARED, PackageType.STATIC]:
+            if self._type is None or self._type not in [PackageType.SHARED, PackageType.STATIC]:
                 raise ConanException(f"{name} location defined without defined library type")
             return
 


### PR DESCRIPTION
Changelog: Fix: Better error message for ``CMakeConfigDeps`` when the package_type or component type is not defined for something with ``.location`` defined.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19062
