### PR TITLE
default parallel download

### DIFF
--- a/conan/internal/graph/installer.py
+++ b/conan/internal/graph/installer.py
@@ -15,6 +15,7 @@ from conan.errors import ConanException
 from conan.internal.model.cpp_info import CppInfo, MockInfoProperty
 from conan.api.model import PkgReference
 from conan.internal.paths import CONANINFO
+from conan.internal.util import cpu_count
 from conan.internal.util.files import clean_dirty, is_dirty, mkdir, rmdir, save, set_dirty, chdir
 
 
@@ -277,8 +278,9 @@ class BinaryInstaller:
         download_count = len(downloads)
         plural = 's' if download_count != 1 else ''
         ConanOutput().subtitle(f"Downloading {download_count} package{plural}")
-        parallel = self._global_conf.get("core.download:parallel", check_type=int)
-        if parallel is not None:
+        parallel = self._global_conf.get("core.download:parallel", check_type=int,
+                                         default=cpu_count())
+        if parallel:  # User can define core.download:parallel=0 to deactivate parallelism
             ConanOutput().info("Downloading binary packages in %s parallel threads" % parallel)
             thread_pool = ThreadPool(parallel)
             thread_pool.map(self._download_pkg, downloads)
@@ -329,7 +331,8 @@ class BinaryInstaller:
                 pref = node.pref
                 self._cache.update_package_lru(pref)
                 assert node.prev, "PREV for %s is None" % str(pref)
-                node.conanfile.output.success(f'Already installed! ({handled_count} of {total_count})')
+                msg = f'Already installed! ({handled_count} of {total_count})'
+                node.conanfile.output.success(msg)
 
         # Make sure that all nodes with same pref compute package_info()
         pkg_folder = package_layout.package()

--- a/conan/internal/util/__init__.py
+++ b/conan/internal/util/__init__.py
@@ -1,0 +1,30 @@
+import math
+import multiprocessing
+
+from conan.internal.util.files import load
+
+
+def cpu_count():
+    try:
+        try:
+            # This is necessary to deduce docker cpu_count
+            cfs_quota_us = cfs_period_us = 0
+            # cgroup2
+            if os.path.exists("/sys/fs/cgroup/cgroup.controllers"):
+                cpu_max = load("/sys/fs/cgroup/cpu.max").split()
+                if cpu_max[0] != "max":
+                    if len(cpu_max) == 1:
+                        cfs_quota_us, cfs_period_us = int(cpu_max[0]), 100_000
+                    else:
+                        cfs_quota_us, cfs_period_us = map(int, cpu_max)
+            else:  # cgroup1
+                cfs_quota_us = int(load("/sys/fs/cgroup/cpu/cpu.cfs_quota_us"))
+                cfs_period_us = int(load("/sys/fs/cgroup/cpu/cpu.cfs_period_us"))
+            if cfs_quota_us > 0 and cfs_period_us > 0:
+                return int(math.ceil(cfs_quota_us / cfs_period_us))
+        except (EnvironmentError, TypeError):
+            pass
+        return multiprocessing.cpu_count()
+    except NotImplementedError:
+        # print("multiprocessing.cpu_count() not implemented. Defaulting to 1 cpu")
+        return 1  # Safe guess

--- a/conan/internal/util/__init__.py
+++ b/conan/internal/util/__init__.py
@@ -1,5 +1,6 @@
 import math
 import multiprocessing
+import os
 
 from conan.internal.util.files import load
 

--- a/conan/tools/build/cpu.py
+++ b/conan/tools/build/cpu.py
@@ -1,8 +1,4 @@
-import math
-import multiprocessing
-import os
-
-from conan.internal.util.files import load
+from conan.internal.util import cpu_count
 
 
 def build_jobs(conanfile):
@@ -22,30 +18,4 @@ def build_jobs(conanfile):
     :param conanfile: The current recipe object. Always use ``self``.
     :return: ``int`` with the number of jobs
     """
-    return conanfile.conf.get("tools.build:jobs", default=_cpu_count(), check_type=int)
-
-
-def _cpu_count():
-    try:
-        try:
-            # This is necessary to deduce docker cpu_count
-            cfs_quota_us = cfs_period_us = 0
-            # cgroup2
-            if os.path.exists("/sys/fs/cgroup/cgroup.controllers"):
-                cpu_max = load("/sys/fs/cgroup/cpu.max").split()
-                if cpu_max[0] != "max":
-                    if len(cpu_max) == 1:
-                        cfs_quota_us, cfs_period_us = int(cpu_max[0]), 100_000
-                    else:
-                        cfs_quota_us, cfs_period_us = map(int, cpu_max)
-            else:  # cgroup1
-                cfs_quota_us = int(load("/sys/fs/cgroup/cpu/cpu.cfs_quota_us"))
-                cfs_period_us = int(load("/sys/fs/cgroup/cpu/cpu.cfs_period_us"))
-            if cfs_quota_us > 0 and cfs_period_us > 0:
-                return int(math.ceil(cfs_quota_us / cfs_period_us))
-        except (EnvironmentError, TypeError):
-            pass
-        return multiprocessing.cpu_count()
-    except NotImplementedError:
-        # print("multiprocessing.cpu_count() not implemented. Defaulting to 1 cpu")
-        return 1  # Safe guess
+    return conanfile.conf.get("tools.build:jobs", default=cpu_count(), check_type=int)


### PR DESCRIPTION
Changelog: Feature: Enable parallel download of packages by default, by defaulting ``core.download:parallel`` to the available CPU cores.
Docs: https://github.com/conan-io/docs/pull/4282

This has been tested as default in ConanCenter for a couple of months already.

Close https://github.com/conan-io/conan/issues/18717