### PR TITLE
[Workspaces] Fix conanws.yml requiring 'ref' specification

### DIFF
--- a/conan/api/subapi/workspace.py
+++ b/conan/api/subapi/workspace.py
@@ -263,10 +263,11 @@ class WorkspaceAPI:
 
     def super_build_graph(self, deps_graph, profile_host, profile_build):
         order = []
-        packages = self._ws.packages()
+        packages = self.packages()
 
         def find_folder(ref):
-            return next(p["path"] for p in packages if RecipeReference.loads(p["ref"]) == ref)
+            return next(os.path.dirname(os.path.relpath(p["path"], self._folder)) for p_ref, p in
+                        packages.items() if p_ref == ref)
 
         for level in deps_graph.by_levels():
             items = [item for item in level if item.recipe == "Editable"]

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -1117,6 +1117,11 @@ def test_workspace_defining_only_paths():
     assert "liba/0.1@myuser/mychannel - Editable" in c.out
     assert "libb/0.1 - Editable" in c.out
 
+    c.run("workspace super-install")
+    assert "app1/0.1 - Editable" in c.out
+    assert "liba/0.1@myuser/mychannel - Editable" in c.out
+    assert "libb/0.1 - Editable" in c.out
+
 
 def test_workspace_defining_duplicate_references():
     """


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

This PR fixes the seemingly (according to [docs](https://github.com/conan-io/docs/blob/develop2/reference/workspace_files.rst?plain=1#L26)) incorrect requirement for `ref` field presence in the `conanws.yml` file. Without the fix `conan workspace super-install` fails with `KeyError: 'ref'` if any of listed packages lacks `ref` specification.

It seems that the behaviour was accidentally broken in [this](https://github.com/conan-io/conan/commit/340e44e880b9849cfddd7d7b29406574358037c2) commit, so I also removed `ref` specification from one of the packages in the workspaces template file, so that it's covered by the existing tests.