### PR TITLE
Add groups for argument options

### DIFF
--- a/conan/api/output.py
+++ b/conan/api/output.py
@@ -125,21 +125,25 @@ class ConanOutput:
         cls._warnings_as_errors = value
 
     @classmethod
+    def valid_log_levels(cls):
+        return {"quiet": LEVEL_QUIET,  # -vquiet 80
+            "error": LEVEL_ERROR,  # -verror 70
+            "warning": LEVEL_WARNING,  # -vwaring 60
+            "notice": LEVEL_NOTICE,  # -vnotice 50
+            "status": LEVEL_STATUS,  # -vstatus 40
+            None: LEVEL_VERBOSE,  # -v 30
+            "verbose": LEVEL_VERBOSE,  # -vverbose 30
+            "debug": LEVEL_DEBUG,  # -vdebug 20
+            "v": LEVEL_DEBUG,  # -vv 20
+            "trace": LEVEL_TRACE,  # -vtrace 10
+            "vv": LEVEL_TRACE  # -vvv 10
+        }
+
+    @classmethod
     def define_log_level(cls, v):
         env_level = os.getenv("CONAN_LOG_LEVEL")
         v = env_level or v
-        levels = {"quiet": LEVEL_QUIET,  # -vquiet 80
-                  "error": LEVEL_ERROR,  # -verror 70
-                  "warning": LEVEL_WARNING,  # -vwaring 60
-                  "notice": LEVEL_NOTICE,  # -vnotice 50
-                  "status": LEVEL_STATUS,  # -vstatus 40
-                  None: LEVEL_VERBOSE,  # -v 30
-                  "verbose": LEVEL_VERBOSE,  # -vverbose 30
-                  "debug": LEVEL_DEBUG,  # -vdebug 20
-                  "v": LEVEL_DEBUG,  # -vv 20
-                  "trace": LEVEL_TRACE,  # -vtrace 10
-                  "vv": LEVEL_TRACE  # -vvv 10
-                  }
+        levels = cls.valid_log_levels()
         try:
             level = levels[v]
         except KeyError:

--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -27,29 +27,32 @@ _help_build_policies = '''Optional, specify which packages to build from source.
 
 
 def add_lockfile_args(parser):
-    parser.add_argument("-l", "--lockfile", action=OnceArgument,
-                        help="Path to a lockfile. Use --lockfile=\"\" to avoid automatic use of "
-                             "existing 'conan.lock' file")
-    parser.add_argument("--lockfile-partial", action="store_true",
-                        help="Do not raise an error if some dependency is not found in lockfile")
-    parser.add_argument("--lockfile-out", action=OnceArgument,
-                        help="Filename of the updated lockfile")
-    parser.add_argument("--lockfile-packages", action="store_true",
-                        help=argparse.SUPPRESS)
-    parser.add_argument("--lockfile-clean", action="store_true",
-                        help="Remove unused entries from the lockfile")
-    parser.add_argument("--lockfile-overrides",
-                        help="Overwrite lockfile overrides")
+    group = parser.add_argument_group("lockfile options")
+    group.add_argument("-l", "--lockfile", action=OnceArgument,
+                       help="Path to a lockfile. Use --lockfile=\"\" to avoid automatic use of "
+                            "existing 'conan.lock' file")
+    group.add_argument("--lockfile-partial", action="store_true",
+                       help="Do not raise an error if some dependency is not found in lockfile")
+    group.add_argument("--lockfile-out", action=OnceArgument,
+                       help="Filename of the updated lockfile")
+    group.add_argument("--lockfile-packages", action="store_true",
+                       help=argparse.SUPPRESS)
+    group.add_argument("--lockfile-clean", action="store_true",
+                       help="Remove unused entries from the lockfile")
+    group.add_argument("--lockfile-overrides",
+                       help="Overwrite lockfile overrides")
+    return group
 
 
-def add_common_install_arguments(parser):
-    parser.add_argument("-b", "--build", action="append", help=_help_build_policies)
+def add_common_install_arguments(parser, group=None):
+    group = group or parser.add_argument_group("common install options")
+    group.add_argument("-b", "--build", action="append", help=_help_build_policies)
 
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument("-r", "--remote", action="append", default=None,
-                       help='Look in the specified remote or remotes server')
-    group.add_argument("-nr", "--no-remote", action="store_true",
-                       help='Do not use remote, resolve exclusively in the cache')
+    remotes_group = group.add_mutually_exclusive_group()
+    remotes_group.add_argument("-r", "--remote", action="append", default=None,
+                               help='Look in the specified remote or remotes server')
+    remotes_group.add_argument("-nr", "--no-remote", action="store_true",
+                               help='Do not use remote, resolve exclusively in the cache')
 
     update_help = ("Will install newer versions and/or revisions in the local cache "
                    "for the given reference name, or all references in the graph if no argument is supplied. "
@@ -57,12 +60,15 @@ def add_common_install_arguments(parser):
                    "satisfies the range. It will update to the "
                    "latest revision for the resolved version range.")
 
-    parser.add_argument("-u", "--update", action="append", nargs="?", help=update_help, const="*")
-    add_profiles_args(parser)
+    group.add_argument("-u", "--update", action="append", nargs="?", help=update_help, const="*")
+    profile_group = add_profiles_args(parser)
+    return group, profile_group
 
 
 def add_profiles_args(parser):
     contexts = ["build", "host"]
+
+    group = parser.add_argument_group("configuration options")
 
     # This comes from the _AppendAction code but modified to add to the contexts
     class ContextAllAction(argparse.Action):
@@ -75,45 +81,48 @@ def add_profiles_args(parser):
                 setattr(namespace, self.dest + "_" + context, items)
 
     def create_config(short, long, example=None):
-        parser.add_argument(f"-{short}", f"--{long}",
-                            default=None,
-                            action="append",
-                            dest=f"{long}_host",
-                            metavar=long.upper(),
-                            help=f'Apply the specified {long}. '
-                                 f'By default, or if specifying -{short}:h (--{long}:host), it applies to the host context. '
-                                 f'Use -{short}:b (--{long}:build) to specify the build context, '
-                                 f'or -{short}:a (--{long}:all) to specify both contexts at once'
-                                   + ('' if not example else f". Example: {example}"))
+        group.add_argument(f"-{short}", f"--{long}",
+                           default=None,
+                           action="append",
+                           dest=f"{long}_host",
+                           metavar=long.upper(),
+                           help=f'Apply the specified {long}. '
+                                f'By default, or if specifying -{short}:h (--{long}:host), it applies to the host context. '
+                                f'Use -{short}:b (--{long}:build) to specify the build context, '
+                                f'or -{short}:a (--{long}:all) to specify both contexts at once'
+                                + ('' if not example else f". Example: {example}"))
         for context in contexts:
-            parser.add_argument(f"-{short}:{context[0]}", f"--{long}:{context}",
-                                default=None,
-                                action="append",
-                                dest=f"{long}_{context}",
-                                help="")
+            group.add_argument(f"-{short}:{context[0]}", f"--{long}:{context}",
+                               default=None,
+                               action="append",
+                               dest=f"{long}_{context}",
+                               help="")
 
-        parser.add_argument(f"-{short}:a", f"--{long}:all",
-                            default=None,
-                            action=ContextAllAction,
-                            dest=long,
-                            metavar=f"{long.upper()}_ALL",
-                            help="")
+        group.add_argument(f"-{short}:a", f"--{long}:all",
+                           default=None,
+                           action=ContextAllAction,
+                           dest=long,
+                           metavar=f"{long.upper()}_ALL",
+                           help="")
 
     create_config("pr", "profile")
     create_config("o", "options", '-o="pkg/*:with_qt=True"')
     create_config("s", "settings", '-s="compiler=gcc"')
     create_config("c", "conf", '-c="tools.cmake.cmaketoolchain:generator=Xcode"')
+    return group
 
 
 def add_reference_args(parser):
-    parser.add_argument("--name", action=OnceArgument,
-                        help='Provide a package name if not specified in conanfile')
-    parser.add_argument("--version", action=OnceArgument,
-                        help='Provide a package version if not specified in conanfile')
-    parser.add_argument("--user", action=OnceArgument,
-                        help='Provide a user if not specified in conanfile')
-    parser.add_argument("--channel", action=OnceArgument,
-                        help='Provide a channel if not specified in conanfile')
+    group = parser.add_argument_group("reference options")
+    group.add_argument("--name", action=OnceArgument,
+                       help='Provide a package name if not specified in conanfile')
+    group.add_argument("--version", action=OnceArgument,
+                       help='Provide a package version if not specified in conanfile')
+    group.add_argument("--user", action=OnceArgument,
+                       help='Provide a user if not specified in conanfile')
+    group.add_argument("--channel", action=OnceArgument,
+                       help='Provide a channel if not specified in conanfile')
+    return group
 
 
 def common_graph_args(subparser):
@@ -124,13 +133,15 @@ def common_graph_args(subparser):
                                 "directory when no --requires or --tool-requires is "
                                 "given",
                            default=None)
-    add_reference_args(subparser)
-    subparser.add_argument("--requires", action="append",
-                           help='Directly provide requires instead of a conanfile')
-    subparser.add_argument("--tool-requires", action='append',
-                           help='Directly provide tool-requires instead of a conanfile')
-    add_common_install_arguments(subparser)
-    add_lockfile_args(subparser)
+    group = subparser.add_argument_group("common graph options")
+    group.add_argument("--requires", action="append",
+                       help='Directly provide requires instead of a conanfile')
+    group.add_argument("--tool-requires", action='append',
+                       help='Directly provide tool-requires instead of a conanfile')
+    ref_group = add_reference_args(subparser)
+    install_group, profile_group = add_common_install_arguments(subparser, group)
+    lockfile_group = add_lockfile_args(subparser)
+    return ref_group, install_group, profile_group, lockfile_group
 
 
 def validate_common_graph_args(args):

--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -47,7 +47,8 @@ def add_lockfile_args(parser):
 def add_common_install_arguments(parser):
     parser.add_argument("-b", "--build", action="append", help=_help_build_policies)
 
-    remotes_group = parser.add_mutually_exclusive_group()
+    group = parser.add_argument_group("remote arguments")
+    remotes_group = group.add_mutually_exclusive_group()
     remotes_group.add_argument("-r", "--remote", action="append", default=None,
                                help='Look in the specified remote or remotes server')
     remotes_group.add_argument("-nr", "--no-remote", action="store_true",
@@ -59,7 +60,7 @@ def add_common_install_arguments(parser):
                    "satisfies the range. It will update to the "
                    "latest revision for the resolved version range.")
 
-    parser.add_argument("-u", "--update", action="append", nargs="?", help=update_help, const="*")
+    group.add_argument("-u", "--update", action="append", nargs="?", help=update_help, const="*")
     add_profiles_args(parser)
 
 
@@ -133,7 +134,7 @@ def common_graph_args(subparser):
                            default=None)
     add_common_install_arguments(subparser)
     subparser.add_argument("--requires", action="append",
-                                                  help='Directly provide requires instead of a conanfile')
+                           help='Directly provide requires instead of a conanfile')
     subparser.add_argument("--tool-requires", action='append',
                                                   help='Directly provide tool-requires instead of a conanfile')
     add_reference_args(subparser)

--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -44,8 +44,8 @@ def add_lockfile_args(parser):
     return group
 
 
-def add_common_install_arguments(parser, group=None):
-    group = group or parser.add_argument_group("common install options")
+def add_common_install_arguments(parser):
+    group = parser.add_argument_group("common install options")
     group.add_argument("-b", "--build", action="append", help=_help_build_policies)
 
     remotes_group = group.add_mutually_exclusive_group()
@@ -61,8 +61,8 @@ def add_common_install_arguments(parser, group=None):
                    "latest revision for the resolved version range.")
 
     group.add_argument("-u", "--update", action="append", nargs="?", help=update_help, const="*")
-    profile_group = add_profiles_args(parser)
-    return group, profile_group
+    add_profiles_args(parser)
+    return group
 
 
 def add_profiles_args(parser):
@@ -133,15 +133,14 @@ def common_graph_args(subparser):
                                 "directory when no --requires or --tool-requires is "
                                 "given",
                            default=None)
-    group = subparser.add_argument_group("common graph options")
-    group.add_argument("--requires", action="append",
-                       help='Directly provide requires instead of a conanfile')
-    group.add_argument("--tool-requires", action='append',
-                       help='Directly provide tool-requires instead of a conanfile')
-    ref_group = add_reference_args(subparser)
-    install_group, profile_group = add_common_install_arguments(subparser, group)
-    lockfile_group = add_lockfile_args(subparser)
-    return ref_group, install_group, profile_group, lockfile_group
+    install_group = add_common_install_arguments(subparser)
+    install_group.add_argument("--requires", action="append",
+                                                  help='Directly provide requires instead of a conanfile')
+    install_group.add_argument("--tool-requires", action='append',
+                                                  help='Directly provide tool-requires instead of a conanfile')
+    add_reference_args(subparser)
+    add_lockfile_args(subparser)
+    return install_group
 
 
 def validate_common_graph_args(args):

--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -68,7 +68,7 @@ def add_common_install_arguments(parser):
 def add_profiles_args(parser):
     contexts = ["build", "host"]
 
-    group = parser.add_argument_group("configuration options")
+    group = parser.add_argument_group("profile options")
 
     # This comes from the _AppendAction code but modified to add to the contexts
     class ContextAllAction(argparse.Action):

--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -49,9 +49,9 @@ def add_common_install_arguments(parser):
     group = parser.add_argument_group("remote arguments")
     exclusive_group = group.add_mutually_exclusive_group()
     exclusive_group.add_argument("-r", "--remote", action="append", default=None,
-                               help='Look in the specified remote or remotes server')
+                                 help='Look in the specified remote or remotes server')
     exclusive_group.add_argument("-nr", "--no-remote", action="store_true",
-                               help='Do not use remote, resolve exclusively in the cache')
+                                 help='Do not use remote, resolve exclusively in the cache')
 
     update_help = ("Will install newer versions and/or revisions in the local cache "
                    "for the given reference name, or all references in the graph if no argument is supplied. "

--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -41,17 +41,16 @@ def add_lockfile_args(parser):
                        help="Remove unused entries from the lockfile")
     group.add_argument("--lockfile-overrides",
                        help="Overwrite lockfile overrides")
-    return group
 
 
 def add_common_install_arguments(parser):
     parser.add_argument("-b", "--build", action="append", help=_help_build_policies)
 
     group = parser.add_argument_group("remote arguments")
-    remotes_group = group.add_mutually_exclusive_group()
-    remotes_group.add_argument("-r", "--remote", action="append", default=None,
+    exclusive_group = group.add_mutually_exclusive_group()
+    exclusive_group.add_argument("-r", "--remote", action="append", default=None,
                                help='Look in the specified remote or remotes server')
-    remotes_group.add_argument("-nr", "--no-remote", action="store_true",
+    exclusive_group.add_argument("-nr", "--no-remote", action="store_true",
                                help='Do not use remote, resolve exclusively in the cache')
 
     update_help = ("Will install newer versions and/or revisions in the local cache "
@@ -108,7 +107,6 @@ def add_profiles_args(parser):
     create_config("o", "options", '-o="pkg/*:with_qt=True"')
     create_config("s", "settings", '-s="compiler=gcc"')
     create_config("c", "conf", '-c="tools.cmake.cmaketoolchain:generator=Xcode"')
-    return group
 
 
 def add_reference_args(parser):
@@ -121,7 +119,6 @@ def add_reference_args(parser):
                        help='Provide a user if not specified in conanfile')
     group.add_argument("--channel", action=OnceArgument,
                        help='Provide a channel if not specified in conanfile')
-    return group
 
 
 def common_graph_args(subparser):

--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -27,7 +27,7 @@ _help_build_policies = '''Optional, specify which packages to build from source.
 
 
 def add_lockfile_args(parser):
-    group = parser.add_argument_group("lockfile options")
+    group = parser.add_argument_group("lockfile arguments")
     group.add_argument("-l", "--lockfile", action=OnceArgument,
                        help="Path to a lockfile. Use --lockfile=\"\" to avoid automatic use of "
                             "existing 'conan.lock' file")
@@ -45,10 +45,9 @@ def add_lockfile_args(parser):
 
 
 def add_common_install_arguments(parser):
-    group = parser.add_argument_group("common install options")
-    group.add_argument("-b", "--build", action="append", help=_help_build_policies)
+    parser.add_argument("-b", "--build", action="append", help=_help_build_policies)
 
-    remotes_group = group.add_mutually_exclusive_group()
+    remotes_group = parser.add_mutually_exclusive_group()
     remotes_group.add_argument("-r", "--remote", action="append", default=None,
                                help='Look in the specified remote or remotes server')
     remotes_group.add_argument("-nr", "--no-remote", action="store_true",
@@ -60,15 +59,14 @@ def add_common_install_arguments(parser):
                    "satisfies the range. It will update to the "
                    "latest revision for the resolved version range.")
 
-    group.add_argument("-u", "--update", action="append", nargs="?", help=update_help, const="*")
+    parser.add_argument("-u", "--update", action="append", nargs="?", help=update_help, const="*")
     add_profiles_args(parser)
-    return group
 
 
 def add_profiles_args(parser):
     contexts = ["build", "host"]
 
-    group = parser.add_argument_group("profile options")
+    group = parser.add_argument_group("profile arguments")
 
     # This comes from the _AppendAction code but modified to add to the contexts
     class ContextAllAction(argparse.Action):
@@ -113,7 +111,7 @@ def add_profiles_args(parser):
 
 
 def add_reference_args(parser):
-    group = parser.add_argument_group("reference options")
+    group = parser.add_argument_group("reference arguments")
     group.add_argument("--name", action=OnceArgument,
                        help='Provide a package name if not specified in conanfile')
     group.add_argument("--version", action=OnceArgument,
@@ -133,14 +131,13 @@ def common_graph_args(subparser):
                                 "directory when no --requires or --tool-requires is "
                                 "given",
                            default=None)
-    install_group = add_common_install_arguments(subparser)
-    install_group.add_argument("--requires", action="append",
+    add_common_install_arguments(subparser)
+    subparser.add_argument("--requires", action="append",
                                                   help='Directly provide requires instead of a conanfile')
-    install_group.add_argument("--tool-requires", action='append',
+    subparser.add_argument("--tool-requires", action='append',
                                                   help='Directly provide tool-requires instead of a conanfile')
     add_reference_args(subparser)
     add_lockfile_args(subparser)
-    return install_group
 
 
 def validate_common_graph_args(args):

--- a/conan/cli/command.py
+++ b/conan/cli/command.py
@@ -187,8 +187,7 @@ class ConanCommand(BaseConanCommand):
         parser = ConanArgumentParser(conan_api, description=self._doc,
                                      prog="conan {}".format(self._name),
                                      formatter_class=SmartFormatter,
-                                     add_help=False,
-                                     command=self)
+                                     add_help=False)
         self._init_formatters(parser)
         self._init_core_options(parser)
         parser.suggest_on_error = True
@@ -237,7 +236,7 @@ class ConanSubCommand(BaseConanCommand):
 
     def set_parser(self, subcommand_parser, conan_api):
         self._parser = subcommand_parser.add_parser(self._name, conan_api=conan_api, help=self._doc,
-                                                    add_help=False, command=self)
+                                                    add_help=False)
         self._parser.description = self._doc
         self._init_formatters(self._parser)
         self._init_core_options(self._parser)

--- a/conan/cli/command.py
+++ b/conan/cli/command.py
@@ -47,20 +47,18 @@ class BaseConanCommand:
 
     @staticmethod
     def _init_core_options(parser):
-        group = parser.add_argument_group("core options")
         # Define possible levels, including "" for verbose
         possible_levels = list(ConanOutput.valid_log_levels().keys())
         possible_levels[possible_levels.index(None)] = ""
-        group.add_argument("-v", default="status", nargs='?',
-                           help="Level of detail of the output. Valid options from less verbose "
-                                "to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, "
-                                "-v or -vverbose, -vv or -vdebug, -vvv or -vtrace",
-                           choices=possible_levels,
-                           )
-        group.add_argument("-cc", "--core-conf", action="append",
-                           help="Define core configuration, overwriting global.conf "
-                                "values. E.g.: -cc core:non_interactive=True")
-        group.add_argument("-h", "--help", action="help", help="Show this help message and exit")
+        parser.add_argument("-v", default="status", nargs='?',
+                            help="Level of detail of the output. Valid options from less verbose "
+                                 "to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, "
+                                 "-v or -vverbose, -vv or -vdebug, -vvv or -vtrace",
+                            choices=possible_levels,
+                            )
+        parser.add_argument("-cc", "--core-conf", action="append",
+                            help="Define core configuration, overwriting global.conf "
+                                 "values. E.g.: -cc core:non_interactive=True")
 
     @property
     def _help_formatters(self):
@@ -72,13 +70,13 @@ class BaseConanCommand:
 
     def _init_formatters(self, parser):
         formatters = self._help_formatters
-        group = parser.add_argument_group("formatting options")
         if formatters:
             help_message = "Select the output format: {}".format(", ".join(formatters))
-            group.add_argument('-f', '--format', action=OnceArgument, help=help_message)
+            parser.add_argument('-f', '--format', action=OnceArgument, help=help_message)
 
-        group.add_argument("--out-file", action=OnceArgument,
-                           help="Write the output of the command to the specified file instead of stdout.")
+        parser.add_argument("--out-file", action=OnceArgument,
+                            help="Write the output of the command to the specified file instead of "
+                                 "stdout.")
 
     @property
     def name(self):
@@ -162,8 +160,7 @@ class ConanCommand(BaseConanCommand):
     def run_cli(self, conan_api, *args):
         parser = ConanArgumentParser(conan_api, description=self._doc,
                                      prog="conan {}".format(self._name),
-                                     formatter_class=SmartFormatter,
-                                     add_help=False)
+                                     formatter_class=SmartFormatter)
         self._init_formatters(parser)
         self._init_core_options(parser)
         parser.suggest_on_error = True
@@ -186,8 +183,7 @@ class ConanCommand(BaseConanCommand):
     def run(self, conan_api, *args):
         parser = ConanArgumentParser(conan_api, description=self._doc,
                                      prog="conan {}".format(self._name),
-                                     formatter_class=SmartFormatter,
-                                     add_help=False)
+                                     formatter_class=SmartFormatter)
         self._init_formatters(parser)
         self._init_core_options(parser)
         parser.suggest_on_error = True
@@ -235,8 +231,7 @@ class ConanSubCommand(BaseConanCommand):
         self._name = self._subcommand_name.replace(f'{parent_name}-', '', 1)
 
     def set_parser(self, subcommand_parser, conan_api):
-        self._parser = subcommand_parser.add_parser(self._name, conan_api=conan_api, help=self._doc,
-                                                    add_help=False)
+        self._parser = subcommand_parser.add_parser(self._name, conan_api=conan_api, help=self._doc)
         self._parser.description = self._doc
         self._init_formatters(self._parser)
         self._init_core_options(self._parser)

--- a/conan/cli/command.py
+++ b/conan/cli/command.py
@@ -46,14 +46,21 @@ class BaseConanCommand:
                                  "its use briefly.".format(self._name))
 
     @staticmethod
-    def _init_log_levels(parser):
-        parser.add_argument("-v", default="status", nargs='?',
-                            help="Level of detail of the output. Valid options from less verbose "
-                                 "to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, "
-                                 "-v or -vverbose, -vv or -vdebug, -vvv or -vtrace")
-        parser.add_argument("-cc", "--core-conf", action="append",
-                            help="Define core configuration, overwriting global.conf "
-                                 "values. E.g.: -cc core:non_interactive=True")
+    def _init_core_options(parser):
+        group = parser.add_argument_group("core options")
+        # Define possible levels, including "" for verbose
+        possible_levels = list(ConanOutput.valid_log_levels().keys())
+        possible_levels[possible_levels.index(None)] = ""
+        group.add_argument("-v", default="status", nargs='?',
+                           help="Level of detail of the output. Valid options from less verbose "
+                                "to more verbose: -vquiet, -verror, -vwarning, -vnotice, -vstatus, "
+                                "-v or -vverbose, -vv or -vdebug, -vvv or -vtrace",
+                           choices=possible_levels,
+                           )
+        group.add_argument("-cc", "--core-conf", action="append",
+                           help="Define core configuration, overwriting global.conf "
+                                "values. E.g.: -cc core:non_interactive=True")
+        group.add_argument("-h", "--help", action="help", help="Show this help message and exit")
 
     @property
     def _help_formatters(self):
@@ -65,12 +72,13 @@ class BaseConanCommand:
 
     def _init_formatters(self, parser):
         formatters = self._help_formatters
+        group = parser.add_argument_group("formatting options")
         if formatters:
             help_message = "Select the output format: {}".format(", ".join(formatters))
-            parser.add_argument('-f', '--format', action=OnceArgument, help=help_message)
+            group.add_argument('-f', '--format', action=OnceArgument, help=help_message)
 
-        parser.add_argument("--out-file", action=OnceArgument,
-                            help="Write the output of the command to the specified file instead of stdout.")
+        group.add_argument("--out-file", action=OnceArgument,
+                           help="Write the output of the command to the specified file instead of stdout.")
 
     @property
     def name(self):
@@ -117,8 +125,9 @@ class BaseConanCommand:
 
 class ConanArgumentParser(argparse.ArgumentParser):
 
-    def __init__(self, conan_api, *args, **kwargs):
+    def __init__(self, conan_api, command, *args, **kwargs):
         self._conan_api = conan_api
+        self._command = command
         super().__init__(*args, **kwargs)
 
     def parse_args(self, args=None, namespace=None):
@@ -139,6 +148,11 @@ class ConanArgumentParser(argparse.ArgumentParser):
                                                             default=[], check_type=list))
         return args
 
+    def parse_known_args(self, args=None, namespace=None):
+        self._command._init_formatters(self)
+        self._command._init_core_options(self)
+        return super().parse_known_args(args, namespace)
+
 
 class ConanCommand(BaseConanCommand):
     def __init__(self, method, group=None, formatters=None):
@@ -154,9 +168,10 @@ class ConanCommand(BaseConanCommand):
     def run_cli(self, conan_api, *args):
         parser = ConanArgumentParser(conan_api, description=self._doc,
                                      prog="conan {}".format(self._name),
-                                     formatter_class=SmartFormatter)
-        self._init_log_levels(parser)
-        self._init_formatters(parser)
+                                     formatter_class=SmartFormatter,
+                                     add_help=False,
+                                     command=self)
+        parser.suggest_on_error = True
         info = self._method(conan_api, parser, *args)
         if not self._subcommands:
             return info
@@ -176,9 +191,10 @@ class ConanCommand(BaseConanCommand):
     def run(self, conan_api, *args):
         parser = ConanArgumentParser(conan_api, description=self._doc,
                                      prog="conan {}".format(self._name),
-                                     formatter_class=SmartFormatter)
-        self._init_log_levels(parser)
-        self._init_formatters(parser)
+                                     formatter_class=SmartFormatter,
+                                     add_help=False,
+                                     command=self)
+        parser.suggest_on_error = True
 
         info = self._method(conan_api, parser, *args)
 
@@ -223,10 +239,10 @@ class ConanSubCommand(BaseConanCommand):
         self._name = self._subcommand_name.replace(f'{parent_name}-', '', 1)
 
     def set_parser(self, subcommand_parser, conan_api):
-        self._parser = subcommand_parser.add_parser(self._name, conan_api=conan_api, help=self._doc)
+        self._parser = subcommand_parser.add_parser(self._name, conan_api=conan_api, help=self._doc,
+                                                    add_help=False, command=self)
         self._parser.description = self._doc
-        self._init_formatters(self._parser)
-        self._init_log_levels(self._parser)
+        self._parser.suggest_on_error = True
 
 
 def conan_command(group=None, formatters=None):

--- a/conan/cli/command.py
+++ b/conan/cli/command.py
@@ -125,9 +125,8 @@ class BaseConanCommand:
 
 class ConanArgumentParser(argparse.ArgumentParser):
 
-    def __init__(self, conan_api, command, *args, **kwargs):
+    def __init__(self, conan_api, *args, **kwargs):
         self._conan_api = conan_api
-        self._command = command
         super().__init__(*args, **kwargs)
 
     def parse_args(self, args=None, namespace=None):
@@ -148,11 +147,6 @@ class ConanArgumentParser(argparse.ArgumentParser):
                                                             default=[], check_type=list))
         return args
 
-    def parse_known_args(self, args=None, namespace=None):
-        self._command._init_formatters(self)
-        self._command._init_core_options(self)
-        return super().parse_known_args(args, namespace)
-
 
 class ConanCommand(BaseConanCommand):
     def __init__(self, method, group=None, formatters=None):
@@ -169,8 +163,9 @@ class ConanCommand(BaseConanCommand):
         parser = ConanArgumentParser(conan_api, description=self._doc,
                                      prog="conan {}".format(self._name),
                                      formatter_class=SmartFormatter,
-                                     add_help=False,
-                                     command=self)
+                                     add_help=False)
+        self._init_formatters(parser)
+        self._init_core_options(parser)
         parser.suggest_on_error = True
         info = self._method(conan_api, parser, *args)
         if not self._subcommands:
@@ -194,6 +189,8 @@ class ConanCommand(BaseConanCommand):
                                      formatter_class=SmartFormatter,
                                      add_help=False,
                                      command=self)
+        self._init_formatters(parser)
+        self._init_core_options(parser)
         parser.suggest_on_error = True
 
         info = self._method(conan_api, parser, *args)
@@ -242,6 +239,8 @@ class ConanSubCommand(BaseConanCommand):
         self._parser = subcommand_parser.add_parser(self._name, conan_api=conan_api, help=self._doc,
                                                     add_help=False, command=self)
         self._parser.description = self._doc
+        self._init_formatters(self._parser)
+        self._init_core_options(self._parser)
         self._parser.suggest_on_error = True
 
 

--- a/test/integration/command/test_output.py
+++ b/test/integration/command/test_output.py
@@ -13,7 +13,6 @@ class TestOutputLevel:
         t.save({"conanfile.py": GenConanfile("foo", "1.0")})
         t.run("create . -vfooling", assert_error=True)
         assert "argument -v: invalid choice: 'fooling'" in t.out
-        assert "(choose from quiet, error, warning, notice, status, , verbose, debug, v, trace, vv)" in t.out
 
         with environment_update({"CONAN_LOG_LEVEL": "fail"}):
             t.run("create .", assert_error=True)

--- a/test/integration/command/test_output.py
+++ b/test/integration/command/test_output.py
@@ -12,9 +12,8 @@ class TestOutputLevel:
         t = TestClient(light=True)
         t.save({"conanfile.py": GenConanfile("foo", "1.0")})
         t.run("create . -vfooling", assert_error=True)
-        assert "Invalid argument '-vfooling'" in t.out
-        assert "Allowed values: quiet, error, warning, notice, status, verbose, " \
-               "debug(v), trace(vv)" in t.out
+        assert "argument -v: invalid choice: 'fooling'" in t.out
+        assert "(choose from quiet, error, warning, notice, status, , verbose, debug, v, trace, vv)" in t.out
 
         with environment_update({"CONAN_LOG_LEVEL": "fail"}):
             t.run("create .", assert_error=True)


### PR DESCRIPTION
Changelog: Feature: Group arguments in CLI help.
Changelog: Feature: Suggest possible typos for CLI arguments declared as string choices.
Docs: Omit

We have added only 3 groups, while we think about the groupings for the rest of the arguments

<img width="3446" height="2030" alt="image" src="https://github.com/user-attachments/assets/4419750d-f188-4762-bfb9-67502869b5ea" />

