### PR TITLE
public name for conan config install-pkg --url remote

### DIFF
--- a/conan/cli/commands/config.py
+++ b/conan/cli/commands/config.py
@@ -87,7 +87,7 @@ def config_install_pkg(conan_api, parser, subparser, *args):
         default_profile = None
     profiles = [default_profile] if default_profile else []
     profile = conan_api.profiles.get_profile(profiles, args.settings, args.options)
-    remotes = [Remote("_tmp_conan_config", url=args.url)] if args.url else None
+    remotes = [Remote("config_install_url", url=args.url)] if args.url else None
     config_pref = conan_api.config.install_pkg(args.item, lockfile=lockfile, force=args.force,
                                                remotes=remotes, profile=profile)
     lockfile = conan_api.lockfile.add_lockfile(lockfile, config_requires=[config_pref.ref])

--- a/test/functional/command/config_install_test.py
+++ b/test/functional/command/config_install_test.py
@@ -753,6 +753,7 @@ class TestConfigInstallPkg:
         # This uses the same server and URL, because the TestClient+TestServer
         # does not allow atm to test this, as it requires the remote to be defined
         c.run(f"config install-pkg myconf/[*] --url={remote_url}")
+        assert "Connecting to remote 'config_install_url' with user 'admin'" in c.out
         assert "myconf/0.1: Downloaded package revision" in c.out
         assert "Copying file global.conf" in c.out
         c.run("config show *")


### PR DESCRIPTION
Changelog: Feature: Make the remote name used by ``conan config install-pkg --url=<url>`` public.
Docs: https://github.com/conan-io/docs/pull/4281

Close https://github.com/conan-io/conan/issues/19122
