### PR TITLE
Revert "Error out if components miss requiring direct dependencies in…"

### DIFF
--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -803,17 +803,13 @@ class CppInfo:
                   f"other internal components that are not defined: {missing_internal}"
             raise ConanException(msg)
         external = [c[0] for c in comps if c[0] is not None]
+        if not external:
+            return
         # Only direct host (not test) dependencies can define required components
         # We use conanfile.dependencies to use the already replaced ones by "replace_requires"
         # So consumers can keep their ``self.cpp_info.requires = ["pkg_name::comp"]``
         direct_dependencies = [r.ref.name for r, d in conanfile.dependencies.items() if r.direct
                                and not r.build and not r.is_test and r.visible and not r.override]
-        if not external:
-            if direct_dependencies and comps:
-                msg = (f"{conanfile}: package_info(): There are direct dependencies, "
-                       "but no '(cpp_info/components).requires' to them.")
-                raise ConanException(msg)
-            return
 
         for e in external:
             if e not in direct_dependencies:
@@ -821,6 +817,7 @@ class CppInfo:
                       f"that includes package '{e}::', but such package is not a a direct " \
                       f"requirement of the recipe"
                 raise ConanException(msg)
+        # TODO: discuss if there are cases that something is required but not transitive
         for e in direct_dependencies:
             if e not in external:
                 msg = f"{conanfile}: package_info(): The direct dependency '{e}' is not used by " \

--- a/test/integration/test_components_error.py
+++ b/test/integration/test_components_error.py
@@ -139,28 +139,6 @@ def test_missing_internal(component):
            "to other internal components that are not defined: ['other', 'another']" in t.out
 
 
-def test_missing_external_components():
-    foo = textwrap.dedent("""
-        from conan import ConanFile
-        class Recipe(ConanFile):
-            name = "consumer"
-            version = "1.0"
-            requires = "foo/1.0", "bar/1.0"
-            def package_info(self):
-                self.cpp_info.components["comp1"].libs = []
-                self.cpp_info.components["comp2"].requires = ["comp1"]
-        """)
-    t = TestClient()
-    t.save({'bar/conanfile.py': GenConanfile("bar", "1.0"),
-            'foo/conanfile.py': GenConanfile("foo", "1.0"),
-            "consumer/conanfile.py": foo})
-    t.run('create foo')
-    t.run("create bar")
-    t.run('create consumer', assert_error=True)
-    assert ("package_info(): There are direct dependencies, "
-            "but no '(cpp_info/components).requires' to them.") in t.out
-
-
 def test_unused_tool_requirement():
     """ Requires should include all listed requirements
         This error is known when creating the package if the requirement is consumed.


### PR DESCRIPTION
Changelog: Bugfix: Revert "Error out if components miss requiring direct dependencies in more cases".
Docs: Omit

Closes: https://github.com/conan-io/conan/issues/19166

Revert: https://github.com/conan-io/conan/pull/18830

There are more packages than we anticipated affected by this, and our testing was flawed when considering them

🍔 