### PR TITLE
Add rename info for files in `conan report diff`

### DIFF
--- a/conan/api/subapi/report.py
+++ b/conan/api/subapi/report.py
@@ -41,7 +41,6 @@ class ReportAPI:
                               remotes)
             return export_ref, cache_path
 
-
         old_export_ref, old_cache_path = _source(old_path, old_reference)
         new_export_ref, new_cache_path = _source(new_path, new_reference)
 

--- a/conan/cli/formatters/report/diff.py
+++ b/conan/cli/formatters/report/diff.py
@@ -58,12 +58,21 @@ def _render_diff(content, template, template_folder, **kwargs):
         return _remove_prefixes(_replace_cache_paths(line))
 
     def _extract_header(diff_lines):
-        return diff_lines[:10]  # First 10 lines contain the header
+        # Header ends at the first occurrence of +++ line,
+        # and it can be at most 10 lines long
+        for i, line in enumerate(diff_lines[:10]):
+            if line.startswith("+++ "):
+                return diff_lines[:i + 1]
+        return diff_lines[:10]
 
-    def _parse_rename_header(contents):
-        if not any("similarity index" in line for line in contents):
+    def _parse_header_is_deleted(header_contents):
+        return ("+++ /dev/null" in header_contents
+                or any("deleted file mode" in line for line in header_contents))
+
+    def _parse_header_rename_to(header_contents):
+        if not any("similarity index" in line for line in header_contents):
             return None
-        for line in contents:
+        for line in header_contents:
             if line.startswith("rename to "):
                 return line[len("rename to "):]
         return None
@@ -71,7 +80,7 @@ def _render_diff(content, template, template_folder, **kwargs):
     per_folder = {"folders": {}, "files": {}}
     for file in content:
         header = _extract_header(content[file])
-        renamed_to = _parse_rename_header(header)
+        renamed_to = _parse_header_rename_to(header)
         replaced_path = _replace_paths(renamed_to or file)
         replaced_file = replaced_path.replace("(old)", "").replace("(new)", "").replace("\\", "/")
         bits = replaced_file.split("/")[1:]
@@ -81,9 +90,7 @@ def _render_diff(content, template, template_folder, **kwargs):
         filename = bits[-1]
         cur["files"][filename] = {"filename": file,  # This is file so renamed use old name
                                   "is_new": "(new)" in replaced_path,
-                                  "is_deleted": "+++ /dev/null" in header
-                                                or any("deleted file mode" in line
-                                                       for line in header),
+                                  "is_deleted": _parse_header_is_deleted(header),
                                   "renamed_to": renamed_to,
                                   "relative_path": replaced_path}
 

--- a/conan/cli/formatters/report/diff.py
+++ b/conan/cli/formatters/report/diff.py
@@ -57,29 +57,34 @@ def _render_diff(content, template, template_folder, **kwargs):
     def _replace_paths(line):
         return _remove_prefixes(_replace_cache_paths(line))
 
+    def _extract_header(diff_lines):
+        return diff_lines[:10]  # First 10 lines contain the header
+
     def _parse_rename_header(contents):
         if not any("similarity index" in line for line in contents):
             return None
         for line in contents:
             if line.startswith("rename to "):
-                renamed = line[len("rename to "):]
-                return _replace_paths(renamed)
+                return line[len("rename to "):]
         return None
 
     per_folder = {"folders": {}, "files": {}}
     for file in content:
-        replaced_path = _replace_paths(file)
+        header = _extract_header(content[file])
+        renamed_to = _parse_rename_header(header)
+        replaced_path = _replace_paths(renamed_to or file)
         replaced_file = replaced_path.replace("(old)", "").replace("(new)", "").replace("\\", "/")
         bits = replaced_file.split("/")[1:]
         cur = per_folder
-        header = content[file][:10]
         for folder in bits[:-1]:
             cur = cur["folders"].setdefault(folder, {"folders": {}, "files": {}})
-        cur["files"][bits[-1]] = {"filename": file, "is_new": "(new)" in replaced_path,
+        filename = bits[-1]
+        cur["files"][filename] = {"filename": file,  # This is file so renamed use old name
+                                  "is_new": "(new)" in replaced_path,
                                   "is_deleted": "+++ /dev/null" in header
                                                 or any("deleted file mode" in line
                                                        for line in header),
-                                  "renamed_to": _parse_rename_header(header),
+                                  "renamed_to": renamed_to,
                                   "relative_path": replaced_path}
 
     def flatten_empty_folders(current_node):

--- a/conan/cli/formatters/report/diff.py
+++ b/conan/cli/formatters/report/diff.py
@@ -57,18 +57,29 @@ def _render_diff(content, template, template_folder, **kwargs):
     def _replace_paths(line):
         return _remove_prefixes(_replace_cache_paths(line))
 
+    def _parse_rename_header(contents):
+        if not any("similarity index" in line for line in contents):
+            return None
+        for line in contents:
+            if line.startswith("rename to "):
+                renamed = line[len("rename to "):]
+                return _replace_paths(renamed)
+        return None
+
     per_folder = {"folders": {}, "files": {}}
     for file in content:
         replaced_path = _replace_paths(file)
         replaced_file = replaced_path.replace("(old)", "").replace("(new)", "").replace("\\", "/")
         bits = replaced_file.split("/")[1:]
         cur = per_folder
+        header = content[file][:10]
         for folder in bits[:-1]:
             cur = cur["folders"].setdefault(folder, {"folders": {}, "files": {}})
         cur["files"][bits[-1]] = {"filename": file, "is_new": "(new)" in replaced_path,
-                                  "is_deleted": "+++ /dev/null" in content[file][:10]
+                                  "is_deleted": "+++ /dev/null" in header
                                                 or any("deleted file mode" in line
-                                                       for line in content[file][:10]),
+                                                       for line in header),
+                                  "renamed_to": _parse_rename_header(header),
                                   "relative_path": replaced_path}
 
     def flatten_empty_folders(current_node):

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -12,13 +12,18 @@ diff_html = r"""
         </li>
     {%- endfor %}
     {%- for name, file_info in folder_info["files"].items() %}
-        <li class="file file-{{ "deleted" if file_info["is_deleted"] else (
-                                "new" if file_info["is_new"] else "old") }}"
+        <li class="file file-{{ "renamed" if file_info["renamed_to"] else (
+                                "deleted" if file_info["is_deleted"] else (
+                                "new" if file_info["is_new"] else "old")) }}"
             data-path="{{ file_info["relative_path"] }}">
             <a href="#diff_{{- safe_filename(file_info["filename"]) -}}"
                 onclick="setDataIsLinked(event)" draggable="false"
                 class="side-link">
-                {{ name }}
+                {% if file_info["renamed_to"] %}
+                    {{ file_info["renamed_to"].split("/")[1:][-1] }}
+                {% else %}
+                    {{ name }}
+                {% endif %}
             </a>
         </li>
     {%- endfor %}
@@ -37,6 +42,10 @@ diff_html = r"""
                     <summary class="diff-summary">
                         <b id="diff_{{ safe_filename(filename) }}_filename" class="filename" data-replaced-paths="">
                             <span>{{ replace_cache_paths(filename) | replace("(old)/", "") | replace("(new)/", "") }}</span>
+                            {% if file_info["renamed_to"] %}
+                                &nbsp;&#x2192&nbsp;
+                                <span>{{ replace_cache_paths(file_info["renamed_to"]) | replace("(old)/", "") | replace("(new)/", "") }}</span>
+                            {% endif %}
                         </b>
                         <div class="changes-count-container"></div>
                     </summary>
@@ -225,7 +234,8 @@ diff_html = r"""
             /* File Status Indicators */
             .sidebar li.file-new,
             .sidebar li.file-old,
-            .sidebar li.file-deleted {
+            .sidebar li.file-deleted,
+            .sidebar li.file-renamed {
                 list-style: none;
                 padding-left: 0;
             }
@@ -244,6 +254,12 @@ diff_html = r"""
             .sidebar li.file-deleted:before {
                 content: "-";
                 color: var(--sidebar-file-deleted-color);
+                font-weight: bold;
+            }
+
+            .sidebar li.file-renamed:before {
+                content: "\2192";
+                color: var(--sidebar-file-old-color);
                 font-weight: bold;
             }
 


### PR DESCRIPTION
Changelog: Feature: Add rename info for files in `conan report diff`.
Docs: Omit

Now looks something like

<img width="3446" height="1026" alt="image" src="https://github.com/user-attachments/assets/c6080ee4-27ab-4311-949d-af808b73a8d6" />
