### PR TITLE
fix cmakeconfigdeps new cmake_extra_interface_libs property

### DIFF
--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -98,7 +98,7 @@ class TargetConfigurationTemplate2:
                         comp = required_comp
                         default_target = f"{required_pkg}::{required_comp}"
                         link = not (pkg_type is PackageType.SHARED and
-                                dep_comp.type is PackageType.SHARED)
+                                    dep_comp.type is PackageType.SHARED)
 
                     dep_target = self._cmakedeps.get_property("cmake_target_name", dep, comp)
                     dep_target = dep_target or default_target
@@ -163,7 +163,7 @@ class TargetConfigurationTemplate2:
                                                            name)
                 target_name = target_name or f"{pkg_name}::{name}"
                 target = self._get_cmake_lib(component, cpp_info.components, pkg_folder,
-                                             pkg_folder_var)
+                                             pkg_folder_var, comp_name=name)
                 if target is not None:
                     cmake_target_aliases = self._get_aliases(name)
                     target["cmake_target_aliases"] = cmake_target_aliases
@@ -178,8 +178,9 @@ class TargetConfigurationTemplate2:
                 libs[target_name] = target
         return libs
 
-    def _get_cmake_lib(self, info, components, pkg_folder, pkg_folder_var):
-        if info.exe or not (info.package_framework or info.includedirs or info.libs or info.system_libs):
+    def _get_cmake_lib(self, info, components, pkg_folder, pkg_folder_var, comp_name=None):
+        if info.exe or not (info.package_framework or info.includedirs or info.libs
+                            or info.system_libs):
             return
 
         includedirs = ";".join(self._path(i, pkg_folder, pkg_folder_var)
@@ -191,7 +192,7 @@ class TargetConfigurationTemplate2:
         if not self._require.headers:  # If not depending on headers, paths and
             includedirs = defines = None
         extra_libs = self._cmakedeps.get_property("cmake_extra_interface_libs", self._conanfile,
-                                                  check_type=list) or []
+                                                  comp_name=comp_name, check_type=list) or []
         sources = [self._path(source, pkg_folder, pkg_folder_var) for source in info.sources]
         target = {"type": "INTERFACE",
                   "includedirs": includedirs,
@@ -203,7 +204,7 @@ class TargetConfigurationTemplate2:
                   "exelinkflags": " ".join(cmake_escape_value(v) for v in info.exelinkflags),
                   "system_libs": " ".join(info.system_libs + extra_libs),
                   "sources": " ".join(sources)
-        }
+                  }
         # System frameworks (only Apple OS)
         if info.frameworks:
             target['frameworks'] = " ".join([f"-framework {frw}" for frw in info.frameworks])
@@ -216,10 +217,12 @@ class TargetConfigurationTemplate2:
             assert lib_type, f"Unknown package type {info.type}"
             assert info.location, f"cpp_info.location missing for framework {info.package_framework}"
             target["type"] = lib_type
-            target["package_framework"]["location"] = self._path(info.location, pkg_folder, pkg_folder_var)
-            target["includedirs"] = []  # empty array as frameworks have their own way to inject headers
+            target["package_framework"]["location"] = self._path(info.location, pkg_folder,
+                                                                 pkg_folder_var)
+            target["includedirs"] = []  # empty as frameworks have their own way to inject headers
             # FIXME: This is not needed for CMake < 3.24. Remove it when Conan requires CMake >= 3.24
-            target["package_framework"]["frameworkdir"] = self._path(pkg_folder, pkg_folder, pkg_folder_var)
+            target["package_framework"]["frameworkdir"] = self._path(pkg_folder, pkg_folder,
+                                                                     pkg_folder_var)
         if info.libs:
             if len(info.libs) != 1:
                 raise ConanException(f"New CMakeDeps only allows 1 lib per component:\n"

--- a/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
@@ -409,6 +409,31 @@ def test_cmake_extra_dependencies():
            "             $<$<CONFIG:RELEASE>:MyOpenMPILib>)" in dep
 
 
+def test_cmake_extra_dependencies_components():
+    tc = TestClient()
+    dep = textwrap.dedent("""
+        from conan import ConanFile
+        class Pkg(ConanFile):
+            name = "dep"
+            version = "0.1"
+            def package_info(self):
+                self.cpp_info.set_property("cmake_extra_dependencies", ["MyOpenMPI"])
+                self.cpp_info.components["mycomp"].set_property("cmake_extra_interface_libs",
+                                                                ["MyOpenMPILib"])
+                self.cpp_info.components["mycomp"].libs = ["mycomplib"]
+                self.cpp_info.components["mycomp"].type = "static-library"
+                self.cpp_info.components["mycomp"].location = "lib/mycomp.a"
+        """)
+    tc.save({"conanfile.py": dep})
+    tc.run("create .")
+    args = f"-g CMakeDeps -c tools.cmake.cmakedeps:new={new_value}"
+    tc.run(f"install --requires=dep/0.1 {args}")
+    dep = tc.load("dep-Targets-release.cmake")
+    assert "find_dependency(MyOpenMPI REQUIRED )" in dep
+    assert "set_property(TARGET dep::mycomp APPEND PROPERTY INTERFACE_LINK_LIBRARIES\n" \
+           "             $<$<CONFIG:RELEASE>:MyOpenMPILib>)" in dep
+
+
 class TestRequiresToApp:
     def test_requires_to_application(self):
         c = TestClient()
@@ -544,7 +569,6 @@ class TestRequiresToApp:
         assert "automake::automake" not in targets
 
 
-
 def test_alias_cmakedeps_set_property():
     tc = TestClient()
     tc.save({"dep/conanfile.py": textwrap.dedent("""
@@ -601,7 +625,8 @@ def test_package_info_extra_variables():
             def package_info(self):
                 self.cpp_info.set_property("cmake_extra_variables", {"FOO": 42,
                                            "BAR": 42,
-                                           "CMAKE_GENERATOR_INSTANCE": "${GENERATOR_INSTANCE}/buildTools/",
+                                           "CMAKE_GENERATOR_INSTANCE":
+                                                 "${GENERATOR_INSTANCE}/buildTools/",
                                            "CACHE_VAR_DEFAULT_DOC": {"value": "hello world",
                                                                      "cache": True, "type": "PATH"}})
     """)


### PR DESCRIPTION
Changelog: Fix: CMakeConfigDeps management of ``cmake_extra_interface_libs`` per component.
Docs: Omit

Fix as reported in https://github.com/conan-io/conan/issues/18222#issuecomment-3473055585
