### PR TITLE
Allow conan cache path adoptions via conf `core.cache:path_prefix_fmt`

### DIFF
--- a/conan/internal/cache/cache.py
+++ b/conan/internal/cache/cache.py
@@ -26,6 +26,7 @@ class PkgCache:
         # paths
         self._store_folder = global_conf.get("core.cache:storage_path") or \
                              os.path.join(cache_folder, "p")
+        self.path_prefix_format_str = global_conf.get("core.cache:path_prefix_fmt")
 
         try:
             mkdir(self._store_folder)
@@ -73,13 +74,22 @@ class PkgCache:
         # Reduce length in 3 characters 16 - 3 = 13
         return sha_bytes[0:13]
 
-    @staticmethod
-    def _get_path(ref):
-        return ref.name[:5] + PkgCache._short_hash_path(ref.repr_notime())
+    def _get_path_prefix(self, ref):
+        if not self.path_prefix_format_str:
+            return ref.name[:5]
+        else:
+            try:
+                return self.path_prefix_format_str.format(ref=ref)
+            except:
+                raise ConanException(f"Invalid path_prefix: {self.path_prefix_format_str}")
 
-    @staticmethod
-    def _get_path_pref(pref):
-        return pref.ref.name[:5] + PkgCache._short_hash_path(pref.repr_notime())
+    def _get_path(self, ref):
+        prefix = self._get_path_prefix(ref)
+        return prefix + PkgCache._short_hash_path(ref.repr_notime())
+
+    def _get_path_pref(self, pref):
+        prefix = self._get_path_prefix(pref.ref)
+        return prefix + PkgCache._short_hash_path(pref.repr_notime())
 
     def create_export_recipe_layout(self, ref: RecipeReference):
         """  This is a temporary layout while exporting a new recipe, because the revision is not
@@ -90,7 +100,7 @@ class PkgCache:
         """
         assert ref.revision is None, "Recipe revision should be None"
         assert ref.timestamp is None
-        h = ref.name[:5] + PkgCache._short_hash_path(ref.repr_notime())
+        h = self._get_path(ref)
         reference_path = os.path.join("t", h)
         self._create_path(reference_path)
         return RecipeLayout(ref, os.path.join(self._base_folder, reference_path))
@@ -103,7 +113,8 @@ class PkgCache:
         assert pref.timestamp is None
 
         random_id = str(uuid.uuid4())
-        h = pref.ref.name[:5] + PkgCache._short_hash_path(pref.repr_notime() + random_id)
+        prefix = self._get_path_prefix(pref.ref)
+        h = prefix + PkgCache._short_hash_path(pref.repr_notime() + random_id)
         package_path = os.path.join("b", h)
         self._create_path(package_path)
         return PackageLayout(pref, os.path.join(self._base_folder, package_path))

--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -37,6 +37,7 @@ BUILT_IN_CONFS = {
     "core.download:retry_wait": "Seconds to wait between download attempts from Conan server",
     "core.download:download_cache": "Define path to a file download cache",
     "core.cache:storage_path": "Absolute path where the packages and database are stored",
+    "core.cache:path_prefix_fmt": "Format string for the prefix used in cache folders (defaults to ref.name[:5])",
     "core:update_policy": "(Legacy). If equal 'legacy' when multiple remotes, update based on order of remotes, only the timestamp of the first occurrence of each revision counts.",
     # Sources backup
     "core.sources:download_cache": "Folder to store the sources backup",


### PR DESCRIPTION
Allow users to change the conan cache path to a more human-readable one.
Therefore a new conan conf `core.cache:path_prefix_fmt` is introduced which allows users to specify a format string for the path prefix for the cache folder. The prefix defaults to `ref.name[:5]` (which is currently the default).
The format string can resolve the RecipeReference `ref`, for example '{ref.name}_{ref.name}_{ref.revision}_'

This is just a first draft with minimum effort to showcase the proposal.
If you agree with this proposal in general, I will continue to create specific tests for this feature.
Maybe I need your help with the tests: How can I enable this conf for all available tests to make sure that it does not break anything?

---

Changelog: (Feature): Allow conan cache path adoptions
Docs: https://github.com/conan-io/docs/pull/XXXX

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.