### PR TITLE
do not conflict with Ubuntu 24 default `python-distro (1.9.0)`

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -4,6 +4,6 @@ colorama>=0.4.3, <0.5.0
 PyYAML>=6.0, <7.0
 patch-ng>=1.18.0, <1.19
 fasteners>=0.15
-distro>=1.4.0, <=1.8.0; platform_system == 'Linux' or platform_system == 'FreeBSD'
+distro>=1.4.0, <2.0.0; platform_system == 'Linux' or platform_system == 'FreeBSD'
 Jinja2>=3.0, <4.0.0
 python-dateutil>=2.8.0, <3


### PR DESCRIPTION
Changelog: Feature: Allow ``distro 1.19`` python pip package dependency for broader compatibility.
Docs: Omit


This PR updates Conan’s dependency constraints to avoid conflicts with `distro` version `1.9.0`, while still requiring any `1.X` version.

## Motivation
Users often want to install Conan directly on a system—for example, inside a Docker container. Currently, this fails on Ubuntu 24 because Conan restricts the `distro` package to a maximum version of `1.8.0`.

Is there a specific reason for this limitation?

On Ubuntu 24.04, the default `distro` version installed via `apt install python3-pip` is `1.9.0`.
This causes issues when building Docker containers that include packages depending on `python3-distro`.

## Steps to Reproduce
```bash
docker run -it ubuntu:24.04
apt update
apt install -y python3-pip python3-distro
pip3 install conan==2.22.1 --break-system-packages
```
This fails with:
```
ERROR: Cannot uninstall distro 1.9.0, RECORD file not found. Hint: The package was installed by debian.
```

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
