### PR TITLE
[BazelDeps] Adding RPATH to linkopts

### DIFF
--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -291,6 +291,10 @@ class _BazelDepBuildGenerator:
                 "linkopts": []
             }
             if info['is_shared'] and info["lib_path"] and not info["lib_path"].endswith(".dll"):
+                # Issue: https://github.com/conan-io/conan/issues/19190
+                # Issue: https://github.com/conan-io/conan/issues/19135
+                # (UNIX) Adding the rpath flag as any application could link through the library
+                # which points out a symlink, but that name does not appear in the library location
                 info["linkopts"] = [f'"-Wl,-rpath,{cpp_info.libdirs[0]}"']
             return info
 

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -53,6 +53,13 @@ class _BazelDepBuildGenerator:
         {% if lib_info['import_lib_path'] %}
         interface_library = "{{ lib_info['import_lib_path'] }}",
         {% endif %}
+        {% if lib_info["linkopts"] %}
+        linkopts = [
+            {% for linkopt in lib_info["linkopts"] %}
+            {{ linkopt }},
+            {% endfor %}
+        ],
+        {% endif %}
     )
     {% endfor %}
     {% endmacro %}
@@ -276,12 +283,16 @@ class _BazelDepBuildGenerator:
     def _get_lib_info(self, cpp_info, deduced_cpp_info, component_name=None):
 
         def _lib_info(lib_name, virtual_cpp_info):
-            return {
+            info = {
                 "name": lib_name,
                 "is_shared": virtual_cpp_info.type == PackageType.SHARED,
                 "lib_path": _relativize_path(virtual_cpp_info.location, self._package_folder),
-                "import_lib_path": _relativize_path(virtual_cpp_info.link_location, self._package_folder)
+                "import_lib_path": _relativize_path(virtual_cpp_info.link_location, self._package_folder),
+                "linkopts": []
             }
+            if info['is_shared'] and not info["lib_path"].endswith(".dll"):
+                info["linkopts"] = [f'"-Wl,-rpath,{cpp_info.libdirs[0]}"']
+            return info
 
         libs = cpp_info.libs
         libs_info = []

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -290,7 +290,7 @@ class _BazelDepBuildGenerator:
                 "import_lib_path": _relativize_path(virtual_cpp_info.link_location, self._package_folder),
                 "linkopts": []
             }
-            if info['is_shared'] and not info["lib_path"].endswith(".dll"):
+            if info['is_shared'] and info["lib_path"] and not info["lib_path"].endswith(".dll"):
                 info["linkopts"] = [f'"-Wl,-rpath,{cpp_info.libdirs[0]}"']
             return info
 

--- a/conan/tools/google/bazeldeps.py
+++ b/conan/tools/google/bazeldeps.py
@@ -295,7 +295,7 @@ class _BazelDepBuildGenerator:
                 # Issue: https://github.com/conan-io/conan/issues/19135
                 # (UNIX) Adding the rpath flag as any application could link through the library
                 # which points out a symlink, but that name does not appear in the library location
-                info["linkopts"] = [f'"-Wl,-rpath,{cpp_info.libdirs[0]}"']
+                info["linkopts"] = [f'"-Wl,-rpath,{libdir}"' for libdir in cpp_info.libdirs]
             return info
 
         libs = cpp_info.libs

--- a/test/integration/toolchains/google/test_bazeldeps.py
+++ b/test/integration/toolchains/google/test_bazeldeps.py
@@ -1392,4 +1392,4 @@ def test_shared_libs_and_unix_includes_rpath():
     assert '"-Wl,-rpath,' not in build_content
     client.run("install . -g BazelDeps -s 'os=Linux'")
     build_content = load(None, os.path.join(client.current_folder, "csm", "BUILD.bazel"))
-    assert re.search('"-Wl,-rpath,.*/p/lib"', build_content)
+    assert re.search('"-Wl,-rpath,.*/p/lib"', build_content.replace("\\", "/"))

--- a/test/integration/toolchains/google/test_bazeldeps.py
+++ b/test/integration/toolchains/google/test_bazeldeps.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
 import platform
+import re
 import textwrap
 
 import pytest
@@ -1347,3 +1348,48 @@ def test_apple_frameworks_and_frameworkdirs():
     )
     """)
     assert build_file_expected in build_content
+
+
+def test_shared_libs_and_unix_includes_rpath():
+    """
+    Testing the RPATH flag is added to the BUILD.bazel file if these conditions
+    are given: shared library and UNIX systems.
+
+    Issue: https://github.com/conan-io/conan/issues/19190
+    Issue: https://github.com/conan-io/conan/issues/19135
+    """
+    client = TestClient()
+    csm = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+        from conan.tools.files import save
+        class Pkg(ConanFile):
+            name = "csm"
+            version = "1.0"
+            settings = "os"
+            options = {"shared": [True, False]}
+            default_options = {"shared": False}
+            def package(self):
+                if self.settings.os == "Windows":
+                    save(self, os.path.join(self.package_folder, "bin", "csmapi.dll"), "")
+                    save(self, os.path.join(self.package_folder, "lib", "csmapi.lib"), "")
+                else:
+                    save(self, os.path.join(self.package_folder, "lib", "libcsmapi.so"), "")
+            def package_info(self):
+                self.cpp_info.libs = ["csmapi"]
+        """)
+    consumer = textwrap.dedent("""
+        [requires]
+        csm/1.0
+        [options]
+        *:shared=True
+    """)
+    client.save({"conanfile.txt": consumer, "csm/conanfile.py": csm})
+    client.run("export-pkg csm -o '*:shared=True' -s 'os=Windows'")
+    client.run("export-pkg csm -o '*:shared=True' -s 'os=Linux'")
+    client.run("install . -g BazelDeps -s 'os=Windows'")
+    build_content = load(None, os.path.join(client.current_folder, "csm", "BUILD.bazel"))
+    assert '"-Wl,-rpath,' not in build_content
+    client.run("install . -g BazelDeps -s 'os=Linux'")
+    build_content = load(None, os.path.join(client.current_folder, "csm", "BUILD.bazel"))
+    assert re.search('"-Wl,-rpath,.*/p/lib"', build_content)


### PR DESCRIPTION
Changelog: Fix: [BazelDeps] Adding RPATH flag in `linkopts` field for dynamic builds and UNIX systems.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/19135
Closes: https://github.com/conan-io/conan/issues/19190


**Rationale**

For instance, the `csm` library creates these binaries:
```
.
├── libcsmapi.3.0.4.dylib
├── libcsmapi.3.dylib -> libcsmapi.3.0.4.dylib
└── libcsmapi.dylib -> libcsmapi.3.dylib
```
And the `csm/BUILD.bazel` file has this:
```
shared_library = "lib/libcsmapi.dylib"
```
Any application linking with that will show this:

```
$ otool -L bazel-bin/main/demo
bazel-bin/main/demo:
    @rpath/libcsmapi.3.dylib (compatibility version 3.0.0, current version 3.0.4)
```
It points to the symlink, but Bazel only copies the matched library into its own cache (_libcsmapi.dylib_). Adding the rpath flag, we solve that problem.
