### PR TITLE
improve PipEnv

### DIFF
--- a/conan/tools/system/pip_manager.py
+++ b/conan/tools/system/pip_manager.py
@@ -16,8 +16,7 @@ class PipEnv:
         :param name: Optional name for the virtualenv, by default "conan_pipenv"
         """
         self._conanfile = conanfile
-        name = f"_{name}" if name else ""
-        self.env_name = f"conan_pipenv{name}"
+        self.env_name = f"conan_pipenv{f'_{name}' if name else ''}"
         self._env_dir = os.path.abspath(os.path.join(folder or conanfile.build_folder,
                                                      self.env_name))
         bins = "Scripts" if platform.system() == "Windows" else "bin"

--- a/conan/tools/system/pip_manager.py
+++ b/conan/tools/system/pip_manager.py
@@ -9,12 +9,22 @@ from conan.errors import ConanException
 
 class PipEnv:
 
-    def __init__(self, conanfile, folder=None):
+    def __init__(self, conanfile, folder=None, name=""):
+        """
+        :param conanfile: The current conanfile "self"
+        :param folder: Optional folder, by default the "build_folder"
+        :param name: Optional name for the virtualenv, by default "conan_pipenv"
+        """
         self._conanfile = conanfile
-        self.env_name = f"pip_venv_{self._conanfile.name}"
-        self._env_dir = os.path.abspath(os.path.join(folder or self._conanfile.build_folder, self.env_name))
-        self.bin_dir = os.path.join(self._env_dir, "Scripts" if platform.system() == "Windows" else "bin")
-        self._python_exe = os.path.join(self.bin_dir, "python.exe" if platform.system() == "Windows" else "python")
+        name = f"_{name}" if name else ""
+        self.env_name = f"conan_pipenv{name}"
+        self._env_dir = os.path.abspath(os.path.join(folder or conanfile.build_folder,
+                                                     self.env_name))
+        bins = "Scripts" if platform.system() == "Windows" else "bin"
+        self.bin_dir = os.path.join(self._env_dir, bins)
+        pyexe = "python.exe" if platform.system() == "Windows" else "python"
+        self._python_exe = os.path.join(self.bin_dir, pyexe)
+        self._create_venv()
 
     def generate(self):
         """
@@ -26,20 +36,25 @@ class PipEnv:
 
     @staticmethod
     def _default_python():
-        default_python = shutil.which('python') if platform.system() == "Windows" else shutil.which('python3')
+        python = "python" if platform.system() == "Windows" else "python3"
+        default_python = shutil.which(python)
         return os.path.realpath(default_python) if default_python else None
 
     def _create_venv(self):
-        python_interpreter = self._conanfile.conf.get("tools.system.pipenv:python_interpreter") or self._default_python()
+        python_interpreter = self._conanfile.conf.get("tools.system.pipenv:python_interpreter")
+        python_interpreter = python_interpreter or self._default_python()
         if not python_interpreter:
-            raise ConanException("PipEnv could not find a Python executable path. "
-                                 "Please, install Python system-wide or set the 'tools.system.pipenv:python_interpreter' "
+            raise ConanException("PipEnv could not find a Python executable path. Please, install "
+                                 "Python system-wide or set the "
+                                 "'tools.system.pipenv:python_interpreter' "
                                  "conf to the full path of a Python executable")
 
         try:
-            self._conanfile.run(cmd_args_to_string([python_interpreter, '-m', 'venv', self._env_dir]))
+            self._conanfile.run(cmd_args_to_string([python_interpreter, '-m', 'venv',
+                                                    self._env_dir]))
         except ConanException as e:
-            raise ConanException(f"PipEnv could not create a Python virtual environment using '{python_interpreter}': {e}")
+            raise ConanException(f"PipEnv could not create a Python virtual "
+                                 f"environment using '{python_interpreter}': {e}")
 
     def install(self, packages, pip_args=None):
         """
@@ -47,12 +62,10 @@ class PipEnv:
 
         :param packages: try to install the list of pip packages passed as a parameter.
         :param pip_args: additional argument list to be passed to the 'pip install' command,
-                         for example: ['--no-cache-dir', '--index-url', 'https://my.pypi.org/simple'].
+                         e.g.: ['--no-cache-dir', '--index-url', 'https://my.pypi.org/simple'].
                          Defaults to ``None``.
         :return: the return code of the executed pip command.
         """
-
-        self._create_venv()
         args = [self._python_exe, "-m", "pip", "install", "--disable-pip-version-check"]
         if pip_args:
             args += list(pip_args)

--- a/test/functional/tools/system/pip_manager_test.py
+++ b/test/functional/tools/system/pip_manager_test.py
@@ -23,6 +23,30 @@ def _create_py_hello_world(folder):
     save_files(folder, {"setup.py": setup_py, "hello/__init__.py": hello_py})
 
 
+def test_empty_pipenv():
+    conanfile = textwrap.dedent(f"""
+        from conan import ConanFile
+        from conan.tools.system import PipEnv
+
+        class PipPackage(ConanFile):
+
+            def generate(self):
+                PipEnv(self).generate()
+
+            def build(self):
+                self.run("python -m pip list")
+        """)
+
+    c = TestClient(path_with_spaces=False)
+    c.save({"conanfile.py": conanfile})
+    c.run("build")
+    # Test that some Conan common deps are not in this pip list
+    assert "requests" not in c.out
+    assert "colorama" not in c.out
+    assert "Jinja2" not in c.out
+    assert "PyJWT" not in c.out
+
+
 def test_build_pip_manager():
 
     pip_package_folder = temp_folder(path_with_spaces=True)
@@ -52,7 +76,8 @@ def test_build_pip_manager():
                 self.run("hello-world")
         """)
 
-    client = TestClient(path_with_spaces=False)  # FIXME: the python shebang inside vitual env packages fails when using path_with_spaces
+    client = TestClient(path_with_spaces=False)
+    # FIXME: the python shebang inside vitual env packages fails when using path_with_spaces
     client.save({"pip/conanfile.py": conanfile_pip})
     client.run("build pip/conanfile.py")
 
@@ -106,7 +131,8 @@ def test_create_pip_manager():
                 self.run("hello-world")
         """)
 
-    client = TestClient(path_with_spaces=False)  # FIXME: the python shebang inside vitual env packages fails when using path_with_spaces
+    client = TestClient(path_with_spaces=False)
+    # FIXME: the python shebang inside vitual env packages fails when using path_with_spaces
     client.save({"pip/conanfile.py": conanfile_pip, "consumer/conanfile.py": conanfile})
     client.run("create pip/conanfile.py --version=0.1")
     client.run("build consumer/conanfile.py")

--- a/test/unittests/tools/system/pip_manager_test.py
+++ b/test/unittests/tools/system/pip_manager_test.py
@@ -10,15 +10,16 @@ from conan.test.utils.mocks import ConanFileMock
 def test_pipenv_conf(mock_shutil_which):
     conanfile = ConanFileMock()
     conanfile.settings = Settings()
-    conanfile.conf.define("tools.system.pipenv:python_interpreter", "/python/interpreter/from/config")
+    conanfile.conf.define("tools.system.pipenv:python_interpreter",
+                          "/python/interpreter/from/config")
     result = "/python/interpreter/from/config -m venv"
-    pipenv = PipEnv(conanfile, "testenv")
+    PipEnv(conanfile, "testenv")
 
-    def fake_run(command, win_bash=False, subsystem=None, env=None, ignore_errors=False, quiet=False):
+    def fake_run(command, win_bash=False, subsystem=None, env=None, ignore_errors=False,   # noqa
+                 quiet=False):  # noqa
         assert result in command
         return 100
     conanfile.run = fake_run
-    pipenv._create_venv()
     mock_shutil_which.assert_not_called()
 
 
@@ -28,20 +29,21 @@ def test_pipenv_error_message(mock_shutil_which):
     conanfile.settings = Settings()
     mock_shutil_which.return_value = None
     with pytest.raises(ConanException) as exc_info:
-        pipenv = PipEnv(conanfile, "testenv")
-        pipenv._create_venv()
-    assert "install Python system-wide or set the 'tools.system.pipenv:python_interpreter' conf" in exc_info.value.args[0]
+        PipEnv(conanfile, "testenv")
+    assert ("install Python system-wide or set the 'tools.system.pipenv:python_interpreter' "
+            "conf") in exc_info.value.args[0]
 
 
 def test_pipenv_creation_error_message():
     conanfile = ConanFileMock()
     conanfile.settings = Settings()
-    conanfile.conf.define("tools.system.pipenv:python_interpreter", "/python/interpreter/from/config")
-    pipenv = PipEnv(conanfile, "testenv")
+    conanfile.conf.define("tools.system.pipenv:python_interpreter",
+                          "/python/interpreter/from/config")
 
-    def fake_run(command, win_bash=False, subsystem=None, env=None, ignore_errors=False, quiet=False):
+    def fake_run(command, win_bash=False, subsystem=None, env=None, ignore_errors=False,   # noqa
+                 quiet=False):  # noqa
         raise ConanException("fake error message")
     conanfile.run = fake_run
     with pytest.raises(ConanException) as exc_info:
-        pipenv._create_venv()
+        PipEnv(conanfile, "testenv")
     assert "using '/python/interpreter/from/config': fake error message" in exc_info.value.args[0]


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Some improvements to PipEnv, like automatic generation of the venv at constructor time, not at install time, that allows to define and use empty pipenvs (for testing
