### PR TITLE
document the Remote() constructor as public

### DIFF
--- a/conan/api/model/remote.py
+++ b/conan/api/model/remote.py
@@ -3,11 +3,23 @@ LOCAL_RECIPES_INDEX = "local-recipes-index"
 
 class Remote:
     """
-    The ``Remote`` class represents a remote registry of packages. It's a read-only opaque object that
-    should not be created directly, but obtained from the relevant ``RemotesAPI`` subapi methods.
+    The ``Remote`` class represents a remote registry of packages.
     """
     def __init__(self, name, url, verify_ssl=True, disabled=False, allowed_packages=None,
                  remote_type=None, recipes_only=False):
+        """ A Remote object can be constructed to be passed as an argument to
+        RemotesAPI methods. When possible, it is better to use Remote objects returned by the API,
+        but for the ``RemotesAPI.add()`` method, a new constructed object is necessary.
+        It is recommended to use named arguments like ``Remote(..., verify_ssl=False)`` in
+        the constructor.
+        :param name: The name of the remote.
+        :param url: The URL of the remote repository (or local folder for "local-recipes-index").
+        :param verify_ssl: Enable SSL Certificate validation.
+        :param disabled: Disable the remote repository.
+        :param allowed_packages: List of patterns of allowed packages from this remote
+        :param remote_type: Type of the remote repository, use "local-recipes-index" or ``None``
+        :param recipes_only: If True, binaries form this remote will be ignored and never used
+        """
         self.name = name  # Read only, is the key
         self.url = url
         self.verify_ssl = verify_ssl

--- a/conan/api/model/remote.py
+++ b/conan/api/model/remote.py
@@ -9,7 +9,7 @@ class Remote:
                  remote_type=None, recipes_only=False):
         """ A Remote object can be constructed to be passed as an argument to
         RemotesAPI methods. When possible, it is better to use Remote objects returned by the API,
-        but for the ``RemotesAPI.add()`` method, a new constructed object is necessary.
+        but for the ``RemotesAPI.add()`` method, for which a new constructed object is necessary.
         It is recommended to use named arguments like ``Remote(..., verify_ssl=False)`` in
         the constructor.
         :param name: The name of the remote.


### PR DESCRIPTION
Changelog: Feature: Document the ``Remote()`` constructor as public API.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19163
