### PR TITLE
Fix assert when finding compatible binaries of a package that exists in both contexts with different settings

### DIFF
--- a/conan/__init__.py
+++ b/conan/__init__.py
@@ -2,5 +2,5 @@ from conan.internal.model.conan_file import ConanFile
 from conan.internal.model.workspace import Workspace
 from conan.internal.model.version import Version
 
-__version__ = '2.22.1'
+__version__ = '2.22.2'
 conan_version = Version(__version__)

--- a/conan/internal/graph/graph_binaries.py
+++ b/conan/internal/graph/graph_binaries.py
@@ -195,6 +195,7 @@ class GraphBinariesAnalyzer:
                                       f"{conanfile.info.dump_diff(compatible_package)}")
                 node._package_id = package_id  # Modifying package id under the hood, FIXME
                 node.binary = None  # Invalidate it
+
                 if self._evaluate_is_cached(node):
                     # If we have already processed this compatible pref,
                     # mark it as usable based on previous evaluation

--- a/conan/internal/graph/graph_binaries.py
+++ b/conan/internal/graph/graph_binaries.py
@@ -164,13 +164,18 @@ class GraphBinariesAnalyzer:
             for package_id, compatible_package in compatibles.items():
                 node._package_id = package_id  # Modifying package id under the hood, FIXME
                 node.binary = None  # Invalidate it
+                # Check that this same reference hasn't already been checked
+                if self._evaluate_is_cached(node):
+                    # If we have already processed this compatible pref,
+                    # mark it as usable based on previous evaluation
+                    if node.binary in (BINARY_CACHE, BINARY_DOWNLOAD):
+                        self._compatible_found(conanfile, package_id, compatible_package)
+                    return
                 cache_latest_prev = self._compatible_cache_latest_prev(node)  # not check remotes
                 if cache_latest_prev:
                     # If we have binary info, it means that the package was already processed,
                     # and we got a hit from the cache of compatibles
-                    if node.binary is None:
-                        self._binary_in_cache(node, cache_latest_prev)
-
+                    self._binary_in_cache(node, cache_latest_prev)
                     self._compatible_found(conanfile, package_id, compatible_package)
                     return
             # If not found in the cache, then look first one in servers
@@ -190,6 +195,12 @@ class GraphBinariesAnalyzer:
                                       f"{conanfile.info.dump_diff(compatible_package)}")
                 node._package_id = package_id  # Modifying package id under the hood, FIXME
                 node.binary = None  # Invalidate it
+                if self._evaluate_is_cached(node):
+                    # If we have already processed this compatible pref,
+                    # mark it as usable based on previous evaluation
+                    if node.binary in (BINARY_CACHE, BINARY_DOWNLOAD, BINARY_UPDATE):
+                        self._compatible_found(conanfile, package_id, compatible_package)
+                    return
                 cache_latest_prev = self._compatible_cache_latest_prev(node)  # Not check remotes
                 if cache_latest_prev:
                     self._evaluate_cache_update(cache_latest_prev, node, remotes, update)
@@ -207,12 +218,6 @@ class GraphBinariesAnalyzer:
         """ simplified checking of compatible_packages, that should be found existing, but
         will never be built, for example. They cannot be editable either at this point.
         """
-        # Check that this same reference hasn't already been checked
-        if self._evaluate_is_cached(node):
-            # If we have already processed this compatible pref,
-            # mark it as usable based on previous evaluation
-            return node.pref if node.binary in (BINARY_CACHE, BINARY_DOWNLOAD) else None
-
         # TODO: Test that this works
         if node.conanfile.info.invalid:
             node.binary = BINARY_INVALID

--- a/conan/internal/graph/graph_binaries.py
+++ b/conan/internal/graph/graph_binaries.py
@@ -166,7 +166,11 @@ class GraphBinariesAnalyzer:
                 node.binary = None  # Invalidate it
                 cache_latest_prev = self._compatible_cache_latest_prev(node)  # not check remotes
                 if cache_latest_prev:
-                    self._binary_in_cache(node, cache_latest_prev)
+                    # If we have binary info, it means that the package was already processed,
+                    # and we got a hit from the cache of compatibles
+                    if node.binary is None:
+                        self._binary_in_cache(node, cache_latest_prev)
+
                     self._compatible_found(conanfile, package_id, compatible_package)
                     return
             # If not found in the cache, then look first one in servers
@@ -205,7 +209,9 @@ class GraphBinariesAnalyzer:
         """
         # Check that this same reference hasn't already been checked
         if self._evaluate_is_cached(node):
-            return
+            # If we have already processed this compatible pref,
+            # mark it as usable based on previous evaluation
+            return node.pref if node.binary in (BINARY_CACHE, BINARY_DOWNLOAD) else None
 
         # TODO: Test that this works
         if node.conanfile.info.invalid:

--- a/test/integration/package_id/compatible_test.py
+++ b/test/integration/package_id/compatible_test.py
@@ -1,6 +1,8 @@
 import json
 import textwrap
 
+import pytest
+
 from conan.test.utils.tools import TestClient, GenConanfile
 
 
@@ -768,3 +770,19 @@ def test_compatibility_remove_cppstd():
     # Now we try again, this time app will find the compatible dep without cppstd
     tc.run("install --requires=dep/1.0 -pr=profile -s=compiler.cppstd=17")
     assert f"dep/1.0: Found compatible package '{dep_package_id}'" in tc.out
+
+
+@pytest.mark.parametrize("from_remote", [True, False])
+def test_compatibility_different_settings_per_context(from_remote):
+    tc = TestClient(default_server_user=True)
+    tc.save({"protobuf/conanfile.py": GenConanfile("protobuf", "1.0")
+                .with_settings("compiler"),
+             "conanfile.py": GenConanfile("consumer", "1.0")
+                .with_require("protobuf/1.0")
+                .with_tool_requires("protobuf/1.0")
+    })
+    tc.run("create protobuf -s=compiler.cppstd=14")
+    if from_remote:
+        tc.run("upload * -r=default -c")
+        tc.run("remove * -c")
+    tc.run(f"install . -s=compiler.cppstd=14 -s:b=compiler.cppstd=17 --build=missing")

--- a/test/integration/package_id/compatible_test.py
+++ b/test/integration/package_id/compatible_test.py
@@ -773,7 +773,8 @@ def test_compatibility_remove_cppstd():
 
 
 @pytest.mark.parametrize("from_remote", [True, False])
-def test_compatibility_different_settings_per_context(from_remote):
+@pytest.mark.parametrize("update", [True, False])
+def test_compatibility_different_settings_per_context(from_remote, update):
     tc = TestClient(default_server_user=True)
     tc.save({"protobuf/conanfile.py": GenConanfile("protobuf", "1.0")
                 .with_settings("compiler"),
@@ -785,4 +786,5 @@ def test_compatibility_different_settings_per_context(from_remote):
     if from_remote:
         tc.run("upload * -r=default -c")
         tc.run("remove * -c")
-    tc.run(f"install . -s=compiler.cppstd=14 -s:b=compiler.cppstd=17 --build=missing")
+    update_arg = "--update" if update else ""
+    tc.run(f"install . -s=compiler.cppstd=14 -s:b=compiler.cppstd=17 --build=missing {update_arg}")

--- a/test/integration/package_id/compatible_test.py
+++ b/test/integration/package_id/compatible_test.py
@@ -791,9 +791,8 @@ def test_compatibility_different_settings_per_context(from_remote, update):
     tc.run(f"install . -s=compiler.cppstd=14 -s:b=compiler.cppstd=17 --build=missing {update_arg}")
 
 
-@pytest.mark.parametrize("from_remote", [True, False])
 @pytest.mark.parametrize("update", [True, False])
-def test_compatibility_different_settings_per_context_prevs(from_remote, update):
+def test_compatibility_different_settings_per_context_prevs(update):
     tc = TestClient(default_server_user=True)
     proto = GenConanfile("protobuf", "1.0").with_settings("compiler")
     proto.with_package_file("file.txt", env_var="MY_VAR")

--- a/test/integration/package_id/compatible_test.py
+++ b/test/integration/package_id/compatible_test.py
@@ -3,6 +3,7 @@ import textwrap
 
 import pytest
 
+from conan.test.utils.env import environment_update
 from conan.test.utils.tools import TestClient, GenConanfile
 
 
@@ -788,3 +789,34 @@ def test_compatibility_different_settings_per_context(from_remote, update):
         tc.run("remove * -c")
     update_arg = "--update" if update else ""
     tc.run(f"install . -s=compiler.cppstd=14 -s:b=compiler.cppstd=17 --build=missing {update_arg}")
+
+
+@pytest.mark.parametrize("from_remote", [True, False])
+@pytest.mark.parametrize("update", [True, False])
+def test_compatibility_different_settings_per_context_prevs(from_remote, update):
+    tc = TestClient(default_server_user=True)
+    proto = GenConanfile("protobuf", "1.0").with_settings("compiler")
+    proto.with_package_file("file.txt", env_var="MY_VAR")
+    consumer = GenConanfile().with_requires("protobuf/1.0").with_tool_requires("protobuf/1.0")
+    tc.save({"protobuf/conanfile.py": proto,
+             "conanfile.py": consumer})
+
+    settings = "-s:a compiler=gcc -s:a compiler.version=9 -s:a compiler.libcxx=libstdc++"
+    with environment_update({"MY_VAR": "value"}):
+        tc.run(f"create protobuf {settings} -s=compiler.cppstd=14")
+    tc.run("upload * -r=default -c")
+
+    tc2 = TestClient(servers=tc.servers)
+    tc2.save({"conanfile.py": consumer})
+    update_arg = "--update" if update else ""
+    tc2.run(f"install . {settings} -s=compiler.cppstd=14 -s:b=compiler.cppstd=17 {update_arg}")
+    tc2.assert_listed_binary({"protobuf/1.0": ("36d978cbb4dc35906d0fd438732d5e17cd1e388d",
+                                               "Download (default)")})
+
+    with environment_update({"MY_VAR": "value2"}):
+        tc.run(f"create protobuf {settings} -s=compiler.cppstd=14")
+    tc.run("upload * -r=default -c")
+    tc2.run(f"install . {settings} -s=compiler.cppstd=14 -s:b=compiler.cppstd=17 {update_arg}")
+    origin = "Cache" if not update else "Update (default)"
+    tc2.assert_listed_binary({"protobuf/1.0": ("36d978cbb4dc35906d0fd438732d5e17cd1e388d",
+                                               origin)})


### PR DESCRIPTION
Changelog: Bugfix: Fix assert when finding compatible binaries of a package that exists in both contexts with different settings.
Docs: Omit

We get assertions related to the fact that the cache is modifying the underlying node when we process the second package (usually build context)