### PR TITLE
respect build requirement env vars when using native build in meson cross compilation

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -296,8 +296,12 @@ class MesonToolchain:
         compilers_by_conf = self._conanfile_conf.get("tools.build:compiler_executables", default={},
                                                      check_type=dict)
         # Read the VirtualBuildEnv to update the variables
-        build_env = self._conanfile.buildenv_build.vars(self._conanfile) if native else (
-            VirtualBuildEnv(self._conanfile, auto_generate=True).vars())
+        venv = VirtualBuildEnv(self._conanfile, auto_generate=True)
+        if native:
+            # respect any vars from build requirements but prefer build profile vars if there are any
+            build_env = self._conanfile.buildenv_build.compose_env(venv.environment()).vars(self._conanfile)
+        else:
+            build_env = venv.vars()
         #: Sets the Meson ``c`` variable, defaulting to the ``CC`` build environment value.
         #: If provided as a blank-separated string, it will be transformed into a list.
         #: Otherwise, it remains a single string.

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -653,6 +653,68 @@ def test_native_attribute():
     assert "[host_machine]" in cross_content
 
 
+def test_native_attribute_respects_environment_from_build_requirement():
+    """
+    Tests that environment vars set by build requirements are respected by the
+    native toolchain configuration
+    """
+    host = textwrap.dedent("""
+    [settings]
+    arch=armv8
+    build_type=Release
+    compiler=gcc
+    compiler.cppstd=gnu17
+    compiler.libcxx=libstdc++11
+    compiler.version=11
+    os=Linux
+
+    [conf]
+    tools.build:compiler_executables={"c": "gcc", "cpp": "g++"}
+    """)
+    build = textwrap.dedent("""
+    [settings]
+    os=Linux
+    arch=x86_64
+    compiler=clang
+    compiler.version=12
+    compiler.libcxx=libc++
+    compiler.cppstd=11
+
+    [conf]
+    tools.build:compiler_executables={"c": "clang", "cpp": "clang++"}
+    """)
+    client = TestClient()
+    pkgconf = textwrap.dedent(r"""
+            from conan import ConanFile
+            class Pkg(ConanFile):
+                settings = "os"
+                def package_info(self):
+                    self.buildenv_info.define_path("PKG_CONFIG", "/usr/local/mypkgconf")
+            """)
+    conanfile = textwrap.dedent("""
+    from conan import ConanFile
+    from conan.tools.meson import MesonToolchain
+    class Pkg(ConanFile):
+        settings = "os", "compiler", "arch", "build_type"
+        tool_requires = "pkgconf/1.0"
+        def generate(self):
+            tc = MesonToolchain(self)
+            tc.generate()
+            # We're cross-building, no need to check it
+            tc = MesonToolchain(self, native=True)
+            tc.generate()
+    """)
+    client.save({"host": host,
+                 "build": build,
+                 "pkgconf/conanfile.py": pkgconf,
+                 "conanfile.py": conanfile})
+
+    client.run("export pkgconf --name=pkgconf --version=1.0")
+    client.run("install . -pr:h host -pr:b build --build='*'")
+    native_content = client.load(MesonToolchain.native_filename)
+    assert "pkg-config = '/usr/local/mypkgconf'" in native_content
+
+
 def test_native_attribute_error():
     client = TestClient()
     conanfile = textwrap.dedent("""


### PR DESCRIPTION
Changelog: (Bugfix): Respect environment vars set in build requirements when writing the native meson configuration file in a cross compilation context. Environment vars set in a build profile still have precedence, preserving the existing behaviour.
Docs: Omit


Fixes #19214 


- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
