### PR TITLE
Show provide conflicts in `conan graph info` html output

### DIFF
--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -87,8 +87,11 @@ graph_info_html = r"""
                 global_edges = {};
                 let edge_counter = 0;
                 let conflict=null;
+                let provide_conflict=null;
                 if (graph_data["error"] && graph_data["error"]["type"] == "conflict")
                     conflict = graph_data["error"];
+                else if (graph_data["error"] && graph_data["error"]["type"] == "provide_conflict")
+                    provide_conflict = graph_data["error"];
                 for (const [node_id, node] of Object.entries(graph_data["nodes"])) {
                     if (node.context == "build" && hide_build) continue;
                     if (node.test && hide_test) continue;
@@ -124,6 +127,11 @@ graph_info_html = r"""
                     shapeProperties = {};
                     let color = color_map[node.binary]
                     if (conflict && conflict.branch1.dst_id == node_id){
+                        font.color = "white";
+                        color = "Black";
+                        shape = "circle";
+                    }
+                    if (provide_conflict && provide_conflict.node.id == node_id){
                         font.color = "white";
                         color = "Black";
                         shape = "circle";
@@ -198,6 +206,18 @@ graph_info_html = r"""
                                 color: {color: "Red", highlight: "Red"},
                                 label: conflict.branch2.require.ref});
                     global_edges[edge_counter++] = conflict.branch2.require;
+                }
+                if (provide_conflict) {
+                    // The nodes are already there, we'll just add an edge to the conflict node
+                    edges.push({id: edge_counter,
+                                from: provide_conflict.conflicting_node.id,
+                                to: provide_conflict.node.id,
+                                color: {color: "Red", highlight: "Red"},
+                                label: provide_conflict.provided,
+                                title: "Both nodes provide the same requirement: " + provide_conflict.provided.join(", "),
+                                dashes: true});
+                    global_edges[edge_counter++] = {"provided": provide_conflict.provided};
+
                 }
                 return {nodes: new vis.DataSet(nodes), edges: new vis.DataSet(edges)};
             };

--- a/conan/internal/graph/graph_error.py
+++ b/conan/internal/graph/graph_error.py
@@ -68,6 +68,13 @@ class GraphProvidesError(GraphError):
         self.conflicting_node = conflicting_node
         node.error = conflicting_node.error
 
+    def serialize(self):
+        return {"type": "provide_conflict",
+                "node": {"id": self.node.id, "ref": str(self.node.ref)},
+                "conflicting_node": {"id": self.conflicting_node.id,
+                                     "ref": str(self.conflicting_node.ref)},
+                "provided": self.node.conanfile.provides or self.conflicting_node.conanfile.provides}
+
     def __str__(self):
         return f"Provide Conflict: Both '{self.node.ref}' and '{self.conflicting_node.ref}' " \
                f"provide '{self.node.conanfile.provides or self.conflicting_node.conanfile.provides}'."

--- a/test/integration/command/info/info_test.py
+++ b/test/integration/command/info/info_test.py
@@ -502,3 +502,17 @@ def test_graph_info_bundle():
 
     c.run("graph info . -c tools.graph:vendor=build --build='lib*'")
     c.assert_listed_binary({"lib/1.0": (NO_SETTINGS_PACKAGE_ID, "Build")})
+
+
+def test_graph_info_provides_conflict_html():
+    """ This test also makes sure that the serialization of the GraphProvidesConflict works"""
+    tc = TestClient(light=True)
+    tc.save({"bar/conanfile.py": GenConanfile("bar", "1.0"),
+             "foo/conanfile.py": GenConanfile("foo", "1.0").with_provides("bar")})
+
+    tc.run("export bar")
+    tc.run("export foo")
+    tc.run("graph info --requires=bar/1.0 --requires=foo/1.0 --format=html", assert_error=True)
+    # It got properly serialized
+    assert '"type": "provide_conflict"' in tc.out
+    assert "Both 'bar/1.0' and 'foo/1.0' provide '['bar']'"


### PR DESCRIPTION
Changelog: Feature: Show `provides` conflicts in `conan graph info -f=html`.
Docs: Omit

Closes https://github.com/conan-io/conan/issues/19221

<img width="1185" height="375" alt="image" src="https://github.com/user-attachments/assets/ba73fb68-3948-432d-abb0-7b3db0bb90fd" />
