### PR TITLE
Show full package prog in usage 

### DIFF
--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -95,6 +95,7 @@ class Cli:
             if command_wrapper.doc:
                 name = f"{package}:{command_wrapper.name}" if package else command_wrapper.name
                 self._commands[name] = command_wrapper
+                command_wrapper._prog = name  # set the program name with possible package, if any
                 # Avoiding duplicated command help messages
                 if name not in self._groups[command_wrapper.group]:
                     self._groups[command_wrapper.group].append(name)

--- a/conan/cli/command.py
+++ b/conan/cli/command.py
@@ -152,6 +152,7 @@ class ConanCommand(BaseConanCommand):
         self._subcommands = {}
         self._group = group or "Other"
         self._name = method.__name__.replace("_", "-")
+        self._prog = self._name
 
     def add_subcommand(self, subcommand):
         subcommand.set_name(self.name)
@@ -159,7 +160,7 @@ class ConanCommand(BaseConanCommand):
 
     def run_cli(self, conan_api, *args):
         parser = ConanArgumentParser(conan_api, description=self._doc,
-                                     prog="conan {}".format(self._name),
+                                     prog="conan {}".format(self._prog),
                                      formatter_class=SmartFormatter)
         self._init_formatters(parser)
         self._init_core_options(parser)
@@ -182,7 +183,7 @@ class ConanCommand(BaseConanCommand):
 
     def run(self, conan_api, *args):
         parser = ConanArgumentParser(conan_api, description=self._doc,
-                                     prog="conan {}".format(self._name),
+                                     prog="conan {}".format(self._prog),
                                      formatter_class=SmartFormatter)
         self._init_formatters(parser)
         self._init_core_options(parser)

--- a/test/integration/command/custom_commands_test.py
+++ b/test/integration/command/custom_commands_test.py
@@ -148,6 +148,8 @@ class TestCustomCommands:
         assert "greet:bye" in client.out
 
         # Ensure the prog has the full command name
+        client.run("hello -h")
+        assert "conan hello" in client.out
         client.run("greet:bye -h")
         assert "conan greet:bye" in client.out
         client.run("greet:bye say -h")

--- a/test/integration/command/custom_commands_test.py
+++ b/test/integration/command/custom_commands_test.py
@@ -147,6 +147,12 @@ class TestCustomCommands:
         client.run("-h")
         assert "greet:bye" in client.out
 
+        # Ensure the prog has the full command name
+        client.run("greet:bye -h")
+        assert "conan greet:bye" in client.out
+        client.run("greet:bye say -h")
+        assert "conan greet:bye say" in client.out
+
     def test_custom_command_with_subcommands(self):
         complex_command = textwrap.dedent("""
             import json


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Found while debugging the art:promote custom command, a bad syntax in my code showed:

```
usage: conan promote [-h] ....
```

Which is not right.

This PR separated the idea of the command name from the prog used to show the help in the Conan client -h output