### PR TITLE
[MesonToolchain] Reverting the 'sys_root' property

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -289,8 +289,6 @@ class MesonToolchain:
 
         # Read configuration for sys_root property (honoring existing conf)
         self._sys_root = self._conanfile_conf.get("tools.build:sysroot", check_type=str)
-        if self._sys_root:
-            self.properties["sys_root"] = self._sys_root
 
         # Read configuration for compilers
         compilers_by_conf = self._conanfile_conf.get("tools.build:compiler_executables", default={},

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -690,8 +690,8 @@ def test_compiler_path_with_spaces():
 def test_meson_sysroot_app():
     """Testing when users pass tools.build:sysroot on the profile with Meson
 
-    The generated conan_meson_cross.ini needs to contain both sys_root property to fill the
-    PKG_CONFIG_PATH and the compiler flags with --sysroot.
+    * The generated conan_meson_cross.ini does not fill the "sys_root" property (see https://github.com/conan-io/conan/issues/16468)
+    * It adds the compiler flags with --sysroot.
 
     When cross-building, Meson needs both compiler_executables in the config, otherwise it will fail
     when running setup.
@@ -728,7 +728,7 @@ def test_meson_sysroot_app():
     client.run("install . -pr:h host -pr:b build")
     # Check the meson configuration file
     conan_meson = client.load("conan_meson_cross.ini")
-    assert f"sys_root = '{sysroot}'\n" in conan_meson
+    assert f"sys_root = '{sysroot}'\n" not in conan_meson
     assert re.search(r"c_args =.+--sysroot={}.+".format(sysroot), conan_meson)
     assert re.search(r"c_link_args =.+--sysroot={}.+".format(sysroot), conan_meson)
     assert re.search(r"cpp_args =.+--sysroot={}.+".format(sysroot), conan_meson)


### PR DESCRIPTION
Changelog: Fix: [MesonToolchain] Omits the `'sys_root'` property field.
Docs: omit
Coming from https://github.com/conan-io/conan/pull/16011
Closes: https://github.com/conan-io/conan/issues/16468
Related to:
* https://github.com/conan-io/conan-center-index/issues/28864
* https://github.com/conan-io/conan-center-index/issues/28865
* https://github.com/conan-io/conan-center-index/pull/28866
* https://github.com/conan-io/conan-center-index/pull/28867
* https://github.com/omnissa-oss-forks/conan/commit/0aecc1f757f0b70e57b51f9a3685c961013664a0
