### PR TITLE
Point slack link to more stable location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Decentralized, open-source (MIT), C/C++ package manager.
 - Homepage: https://conan.io/
 - Github: https://github.com/conan-io/conan
 - Docs: https://docs.conan.io
-- Slack: https://cpplang.slack.com (#conan channel. Please, click [here](https://join.slack.com/t/cpplang/shared_invite/zt-1snzdn6rp-rOUxF3166oz1_11Tr5H~xg) to get an invitation)
+- Slack: https://cpplang.slack.com (#conan channel. Please, click [here](https://cppalliance.org/slack/#cpp-slack) to get an invitation)
 - Twitter: https://twitter.com/conan_io
 - Blog: https://blog.conan.io
 - Security reports: https://jfrog.com/trust/report-vulnerability


### PR DESCRIPTION
Slack invite links expire and one gets strange results when trying to join. Instead of directly having an invite link this change points to the C++ Alliance page for getting the invite link. The link there gets updated as needed to keep it working.

fixes #19227

Changelog: Omit
Docs: Omit

