### PR TITLE
fix git_excluded msg

### DIFF
--- a/conan/internal/api/export.py
+++ b/conan/internal/api/export.py
@@ -128,7 +128,9 @@ def _calc_revision(scoped_output, path, manifest, revision_mode, conanfile):
         if git.is_dirty():
             raise ConanException("Can't have a dirty repository using revision_mode='scm' and doing"
                                  " 'conan export', please commit the changes and run again, or "
-                                 "use 'core.scm:excluded=[list of patterns]' attribute")
+                                 "use 'revision_mode_excluded' recipe attribute or "
+                                 "'core.scm:excluded' global configuration to define the list of "
+                                 "excluded file patterns")
 
         scoped_output.info("Using git commit as the recipe revision: %s" % revision)
 

--- a/conan/internal/api/export.py
+++ b/conan/internal/api/export.py
@@ -128,7 +128,7 @@ def _calc_revision(scoped_output, path, manifest, revision_mode, conanfile):
         if git.is_dirty():
             raise ConanException("Can't have a dirty repository using revision_mode='scm' and doing"
                                  " 'conan export', please commit the changes and run again, or "
-                                 "use 'git_excluded = []' attribute")
+                                 "use 'core.scm:excluded=[list of patterns]' attribute")
 
         scoped_output.info("Using git commit as the recipe revision: %s" % revision)
 


### PR DESCRIPTION
Changelog: Fix: Improve error message referencing  non existing ``git_excluded``, use ``core.scm:excluded`` instead.
Docs: https://github.com/conan-io/docs/pull/4311

Close https://github.com/conan-io/conan/issues/19231
