### PR TITLE
propose stress testing for concurrency primitives

### DIFF
--- a/test/unittests/util/test_filelocks.py
+++ b/test/unittests/util/test_filelocks.py
@@ -1,0 +1,48 @@
+import os
+import tempfile
+import time
+from multiprocessing import Process
+from string import ascii_lowercase
+
+import fasteners
+
+tmpf = os.path.join(tempfile.gettempdir(), "conan_test", "filelocks")
+datafile = os.path.join(tmpf, "data.txt")
+lock = os.path.join(tmpf, "data.txt.lock")
+
+
+def _mywriter():
+    for c in ascii_lowercase:
+        with fasteners.InterProcessLock(lock):
+            open(datafile, "w").write(c * 50)
+            for _ in range(4):
+                time.sleep(0.1)  # slow writes to cause race conditions
+                open(datafile, "a").write(c * 50)
+        time.sleep(0.1)
+
+
+def _myreader():
+    while True:
+        with fasteners.InterProcessLock(lock):
+            contents = open(datafile, "r").read()
+            d = contents[0]
+            assert contents == d * 250, f"{len(contents)}: {contents}"
+            if d == "z":
+                break
+        time.sleep(0.01)
+
+
+def test_simple_mutex():
+    os.makedirs(os.path.dirname(datafile), exist_ok=True)
+    open(datafile, "w+").write("a" * 250)
+
+    pread = Process(target=_myreader)
+    pread.start()
+    pwrite = Process(target=_mywriter)
+    pwrite.start()
+
+    pread.join()
+    if pread.exitcode:
+        pwrite.terminate()
+        raise Exception("pread failed")
+    pwrite.join()


### PR DESCRIPTION
Changelog: Omit
Docs: Omit


Checking https://github.com/conan-io/conan/pull/18253, I think that we will need first some minimal "stress" testing of the synchronization primitives (mutex, readers-writers) without any added Conan complexity. Furthermore the wrappers around ``fasteners`` in https://github.com/conan-io/conan/pull/18253 seems a bit over-designed, I'd prefer to develop them bottom-up, based on test use cases and needs.

The current PR is only initial proposal of "mutex", but still pending semaphore (readers-writers).
