### PR TITLE
Add extra parameter to support custom Premake configuration names

### DIFF
--- a/conan/test/assets/premake.py
+++ b/conan/test/assets/premake.py
@@ -3,12 +3,12 @@ import textwrap
 from jinja2 import Template
 
 
-def gen_premake5(workspace, projects, includedirs=None):
+def gen_premake5(workspace, projects, includedirs=None, configurations=None):
     includedirs = includedirs if includedirs is not None else ["."]
     premake5 = textwrap.dedent("""\
         workspace "{{workspace}}"
             cppdialect "C++17"
-            configurations { "Debug", "Release" }
+            configurations {{premake_quote(configurations)}}
             fatalwarnings {"All"}
             floatingpoint "Fast"
             includedirs {{premake_quote(includedirs)}}
@@ -38,6 +38,7 @@ def gen_premake5(workspace, projects, includedirs=None):
         {
             "premake_quote": premake_quote,
             "workspace": workspace,
+            "configurations": configurations or ["Debug", "Release"],
             "includedirs": includedirs,
             "projects": projects,
         }

--- a/conan/tools/premake/premake.py
+++ b/conan/tools/premake/premake.py
@@ -99,7 +99,7 @@ class Premake:
         # --verbose does not print compilation commands but internal Makefile progress logic
         return " verbose=1" if verbosity == "verbose" else ""
 
-    def build(self, workspace, targets=None, msbuild_platform=None):
+    def build(self, workspace, targets=None, configuration=None, msbuild_platform=None):
         """
         Depending on the action, this method will run either ``msbuild`` or ``make`` with ``N_JOBS``.
         You can specify ``N_JOBS`` through the configuration line ``tools.build:jobs=N_JOBS``
@@ -107,18 +107,21 @@ class Premake:
 
         :param workspace: ``str`` Specifies the solution to be compiled (only used by ``MSBuild``).
         :param targets: ``List[str]`` Declare the projects to be built (None to build all projects).
+        :param configuration: ``str`` Specify the configuration build type, default to build_type ("Release" or "Debug"),
+            but this allow setting custom configuration type.
         :param msbuild_platform: ``str`` Specify the platform for the internal MSBuild generator (only used by ``MSBuild``).
         """
         if not self._premake_conan_toolchain.exists():
             raise ConanException("Premake.build() method requires PremakeToolchain to work properly")
 
+        build_type = configuration or str(self._conanfile.settings.build_type)
         if self.action.startswith("vs"):
             msbuild = MSBuild(self._conanfile)
             if msbuild_platform:
                 msbuild.platform = msbuild_platform
+            msbuild.build_type = build_type
             msbuild.build(sln=f"{workspace}.sln", targets=targets)
         else:
-            build_type = str(self._conanfile.settings.build_type)
             targets = "all" if targets is None else " ".join(targets)
             njobs = build_jobs(self._conanfile)
             self._conanfile.run(f"make config={build_type.lower()} {targets} -j{njobs}{self._compilation_verbosity}")

--- a/test/functional/toolchains/test_premake.py
+++ b/test/functional/toolchains/test_premake.py
@@ -256,3 +256,58 @@ def test_transitive_headers_not_public(transitive_libraries):
     rmdir(ConanFileMock(), os.path.join(c.current_folder, "build-release"))
     c.run("build .", assert_error=True)
     # Error should be about not finding matrix
+
+@pytest.mark.tool("premake")
+def test_premake_custom_configuration(transitive_libraries):
+    c = transitive_libraries
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.layout import basic_layout
+        from conan.tools.premake import Premake, PremakeDeps, PremakeToolchain
+
+        class ConsumerRecipe(ConanFile):
+            name = "consumer"
+            version = "1.0"
+            package_type = "application"
+            settings = "os", "compiler", "build_type", "arch"
+            options = {"sanitizer": [True, False]}
+            default_options = {"sanitizer": False}
+            exports_sources = "*"
+
+            def layout(self):
+                basic_layout(self)
+
+            @property
+            def _premake_configuration(self):
+                return str(self.settings.build_type) + "Sanitizer" if self.options.sanitizer else ""
+
+            def generate(self):
+                deps = PremakeDeps(self)
+                deps.configuration = self._premake_configuration
+                deps.generate()
+                tc = PremakeToolchain(self)
+                tc.generate()
+
+            def build(self):
+                premake = Premake(self)
+                premake.configure()
+                # premake.build(workspace="Consumer")
+                premake.build(workspace="Consumer", configuration=self._premake_configuration)
+    """)
+
+    c.save({"src/main.cpp": gen_function_cpp(name="main"),
+            "premake5.lua": gen_premake5(
+                workspace="Consumer",
+                projects=[
+                    {
+                        "name": "consumer",
+                        "files": ["src/main.cpp"],
+                        "kind": "ConsoleApp",
+                    }
+                ],
+                configurations=["Debug", "Release", "DebugSanitizer", "ReleaseSanitizer"],
+            ),
+            "conanfile.py": conanfile,
+    })
+    # Test it builds successfully with the custom configuration
+    c.run("build . -o sanitizer=True")

--- a/test/integration/toolchains/premake/test_premake.py
+++ b/test/integration/toolchains/premake/test_premake.py
@@ -139,3 +139,33 @@ def test_premake_msbuild_platform():
     tc.run("build . -pr win")
     assert 'conanfile.premake5.lua" vs2022 --arch=x86_64!!' in tc.out
     assert 'Running msbuild.exe "App.sln" -p:Configuration="Release" -p:Platform="Win64"!!' in tc.out
+
+
+def test_premake_build_with_custom_configuration():
+    tc = TestClient()
+    conanfile = textwrap.dedent(
+        """
+        from conan import ConanFile
+        from conan.tools.premake import Premake, PremakeDeps, PremakeToolchain
+
+        class Pkg(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+            generators = "PremakeToolchain"
+            def run(self, cmd, *args, **kwargs):
+                self.output.info(f"Running {cmd}!!")
+            def generate(self):
+                deps = PremakeDeps(self)
+                deps.configuration = "ReleaseDLL"
+            def build(self):
+                premake = Premake(self)
+                premake.configure()
+                premake.build(workspace="App", configuration="ReleaseDLL")
+                """
+    )
+    tc.save({"conanfile.py": conanfile})
+    tc.run(
+        "build . -s compiler=gcc -s compiler.version=13 -s compiler.libcxx=libstdc++ -s arch=armv8 -c tools.build:jobs=4",
+    )
+    assert 'conanfile.premake5.lua" gmake --arch=arm64!!' in tc.out
+    assert "Running make config=releasedll all -j4!!" in tc.out
+


### PR DESCRIPTION
Changelog: Feature: New parameter to support custom Premake configuration names.
Docs: https://github.com/conan-io/docs/pull/4313

In reference to https://github.com/conan-io/conan-center-index/pull/27838, 
The upstream project contains some non-default configuration names:

https://github.com/utelle/wxsqlite3/blob/7c34be98c9859b7525cf3ab33b3b2c8badba6190/premake5.lua#L12:
```lua
  configurations { "Debug", "Release", "Debug wxDLL", "Release wxDLL", "Debug DLL", "Release DLL" }
```

Currently, we do not have any mechanism to refer to those extra configurations except `Debug` or `Release` which are captured from the `build_type` setting of the conanfile.

This PR introduces a mechanism to bypass that default behavior and set a different Premake configuration.

Example:
```py
class MyRecipe(Conanfile):
    ...
    def _premake_configuration(self):
        return str(self.settings.build_type) + ("DLL" if self.options.shared else "") 

    def generate(self):
        deps = PremakeDeps(self)
        deps.configuration = self._premake_configuration
        deps.generate()
        tc = PremakeToolchain(self)
        tc.generate()

    def build(self):
        premake = Premake(self)
        premake.configure()
        premake.build(workspace="MyProject", configuration=self._premake_configuration)
```

Having to set the `configuration` in the `PremakeDeps` is needed (when the project has dependencies), to update the name of the Lua tables accordingly.
```lua
t_conandeps = {}
t_conandeps["releasedll_arm64"] = {}
t_conandeps["releasedll_arm64"]["zstd"] = {}
...
```