### PR TITLE
fix conan new default template name

### DIFF
--- a/conan/api/subapi/new.py
+++ b/conan/api/subapi/new.py
@@ -166,7 +166,7 @@ class NewAPI:
     @staticmethod
     def render(template_files, definitions):
         result = {}
-        name = definitions.get("name", "pkg")
+        name = definitions.get("name", "mypkg")
         if isinstance(name, list):
             raise ConanException(f"name argument can't be multiple: {name}")
         if name != name.lower():

--- a/test/integration/command/test_new.py
+++ b/test/integration/command/test_new.py
@@ -51,10 +51,18 @@ class TestNewCommand:
         c = TestClient(light=True)
         for t in ("cmake_lib", "cmake_exe", "meson_lib", "meson_exe", "msbuild_lib", "msbuild_exe",
                   "bazel_lib", "bazel_exe", "autotools_lib", "autotools_exe"):
-            c.run(f"new {t} -f")
+            c.save({}, clean_first=True)
+            c.run(f"new {t}")
             conanfile = c.load("conanfile.py")
             assert 'name = "mypkg"' in conanfile
             assert 'version = "0.1"' in conanfile
+            if t == "cmake_lib":
+                cmake = c.load("CMakeLists.txt")
+                assert "src/mypkg.cpp" in cmake
+                cpp = c.load("src/mypkg.cpp")
+                assert "mypkg()" in cpp
+                hpp = c.load("include/mypkg.h")
+                assert "void mypkg();" in hpp
 
             c.run(f"new {t} -d name=mylib -f")
             conanfile = c.load("conanfile.py")


### PR DESCRIPTION
Changelog: Bugfix: Fix bug in ``conan new cmake_lib`` template without arguments, incorrect function name.
Docs: Omit