### PR TITLE
Derive `conanfile.version` from latest available in `conandata.yml` as last alternative

### DIFF
--- a/conan/internal/loader.py
+++ b/conan/internal/loader.py
@@ -16,6 +16,7 @@ from conan.api.output import ConanOutput
 from conan.tools.cmake import cmake_layout
 from conan.tools.google import bazel_layout
 from conan.tools.microsoft import vs_layout
+from conan.tools.scm import Version
 from conan.internal.errors import conanfile_exception_formatter, NotFoundException
 from conan.errors import ConanException
 from conan.internal.model.conan_file import ConanFile
@@ -148,8 +149,10 @@ class ConanFileLoader:
             # Only works if only one version is present
             conan_data = getattr(conanfile, "conan_data", {})
             sources = conan_data.get("sources", {}) if conan_data else {}
-            if len(sources) == 1:
-                conanfile.version = next(iter(sources))
+            sources = sources or {}
+            sorted_versions = sorted(sources.keys(), key=lambda x: Version(x))
+            if sorted_versions:
+                conanfile.version = sorted_versions.pop()
 
         return conanfile
 

--- a/conan/internal/loader.py
+++ b/conan/internal/loader.py
@@ -143,6 +143,13 @@ class ConanFileLoader:
             with conanfile_exception_formatter("conanfile.py", "set_version"):
                 conanfile.set_version()
 
+        if not conanfile.version:
+            # Last chance, try to get version from conan_data.
+            # Only works if only one version is present
+            sources = getattr(conanfile, "conan_data", {}).get("sources", {})
+            if len(sources) == 1:
+                conanfile.version = next(iter(sources))
+
         return conanfile
 
     def load_export(self, conanfile_path, name, version, user, channel, graph_lock=None,

--- a/conan/internal/loader.py
+++ b/conan/internal/loader.py
@@ -146,7 +146,8 @@ class ConanFileLoader:
         if not conanfile.version:
             # Last chance, try to get version from conan_data.
             # Only works if only one version is present
-            sources = getattr(conanfile, "conan_data", {}).get("sources", {})
+            conan_data = getattr(conanfile, "conan_data", {})
+            sources = conan_data.get("sources", {}) if conan_data else {}
             if len(sources) == 1:
                 conanfile.version = next(iter(sources))
 

--- a/test/integration/conanfile/conan_data_test.py
+++ b/test/integration/conanfile/conan_data_test.py
@@ -485,14 +485,13 @@ def test_trim_conandata_anchors():
         """)
 
 
-@pytest.mark.parametrize("multiple_versions", [True, False])
 @pytest.mark.parametrize("command", [
-    ("source", False),
-     ("graph info", False),
-      ("create", True),
-       ("export", True)
+    "source",
+    "graph info",
+    "create",
+    "export"
 ])
-def test_commands_auto_pick_version(multiple_versions, command):
+def test_commands_auto_pick_version(command):
     c = TestClient(light=True)
     conanfile = textwrap.dedent("""
         from conan import ConanFile
@@ -502,31 +501,44 @@ def test_commands_auto_pick_version(multiple_versions, command):
             def source(self):
                 self.output.info("ok")
         """)
-    if multiple_versions:
-        conandata = textwrap.dedent("""
-            sources:
-                1.0:
-                    url: "url1"
-                    sha256: "sha1"
-                2.0:
-                    url: "url2"
-                    sha256: "sha2"
-        """)
-    else:
-        conandata = textwrap.dedent("""
+    conandata = textwrap.dedent("""
         sources:
             1.0:
                 url: "url1"
-                sha256: "sha1"
-        """)
+            2.0:
+                url: "url2"
+    """)
+
     c.save({"conanfile.py": conanfile,
             "conandata.yml": conandata})
-    assert_error = multiple_versions and command[1]
-    c.run(command[0], assert_error=assert_error)
-    if multiple_versions:
-        if command[1]:
-            assert "ERROR: conanfile didn't specify version" in c.out
-        else:
-            assert "pkg/None" in c.out
-    else:
-        assert "pkg/1.0" in c.out
+    c.run(command)
+    assert "pkg/2.0" in c.out
+
+
+@pytest.mark.parametrize("conandata", [
+    pytest.param(
+        textwrap.dedent("""
+        sources:
+            # Empty, no content
+        """), id="empty sources"),
+    pytest.param(
+        textwrap.dedent("""
+        # No sources key
+        foo: 1
+        """), id="no sources"),
+])
+def test_commands_auto_pick_version_no_version_conandata(conandata):
+    c = TestClient(light=True)
+    conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            class Pkg(ConanFile):
+                name = "pkg"
+
+                def source(self):
+                    self.output.info("ok")
+            """)
+
+    c.save({"conanfile.py": conanfile,
+            "conandata.yml": conandata})
+    c.run("create", assert_error=True)
+    assert "conanfile didn't specify version" in c.out

--- a/test/integration/conanfile/conan_data_test.py
+++ b/test/integration/conanfile/conan_data_test.py
@@ -483,3 +483,50 @@ def test_trim_conandata_anchors():
           '2.0':
             x: foo
         """)
+
+
+@pytest.mark.parametrize("multiple_versions", [True, False])
+@pytest.mark.parametrize("command", [
+    ("source", False),
+     ("graph info", False),
+      ("create", True),
+       ("export", True)
+])
+def test_commands_auto_pick_version(multiple_versions, command):
+    c = TestClient(light=True)
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        class Pkg(ConanFile):
+            name = "pkg"
+
+            def source(self):
+                self.output.info("ok")
+        """)
+    if multiple_versions:
+        conandata = textwrap.dedent("""
+            sources:
+                1.0:
+                    url: "url1"
+                    sha256: "sha1"
+                2.0:
+                    url: "url2"
+                    sha256: "sha2"
+        """)
+    else:
+        conandata = textwrap.dedent("""
+        sources:
+            1.0:
+                url: "url1"
+                sha256: "sha1"
+        """)
+    c.save({"conanfile.py": conanfile,
+            "conandata.yml": conandata})
+    assert_error = multiple_versions and command[1]
+    c.run(command[0], assert_error=assert_error)
+    if multiple_versions:
+        if command[1]:
+            assert "ERROR: conanfile didn't specify version" in c.out
+        else:
+            assert "pkg/None" in c.out
+    else:
+        assert "pkg/1.0" in c.out


### PR DESCRIPTION
Changelog: Feature: Derive `conanfile.version` from latest available in `conandata.yml` as last alternative
Docs: TODO

This makes commands like `conan source` (note, no arguments!) possible to work if:
* You're in a folder with a conanfile present (Thanks to https://github.com/conan-io/conan/pull/18964)
* You are using a recipe that defines versions as subkeys of a root `sources` key in the `conandata.yml` file

