### PR TITLE
Add message when compatibility does not find a matching package

### DIFF
--- a/conan/internal/graph/graph_binaries.py
+++ b/conan/internal/graph/graph_binaries.py
@@ -211,7 +211,7 @@ class GraphBinariesAnalyzer:
                     self._compatible_found(conanfile, package_id, compatible_package)
                     return
 
-        node.conanfile.output.info("No compatible configuration not found", fg=Color.BRIGHT_CYAN)
+        node.conanfile.output.info("No compatible configuration found", fg=Color.BRIGHT_CYAN)
         # If no compatible is found, restore original state
         node.binary = original_binary
         node._package_id = original_package_id

--- a/conan/internal/graph/graph_binaries.py
+++ b/conan/internal/graph/graph_binaries.py
@@ -2,7 +2,7 @@ import json
 import os
 from collections import OrderedDict
 
-from conan.api.output import ConanOutput
+from conan.api.output import ConanOutput, Color
 from conan.internal.cache.home_paths import HomePaths
 from conan.internal.graph.build_mode import BuildMode
 from conan.internal.graph.compatibility import BinaryCompatibility
@@ -211,6 +211,7 @@ class GraphBinariesAnalyzer:
                     self._compatible_found(conanfile, package_id, compatible_package)
                     return
 
+        node.conanfile.output.info("No compatible configuration not found", fg=Color.BRIGHT_CYAN)
         # If no compatible is found, restore original state
         node.binary = original_binary
         node._package_id = original_package_id


### PR DESCRIPTION
Changelog: Feature: Add message when compatibility does not find a matching package.
Docs: Omit

Small UX improvement, useful when there are multiple packages

<img width="1004" height="144" alt="image" src="https://github.com/user-attachments/assets/04e06023-dbcd-41f1-bff6-ab928471a2b7" />
