### PR TITLE
Drop mock module usage in favour of standard unittest.mock (#19263)

### DIFF
--- a/conan/test/utils/tools.py
+++ b/conan/test/utils/tools.py
@@ -16,10 +16,10 @@ from contextlib import contextmanager
 from inspect import getframeinfo, stack
 from urllib.parse import urlsplit, urlunsplit
 
-import mock
+from unittest import mock
 import pytest
 import requests
-from mock import Mock
+from unittest.mock import Mock
 from requests.exceptions import HTTPError
 from webtest.app import TestApp
 

--- a/conans/requirements_dev.txt
+++ b/conans/requirements_dev.txt
@@ -1,7 +1,6 @@
 pytest>=7, <8.0.0
 pytest-xdist  # To launch in N cores with pytest -n
 parameterized>=0.6.3
-mock>=1.3.0, <1.4.0
 WebTest>=3.0.0, <4
 bottle
 PyJWT

--- a/test/functional/command/test_config_install.py
+++ b/test/functional/command/test_config_install.py
@@ -5,7 +5,7 @@ import stat
 import textwrap
 
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 from conan.api.model import Remote
 from conan.internal.api.config.config_installer import _hide_password

--- a/test/functional/layout/test_source_folder.py
+++ b/test/functional/layout/test_source_folder.py
@@ -2,7 +2,7 @@ import os
 import platform
 from shutil import copy
 
-import mock
+from unittest import mock
 import pytest
 
 from conan.test.assets.cmake import gen_cmakelists

--- a/test/functional/revisions_test.py
+++ b/test/functional/revisions_test.py
@@ -4,7 +4,7 @@ import unittest
 from collections import OrderedDict
 
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 from conan.test.utils.env import environment_update
 from conan.internal.errors import RecipeNotFoundException

--- a/test/integration/cache/cache2_update_test.py
+++ b/test/integration/cache/cache2_update_test.py
@@ -2,7 +2,7 @@ import copy
 from collections import OrderedDict
 
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 from conan.api.model import RecipeReference
 from conans.server.revision_list import RevisionList

--- a/test/integration/cache/test_package_revisions.py
+++ b/test/integration/cache/test_package_revisions.py
@@ -1,4 +1,4 @@
-from mock import mock
+from unittest import mock
 
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient

--- a/test/integration/command/help_test.py
+++ b/test/integration/command/help_test.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 
 from conan import __version__
 from conan.test.utils.env import environment_update

--- a/test/integration/command/remote/test_remote_users.py
+++ b/test/integration/command/remote/test_remote_users.py
@@ -4,7 +4,7 @@ import time
 from collections import OrderedDict
 from datetime import timedelta
 
-from mock import patch
+from unittest.mock import patch
 
 from conan.internal.api.remotes.localdb import LocalDB
 from conan.test.utils.tools import TestClient, TestServer

--- a/test/integration/command/test_audit.py
+++ b/test/integration/command/test_audit.py
@@ -5,7 +5,7 @@ import sys
 from contextlib import contextmanager
 
 import pytest
-from mock.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock
 
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.env import environment_update

--- a/test/integration/command/upload/upload_test.py
+++ b/test/integration/command/upload/upload_test.py
@@ -6,7 +6,7 @@ import textwrap
 from collections import OrderedDict
 
 import pytest
-from mock import patch
+from unittest.mock import patch
 from requests import Response
 
 from conan.errors import ConanException

--- a/test/integration/conanfile/required_conan_version_test.py
+++ b/test/integration/conanfile/required_conan_version_test.py
@@ -1,6 +1,6 @@
 import textwrap
 
-import mock
+from unittest import mock
 
 from conan import __version__
 from conan.test.utils.tools import TestClient

--- a/test/integration/configuration/conf/test_conf.py
+++ b/test/integration/configuration/conf/test_conf.py
@@ -3,7 +3,7 @@ import platform
 import textwrap
 
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 from conan import conan_version
 from conan.internal.api.detect import detect_api

--- a/test/integration/configuration/requester_test.py
+++ b/test/integration/configuration/requester_test.py
@@ -1,7 +1,7 @@
 import os
 
-import mock
-from mock import Mock, MagicMock
+from unittest import mock
+from unittest.mock import Mock, MagicMock
 
 from conan import __version__
 from conan.internal.rest.conan_requester import ConanRequester

--- a/test/integration/configuration/required_version_test.py
+++ b/test/integration/configuration/required_version_test.py
@@ -1,5 +1,5 @@
 import os
-import mock
+from unittest import mock
 
 from conan import __version__
 from conan.test.utils.test_files import temp_folder

--- a/test/integration/graph/version_ranges/version_ranges_cached_test.py
+++ b/test/integration/graph/version_ranges/version_ranges_cached_test.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 from conan.internal.rest.remote_manager import RemoteManager
 from conan.api.model import RecipeReference

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -5,7 +5,7 @@ import re
 import textwrap
 
 import pytest
-from mock import mock
+from unittest import mock
 
 from conan.tools.cmake.presets import load_cmake_presets
 from conan.test.assets.genconanfile import GenConanfile

--- a/test/integration/tools/system/package_manager_test.py
+++ b/test/integration/tools/system/package_manager_test.py
@@ -1,7 +1,7 @@
 import platform
 from unittest.mock import MagicMock, patch
 
-import mock
+from unittest import mock
 import pytest
 from unittest.mock import PropertyMock
 

--- a/test/unittests/client/conf/detect/test_gcc_compiler.py
+++ b/test/unittests/client/conf/detect/test_gcc_compiler.py
@@ -1,5 +1,5 @@
 
-import mock
+from unittest import mock
 import pytest
 
 from conan.internal.api.detect.detect_api import detect_gcc_compiler

--- a/test/unittests/client/graph/deps_graph_test.py
+++ b/test/unittests/client/graph/deps_graph_test.py
@@ -1,4 +1,4 @@
-from mock import Mock
+from unittest.mock import Mock
 
 from conan.internal.graph.graph import CONTEXT_HOST
 from conan.internal.graph.graph_builder import DepsGraph, Node

--- a/test/unittests/client/rest/rest_client_v2/rest_client_v2_test.py
+++ b/test/unittests/client/rest/rest_client_v2/rest_client_v2_test.py
@@ -1,5 +1,5 @@
 from conan.internal.rest.rest_client_v2 import RestV2Methods
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 
 @patch("conan.internal.rest.conan_requester.ConanRequester")

--- a/test/unittests/client/tools/cppstd_required_test.py
+++ b/test/unittests/client/tools/cppstd_required_test.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import mock
+from unittest import mock
 
 from conan.tools.build import check_max_cppstd, check_min_cppstd, valid_max_cppstd, valid_min_cppstd, \
     valid_min_cstd, valid_max_cstd

--- a/test/unittests/client/tools/test_env.py
+++ b/test/unittests/client/tools/test_env.py
@@ -1,5 +1,5 @@
 import os
-import mock
+from unittest import mock
 
 import conan.test.utils.env
 

--- a/test/unittests/tools/apple/test_apple_tools.py
+++ b/test/unittests/tools/apple/test_apple_tools.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 import textwrap
 

--- a/test/unittests/tools/cmake/test_cmake_presets_definitions.py
+++ b/test/unittests/tools/cmake/test_cmake_presets_definitions.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import mock
+from unittest import mock
 
 from conan.tools.cmake import CMake
 from conan.tools.cmake.presets import write_cmake_presets

--- a/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -1,7 +1,7 @@
 import types
 
 import pytest
-from mock import Mock
+from unittest.mock import Mock
 
 from conan import ConanFile
 from conan.internal.default_settings import default_settings_yml

--- a/test/unittests/tools/files/test_tool_copy.py
+++ b/test/unittests/tools/files/test_tool_copy.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import os
 import platform
 import pytest

--- a/test/unittests/tools/gnu/autotools_test.py
+++ b/test/unittests/tools/gnu/autotools_test.py
@@ -1,6 +1,6 @@
 import pytest
 import os
-from mock import patch
+from unittest.mock import patch
 
 from conan.tools.build import save_toolchain_args
 from conan.tools.gnu import Autotools

--- a/test/unittests/tools/gnu/gnudepsflags_test.py
+++ b/test/unittests/tools/gnu/gnudepsflags_test.py
@@ -1,5 +1,5 @@
 import pytest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from conan.tools.apple.apple import is_apple_os
 from conan.tools.gnu.gnudeps_flags import GnuDepsFlags

--- a/test/unittests/tools/intel/test_intel_cc.py
+++ b/test/unittests/tools/intel/test_intel_cc.py
@@ -2,7 +2,7 @@ import os
 import textwrap
 
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 from conan.tools.build.flags import architecture_flag, cppstd_flag
 from conan.tools.intel import IntelCC

--- a/test/unittests/util/detect_test.py
+++ b/test/unittests/util/detect_test.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 from unittest.mock import patch
 import pytest
 

--- a/test/unittests/util/detected_architecture_test.py
+++ b/test/unittests/util/detected_architecture_test.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from conan.internal.api.detect.detect_api import detect_arch


### PR DESCRIPTION
Since Python 3.3 the mock module became part of the standard unittest library as unittest.mock.

This MR removes the usage of that in favour of the standard library, simplyfing the dependency tree and uniforming usage in code.

Changelog: Omit
Docs: Omit

- [X] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
