### PR TITLE
cli_args for meson install

### DIFF
--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -88,7 +88,7 @@ class Meson(object):
         if self._conanfile.conf.get("tools.build:install_strip", check_type=bool):
             cmd += " --strip"
         if cli_args:
-            cmd += " " + " ".join(filter(None, cli_args))
+            cmd += " " + " ".join(cli_args)
         self._conanfile.run(cmd)
 
     def test(self):

--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -71,9 +71,12 @@ class Meson(object):
         self._conanfile.output.info("Meson build cmd: {}".format(cmd))
         self._conanfile.run(cmd)
 
-    def install(self):
+    def install(self, cli_args=None):
         """
-        Runs ``meson install -C "." --destdir`` in the build folder.
+        Runs ``meson install -C "." --destdir ..`` in the build folder.
+
+        :param cli_args: List of arguments to be added to the command:
+                    ``meson install -C "." --destdir ... arg1 arg2``
         """
         meson_build_folder = self._conanfile.build_folder.replace("\\", "/")
         meson_package_folder = self._conanfile.package_folder.replace("\\", "/")
@@ -84,6 +87,8 @@ class Meson(object):
             cmd += " " + verbosity
         if self._conanfile.conf.get("tools.build:install_strip", check_type=bool):
             cmd += " --strip"
+        if cli_args:
+            cmd += " " + " ".join(filter(None, cli_args))
         self._conanfile.run(cmd)
 
     def test(self):

--- a/test/unittests/tools/meson/test_meson.py
+++ b/test/unittests/tools/meson/test_meson.py
@@ -90,3 +90,25 @@ def test_meson_install_strip():
     meson.install()
 
     assert '--strip' in str(conanfile.command)
+
+def test_meson_install_cli_args():
+    """When the `cli_args` are provided, the Meson install command should include them.
+    """
+    c = ConfDefinition()
+
+    settings = MockSettings({"build_type": "Release",
+                             "compiler": "gcc",
+                             "compiler.version": "7",
+                             "os": "Linux",
+                             "arch": "x86_64"})
+    conanfile = ConanFileMock()
+    conanfile.settings = settings
+    conanfile.conf = c.get_conanfile_conf(None)
+    conanfile.folders.generators = "."
+    conanfile.folders.set_base_generators(temp_folder())
+    conanfile.folders.set_base_package(temp_folder())
+
+    meson = Meson(conanfile)
+    meson.install(cli_args=["--no-rebuild"])
+
+    assert '--no-rebuild' in str(conanfile.command)


### PR DESCRIPTION
Changelog: Feature: Adding optional ``cli_args`` to meson install. 
Docs: Omit

This is needed to skip rebuilding on external libraries modification for example, as explained in - https://github.com/conan-io/conan/issues/19292

And to mimic cmake's api a bit closer.

cli_args for cmake isn't mentioned in https://github.com/conan-io/docs/, only with docstring in conan itself, so not sure how to approach documentation for meson regarding it