### PR TITLE
Meson: fix pkgconf sysroot prefix to conan paths when cross-compiling

### DIFF
--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -37,6 +37,9 @@ class Meson(object):
                                                  default=[], check_type=list)
         cmd = "meson setup "
         if is_cross_build:
+            #Do not let pkgconf prefix sysroot path in front of paths to Conan packages (that are 
+            #outside the toolchain sysroot).
+            os.environ['PKG_CONFIG_FDO_SYSROOT_RULES'] = "1"
             machine_files.insert(0, cross)
             cmd += " ".join([f'--cross-file "{file}"' for file in machine_files])
         if os.path.exists(native):


### PR DESCRIPTION
Currently when a package uses the Meson build helper classes sometimes the include and library paths to other Conan packages in the cache are prefixed with the toolchain sysroot path. This will cause the build to fail because the Conan packages are located outside the toolchain sysroot. See issue #16468.
This happens when the include and/or lib path are retrieved with pkgconf. If a sysroot path is passed to pkgconf it will prefix all -I and -L paths with the sysroot path. To prevent this you can set environment variable PKG_CONFIG_FDO_SYSROOT_RULES, which is what this PR does.
Examples of CCI packages that currently fail when cross-compiling are:
- freetype
- fontconfig
- harfbuzz
- glib

Fixes #16468.

Changelog: (Fix): Meson: do not prefix toolchain sysroot path to include and lib paths to Conan packages when cross-compiling.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
