### PR TITLE
Feature/global conf hash str

### DIFF
--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -1,4 +1,5 @@
 import copy
+import hashlib
 import numbers
 import platform
 import re
@@ -751,10 +752,16 @@ def load_global_conf(home_folder):
         template = Environment(loader=FileSystemLoader(home_folder)).from_string(text)
         home_folder = home_folder.replace("\\", "/")
         from conan import conan_version
+
+        def hash_str(value, name="sha256"):
+            h = hashlib.new(name, value.encode(), usedforsecurity=False)
+            return h.hexdigest()
+
         content = template.render({"platform": platform, "os": os, "distro": distro,
                                    "conan_version": conan_version,
                                    "conan_home_folder": home_folder,
-                                   "detect_api": detect_api})
+                                   "detect_api": detect_api,
+                                   "hash_str": hash_str})
         new_config.loads(content)
     else:  # creation of a blank global.conf file for user convenience
         default_global_conf = textwrap.dedent("""\

--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -754,16 +754,11 @@ def load_global_conf(home_folder):
         template = Environment(loader=FileSystemLoader(home_folder)).from_string(text)
         home_folder = home_folder.replace("\\", "/")
         from conan import conan_version
-
-        def hash_str(value, name="sha256"):
-            h = hashlib.new(name, value.encode(), usedforsecurity=False)
-            return h.hexdigest()
-
         content = template.render({"platform": platform, "os": os, "distro": distro,
                                    "conan_version": conan_version,
                                    "conan_home_folder": home_folder,
                                    "detect_api": detect_api,
-                                   "hash_str": hash_str})
+                                   "hashlib": hashlib})
         new_config.loads(content)
     else:  # creation of a blank global.conf file for user convenience
         default_global_conf = textwrap.dedent("""\

--- a/test/integration/cache/storage_path_test.py
+++ b/test/integration/cache/storage_path_test.py
@@ -29,7 +29,9 @@ def test_wrong_home_error():
 def test_short_storage_path():
     c = TestClient()
     global_conf = textwrap.dedent("""\
-        core.cache:storage_path=C:/conan_{{hash_str(conan_home_folder)}}
+        {% set h = hashlib.new("sha256", conan_home_folder.encode(),
+                               usedforsecurity=False).hexdigest() %}
+        core.cache:storage_path=C:/conan_{{h[:6]}}
         """)
     c.save_home({"global.conf": global_conf})
     c.run("config show *")

--- a/test/integration/cache/storage_path_test.py
+++ b/test/integration/cache/storage_path_test.py
@@ -1,4 +1,6 @@
 import os
+import textwrap
+from hashlib import sha256
 
 from conan.test.utils.test_files import temp_folder
 from conan.test.utils.tools import TestClient, GenConanfile
@@ -22,3 +24,16 @@ def test_wrong_home_error():
     client.save_home({"global.conf": "core.cache:storage_path=//"})
     client.run("list *")
     assert "Couldn't initialize storage in" in client.out
+
+
+def test_short_storage_path():
+    c = TestClient()
+    global_conf = textwrap.dedent("""\
+        core.cache:storage_path=C:/conan_{{hash_str(conan_home_folder)}}
+        """)
+    c.save_home({"global.conf": global_conf})
+    c.run("config show *")
+    myhash = sha256()
+    myhash.update(c.cache_folder.replace("\\", "/").encode())
+    myhash = myhash.hexdigest()[:6]
+    assert f"core.cache:storage_path: C:/conan_{myhash}" in c.out


### PR DESCRIPTION
Changelog: Feature: Inject ``hashlib`` in the ``global.conf`` jinja2 rendering to be able to compute hashes (for paths, for example).
Docs: https://github.com/conan-io/docs/pull/4338

Close https://github.com/conan-io/conan/issues/19305
