### PR TITLE
fix logic for env-vars unset vs empty

### DIFF
--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -82,6 +82,9 @@ class _EnvValue:
         self._path = path
         self._sep = separator
 
+    def __bool__(self):
+        return bool(self._values)  # Empty means unset
+
     def dumps(self):
         result = []
         path = "(path)" if self._path else ""
@@ -467,7 +470,7 @@ class EnvVars:
                 result.append(
                     f'if ($env:{varname}) {{ $env:{_old_env_prefix(filename)}_{varname} = $env:{varname} }}'
                 )
-            if value:
+            if varvalues:
                 value = value.replace('"', '`"')  # escape quotes
                 result.append(f'$env:{varname}="{value}"')
             else:
@@ -497,7 +500,7 @@ class EnvVars:
                     f'export {_old_env_prefix(filename)}_{varname}="${{{varname}}}"; '
                     f'fi;'
                 )
-            if value:
+            if varvalues:
                 result.append(f'export {varname}="{value}"')
             else:
                 result.append(f'unset {varname}')
@@ -616,6 +619,7 @@ def _ps1_deactivate_contents(deactivation_mode, values, filename):
         }}
         Pop-Location
     """)
+
 
 def _sh_deactivate_contents(deactivation_mode, values, filename):
     vars_list = " ".join(quote(v) for v in values.keys())

--- a/test/integration/environment/test_buildenv_profile.py
+++ b/test/integration/environment/test_buildenv_profile.py
@@ -132,3 +132,20 @@ def test_buildenv_package_patterns():
     assert "WARN: dep ENV:Foo" in client.out
     assert "WARN: pkg ENV:Foo2" in client.out
     assert "WARN: None ENV:Var" in client.out
+
+
+def test_buildenv_error_unset():
+    # https://github.com/conan-io/conan/issues/19285#issuecomment-3569891282
+    c = TestClient()
+    profile = textwrap.dedent("""
+        [buildenv]
+        CLASSPATH=!
+        OTHERPATH=
+        """)
+    c.save({"conanfile.txt": "",
+            "profile": profile})
+
+    c.run("install . -pr=profile -s:a os=Linux")
+    env = c.load("conanbuildenv.sh")
+    assert "unset CLASSPATH" in env
+    assert 'export OTHERPATH=""' in env


### PR DESCRIPTION
Changelog: Bugfix: Fix logic in ``EnvVars`` generation of ``.sh`` and ``.ps1`` scripts for "unset" vs "empty" definition.
Docs: https://github.com/conan-io/docs/pull/4337

For https://github.com/conan-io/conan/issues/19285#issuecomment-3569891282