### PR TITLE
Warn on version range in pattern ref match

### DIFF
--- a/conan/internal/model/recipe_ref.py
+++ b/conan/internal/model/recipe_ref.py
@@ -6,7 +6,7 @@ def ref_matches(ref, pattern, is_consumer):
     if not ref or not str(ref):
         assert is_consumer
         ref = RecipeReference.loads("*/*")  # FIXME: ugly
-    if "[" in pattern or "]" in pattern:
+    if pattern.startswith("["):
         ConanOutput().warning(f"Pattern {pattern} contains a version range, which has no effect. "
                               f"Only '&' for consumer and '*' as wildcard are supported in this context.",
                               warn_tag="risk")

--- a/conan/internal/model/recipe_ref.py
+++ b/conan/internal/model/recipe_ref.py
@@ -6,7 +6,7 @@ def ref_matches(ref, pattern, is_consumer):
     if not ref or not str(ref):
         assert is_consumer
         ref = RecipeReference.loads("*/*")  # FIXME: ugly
-    if pattern.startswith("["):
+    if "[" in pattern:
         ConanOutput().warning(f"Pattern {pattern} contains a version range, which has no effect. "
                               f"Only '&' for consumer and '*' as wildcard are supported in this context.",
                               warn_tag="risk")

--- a/conan/internal/model/recipe_ref.py
+++ b/conan/internal/model/recipe_ref.py
@@ -1,8 +1,13 @@
 from conan.api.model import RecipeReference
+from conan.api.output import ConanOutput
 
 
 def ref_matches(ref, pattern, is_consumer):
     if not ref or not str(ref):
         assert is_consumer
         ref = RecipeReference.loads("*/*")  # FIXME: ugly
+    if "[" in pattern or "]" in pattern:
+        ConanOutput().warning(f"Pattern {pattern} contains a version range, which has no effect. "
+                              f"Only '&' for consumer and '*' as wildcard are supported in this context.",
+                              warn_tag="risk")
     return ref.matches(pattern, is_consumer=is_consumer)

--- a/test/integration/options/options_test.py
+++ b/test/integration/options/options_test.py
@@ -505,6 +505,19 @@ class TestMultipleOptionsPatterns:
         assert "dep3/1.0: SHARED: True!!" in c.out
         assert "dep4/1.0: SHARED: True!!" in c.out
 
+    def test_pattern_version_range_warn(self):
+        c = TestClient(light=True)
+        c.save({"conanfile.py": GenConanfile("foo", "1.0")})
+        c.run("create -o=foo/[>1]:shared=True")
+        assert "WARN: risk: Pattern foo/[>1] contains a version range" in c.out
+
+    def test_pattern_version_range_wrong_split(self):
+        c = TestClient(light=True)
+        c.save({"conanfile.py": GenConanfile("foo", "1.0")})
+        c.run("create -o=foo/[>=1]:shared=True", assert_error=True)
+        # We split by the first =, so this version range we can't catch and warn before it breaks
+        assert "option 'foo/[>' doesn't exist" in c.out
+
 
 class TestTransitiveOptionsShared:
     """


### PR DESCRIPTION
Changelog: Fix: Warn on version ranges in reference pattern, which have no effect (ie ``-o="foo/[>1]:shared=True"``).
Docs: Omit

As reported in https://github.com/conan-io/conan/issues/19335