### PR TITLE
defines, frameworks now also generate CMakeConfigDeps targets

### DIFF
--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -179,8 +179,8 @@ class TargetConfigurationTemplate2:
         return libs
 
     def _get_cmake_lib(self, info, components, pkg_folder, pkg_folder_var, comp_name=None):
-        if info.exe or not (info.package_framework or info.includedirs or info.libs
-                            or info.system_libs):
+        if info.exe or not (info.package_framework or info.frameworks or info.includedirs or info.libs
+                            or info.system_libs or info.defines):
             return
 
         includedirs = ";".join(self._path(i, pkg_folder, pkg_folder_var)

--- a/test/integration/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_frameworks.py
+++ b/test/integration/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_frameworks.py
@@ -42,3 +42,27 @@ def test_package_framework_needs_location():
     })
     client.run(f"create . -c tools.cmake.cmakedeps:new={new_value}", assert_error=True)
     assert "Error in generator 'CMakeConfigDeps': cpp_info.location missing for framework MyFramework" in client.out
+
+
+def test_framework_only_component_generates_target():
+    conanfile = textwrap.dedent(f"""
+    import os
+    from conan import ConanFile
+
+    class MyFramework(ConanFile):
+        name = "frame"
+        version = "1.0"
+        settings = "os", "arch", "compiler", "build_type"
+
+        def package_info(self):
+            self.cpp_info.frameworks = ["MyFramework"]
+            self.cpp_info.libdirs = []
+            self.cpp_info.includedirs = []
+    """)
+
+    tc = TestClient()
+    tc.save({"conanfile.py": conanfile})
+    tc.run("create .")
+    tc.run(f"install --requires=frame/1.0 -g CMakeConfigDeps -c=tools.cmake.cmakedeps:new={new_value}")
+    targets = tc.load("frame-Targets-release.cmake")
+    assert "add_library(frame::frame INTERFACE IMPORTED)" in targets

--- a/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
@@ -640,3 +640,27 @@ def test_package_info_extra_variables():
     assert 'set(CMAKE_GENERATOR_INSTANCE "${GENERATOR_INSTANCE}/buildTools/")' in target
     assert 'set(FOO 42)' in target
     assert 'set(CACHE_VAR_DEFAULT_DOC "hello world" CACHE PATH "CACHE_VAR_DEFAULT_DOC")' in target
+
+
+def test_target_defines_only():
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+
+        class Pkg(ConanFile):
+            name = "pkg"
+            version = "0.1"
+
+            def package_info(self):
+                self.cpp_info.components["base"].includedirs = []
+                self.cpp_info.components["base"].defines = ["FOO=1"]
+                self.cpp_info.components["comp"].includedirs = ["include"]
+                self.cpp_info.components["comp"].requires = ["base"]
+    """)
+    client.save({"conanfile.py": conanfile})
+    client.run("create .")
+
+    client.run(f"install --requires=pkg/0.1 -g CMakeDeps -c tools.cmake.cmakedeps:new={new_value}")
+    target = client.load("pkg-Targets-release.cmake")
+    assert 'add_library(pkg::base INTERFACE IMPORTED)' in target
+    assert "# Requirement pkg::base => Full link: True" in target


### PR DESCRIPTION
Changelog: Fix: `defines` and `frameworks` now also generate `CMakeConfigDeps` targets.
Docs: Omit


This comes as a fix for the opengl recipe in Macos, which has this `package_info()`:

```py
        self.cpp_info.set_property("cmake_file_name", "opengl_system")

        self.cpp_info.bindirs = []
        self.cpp_info.includedirs = []
        self.cpp_info.libdirs = []
        if self.settings.os == "Macos":
            self.cpp_info.defines.append("GL_SILENCE_DEPRECATION=1")
            self.cpp_info.frameworks.append("OpenGL")
        elif self.settings.os == "Windows":
            self.cpp_info.system_libs = ["opengl32"]
        elif self.settings.os in ["Linux", "FreeBSD", "SunOS"]:
            pkg_config = PkgConfig(self, 'gl')
            pkg_config.fill_cpp_info(self.cpp_info, is_system=self.settings.os != "FreeBSD")
```

which did not create a target for opengl, and then having this as a dependency made it error out