### PR TITLE
avoid warning for version-range patterns

### DIFF
--- a/conan/api/subapi/graph.py
+++ b/conan/api/subapi/graph.py
@@ -109,12 +109,15 @@ class GraphAPI:
         Command line helper to scope options when ``command -o myoption=myvalue`` is used,
         that needs to be converted to "-o pkg:myoption=myvalue". The "pkg" value will be
         computed from the given requires/tool_requires
+
+        This is legacy, as options should always be scoped now
         """
-        # FIXME: This helper function here is not great, find a better place
         if requires and len(requires) == 1 and not tool_requires:
-            profile.options.scope(requires[0])
-        if tool_requires and len(tool_requires) == 1 and not requires:
-            profile.options.scope(tool_requires[0])
+            ref = requires[0]
+            if str(ref.version).startswith("["):
+                ref = ref.copy()
+                ref.version = "*"
+            profile.options.scope(ref)
 
     def load_graph_requires(self, requires, tool_requires, profile_host, profile_build,
                             lockfile, remotes, update, check_updates=False, python_requires=None):

--- a/conan/internal/model/recipe_ref.py
+++ b/conan/internal/model/recipe_ref.py
@@ -8,6 +8,6 @@ def ref_matches(ref, pattern, is_consumer):
         ref = RecipeReference.loads("*/*")  # FIXME: ugly
     if "[" in pattern:
         ConanOutput().warning(f"Pattern {pattern} contains a version range, which has no effect. "
-                              f"Only '&' for consumer and '*' as wildcard are supported in this context.",
-                              warn_tag="risk")
+                              f"Only '&' for consumer and '*' as wildcard are supported "
+                              f"in this context.", warn_tag="risk")
     return ref.matches(pattern, is_consumer=is_consumer)

--- a/test/integration/options/options_test.py
+++ b/test/integration/options/options_test.py
@@ -875,3 +875,14 @@ def test_get_safe_none_option_checks():
     assert "get_safe is not None: False" in tc.out
     assert "get_safe == None: True" in tc.out
     assert "get_safe != None: False" in tc.out
+
+
+def test_option_apply_version_range():
+    c = TestClient(light=True)
+    c.save({"conanfile.py": GenConanfile("dep", "0.1").with_shared_option(False)})
+    c.run("create -o shared=True")
+    c.run("install --requires=dep/0.1 -o shared=True")  # This worked without problem
+    c.run("install --requires=dep/[*] -o shared=True")
+    assert "WARN: risk" not in c.out
+    # This failed because of dep/[*] not matching pattern, now it works
+    assert "Install finished successfully" in c.out


### PR DESCRIPTION
Changelog: Bugfix: Do correct scoping of ``conan install --requires=dep/[*] -o myoption=value``.
Docs: Omit

Also avoid false positives warnings from https://github.com/conan-io/conan/pull/19356
