### PR TITLE
follow layout() for workspace super-install

### DIFF
--- a/conan/api/subapi/workspace.py
+++ b/conan/api/subapi/workspace.py
@@ -310,9 +310,17 @@ class WorkspaceAPI:
 
         for level in deps_graph.by_levels():
             items = [item for item in level if item.recipe == "Editable"]
-            items = [{"ref": item.ref, "folder": find_folder(item.ref)} for item in items]
-            if items:
-                order.append(items)
+            level_order = []
+            for node in items:
+                conanfile = node.conanfile
+                if hasattr(conanfile, "layout"):
+                    with conanfile_exception_formatter(conanfile, "layout"):
+                        conanfile.layout()
+                base_folder = find_folder(node.ref)
+                src_folder = os.path.normpath(os.path.join(base_folder, conanfile.folders.source))
+                level_order.append({"ref": node.ref, "folder": src_folder.replace("\\", "/")})
+            order.append(level_order)
+
         self._ws.build_order(order)
 
         ConanOutput().title("Collapsing workspace packages")

--- a/conan/internal/model/workspace.py
+++ b/conan/internal/model/workspace.py
@@ -131,5 +131,5 @@ class Workspace:
         msg = ["Packages build order:"]
         for level in order:
             for item in level:
-                msg.append(f"    {item['ref']}")
+                msg.append(f"    {item['ref']}: {item['folder']}")
         self.output.info("\n".join(msg))

--- a/test/functional/workspace/test_workspace.py
+++ b/test/functional/workspace/test_workspace.py
@@ -69,3 +69,29 @@ def test_new_template_and_different_folder():
     assert "Adding project: liba" in c.out
     assert "Adding project: libb" in c.out
     assert "Adding project: app1" in c.out
+
+
+# The workspace CMake needs at least 3.25 for find_package to work
+@pytest.mark.tool("cmake", "3.27")
+def test_super_build_different_layouts():
+    """
+    https://github.com/conan-io/conan/issues/18875
+    """
+    c = TestClient()
+    c.run("new workspace")
+    liba_src = os.path.join(c.current_folder, "liba", "mysrc")
+    os.makedirs(liba_src)
+    shutil.move(os.path.join(c.current_folder, "liba", "CMakeLists.txt"), liba_src)
+    shutil.move(os.path.join(c.current_folder, "liba", "include"), liba_src,)
+    shutil.move(os.path.join(c.current_folder, "liba", "src"), liba_src)
+    replace_in_file(ConanFileMock(), os.path.join(c.current_folder, "liba", "conanfile.py"),
+                    "cmake_layout(self)",
+                    "cmake_layout(self, src_folder='mysrc')")
+
+    c.run("workspace super-install")
+
+    config_preset = "conan-default" if platform.system() == "Windows" else "conan-release"
+    c.run_command(f"cmake --preset {config_preset}")  # it does not fail
+    assert "Adding project: liba" in c.out
+    assert "Adding project: libb" in c.out
+    assert "Adding project: app1" in c.out

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -658,7 +658,7 @@ class TestMeta:
         c.run("workspace add libb")
         c.run("workspace super-install -g CMakeDeps -g CMakeToolchain -of=build "
               "--envs-generation=false")
-        assert "Packages build order:\n    liba/0.1\n    libb/0.1" in c.out
+        assert "Packages build order:\n    liba/0.1: liba\n    libb/0.1: libb" in c.out
         assert "Workspace conanws.py not found in the workspace folder, using default" in c.out
         files = os.listdir(os.path.join(c.current_folder, "build"))
         assert "conan_toolchain.cmake" in files


### PR DESCRIPTION
Changelog: Feature: Workspace super-install now follows `layout()`.
Docs: https://github.com/conan-io/docs/pull/4336

Close https://github.com/conan-io/conan/issues/18875
