### PR TITLE
[MesonToolchain] `needs_exe_wrapper` depends on `can_run` function

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -266,6 +266,7 @@ class MesonToolchain:
                 sdk_host = conanfile.settings.get_safe("os.sdk")
                 self.cross_build["host"]["subsystem"] = get_apple_subsystem(sdk_host)
                 self.cross_build["build"]["subsystem"] = get_apple_subsystem(sdk_build)
+            # Issue: https://github.com/conan-io/conan/issues/19217
             self.properties["needs_exe_wrapper"] = not can_run(self._conanfile)
             if hasattr(conanfile, 'settings_target') and conanfile.settings_target:
                 settings_target = conanfile.settings_target

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -8,7 +8,7 @@ from conan.internal import check_duplicated_generator
 from conan.internal.internal_tools import raise_on_universal_arch
 from conan.tools.apple.apple import is_apple_os, apple_min_version_flag, \
     resolve_apple_flags, apple_extra_flags
-from conan.tools.build.cross_building import cross_building
+from conan.tools.build.cross_building import cross_building, can_run
 from conan.tools.build.flags import (architecture_link_flag, libcxx_flags, architecture_flag,
                                      threads_flags)
 from conan.tools.env import VirtualBuildEnv
@@ -266,7 +266,7 @@ class MesonToolchain:
                 sdk_host = conanfile.settings.get_safe("os.sdk")
                 self.cross_build["host"]["subsystem"] = get_apple_subsystem(sdk_host)
                 self.cross_build["build"]["subsystem"] = get_apple_subsystem(sdk_build)
-            self.properties["needs_exe_wrapper"] = True
+            self.properties["needs_exe_wrapper"] = not can_run(self._conanfile)
             if hasattr(conanfile, 'settings_target') and conanfile.settings_target:
                 settings_target = conanfile.settings_target
                 os_target = settings_target.get_safe("os")

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -921,6 +921,9 @@ def test_needs_exe_wrapper():
     compiler.libcxx=libc++
     compiler.version=16
     os=Macos
+    [conf]
+    tools.apple:sdk_path=/my/sdk/path
+    tools.build.cross_building:can_run=True
     """)
     build = textwrap.dedent("""
     [settings]
@@ -940,6 +943,6 @@ def test_needs_exe_wrapper():
                         .with_settings("os", "arch", "compiler", "build_type")
                         .with_generator("MesonToolchain")
     })
-    client.run("install . -pr:h host -pr:b build -c tools.build.cross_building:can_run=True")
+    client.run("install . -pr:h host -pr:b build")
     content = client.load(MesonToolchain.cross_filename)
     assert "needs_exe_wrapper = false" in content

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -940,6 +940,6 @@ def test_needs_exe_wrapper():
                         .with_settings("os", "arch", "compiler", "build_type")
                         .with_generator("MesonToolchain")
     })
-    client.run("install . -pr:h host -pr:b build -c 'tools.build.cross_building:can_run=True'")
+    client.run("install . -pr:h host -pr:b build -c tools.build.cross_building:can_run=True")
     content = client.load(MesonToolchain.cross_filename)
     assert "needs_exe_wrapper = false" in content

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -906,6 +906,12 @@ def test_new_public_attributes():
 
 
 def test_needs_exe_wrapper():
+    """
+    Tests needs_exe_wrapper depends on `can_run()` function instead of
+    simply checking the cross_building() one.
+
+    Issue: https://github.com/conan-io/conan/issues/19217
+    """
     host = textwrap.dedent("""
     [settings]
     arch=x86_64

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -903,3 +903,37 @@ def test_new_public_attributes():
     backend = 'xcode'
     """)
     assert expected in content
+
+
+def test_needs_exe_wrapper():
+    host = textwrap.dedent("""
+    [settings]
+    arch=x86_64
+    build_type=Release
+    compiler=apple-clang
+    compiler.cppstd=gnu17
+    compiler.libcxx=libc++
+    compiler.version=16
+    os=Macos
+    """)
+    build = textwrap.dedent("""
+    [settings]
+    arch=armv8
+    build_type=Release
+    compiler=apple-clang
+    compiler.cppstd=gnu17
+    compiler.libcxx=libc++
+    compiler.version=16
+    os=Macos
+    """)
+    client = TestClient()
+    client.save({
+        "host": host,
+        "build": build,
+        "conanfile.py": GenConanfile("pkg", "1.0")
+                        .with_settings("os", "arch", "compiler", "build_type")
+                        .with_generator("MesonToolchain")
+    })
+    client.run("install . -pr:h host -pr:b build -c 'tools.build.cross_building:can_run=True'")
+    content = client.load(MesonToolchain.cross_filename)
+    assert "needs_exe_wrapper = false" in content


### PR DESCRIPTION
Changelog: Feature: MesonToolchain `needs_exe_wrapper` property now listens to `can_run()` function. 
Docs: omit
Closes: https://github.com/conan-io/conan/issues/19217
