### PR TITLE
Allow matching multiple packages by a pattern.

### DIFF
--- a/conan/api/model/refs.py
+++ b/conan/api/model/refs.py
@@ -193,8 +193,8 @@ class RecipeReference:
                 no_user_channel = True
 
             condition_part = ((pattern_part == "&" and is_consumer) or
-                        fnmatch.fnmatchcase(str(self), pattern_part) or
-                        fnmatch.fnmatchcase(self.repr_notime(), pattern_part))
+                              fnmatch.fnmatchcase(str(self), pattern_part) or
+                              fnmatch.fnmatchcase(self.repr_notime(), pattern_part))
             if no_user_channel:
                 condition_part = condition_part and not self.user and not self.channel
             condition |= condition_part

--- a/conan/api/model/refs.py
+++ b/conan/api/model/refs.py
@@ -173,6 +173,8 @@ class RecipeReference:
         :parameter str pattern: the pattern to match against, it can contain wildcards,
             and can start with ``!`` or ``~`` to negate the match.
             A special value of ``&`` will return a match only of ``is_consumer`` is ``True``
+            One can provide multiple patterns separated by | character.
+            The negation is supported only for the whole pattern colletion.
         :parameter bool is_consumer: if ``True``, the pattern ``&`` will match this reference.
         """
         negate = False
@@ -180,19 +182,22 @@ class RecipeReference:
             pattern = pattern[1:]
             negate = True
 
-        no_user_channel = False
-        if pattern.endswith("@"):  # it means we want to match only without user/channel
-            pattern = pattern[:-1]
-            no_user_channel = True
-        elif "@#" in pattern:
-            pattern = pattern.replace("@#", "#")
-            no_user_channel = True
+        condition = False
+        for pattern_part in pattern.split("|"):
+            no_user_channel = False
+            if pattern_part.endswith("@"):  # it means we want to match only without user/channel
+                pattern_part = pattern_part[:-1]
+                no_user_channel = True
+            elif "@#" in pattern_part:
+                pattern_part = pattern_part.replace("@#", "#")
+                no_user_channel = True
 
-        condition = ((pattern == "&" and is_consumer) or
-                     fnmatch.fnmatchcase(str(self), pattern) or
-                     fnmatch.fnmatchcase(self.repr_notime(), pattern))
-        if no_user_channel:
-            condition = condition and not self.user and not self.channel
+            condition_part = ((pattern_part == "&" and is_consumer) or
+                        fnmatch.fnmatchcase(str(self), pattern_part) or
+                        fnmatch.fnmatchcase(self.repr_notime(), pattern_part))
+            if no_user_channel:
+                condition_part = condition_part and not self.user and not self.channel
+            condition |= condition_part
         if negate:
             return not condition
         return condition

--- a/test/unittests/model/test_recipe_reference.py
+++ b/test/unittests/model/test_recipe_reference.py
@@ -93,3 +93,15 @@ def test_error_pref():
     with pytest.raises(ConanException) as exc:
         r1.validate_ref()
     assert "Invalid recipe reference 'pkg/1.0:pid' is a package reference" in str(exc)
+
+
+@pytest.mark.parametrize("pattern", ["pkg/*", "pkg/*|other/*", "other/*|pkg/*", "!other/*", "!other1/*|other2/*", "!&", "&|pkg/*"])
+def test_pattern_match(pattern):
+    r = RecipeReference.loads("pkg/0.1")
+    assert r.matches(pattern, False)
+
+
+@pytest.mark.parametrize("pattern", ["other/*", "!pkg/*", "!other/*|pkg/*", "!pkg/*|other/*", "!&|pkg/*"])
+def test_pattern_no_match(pattern):
+    r = RecipeReference.loads("pkg/0.1")
+    assert not r.matches(pattern, False)


### PR DESCRIPTION
Changelog: Feature: Fix circular dependencies in complex tool_requires
Docs: https://github.com/conan-io/docs/pull/XXXX
Closes #17474
Close https://github.com/conan-io/conan/issues/19773

Profile contains:
```.ini
[tool_requires]
gcc/15.0
mold/1.40
```
gcc conanfile is just an export-pkg, thus has no dependencies.
mold requires cmake to build (and gcc)

So we need to remove mold from cmake and gcc to fix cicular dependency.
I propose `|` as the character to split patterns:
```.ini
[tool_requires]
gcc/15.0
!gcc/*|cmake/*:mold/1.40
```

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
