### PR TITLE
root profile name jinja

### DIFF
--- a/conan/internal/api/profile/profile_loader.py
+++ b/conan/internal/api/profile/profile_loader.py
@@ -99,10 +99,10 @@ class ProfileLoader:
     def load_profile(self, profile_name, cwd=None, context=None):
         # TODO: This can be made private, only used in testing now
         cwd = cwd or os.getcwd()
-        profile = self._load_profile(profile_name, cwd, context)
+        profile = self._load_profile(profile_name, cwd, context, root_profile_name=profile_name)
         return profile
 
-    def _load_profile(self, profile_name, cwd, context):
+    def _load_profile(self, profile_name, cwd, context, root_profile_name):
         """ Will look for "profile_name" in disk if profile_name is absolute path,
         in current folder if path is relative or in the default folder otherwise.
         return: a Profile object
@@ -122,6 +122,7 @@ class ProfileLoader:
                    "subprocess": subprocess,
                    "profile_dir": base_path,
                    "profile_name": file_path,
+                   "root_profile_name": root_profile_name,
                    "conan_version": conan_version,
                    "detect_api": detect_api,
                    "context": context}
@@ -138,11 +139,11 @@ class ProfileLoader:
                                  f"Check your Jinja2 syntax: {str(e)}")
 
         try:
-            return self._recurse_load_profile(text, profile_path, context)
+            return self._recurse_load_profile(text, profile_path, context, profile_name)
         except ConanException as exc:
             raise ConanException("Error reading '%s' profile: %s" % (profile_name, exc))
 
-    def _recurse_load_profile(self, text, profile_path, context):
+    def _recurse_load_profile(self, text, profile_path, context, root_profile_name):
         """ Parse and return a Profile object from a text config like representation.
             cwd is needed to be able to load the includes
         """
@@ -154,7 +155,7 @@ class ProfileLoader:
             # from parent profiles
             for include in profile_parser.includes:
                 # Recursion !!
-                profile = self._load_profile(include, cwd, context)
+                profile = self._load_profile(include, cwd, context, root_profile_name)
                 inherited_profile.compose_profile(profile)
 
             # Current profile before update with parents (but parent variables already applied)

--- a/test/integration/configuration/test_profile_jinja.py
+++ b/test/integration/configuration/test_profile_jinja.py
@@ -232,6 +232,24 @@ def test_profile_template_profile_name():
     assert "conanfile.py: PROFILE NAME: include_default" in client.out
 
 
+def test_profile_root_name():
+    c = TestClient()
+    root = textwrap.dedent("""
+        [conf]
+        user.profile:name = {{ profile_name }}
+        user.profile:root_name = {{ root_profile_name }}
+        """)
+    tpl = textwrap.dedent("""
+        include(myprofile)
+        """)
+
+    c.save({"myprofile": root,
+            "other": tpl})
+    c.run("profile show -pr=other")
+    assert "user.profile:name=myprofile" in c.out
+    assert "user.profile:root_name=other" in c.out
+
+
 class TestProfileDetectAPI:
     def test_profile_detect_os_arch(self):
         """ testing OS & ARCH just to test the UX and interface


### PR DESCRIPTION
Changelog: Feature: Add `root_profile_name` to the profile jinja2 context to allow tracing back the root profile from included profiles.
Docs: https://github.com/conan-io/docs/pull/4350

Close https://github.com/conan-io/conan/issues/19390