### PR TITLE
Reduce sqlite db connection scope

### DIFF
--- a/conan/internal/cache/db/packages_table.py
+++ b/conan/internal/cache/db/packages_table.py
@@ -168,8 +168,8 @@ class PackagesDBTable(BaseDbTable):
                     f'ORDER BY {self.columns.timestamp} DESC'
         with self.db_connection() as conn:
             r = conn.execute(query)
-            for row in r.fetchall():
-                yield self._as_dict(self.row_type(*row))
+            rows = r.fetchall()
+        return [self._as_dict(self.row_type(*row)) for row in rows]
 
     def get_package_revisions_reference_exists(self, pref: PkgReference):
         assert pref.ref.revision, "To check package revision existence you must provide a recipe revision."
@@ -185,7 +185,7 @@ class PackagesDBTable(BaseDbTable):
         with self.db_connection() as conn:
             r = conn.execute(query)
             row = r.fetchone()
-            return bool(row)
+        return bool(row)
 
     def get_package_references(self, ref: RecipeReference, only_latest_prev=True):
         # Return the latest revisions
@@ -212,8 +212,8 @@ class PackagesDBTable(BaseDbTable):
                     f'ORDER BY {self.columns.timestamp} DESC'
         with self.db_connection() as conn:
             r = conn.execute(query)
-            for row in r.fetchall():
-                yield self._as_dict(self.row_type(*row))
+            rows = r.fetchall()
+        return [self._as_dict(self.row_type(*row)) for row in rows]
 
     def get_package_references_with_build_id_match(self, ref: RecipeReference, build_id):
         # Return the latest revisions
@@ -237,9 +237,9 @@ class PackagesDBTable(BaseDbTable):
         with self.db_connection() as conn:
             r = conn.execute(query)
             row = r.fetchone()
-            if row:
-                return self._as_dict(self.row_type(*row))
-            return None
+        if row:
+            return self._as_dict(self.row_type(*row))
+        return None
 
     def path_to_ref(self, path):
         query = f'SELECT * FROM {self.table_name} ' \
@@ -247,9 +247,9 @@ class PackagesDBTable(BaseDbTable):
         with self.db_connection() as conn:
             r = conn.execute(query)
             row = r.fetchone()
-            if not row:
-                return None
-            ref = RecipeReference.loads(row[0])
-            ref.revision = row[1]
-            pref = PkgReference(ref, row[2], row[3], row[5])
-            return pref
+        if not row:
+            return None
+        ref = RecipeReference.loads(row[0])
+        ref.revision = row[1]
+        pref = PkgReference(ref, row[2], row[3], row[5])
+        return pref

--- a/conan/internal/cache/db/recipes_table.py
+++ b/conan/internal/cache/db/recipes_table.py
@@ -85,7 +85,7 @@ class RecipesDBTable(BaseDbTable):
         with self.db_connection() as conn:
             r = conn.execute(query)
             rows = r.fetchall()
-            return [RecipeReference.loads(row[0]) for row in rows]
+        return [RecipeReference.loads(row[0]) for row in rows]
 
     def get_recipe(self, ref: RecipeReference):
         query = f'SELECT * FROM {self.table_name} ' \
@@ -94,9 +94,9 @@ class RecipesDBTable(BaseDbTable):
         with self.db_connection() as conn:
             r = conn.execute(query)
             row = r.fetchone()
-            if not row:
-                raise ConanReferenceDoesNotExistInDB(f"Recipe '{ref.repr_notime()}' not found")
-            ret = self._as_dict(self.row_type(*row))
+        if not row:
+            raise ConanReferenceDoesNotExistInDB(f"Recipe '{ref.repr_notime()}' not found")
+        ret = self._as_dict(self.row_type(*row))
         return ret
 
     def get_latest_recipe(self, ref: RecipeReference):
@@ -112,9 +112,9 @@ class RecipesDBTable(BaseDbTable):
         with self.db_connection() as conn:
             r = conn.execute(query)
             row = r.fetchone()
-            if row is None:
-                raise ConanReferenceDoesNotExistInDB(f"Recipe '{ref}' not found")
-            ret = self._as_dict(self.row_type(*row))
+        if row is None:
+            raise ConanReferenceDoesNotExistInDB(f"Recipe '{ref}' not found")
+        ret = self._as_dict(self.row_type(*row))
         return ret
 
     def get_recipe_revisions_references(self, ref: RecipeReference):
@@ -125,7 +125,8 @@ class RecipesDBTable(BaseDbTable):
 
         with self.db_connection() as conn:
             r = conn.execute(query)
-            ret = [self._as_dict(self.row_type(*row))["ref"] for row in r.fetchall()]
+            rows = r.fetchall()
+        ret = [self._as_dict(self.row_type(*row))["ref"] for row in rows]
         return ret
 
     def path_to_ref(self, path):
@@ -134,9 +135,9 @@ class RecipesDBTable(BaseDbTable):
         with self.db_connection() as conn:
             r = conn.execute(query)
             row = r.fetchone()
-            if not row:
-                return None
-            ref = RecipeReference.loads(row[0])
-            ref.revision = row[1]
-            ref.timestamp = row[3]
-            return ref
+        if not row:
+            return None
+        ref = RecipeReference.loads(row[0])
+        ref.revision = row[1]
+        ref.timestamp = row[3]
+        return ref

--- a/conan/internal/cache/db/table.py
+++ b/conan/internal/cache/db/table.py
@@ -1,7 +1,10 @@
 import sqlite3
-from collections import namedtuple
+import threading
+from collections import defaultdict, namedtuple
 from contextlib import contextmanager
 from typing import Tuple, List
+
+from conan.errors import ConanException
 
 
 class BaseDbTable:
@@ -10,20 +13,29 @@ class BaseDbTable:
     row_type: namedtuple = None
     columns: namedtuple = None
     unique_together: tuple = None
+    _lock: threading.Lock = None
+    _lock_storage = defaultdict(threading.Lock)
 
     def __init__(self, filename):
         self.filename = filename
         column_names: List[str] = [it[0] for it in self.columns_description]
         self.row_type = namedtuple('_', column_names)
         self.columns = self.row_type(*column_names)
+        self._lock = self._lock_storage[self.filename]
 
     @contextmanager
     def db_connection(self):
+        if not self._lock.acquire(timeout=20):
+            raise ConanException("Conan failed to acquire database lock in 20s. Maybe the system is"
+                                 "under very heavy load. Please report it to Github tickets")
+        # isolation_level=None, puts it in regular SQLITE autocommit mode, every
+        # connection.execute() will autocommit
         connection = sqlite3.connect(self.filename, isolation_level=None, timeout=20)
         try:
             yield connection
         finally:
             connection.close()
+            self._lock.release()
 
     def create_table(self):
         def field(name, typename, nullable=False, unique=False):

--- a/conan/internal/cache/db/table.py
+++ b/conan/internal/cache/db/table.py
@@ -1,6 +1,5 @@
 import sqlite3
-import threading
-from collections import defaultdict, namedtuple
+from collections import namedtuple
 from contextlib import contextmanager
 from typing import Tuple, List
 
@@ -11,25 +10,20 @@ class BaseDbTable:
     row_type: namedtuple = None
     columns: namedtuple = None
     unique_together: tuple = None
-    _lock: threading.Lock = None
-    _lock_storage = defaultdict(threading.Lock)
 
     def __init__(self, filename):
         self.filename = filename
         column_names: List[str] = [it[0] for it in self.columns_description]
         self.row_type = namedtuple('_', column_names)
         self.columns = self.row_type(*column_names)
-        self._lock = self._lock_storage[self.filename]
 
     @contextmanager
     def db_connection(self):
-        assert self._lock.acquire(timeout=20), "Conan failed to acquire database lock"
         connection = sqlite3.connect(self.filename, isolation_level=None, timeout=20)
         try:
             yield connection
         finally:
             connection.close()
-            self._lock.release()
 
     def create_table(self):
         def field(name, typename, nullable=False, unique=False):


### PR DESCRIPTION
Changelog: Fix: Reduce the sqlite DB connection scope to try to optimize DB locking. Remove the ``yield`` DB return that could create operational issues.
Docs: Omit

Related to recent https://github.com/conan-io/conan/issues/19181

Replace the DB ``yields`` for regular returns
End the connection a bit earlier, do post-processing of rows outside the connection

Try to remove the ``threading.Lock``, in theory it is not necessary, but the reason might be that some Python sqlite3 in some distros/OSs are built without built-in concurrency support?
See:
- https://github.com/conan-io/conan/issues/13924
- https://github.com/conan-io/conan/pull/14410
- https://github.com/conan-io/conan/pull/14968
- https://github.com/conan-io/conan/issues/14977

Specially https://github.com/conan-io/conan/issues/13924#issuecomment-1784219584, so it is likely that we want to keep this lock for robustness