### PR TITLE
fixing the update to older revisions existing in cache

### DIFF
--- a/conan/internal/graph/proxy.py
+++ b/conan/internal/graph/proxy.py
@@ -3,7 +3,7 @@ from conan.internal.cache.conan_reference_layout import BasicLayout
 from conan.internal.graph.graph import (RECIPE_DOWNLOADED, RECIPE_INCACHE, RECIPE_NEWER,
                                         RECIPE_NOT_IN_REMOTE, RECIPE_UPDATED, RECIPE_EDITABLE,
                                         RECIPE_INCACHE_DATE_UPDATED, RECIPE_UPDATEABLE)
-from conan.internal.errors import NotFoundException
+from conan.internal.errors import NotFoundException, ConanReferenceAlreadyExistsInDB
 from conan.errors import ConanException
 
 
@@ -65,19 +65,22 @@ class ConanProxy:
             return recipe_layout, status, None
 
         # Something found in remotes, check if we already have the latest in local cache
-        # TODO: cache2.0 here if we already have a revision in the cache but we add the
-        #  --update argument and we find that same revision in server, we will not
-        #  download anything but we will UPDATE the date of that revision in the
-        #  local cache and WE ARE ALSO UPDATING THE REMOTE
-        #  Check if this is the flow we want to follow
         assert ref.timestamp
         cache_time = ref.timestamp
         if remote_ref.revision != ref.revision:
             if cache_time < remote_ref.timestamp:
                 # the remote one is newer
                 if should_update_reference(remote_ref, update):
-                    output.info("Retrieving from remote '%s'..." % remote.name)
-                    new_recipe_layout = self._download(remote_ref, remote)
+                    output.info(f"Updating to latest from remote '{remote.name}'...")
+                    try:
+                        new_recipe_layout = self._download(remote_ref, remote)
+                    except ConanReferenceAlreadyExistsInDB:
+                        # When updating to a newer revision in the server, but it already exists
+                        # in the cache with an older timestamp
+                        output.info(f"Latest from '{remote.name}' was found in "
+                                    "the cache, using it and updating its timestamp")
+                        new_recipe_layout = self._cache.recipe_layout(remote_ref)
+                        self._cache.update_recipe_timestamp(remote_ref)  # make it latest
                     status = RECIPE_UPDATED
                     return new_recipe_layout, status, remote
                 else:

--- a/test/integration/cache/cache2_update_test.py
+++ b/test/integration/cache/cache2_update_test.py
@@ -1,4 +1,6 @@
 import copy
+import json
+import textwrap
 from collections import OrderedDict
 
 import pytest
@@ -447,9 +449,9 @@ class TestUpdateFlows:
                                            ["libc", {"liba/1.0": "Cache",
                                                      "libb/1.0": "Cache"}],
                                            ["liba", {"liba/1.1": "Downloaded (default)",
-                                                       "libb/1.0": "Cache"}],
+                                                     "libb/1.0": "Cache"}],
                                            ["libb", {"liba/1.0": "Cache",
-                                                       "libb/1.1": "Downloaded (default)"}],
+                                                     "libb/1.1": "Downloaded (default)"}],
                                            ["", {"liba/1.0": "Cache",
                                                  "libb/1.0": "Cache"}],
                                            # Patterns not supported, only full name match
@@ -480,3 +482,49 @@ def test_muliref_update_pattern(update, result):
     tc.run(f'install --requires="liba/[>=1.0]" --requires="libb/[>=1.0]" -r default {update_flag}')
 
     tc.assert_listed_require(result)
+
+
+def test_update_remote_older_revision():
+    # https://github.com/conan-io/conan/issues/19313
+    c = TestClient(light=True, default_server_user=True)
+    zlib = textwrap.dedent("""
+       from conan import ConanFile
+       class Zlib(ConanFile):
+           name = "zlib"
+           version = "1.2.11"
+           exports_sources = "*"
+        """)
+    c.save({"conanfile.py": zlib,
+            "file.h": "//myheader"})
+    c.run("export")
+    c.run("upload * -r=default -c")
+
+    c2 = TestClient(light=True, servers=c.servers)
+    c2.run("graph info --requires=zlib/[*]")
+    rev1 = "2e87959c586811f8a4eaf12a327cc042"
+    c2.assert_listed_require({f"zlib/1.2.11#{rev1}": "Downloaded (default)"})
+
+    # Modify zlib code
+    c.save({"file.h": "//myheader 2"})
+    c.run("export")
+    c.run("upload * -r=default -c")
+
+    c2.run("graph info --requires=zlib/[*] --update")
+    rev2 = "934b3de03768d9030b61127d588d0a96"
+    c2.assert_listed_require({f"zlib/1.2.11#{rev2}": "Updated (default)"})
+
+    # revert this to old, make it latestlatest
+    c.save({"file.h": "//myheader"})
+    c.run("export")
+    c.run("remove * -r=default -c")
+    c.run("upload * -r=default -c")
+
+    c2.run("graph info --requires=zlib/[*] --update")
+    assert ("Latest from 'default' was found in "
+            "the cache, using it and updating its timestamp") in c2.out
+    c2.assert_listed_require({f"zlib/1.2.11#{rev1}": "Updated (default)"})
+
+    c2.run("list *#* --format=json")
+    revs = json.loads(c2.stdout)["Local Cache"]["zlib/1.2.11"]["revisions"]
+    # we check that the update from the server has made rev1 the latest in the cache again
+    assert revs[rev1]["timestamp"] > revs[rev2]["timestamp"]

--- a/test/integration/remote/test_local_recipes_index.py
+++ b/test/integration/remote/test_local_recipes_index.py
@@ -552,3 +552,48 @@ class TestResetRemote:
                 "requested, but it doesn't match the current available revision in source") in c.out
         assert ("ERROR: The 'zlib/1.2.11' package has 'exports_sources' but sources "
                 "not found in local cache") in c.out
+
+    def test_reverting_to_older_revision(self):
+        # https://github.com/conan-io/conan/issues/19313
+        folder = temp_folder()
+        recipes_folder = os.path.join(folder, "recipes")
+        zlib_config = textwrap.dedent("""
+           versions:
+             "1.2.11":
+               folder: all
+               """)
+        zlib = textwrap.dedent("""
+           from conan import ConanFile
+           class Zlib(ConanFile):
+               name = "zlib"
+               exports_sources = "*"
+               """)
+        save_files(recipes_folder,
+                   {"zlib/config.yml": zlib_config,
+                    "zlib/all/conanfile.py": zlib,
+                    "zlib/all/conandata.yml": "",
+                    "zlib/all/file.h": "//myheader"})
+
+        c = TestClient(light=True)
+        c.run(f"remote add local '{folder}'")
+        c.run("install --requires=zlib/[*] --build=missing")
+        rev1 = "169da4321a56b77e8538821613a81f1d"
+        c.assert_listed_require({f"zlib/1.2.11#{rev1}": "Downloaded (local)"})
+
+        # Modify zlib code
+        save_files(recipes_folder, {"zlib/all/file.h": "//myheader 222"})
+        c.run("install --requires=zlib/[*] --build=missing --update")
+        rev2 = "8e9fa314a3fd51ab4c930f7e4972f3e7"
+        c.assert_listed_require({f"zlib/1.2.11#{rev2}": "Updated (local)"})
+
+        # Modify zlib code again to a new one
+        save_files(recipes_folder, {"zlib/all/file.h": "//myheader 333"})
+        c.run("install --requires=zlib/[*] --update --build=missing")
+        rev3 = "dd54aebe11b96b3661d8360c68619a72"
+        c.assert_listed_require({f"zlib/1.2.11#{rev3}": "Updated (local)"})
+
+        # Revert to previous one
+        save_files(recipes_folder, {"zlib/all/file.h": "//myheader"})
+        c.run("install --requires=zlib/[*] --update --build=missing")
+        # This crashed https://github.com/conan-io/conan/issues/19313
+        c.assert_listed_require({f"zlib/1.2.11#{rev1}": "Updated (local)"})


### PR DESCRIPTION
Changelog: Bugfix: Allow updating to newer remote revisions that already exist in the Conan cache with an older timestamp.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19313