### PR TITLE
Move Install homebrew dependencies

### DIFF
--- a/.github/workflows/osx-tests.yml
+++ b/.github/workflows/osx-tests.yml
@@ -147,7 +147,7 @@ jobs:
           xcrun --sdk macosx --show-sdk-version
           clang --version
 
-      # MOVED: Install system dependencies BEFORE setting up the matrix Python.
+      # Install system dependencies BEFORE setting up the matrix Python.
       # This prevents Emscripten (which requires Python 3.10+) from crashing
       # when trying to use Python 3.8 from the matrix.
       - name: Install homebrew dependencies

--- a/.github/workflows/osx-tests.yml
+++ b/.github/workflows/osx-tests.yml
@@ -147,6 +147,18 @@ jobs:
           xcrun --sdk macosx --show-sdk-version
           clang --version
 
+      # MOVED: Install system dependencies BEFORE setting up the matrix Python.
+      # This prevents Emscripten (which requires Python 3.10+) from crashing
+      # when trying to use Python 3.8 from the matrix.
+      - name: Install homebrew dependencies
+        run: |
+          brew update
+          brew install xcodegen make libtool zlib autoconf automake ninja emscripten
+          export PATH=${HOME}/Applications/CMake/3.15.7/bin:$PATH:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin
+          emcc --version
+          cmake --version
+          bazel --version
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -159,15 +171,6 @@ jobs:
           pip install -r conans/requirements_server.txt
           pip install -r conans/requirements_dev.txt
           pip install meson
-
-      - name: Install homebrew dependencies
-        run: |
-          brew update
-          brew install xcodegen make libtool zlib autoconf automake ninja emscripten
-          export PATH=${HOME}/Applications/CMake/3.15.7/bin:$PATH:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin
-          emcc --version
-          cmake --version
-          bazel --version
 
       - name: Run tests
         uses: ./.github/actions/test-coverage


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Failing CI develop2 branch: https://github.com/conan-io/conan/actions/runs/20332435063/job/58445808144

Could be caused because recent versions of Emscripten require Python 3.10+? and the previous workflow configured the matrix Python version (e.g., 3.8) before running brew install. 
Looks like it fails with Python<3.10 for Emscripten>4.0.21

Related to https://github.com/emscripten-core/emscripten/pull/25891