### PR TITLE
not using lockfile at export time

### DIFF
--- a/conan/api/subapi/lockfile.py
+++ b/conan/api/subapi/lockfile.py
@@ -81,6 +81,7 @@ class LockfileAPI:
     def update_lockfile(lockfile, graph, lock_packages=False, clean=False):
         if lockfile is None or clean:
             lockfile = Lockfile(graph, lock_packages)
+            lockfile.partial = True
         else:
             lockfile.update_lock(graph, lock_packages)
         return lockfile

--- a/conan/cli/commands/create.py
+++ b/conan/cli/commands/create.py
@@ -58,7 +58,8 @@ def create(conan_api, parser, *args):
     is_build = args.build_require or conanfile.package_type == "build-scripts"
     # The package_type is not fully processed at export
     is_python_require = conanfile.package_type == "python-require"
-    lockfile = conan_api.lockfile.update_lockfile_export(lockfile, conanfile, ref, is_build)
+    if lockfile:
+        lockfile = conan_api.lockfile.update_lockfile_export(lockfile, conanfile, ref, is_build)
 
     print_profiles(profile_host, profile_build)
     runner = conan_api.command.get_runner(profile_host)
@@ -76,6 +77,8 @@ def create(conan_api, parser, *args):
                                                          lockfile=lockfile,
                                                          remotes=remotes, update=args.update,
                                                          python_requires=[ref])
+        lockfile = conan_api.lockfile.update_lockfile(lockfile, deps_graph, args.lockfile_packages,
+                                                      clean=args.lockfile_clean)
     else:
         requires = [ref] if not is_build else None
         tool_requires = [ref] if is_build else None

--- a/conan/cli/commands/export_pkg.py
+++ b/conan/cli/commands/export_pkg.py
@@ -58,8 +58,9 @@ def export_pkg(conan_api, parser, *args):
     ref, conanfile = conan_api.export.export(path=path, name=args.name, version=args.version,
                                              user=args.user, channel=args.channel, lockfile=lockfile,
                                              remotes=remotes)
-    lockfile = conan_api.lockfile.update_lockfile_export(lockfile, conanfile, ref,
-                                                         args.build_require)
+    if lockfile:
+        lockfile = conan_api.lockfile.update_lockfile_export(lockfile, conanfile, ref,
+                                                             args.build_require)
 
     # Compute the dependency graph to prepare the exporting of the package biary
     graph = conan_api.export.export_pkg_graph(path=path, ref=ref, profile_host=profile_host,

--- a/test/integration/lockfile/test_lock_pyrequires.py
+++ b/test/integration/lockfile/test_lock_pyrequires.py
@@ -158,8 +158,9 @@ def test_pyrequires_test_package_lockfile_error():
     c.run("create utils --version=1.7.1")
     c.run("create utils --version=1.8.0")
     c.run("create bar --lockfile-out=bar.lock")
-    c.run("create foo", assert_error=True)
-    assert "Missing prebuilt package for 'bar/8.0'" in c.out
+    c.run("create foo")
+    assert "utils/1.7.1" in c.out
+    assert "utils/1.8.0" in c.out
 
     c.run("create foo --lockfile=bar.lock --lockfile-partial --lockfile-out=foo.lock")
     c.assert_listed_require({"utils/1.7.1": "Cache",


### PR DESCRIPTION
Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

This is a pending experiment to not define a lockfile with the exported package information for the graph computation step, only to update if there is already one lockfile defined as input