### PR TITLE
fix CMakeConfigDeps transitive build context

### DIFF
--- a/conan/tools/cmake/cmakedeps2/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps2/target_configuration.py
@@ -121,7 +121,7 @@ class TargetConfigurationTemplate2:
 
         libs = {}
         # The BUILD context does not generate libraries targets atm
-        if self._conanfile.context == CONTEXT_HOST:
+        if not self._require.build:
             libs = self._get_libs(cpp_info, pkg_name, pkg_folder, pkg_folder_var)
             self._add_root_lib_target(libs, pkg_name, cpp_info)
         exes = self._get_exes(cpp_info, pkg_name, pkg_folder, pkg_folder_var)

--- a/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new.py
+++ b/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new.py
@@ -1002,8 +1002,10 @@ class TestToolRequires:
         c.run("new header_lib -d name=hello -d version=1.0 -o=hello")
         c.run("create hello -tf=")
         c.run("new cmake_lib -d name=bye -d version=1.0 -d requires=hello/1.0 -o=bye")
-        c.run(f"install bye --build-require -c:a tools.cmake.cmakedeps:new={new_value}")
-        cmake = c.load("bye/build/generators/hello-TargetsBuild-release.cmake")
+        # Ninja for same layout in all platforms
+        c.run(f"install bye --build-require -c:a tools.cmake.cmakedeps:new={new_value} "
+              f"-c:a tools.cmake.cmaketoolchain:generator=Ninja")
+        cmake = c.load("bye/build/Release/generators/hello-TargetsBuild-release.cmake")
         assert "add_library(hello::hello INTERFACE IMPORTED)" in cmake
 
 

--- a/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new.py
+++ b/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new.py
@@ -997,6 +997,15 @@ class TestToolRequires:
         assert 'set(tool_INCLUDE_DIR' not in tool_config
         assert 'set(tool_LIBRARIES' not in tool_config
 
+    def test_libs_build_context(self):
+        c = TestClient()
+        c.run("new header_lib -d name=hello -d version=1.0 -o=hello")
+        c.run("create hello -tf=")
+        c.run("new cmake_lib -d name=bye -d version=1.0 -d requires=hello/1.0 -o=bye")
+        c.run(f"install bye --build-require -c:a tools.cmake.cmakedeps:new={new_value}")
+        cmake = c.load("bye/build/generators/hello-TargetsBuild-release.cmake")
+        assert "add_library(hello::hello INTERFACE IMPORTED)" in cmake
+
 
 @pytest.mark.tool("cmake")
 @pytest.mark.parametrize("tool_requires", [True, False])


### PR DESCRIPTION
Changelog: Bugfix: Solve issue in ``CMakeConfigDeps`` when building transitive libraries in the "build" context.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19427