### PR TITLE
test: drop usage of parameterized module in favour of standard pytest parametrize

### DIFF
--- a/conans/requirements_dev.txt
+++ b/conans/requirements_dev.txt
@@ -1,6 +1,5 @@
 pytest>=7, <8.0.0
 pytest-xdist  # To launch in N cores with pytest -n
-parameterized>=0.6.3
 WebTest>=3.0.0, <4
 bottle
 PyJWT

--- a/test/integration/command/export/export_test.py
+++ b/test/integration/command/export/export_test.py
@@ -5,7 +5,6 @@ import stat
 import textwrap
 
 import pytest
-from parameterized import parameterized
 
 from conan.internal.model.manifest import FileTreeManifest
 from conan.api.model import RecipeReference
@@ -190,7 +189,7 @@ class TestConan(ConanFile):
         export_path = layout.export_sources()
         assert sorted(['file.txt', 'file.cpp', 'file.h']) == sorted(os.listdir(export_path))
 
-    @parameterized.expand([("myconanfile.py", ), ("Conanfile.py", )])
+    @pytest.mark.parametrize("filename", ["myconanfile.py", "Conanfile.py"])
     def test_filename(self, filename):
         client = TestClient(light=True)
         client.save({filename: GenConanfile("hello", "1.2")})

--- a/test/integration/graph/core/graph_manager_test.py
+++ b/test/integration/graph/core/graph_manager_test.py
@@ -1,5 +1,4 @@
 import pytest
-from parameterized import parameterized
 
 from conan.internal.graph.graph_error import GraphMissingError, GraphLoopError, GraphConflictError
 from conan.errors import ConanException
@@ -342,8 +341,8 @@ class TestLinear(GraphManagerTest):
         _check_transitive(app, [(libb, True, True, False, False)])
         _check_transitive(libb, [(liba, False, False, True, True)])
 
-    @parameterized.expand([("application",), ("shared-library",), ("static-library",),
-                           ("header-library",), ("build-scripts",), (None,)])
+    @pytest.mark.parametrize("package_type", ["application", "shared-library", "static-library",
+                             "header-library", "build-scripts", None])
     def test_generic_build_require_adjust_run_with_package_type(self, package_type):
         # app --br-> cmake (app)
         self.recipe_conanfile("cmake/0.1", GenConanfile().with_package_type(package_type))
@@ -588,8 +587,7 @@ class TestLinearFourLevels(GraphManagerTest):
                                 (libb, True, True, False, False),
                                 (liba, False, True, False, False)])
 
-    @parameterized.expand([("static-library", ),
-                           ("shared-library", )])
+    @pytest.mark.parametrize("library_type", ["static-library", "shared-library"])
     def test_libraries_transitive_headers(self, library_type):
         # app -> libc/0.1 -> libb0.1  -> liba0.1
         # All with transitive_headers, the final application shoud get all headers
@@ -798,8 +796,7 @@ class TestLinearFourLevels(GraphManagerTest):
                                 (libb, False, True, False, False),
                                 (liba, False, True, False, True)])
 
-    @parameterized.expand([(True,),
-                           (False,)])
+    @pytest.mark.parametrize("run", [True, False])
     def test_header_only_run(self, run):
         # app -> libc/0.1 -> libb0.1  -> liba0.1
         # many header-onlys
@@ -1353,7 +1350,7 @@ class TestDiamond(GraphManagerTest):
                                 (libc, True, True, False, False),
                                 (liba, True, True, False, False)])
 
-    @parameterized.expand([(True, ), (False, )])
+    @pytest.mark.parametrize("order", [True, False])
     def test_diamond_additive(self, order):
         # app -> libb0.1 ---------> liba0.1
         #    \-> libc0.1 (run=True)->/

--- a/test/integration/graph/core/test_build_requires.py
+++ b/test/integration/graph/core/test_build_requires.py
@@ -2,8 +2,6 @@ import textwrap
 
 import pytest
 
-from parameterized import parameterized
-
 from conan.internal.graph.graph_error import GraphConflictError, GraphLoopError
 from conan.api.model import RecipeReference
 from test.integration.graph.core.graph_manager_base import GraphManagerTest
@@ -28,7 +26,7 @@ def _check_transitive(node, transitive_deps):
 
 class TestBuildRequiresGraph(GraphManagerTest):
 
-    @parameterized.expand([("recipe", ), ("profile", )])
+    @pytest.mark.parametrize("build_require", ["recipe", "profile"])
     def test_basic(self, build_require):
         # app -(br)-> cmake
         self._cache_recipe("cmake/0.1", GenConanfile())
@@ -69,7 +67,7 @@ class TestBuildRequiresGraph(GraphManagerTest):
         _check_transitive(app, [(lib, True, True, False, False)])
         _check_transitive(lib, [(cmake, False, False, True, True)])
 
-    @parameterized.expand([("shared", ), ("static", ), ("notrun", ), ("run", )])
+    @pytest.mark.parametrize("cmakelib_type", ["shared", "static", "notrun", "run"])
     def test_build_require_transitive(self, cmakelib_type):
         # app -> lib -(br)-> cmake -> cmakelib (cmakelib_type)
 
@@ -331,7 +329,7 @@ class TestTestRequire(GraphManagerTest):
         _check_transitive(app, [(lib, True, True, False, False)])
         _check_transitive(lib, [(gtest, True, True, False, False)])
 
-    @parameterized.expand([("shared",), ("static",), ("notrun",), ("run",)])
+    @pytest.mark.parametrize("gtestlib_type", ["shared", "static", "notrun", "run"])
     def test_test_require_transitive(self, gtestlib_type):
         # app -> lib -(tr)-> gtest -> gtestlib (gtestlib_type)
 
@@ -448,7 +446,7 @@ class TestTestRequiresProblemsShared(GraphManagerTest):
         _check_transitive(lib_c, [(lib_a, True, True, False, True),
                                   (util, True, True, False, True)])
 
-    @parameterized.expand([(True,), (False,)])
+    @pytest.mark.parametrize("reverse", [True, False])
     def test_fixed_versions(self, reverse):
         #  lib_c -(tr)-> lib_a -0.1--> util
         #    \--------(tr)----0.1------/
@@ -460,7 +458,7 @@ class TestTestRequiresProblemsShared(GraphManagerTest):
         deps_graph = self.build_graph(GenConanfile("lib_c", "0.1").with_test_requires(*deps))
         self._check_graph(deps_graph, reverse)
 
-    @parameterized.expand([(True,), (False,)])
+    @pytest.mark.parametrize("reverse", [True, False])
     def test_fixed_versions_conflict(self, reverse):
         #  lib_c -(tr)-> lib_a -0.1--> util
         #    \--------(tr)----0.2------/
@@ -474,7 +472,7 @@ class TestTestRequiresProblemsShared(GraphManagerTest):
         deps_graph = self.build_graph(conanfile, install=False)
         assert type(deps_graph.error) is GraphConflictError
 
-    @parameterized.expand([(True,), (False,)])
+    @pytest.mark.parametrize("reverse", [True, False])
     def test_fixed_versions_hybrid(self, reverse):
         #  lib_c -----> lib_a--0.1--> util
         #    \--------(tr)----0.1------/
@@ -491,7 +489,7 @@ class TestTestRequiresProblemsShared(GraphManagerTest):
         deps_graph = self.build_graph(conanfile)
         self._check_graph(deps_graph, reverse=reverse)
 
-    @parameterized.expand([(True,), (False,)])
+    @pytest.mark.parametrize("reverse", [True, False])
     def test_fixed_versions_hybrid_conflict(self, reverse):
         #  lib_c -----> lib_a--0.1---> util
         #    \--------(tr)----0.2------/
@@ -508,7 +506,7 @@ class TestTestRequiresProblemsShared(GraphManagerTest):
         deps_graph = self.build_graph(conanfile, install=False)
         assert type(deps_graph.error) is GraphConflictError
 
-    @parameterized.expand([(True,), (False,)])
+    @pytest.mark.parametrize("reverse", [True, False])
     def test_version_ranges(self, reverse):
         #  lib_c -(tr)-> lib_a -> util
         #    \--------(tr)-------/
@@ -520,7 +518,7 @@ class TestTestRequiresProblemsShared(GraphManagerTest):
         deps_graph = self.build_graph(GenConanfile("lib_c", "0.1").with_test_requires(*deps))
         self._check_graph(deps_graph, reverse)
 
-    @parameterized.expand([(True,), (False,)])
+    @pytest.mark.parametrize("reverse", [True, False])
     def test_version_ranges_conflict(self, reverse):
         #  lib_c -(tr)-> lib_a -> util/0.1
         #    \--------(tr)------> util/1.0
@@ -533,7 +531,7 @@ class TestTestRequiresProblemsShared(GraphManagerTest):
                                       install=False)
         assert type(deps_graph.error) is GraphConflictError
 
-    @parameterized.expand([(True,), (False,)])
+    @pytest.mark.parametrize("reverse", [True, False])
     def test_version_ranges_hybrid(self, reverse):
         #  lib_c ---> lib_a -> util
         #    \--------(tr)-------/
@@ -549,7 +547,7 @@ class TestTestRequiresProblemsShared(GraphManagerTest):
         deps_graph = self.build_graph(conanfile)
         self._check_graph(deps_graph, reverse)
 
-    @parameterized.expand([(True,), (False,)])
+    @pytest.mark.parametrize("reverse", [True, False])
     def test_version_ranges_hybrid_conflict(self, reverse):
         #  lib_c -(tr)-> lib_a -> util/0.1
         #    \--------(tr)------> util/1.0

--- a/test/integration/graph/core/test_provides.py
+++ b/test/integration/graph/core/test_provides.py
@@ -1,6 +1,6 @@
 import textwrap
 
-from parameterized import parameterized
+import pytest
 
 from conan.internal.graph.graph_error import GraphProvidesError
 from test.integration.graph.core.graph_manager_base import GraphManagerTest
@@ -45,7 +45,7 @@ class TestProvidesTest(GraphManagerTest):
         self._check_node(libb, "libb/0.1#123", deps=[libc], dependents=[app])
         self._check_node(libc, "libc/0.1#123", deps=[], dependents=[libb])
 
-    @parameterized.expand([(True,), (False,)])
+    @pytest.mark.parametrize("private", [True, False])
     def test_branches_conflict(self, private):
         # app -> libb/0.1 (provides feature)
         #  \  -> libc/0.1 (provides feature)

--- a/test/integration/options/test_configure_options.py
+++ b/test/integration/options/test_configure_options.py
@@ -1,7 +1,7 @@
 import os
 import textwrap
 
-from parameterized import parameterized
+import pytest
 
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
@@ -13,7 +13,7 @@ class TestConfigureOptions:
     header_only options automatically.
     """
 
-    @parameterized.expand([
+    @pytest.mark.parametrize("settings_os, shared, fpic, header_only, result", [
         ["Linux", False, False, False, [False, False, False]],
         ["Windows", False, False, False, [False, None, False]],
         ["Windows", True, False, False, [True, None, False]],
@@ -55,7 +55,7 @@ class TestConfigureOptions:
         if header_only:
             assert "Package 'da39a3ee5e6b4b0d3255bfef95601890afd80709' created" in client.out
 
-    @parameterized.expand([
+    @pytest.mark.parametrize("settings_os, shared, fpic, header_only, result", [
         ["Linux", False, False, False, [False, False, False]],
         ["Linux", False, False, True, [False, False, True]],
         ["Linux", False, True, False, [False, True, False]],

--- a/test/integration/toolchains/test_raise_on_universal_binaries.py
+++ b/test/integration/toolchains/test_raise_on_universal_binaries.py
@@ -2,13 +2,12 @@ import platform
 import textwrap
 
 import pytest
-from parameterized import parameterized
 
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
 
 
-@parameterized.expand(["MesonToolchain", "BazelToolchain"])
+@pytest.mark.parametrize("toolchain", ["MesonToolchain", "BazelToolchain"])
 def test_create_universal_binary(toolchain):
     client = TestClient()
     conanfile = (GenConanfile().with_settings("os", "arch", "compiler", "build_type")
@@ -21,7 +20,7 @@ def test_create_universal_binary(toolchain):
             f"Universal binaries not supported by toolchain.") in client.out
 
 
-@parameterized.expand(["AutotoolsToolchain", "GnuToolchain"])
+@pytest.mark.parametrize("toolchain", ["AutotoolsToolchain", "GnuToolchain"])
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
 def test_toolchain_universal_binary_support(toolchain):
     """Test that toolchain now supports universal binaries on macOS"""
@@ -40,7 +39,7 @@ def test_toolchain_universal_binary_support(toolchain):
     assert "-isysroot" not in toolchain_content
 
 
-@parameterized.expand(["AutotoolsToolchain", "GnuToolchain"])
+@pytest.mark.parametrize("toolchain", ["AutotoolsToolchain", "GnuToolchain"])
 def test_toolchain_universal_binary_non_macos(toolchain):
     """Test that toolchain still raises error for universal binaries on non-macOS"""
     client = TestClient()
@@ -54,7 +53,7 @@ def test_toolchain_universal_binary_non_macos(toolchain):
     assert "Universal arch 'armv8|x86_64' is only supported in Apple OSes" in client.out
 
 
-@parameterized.expand(["AutotoolsToolchain", "GnuToolchain"])
+@pytest.mark.parametrize("toolchain", ["AutotoolsToolchain", "GnuToolchain"])
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
 def test_toolchain_universal_binary_with_sdk_path(toolchain):
     """Test that toolchain sets isysroot when sdk_path is configured for universal binaries"""

--- a/test/unittests/util/detect_libc_test.py
+++ b/test/unittests/util/detect_libc_test.py
@@ -1,10 +1,10 @@
-from parameterized import parameterized
+import pytest
 
 from conan.internal.api.detect.detect_api import _parse_gnu_libc, _parse_musl_libc
 
 
 class TestDetectLibc:
-    @parameterized.expand(
+    @pytest.mark.parametrize("ldd_output,expected_glibc_version",
         [
             [
                 """ldd (Debian GLIBC 2.36-9+rpt2+deb12u4) 2.36
@@ -43,7 +43,7 @@ Usage: /lib/ld-musl-x86_64.so.1 [options] [--] pathname""",
         parsed_glibc_version = _parse_gnu_libc(ldd_output)
         assert expected_glibc_version == parsed_glibc_version
 
-    @parameterized.expand(
+    @pytest.mark.parametrize("ldd_output,expected_musl_libc_version",
         [
             [
                 """musl libc (x86_64)


### PR DESCRIPTION
The Python parameterized module is sadly unmaintained (last activity ~3 years ago) and it breaks with latest versions of PyTest 8.4 (due to a very long standing bug here: https://github.com/wolever/parameterized/issues/34).

This MR replaces all the tests that still use it with PyTest parametrize ones and drops therefore the requirement. Tests are also now much more uniform and hopefully therefore easier to maintain in the long term.

Changelog: Omit
Docs: Omit