### PR TITLE
[Workspaces] Support lockfile creation with workspace super-install

### DIFF
--- a/conan/cli/commands/workspace.py
+++ b/conan/cli/commands/workspace.py
@@ -271,6 +271,13 @@ def workspace_super_install(conan_api: ConanAPI, parser, subparser, *args):
                                        deploy=args.deployer, deploy_package=args.deployer_package,
                                        deploy_folder=args.deployer_folder,
                                        envs_generation=args.envs_generation)
+
+    # Update and save lockfile if requested
+    lockfile = conan_api.lockfile.update_lockfile(lockfile, ws_graph, args.lockfile_packages,
+                                                  clean=args.lockfile_clean)
+    cwd = os.getcwd()
+    conan_api.lockfile.save_lockfile(lockfile, args.lockfile_out, cwd)
+
     ConanOutput().success("Install finished successfully")
 
     return {"graph": ws_graph,

--- a/test/functional/workspace/test_workspace.py
+++ b/test/functional/workspace/test_workspace.py
@@ -95,3 +95,21 @@ def test_super_build_different_layouts():
     assert "Adding project: liba" in c.out
     assert "Adding project: libb" in c.out
     assert "Adding project: app1" in c.out
+
+
+def test_super_install_lockfile_out():
+    """
+    Test that workspace super-install can generate a lockfile
+    """
+    c = TestClient()
+    c.run("new cmake_lib -d name=mymath")
+    c.run("create . -tf=")
+
+    c.save({}, clean_first=True)
+    c.run("new workspace -d requires=mymath/0.1")
+    c.run("workspace super-install --lockfile-out=conan.lock")
+
+    # Verify the lockfile was created and contains the expected dependency
+    assert os.path.exists(os.path.join(c.current_folder, "conan.lock"))
+    lock = c.load("conan.lock")
+    assert "mymath/0.1" in lock


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

As of now, `conan workspace super-install` ignores the `--lockfile-out` argument and does not produce the lockfile. This PR fixes that and add a basic test for the case.