### PR TITLE
WIP: register_env_script "important" flag for configuration scripts priority

### DIFF
--- a/conan/internal/api/install/generators.py
+++ b/conan/internal/api/install/generators.py
@@ -190,6 +190,7 @@ def _generate_aggregated_env(conanfile):
     generated = []
     for group, env_scripts in conanfile.env_scripts.items():
         subsystem = deduce_subsystem(conanfile, group)
+        env_scripts = [env_script[0] for env_script in sorted(env_scripts, key=lambda x: x[1])]
         bats = []
         shs = []
         ps1s = []

--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -509,7 +509,7 @@ class EnvVars:
         content = f'script_folder="{os.path.abspath(filepath)}"\n' + content
         save(file_location, content)
 
-    def save_script(self, filename):
+    def save_script(self, filename, important=False):
         """
         Saves a script file (bat, sh, ps1) with a launcher to set the environment.
         If the conf "tools.env.virtualenv:powershell" is not an empty string
@@ -519,6 +519,7 @@ class EnvVars:
         :param filename: Name of the file to generate. If the extension is provided, it will generate
                          the launcher script for that extension, otherwise the format will be deduced
                          checking if we are running inside Windows (checking also the subsystem) or not.
+        :param important (boolean): It will be applied after the other scripts to ensure that it has priority.
         """
         name, ext = os.path.splitext(filename)
         if ext:
@@ -565,7 +566,7 @@ class EnvVars:
             self.save_dotenv(f"{name}.env")
 
         if self._scope:
-            register_env_script(self._conanfile, path, self._scope)
+            register_env_script(self._conanfile, path, self._scope, important)
 
 
 def _deactivate_func_name(filename):
@@ -760,7 +761,7 @@ class ProfileEnvironment:
         return result
 
 
-def create_env_script(conanfile, content, filename, scope="build"):
+def create_env_script(conanfile, content, filename, scope="build", important=False):
     """
     Create a file with any content which will be registered as a new script for the defined "scope".
 
@@ -769,15 +770,16 @@ def create_env_script(conanfile, content, filename, scope="build"):
         content (str): The content of the script to write into the file.
         filename (str): The name of the file to be created in the generators folder.
         scope (str): The scope or environment group for which the script will be registered.
+        important (boolean): It will be applied after the other scripts to ensure that it has priority.
     """
     path = os.path.join(conanfile.generators_folder, filename)
     save(path, content)
 
     if scope:
-        register_env_script(conanfile, path, scope)
+        register_env_script(conanfile, path, scope, important)
 
 
-def register_env_script(conanfile, env_script_path, scope="build"):
+def register_env_script(conanfile, env_script_path, scope="build", important=False):
     """
     Add the "env_script_path" to the current list of registered scripts for defined "scope"
     These will be mapped to files:
@@ -787,7 +789,11 @@ def register_env_script(conanfile, env_script_path, scope="build"):
         conanfile: The Conanfile instance.
         env_script_path (str): The full path of the script to register.
         scope (str): The scope ('build' or 'host') for which the script will be registered.
+        important (boolean): It will be applied after the other scripts to ensure that it has priority.
     """
     existing = conanfile.env_scripts.setdefault(scope, [])
     if env_script_path not in existing:
-        existing.append(env_script_path)
+        if important:
+            existing.append(env_script_path)
+        else:
+            existing.insert(0, env_script_path)

--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -793,7 +793,4 @@ def register_env_script(conanfile, env_script_path, scope="build", important=Fal
     """
     existing = conanfile.env_scripts.setdefault(scope, [])
     if env_script_path not in existing:
-        if important:
-            existing.append(env_script_path)
-        else:
-            existing.insert(0, env_script_path)
+        existing.append((env_script_path, important))

--- a/conan/tools/system/pip_manager.py
+++ b/conan/tools/system/pip_manager.py
@@ -31,7 +31,7 @@ class PipEnv:
         """
         env = Environment()
         env.prepend_path("PATH", self.bin_dir)
-        env.vars(self._conanfile).save_script(self.env_name)
+        env.vars(self._conanfile).save_script(self.env_name, important=True)
 
     @staticmethod
     def _default_python():

--- a/test/functional/toolchains/env/test_virtualenv_powershell.py
+++ b/test/functional/toolchains/env/test_virtualenv_powershell.py
@@ -90,9 +90,9 @@ def test_virtualenv_test_package(powershell):
             def generate(self):
                 # Emulates vcvars.bat behavior
                 save(self, "myenv.bat", "echo MYENV!!!\nset MYVC_CUSTOMVAR1=PATATA1")
-                self.env_scripts.setdefault("build", []).append("myenv.bat")
+                self.env_scripts.setdefault("build", []).append(("myenv.bat", False))
                 save(self, "myps.ps1", "echo MYPS1!!!!\n$env:MYVC_CUSTOMVAR2=\"PATATA2\"")
-                self.env_scripts.setdefault("build", []).append("myps.ps1")
+                self.env_scripts.setdefault("build", []).append(("myps.ps1", False))
             def layout(self):
                 self.folders.build = "mybuild"
                 self.folders.generators = "mybuild"

--- a/test/functional/tools/system/pip_manager_test.py
+++ b/test/functional/tools/system/pip_manager_test.py
@@ -139,3 +139,40 @@ def test_create_pip_manager():
 
     assert "RUN: hello-world" in client.out
     assert "Hello Test World!" in client.out
+
+
+def test_pip_manager_env_path_order():
+
+    conanfile_pip = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.system import PipEnv
+        from conan.tools.layout import basic_layout
+        import platform
+        import os
+
+
+        class PipPackage(ConanFile):
+            name = "pip_hello_test"
+            version = "0.1"
+
+            def layout(self):
+                basic_layout(self)
+
+            def generate(self):
+                PipEnv(self).generate()
+        """)
+
+    profile = textwrap.dedent("""
+        [buildenv]
+        PATH=+(path)/opt/profile/test/path/
+        """)
+
+    client = TestClient(path_with_spaces=False)
+    # FIXME: the python shebang inside vitual env packages fails when using path_with_spaces
+    client.save({"pip/conanfile.py": conanfile_pip,
+                 "profile": profile})
+    client.run("install pip/conanfile.py -pr:a default -pr:a profile")
+
+    content = client.load("pip/build/conan/conanbuild.sh").split(" && ")
+    assert "conanbuildenv" in content[0]
+    assert "conan_pipenv" in content[1]

--- a/test/functional/tools/system/pip_manager_test.py
+++ b/test/functional/tools/system/pip_manager_test.py
@@ -1,4 +1,8 @@
+import platform
 import textwrap
+
+import pytest
+
 from conan.test.utils.tools import TestClient
 from conan.internal.util.files import save_files
 from conan.test.utils.test_files import temp_folder
@@ -141,6 +145,7 @@ def test_create_pip_manager():
     assert "Hello Test World!" in client.out
 
 
+@pytest.mark.skipif(platform.system() == "Windows", reason="Unix paths only")
 def test_pip_manager_env_path_order():
 
     conanfile_pip = textwrap.dedent("""


### PR DESCRIPTION
``important`` flag added for env config scripts. Scripts marked with this flag are now executed last, ensuring their settings take priority and are not overridden by other scripts like profile.

Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
