### PR TITLE
[fix] Respect preprocessor value type for MesonToolchain

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -33,7 +33,16 @@ class MesonToolchain:
 
     [constants]
     preprocessor_definitions = [{% for it, value in preprocessor_definitions.items() -%}
-    '-D{{ it }}="{{ value}}"'{%- if not loop.last %}, {% endif %}{% endfor %}]
+    {%- if value is none -%}
+    '-D{{ it }}'
+    {%- elif value is boolean -%}
+    '-D{{ it }}={{ value | int }}'
+    {%- elif value is number -%}
+    '-D{{ it }}={{ value }}'
+    {%- else -%}
+    '-D{{ it }}="{{ value }}"'
+    {%- endif -%}
+    {%- if not loop.last %}, {% endif %}{% endfor %}]
 
     [project options]
     {% for it, value in project_options.items() -%}

--- a/test/functional/toolchains/meson/_base.py
+++ b/test/functional/toolchains/meson/_base.py
@@ -20,6 +20,5 @@ def check_binary(t):
         assert "main _MSC_VER19" in t.out
         assert "main _MSVC_LANG2014" in t.out
     elif platform.system() == "Linux":
-        return
         assert f"main {arch_macro['gcc'][host_arch]} defined" in t.out
         assert "main __GNUC__9" in t.out

--- a/test/functional/toolchains/meson/_base.py
+++ b/test/functional/toolchains/meson/_base.py
@@ -20,5 +20,6 @@ def check_binary(t):
         assert "main _MSC_VER19" in t.out
         assert "main _MSVC_LANG2014" in t.out
     elif platform.system() == "Linux":
+        return
         assert f"main {arch_macro['gcc'][host_arch]} defined" in t.out
         assert "main __GNUC__9" in t.out

--- a/test/functional/toolchains/meson/test_preprocessor_definitions.py
+++ b/test/functional/toolchains/meson/test_preprocessor_definitions.py
@@ -28,8 +28,7 @@ class TestMesonPreprocessorDefinitionsTest:
 
         def generate(self):
             tc = MesonToolchain(self)
-            tc.preprocessor_definitions["TEST_DEFINITION1"] = "TestPpdValue1"
-            tc.preprocessor_definitions["TEST_DEFINITION2"] = "TestPpdValue2"
+    preprocessor_definitions
             tc.generate()
 
         def build(self):
@@ -44,16 +43,28 @@ class TestMesonPreprocessorDefinitionsTest:
     executable('demo', 'main.cpp', link_with: hello)
     """)
 
+    def _inject_definitions(self, content: str, defines: dict) -> str:
+        lines = []
+        for define, value in defines.items():
+            lines.append(f"        tc.preprocessor_definitions['{define}'] = {value}")
+        return content.replace("preprocessor_definitions", "\n".join(lines))
+
     @pytest.mark.tool("ninja")
     @pytest.mark.tool("meson")
-    def test_build(self):
+    @pytest.mark.parametrize("defines", [{"TEST_DEFINITION1": '"TestPpdValue1"', "TEST_DEFINITION2": '"TestPpdValue2"'},
+                                         {"DEADBEEF": 3735928495, "CAFED00D": 3405697037},
+                                         {"DEAD10CC": None},
+                                         {"BAADF00D": True, "BAD22222": False}])
+    def test_build(self, defines):
         hello_h = gen_function_h(name="hello")
         hello_cpp = gen_function_cpp(name="hello",
-                                     preprocessor=["TEST_DEFINITION1", "TEST_DEFINITION2"])
+                                     preprocessor=defines.keys())
         app = gen_function_cpp(name="main", includes=["hello"], calls=["hello"])
 
+        conanfile = self._inject_definitions(self._conanfile_py, defines)
+
         t = TestClient()
-        t.save({"conanfile.py": self._conanfile_py,
+        t.save({"conanfile.py": conanfile,
                 "meson.build": self._meson_build,
                 "hello.h": hello_h,
                 "hello.cpp": hello_cpp,
@@ -66,11 +77,33 @@ class TestMesonPreprocessorDefinitionsTest:
         assert "[built-in options]" in content
         assert "buildtype = 'release'" in content
 
+        definitions = []
+        for define, value in defines.items():
+            if value is None:
+                definitions.append(f"'-D{define}'")
+            elif isinstance(value, bool):
+                expected_value = "1" if value else "0"
+                definitions.append(f"'-D{define}={expected_value}'")
+            elif isinstance(value, str):
+                definitions.append(f"'-D{define}={value}'")
+            elif isinstance(value, int):
+                definitions.append(f"'-D{define}={value}'")
+        assert f"preprocessor_definitions = [{', '.join(definitions)}]" in content
+
         t.run("build .")
         t.run_command(os.path.join("build", "demo"))
 
         assert "hello: Release!" in t.out
-        assert "TEST_DEFINITION1: TestPpdValue1" in t.out
-        assert "TEST_DEFINITION2: TestPpdValue2" in t.out
+        for define, value in defines.items():
+            if value is None:
+                assert f"{define}" in t.out
+            elif isinstance(value, bool):
+                expected_value = "1" if value else "0"
+                assert f"{define}={expected_value}" in t.out
+            elif isinstance(value, str):
+                value = value.replace('"', '')
+                assert f"{define}: {value}" in t.out
+            elif isinstance(value, int):
+                assert f"{define}: {value}" in t.out
 
         check_binary(t)

--- a/test/functional/toolchains/meson/test_preprocessor_definitions.py
+++ b/test/functional/toolchains/meson/test_preprocessor_definitions.py
@@ -58,7 +58,7 @@ class TestMesonPreprocessorDefinitionsTest:
     def test_build(self, defines):
         hello_h = gen_function_h(name="hello")
         hello_cpp = gen_function_cpp(name="hello",
-                                     preprocessor=defines.keys())
+                                     preprocessor=defines)
         app = gen_function_cpp(name="main", includes=["hello"], calls=["hello"])
 
         conanfile = self._inject_definitions(self._conanfile_py, defines)

--- a/test/functional/toolchains/meson/test_preprocessor_definitions.py
+++ b/test/functional/toolchains/meson/test_preprocessor_definitions.py
@@ -98,8 +98,8 @@ class TestMesonPreprocessorDefinitionsTest:
             if value is None:
                 assert f"{define}" in t.out
             elif isinstance(value, bool):
-                expected_value = "1" if value else "0"
-                assert f"{define}={expected_value}" in t.out
+                value = "1" if value else "0"
+                assert f"{define}: {value}" in t.out
             elif isinstance(value, str):
                 value = value.replace('"', '')
                 assert f"{define}: {value}" in t.out


### PR DESCRIPTION
Changelog: Fix: Unquote non-string values for MesonToolchain.preprocessor_definitions
Docs: Omit

fixes #19463

Change the rules for `MesonToolchain.preprocessor_definitions` values, following the rule:

- When passing string values it will not change, it will keep quoted as before (e.g. `-DFOOBAR="qux"`)
- When passing a number, it will be unquoted (e.g. `-DFOOBAR=1`)
- When passing `None`, only the definition will be passed (e.g. `-DFOOBAR`)
- When passing a python boolean (`True` or `False`), it will be translated to `1` or `0` (e.g. `-DFOOBAR=1`)

Update the test in `test_preprocessor_definitions.py` to validate those new cases. 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
