### PR TITLE
Mark MesonToolchain.preprocessor_definitions as deprecated

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -574,6 +574,7 @@ class MesonToolchain:
             "objcpp_link_args": to_meson_value(self._filter_list_empty_fields(self.objcpp_link_args)),
             "pkg_config_path": self.pkg_config_path,
             "build_pkg_config_path": self.build_pkg_config_path,
+            #: Deprecated: Dict-like object that defines Meson ``preprocessor definitions``. Use the extra_defines attribute instead.
             "preprocessor_definitions": self.preprocessor_definitions,
             "cross_build": self.cross_build,
             "is_apple_system": self._is_apple_system

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -512,6 +512,11 @@ class MesonToolchain:
         self.objc_link_args.extend(self.c_link_args)
         self.objcpp_link_args.extend(self.cpp_link_args)
 
+        if self.preprocessor_definitions:
+            self._conanfile.output.warning(
+                "Use 'extra_defines' attribute for compiler preprocessor definitions instead " +
+                "of 'preprocessor_definitions'", warn_tag="deprecated")
+
         if self.libcxx:
             self.cpp_args.append(self.libcxx)
             self.cpp_link_args.append(self.libcxx)

--- a/test/functional/toolchains/meson/test_meson_and_gnu_deps_flags.py
+++ b/test/functional/toolchains/meson/test_meson_and_gnu_deps_flags.py
@@ -108,6 +108,8 @@ class TestMesonToolchainAndGnuFlags:
                     clean_first=True)
 
         client.run("build . -c 'tools.build:cxxflags=[%s]'" % flags)
+        assert "WARN: deprecated: Use 'extra_defines' attribute for compiler preprocessor " \
+               "definitions instead of 'preprocessor_definitions'" in client.out
 
         app_name = "demo.exe" if platform.system() == "Windows" else "demo"
         client.run_command(os.path.join("build", app_name))

--- a/test/functional/toolchains/meson/test_preprocessor_definitions.py
+++ b/test/functional/toolchains/meson/test_preprocessor_definitions.py
@@ -67,8 +67,10 @@ class TestMesonPreprocessorDefinitionsTest:
         assert "buildtype = 'release'" in content
 
         t.run("build .")
-        t.run_command(os.path.join("build", "demo"))
+        assert "WARN: deprecated: Use 'extra_defines' attribute for compiler preprocessor " \
+               "definitions instead of 'preprocessor_definitions'" in t.out
 
+        t.run_command(os.path.join("build", "demo"))
         assert "hello: Release!" in t.out
         assert "TEST_DEFINITION1: TestPpdValue1" in t.out
         assert "TEST_DEFINITION2: TestPpdValue2" in t.out


### PR DESCRIPTION
Changelog: Feature: Deprecate `MesonToolchain.preprocessor_definitions` in favor of `extra_defines`.
Docs: Omit

Related to #19465
fixes #19463

Only marked are deprecated for now to avoid breaking users.

Still thinking if it's worth adding the following rule for this PR: in case `extra_defines` and `preprocessor_definitions` are defined, then only `extra_defines` is used.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
