### PR TITLE
Add `libzstd-dev` to Docker image for Python 3.14 zstd support

### DIFF
--- a/.ci/docker/conan-tests
+++ b/.ci/docker/conan-tests
@@ -54,6 +54,7 @@ RUN apt-get update && \
         tk-dev \
         libffi-dev \
         liblzma-dev \
+        libzstd-dev \
         python3-openssl \
         ca-certificates \
         sudo \


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Added `libzstd-dev` dependency to the CI Docker image so that Python 3.14 is compiled with the `compression.zstd` module enabled.

This should fix: https://github.com/conan-io/conan/actions/runs/20977540395/job/60295493367