### PR TITLE
more API docstrings

### DIFF
--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -271,12 +271,12 @@ class CacheAPI:
             for f in (EXPORT_FOLDER, EXPORT_SRC_FOLDER, SRC_FOLDER):
                 if f == SRC_FOLDER and no_source:
                     continue
-                path = os.path.join(cache_folder, recipe_folder, f)
-                if os.path.exists(path):
-                    tar_files[f"{recipe_folder}/{f}"] = path
-            path = os.path.join(cache_folder, recipe_folder, DOWNLOAD_EXPORT_FOLDER, METADATA)
+                cachepath = os.path.join(cache_folder, recipe_folder, f)
+                if os.path.exists(cachepath):
+                    tar_files[f"{recipe_folder}/{f}"] = cachepath
+            cachepath = os.path.join(cache_folder, recipe_folder, DOWNLOAD_EXPORT_FOLDER, METADATA)
             if os.path.exists(path):
-                tar_files[f"{recipe_folder}/{DOWNLOAD_EXPORT_FOLDER}/{METADATA}"] = path
+                tar_files[f"{recipe_folder}/{DOWNLOAD_EXPORT_FOLDER}/{METADATA}"] = cachepath
 
             for pref in packages:
                 pref_layout = cache.pkg_layout(pref)

--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -130,7 +130,7 @@ class CacheAPI:
     def package_metadata_path(self, pref: PkgReference):
         """Returns the path of the package metadata folder in the Conan cache
 
-        This is the exception that allows adding or modifying the files within this folder, as
+        Exceptionally, adding or modifying the files within this folder is allowed, as
         the metadata files are not taken into account into the computation of the package hash
         (package revision).
 

--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -24,6 +24,11 @@ from conan.internal.util.files import rmdir, mkdir, remove, save
 
 class CacheAPI:
     """ This CacheAPI is used to interact with the packages storage cache
+
+    Note that the Conan packages cache is exclusively **read-only** for user code. Only Conan
+    can write or modify the folders and files in the Conan cache. In general, when a method
+    returns a folder, it is mostly for debugging purposes and read-only access, but never to
+    modify the contents of the cache.
     """
 
     def __init__(self, conan_api, api_helpers):
@@ -31,42 +36,127 @@ class CacheAPI:
         self._api_helpers = api_helpers
 
     def export_path(self, ref: RecipeReference):
+        """Returns the path of the recipe conanfile and exported files in the Conan cache
+
+        This folder is exclusively for **read-only** access, typically for debugging purposes,
+        it is completely forbidden to modify any of its contents.
+
+        :param ref: RecipeReference. If it includes recipe revision, that exact revision will be
+           returned, if it doesn't include recipe revision, it will return the latest revision one.
+        :return: path to the folder, as a string
+        :raises: ConanExcepcion if the folder doesn't exist
+        """
+
         cache = PkgCache(self._conan_api.cache_folder, self._api_helpers.global_conf)
         ref = _resolve_latest_ref(cache, ref)
         ref_layout = cache.recipe_layout(ref)
         return _check_folder_existence(ref, "export", ref_layout.export())
 
     def recipe_metadata_path(self, ref: RecipeReference):
+        """Returns the path of the recipe metadata files in the Conan cache
+
+        This is the exception that allows adding or modifying the files within this folder, as
+        the metadata files are not taken into account into the computation of the recipe hash
+        (recipe revision).
+
+        :param ref: RecipeReference. If it includes recipe revision, that exact revision will be
+           returned, if it doesn't include recipe revision, it will return the latest revision one.
+        :return: path to the folder, as a string
+        :raises: ConanExcepcion if the folder doesn't exist
+        """
         cache = PkgCache(self._conan_api.cache_folder, self._api_helpers.global_conf)
         ref = _resolve_latest_ref(cache, ref)
         ref_layout = cache.recipe_layout(ref)
         return _check_folder_existence(ref, "metadata", ref_layout.metadata())
 
     def export_source_path(self, ref: RecipeReference):
+        """Returns the path of the exported sources in the Conan cache
+
+        Note that the exported sources only exist in the cache when the package has been created
+        locally or built from source.
+
+        This folder is exclusively for **read-only** access, typically for debugging purposes,
+        it is completely forbidden to modify any of its contents.
+
+        :param ref: RecipeReference. If it includes recipe revision, that exact revision will be
+           returned, if it doesn't include recipe revision, it will return the latest revision one.
+        :return: path to the folder, as a string
+        :raises: ConanExcepcion if the folder doesn't exist
+        """
         cache = PkgCache(self._conan_api.cache_folder, self._api_helpers.global_conf)
         ref = _resolve_latest_ref(cache, ref)
         ref_layout = cache.recipe_layout(ref)
         return _check_folder_existence(ref, "export_sources", ref_layout.export_sources())
 
     def source_path(self, ref: RecipeReference):
+        """Returns the path of the temporary source folder in the Conan cache
+
+        Note that the source folder only exist in the cache when the package has been created
+        locally or built from source.
+
+        This folder is exclusively for **read-only** access, typically for debugging purposes,
+        it is completely forbidden to modify any of its contents.
+
+        :param ref: RecipeReference. If it includes recipe revision, that exact revision will be
+           returned, if it doesn't include recipe revision, it will return the latest revision one.
+        :return: path to the folder, as a string
+        :raises: ConanExcepcion if the folder doesn't exist
+        """
         cache = PkgCache(self._conan_api.cache_folder, self._api_helpers.global_conf)
         ref = _resolve_latest_ref(cache, ref)
         ref_layout = cache.recipe_layout(ref)
         return _check_folder_existence(ref, "source", ref_layout.source())
 
     def build_path(self, pref: PkgReference):
+        """Returns the path of the temporary build folder in the Conan cache
+
+        Note that the build folder only exist in the cache when the package has been created
+        locally or built from source.
+
+        This folder is exclusively for **read-only** access, typically for debugging purposes,
+        it is completely forbidden to modify any of its contents.
+
+        :param pref: PkgReference. If it includes recipe revision, that exact revision will be
+           returned, if it doesn't include recipe revision, it will return the latest revision one.
+           Exactly same behavior for the package revision.
+        :return: path to the folder, as a string
+        :raises: ConanExcepcion if the folder doesn't exist
+        """
         cache = PkgCache(self._conan_api.cache_folder, self._api_helpers.global_conf)
         pref = _resolve_latest_pref(cache, pref)
         ref_layout = cache.pkg_layout(pref)
         return _check_folder_existence(pref, "build", ref_layout.build())
 
     def package_metadata_path(self, pref: PkgReference):
+        """Returns the path of the package metadata folder in the Conan cache
+
+        This is the exception that allows adding or modifying the files within this folder, as
+        the metadata files are not taken into account into the computation of the package hash
+        (package revision).
+
+       :param pref: PkgReference. If it includes recipe revision, that exact revision will be
+           returned, if it doesn't include recipe revision, it will return the latest revision one.
+           Exactly same behavior for the package revision.
+       :return: path to the folder, as a string
+       :raises: ConanExcepcion if the folder doesn't exist
+        """
         cache = PkgCache(self._conan_api.cache_folder, self._api_helpers.global_conf)
         pref = _resolve_latest_pref(cache, pref)
         ref_layout = cache.pkg_layout(pref)
         return _check_folder_existence(pref, "metadata", ref_layout.metadata())
 
     def package_path(self, pref: PkgReference):
+        """Returns the path of the package folder in the Conan cache
+
+        This folder is exclusively for **read-only** access, typically for debugging purposes,
+        it is completely forbidden to modify any of its contents.
+
+        :param pref: PkgReference. If it includes recipe revision, that exact revision will be
+           returned, if it doesn't include recipe revision, it will return the latest revision one.
+           Exactly same behavior for the package revision.
+        :return: path to the folder, as a string
+        :raises: ConanExcepcion if the folder doesn't exist
+        """
         cache = PkgCache(self._conan_api.cache_folder, self._api_helpers.global_conf)
         pref = _resolve_latest_pref(cache, pref)
         ref_layout = cache.pkg_layout(pref)
@@ -92,7 +182,7 @@ class CacheAPI:
             raise ConanException("There are corrupted artifacts, check the error logs")
 
     def clean(self, package_list, source=True, build=True, download=True, temp=True,
-              backup_sources=False):
+              backup_sources=False) -> None:
         """
         Remove non critical folders from the cache, like source, build and download (.tgz store)
         folders.
@@ -143,13 +233,27 @@ class CacheAPI:
                 if download:
                     rmdir(pref_layout.download_package())
 
-    def save(self, package_list: PackagesList, tgz_path, no_source=False) -> None:
+    def save(self, package_list: PackagesList, path, no_source=False) -> None:
+        """Create a compressed archive with recipes and packages from the Conan cache that
+        can be later restored in another cache.
+
+        Do not manipulate the contents of the resulting archive, as it also contains metadata,
+        and modifying the contents would be equivalent to modify the Conan package cache, which
+        is forbidden.
+
+        :param package_list: PackagesList containing the recipes and packages to add
+           to the compressed archive
+        :param path: The archive file to generate. Based on the extension of the file, different
+           compression formats can be used (.tgz, .txz and .tzst, the latter only for Python>=3.14).
+        :param no_source: If True, the source folders in the cache will not be added to the archive.
+        :return:
+        """
         global_conf = self._api_helpers.global_conf
         cache = PkgCache(self._conan_api.cache_folder, global_conf)
         cache_folder = cache.store  # Note, this is not the home, but the actual package cache
         out = ConanOutput()
-        mkdir(os.path.dirname(tgz_path))
-        tgz_name = os.path.basename(tgz_path)
+        mkdir(os.path.dirname(path))
+        tgz_name = os.path.basename(path)
         compressformat = next((e for e in COMPRESSIONS if tgz_name.endswith(e)), None)
         if not compressformat:
             raise ConanException(f"Unsupported compression format for {tgz_name}")
@@ -196,11 +300,18 @@ class CacheAPI:
         pkglist_path = os.path.join(tempfile.gettempdir(), "pkglist.json")
         save(pkglist_path, serialized)
         tar_files["pkglist.json"] = pkglist_path
-        compress_files(tar_files, tgz_name, os.path.dirname(tgz_path), compresslevel, recursive=True)
+        compress_files(tar_files, tgz_name, os.path.dirname(path), compresslevel, recursive=True)
         remove(pkglist_path)
-        ConanOutput().success(f"Created cache save file: {tgz_path}")
+        ConanOutput().success(f"Created cache save file: {path}")
 
     def restore(self, path) -> PackagesList:
+        """Restore a compressed archive with recipes and packages previously saved from another
+        Conan cache into the currently active Conan cache.
+
+        :param path: The archive file to restore. Based on the extension of the file, different
+           compression formats can be used (.tgz, .txz and .tzst, the latter only for Python>=3.14).
+        :return: a PackageLists with the recipes and packages that have been restored to the cache
+        """
         if not os.path.isfile(path):
             raise ConanException(f"Restore archive doesn't exist in {path}")
 
@@ -280,6 +391,7 @@ class CacheAPI:
         :param exclude: if True, exclude the sources that come from URLs present the
           core.sources:exclude_urls global conf
         :param only_upload: if True, only return the files for packages that are set to be uploaded
+        :return: A list of files that need to be uploaded
         """
         config = self._api_helpers.global_conf
         download_cache_path = config.get("core.sources:download_cache")
@@ -291,6 +403,8 @@ class CacheAPI:
         return download_cache.get_backup_sources_files(excluded_urls, package_list, only_upload)
 
     def path_to_ref(self, path):
+        # This method is explicitly not publicly documented, as mostly a command helper for
+        # debugging, it shouldn't be used in any real API usage
         cache = PkgCache(self._conan_api.cache_folder, self._api_helpers.global_conf)
         result = cache.path_to_ref(path)
         if result is None:

--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -275,7 +275,7 @@ class CacheAPI:
                 if os.path.exists(cachepath):
                     tar_files[f"{recipe_folder}/{f}"] = cachepath
             cachepath = os.path.join(cache_folder, recipe_folder, DOWNLOAD_EXPORT_FOLDER, METADATA)
-            if os.path.exists(path):
+            if os.path.exists(cachepath):
                 tar_files[f"{recipe_folder}/{DOWNLOAD_EXPORT_FOLDER}/{METADATA}"] = cachepath
 
             for pref in packages:

--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -55,7 +55,7 @@ class CacheAPI:
     def recipe_metadata_path(self, ref: RecipeReference):
         """Returns the path of the recipe metadata files in the Conan cache
 
-        This is the exception that allows adding or modifying the files within this folder, as
+        Exceptionally, adding or modifying the files within this folder is allowed, as
         the metadata files are not taken into account into the computation of the recipe hash
         (recipe revision).
 

--- a/conan/api/subapi/config.py
+++ b/conan/api/subapi/config.py
@@ -36,10 +36,25 @@ class ConfigAPI:
         """
         return self._conan_api.cache_folder
 
-    def install(self, path_or_url, verify_ssl, config_type=None, args=None,
-                source_folder=None, target_folder=None):
+    def install(self, path_or_url: str, verify_ssl, config_type=None, args=None,
+                source_folder=None, target_folder=None) -> None:
         """ install Conan configuration from a git repo, from a zip file in an http server
         or a local folder
+
+        Calling this method will cause a reinitilization of the full ConanAPI, with possible
+        invalidation of cached information, and references to objects from the ConanAPI might
+        become dangling or outdated.
+
+        :param path_or_url: path or url to install. It can be a http://.../somefile.zip, a
+            git repository URL, or a local folder
+        :param verify_ssl: Argument passed to python-requests library for SSL verification
+        :param config_type: type of configuration to install: "git", "dir", "file", "url"
+        :param args: additional arguments to pass to git repositories cloning
+        :param source_folder: If specified, install files from that folder of the origin only
+        :param target_folder: If the files are to be installed in a specific folder in the Conan
+            home. For example, if it is desired to install only profiles from a configuration and
+            using source_folder="profiles", it might be expected to use target_folder="profiles"
+            to keep the correct profile files location in the local home.
         """
         from conan.internal.api.config.config_installer import configuration_install
         cache_folder = self._conan_api.cache_folder
@@ -50,6 +65,25 @@ class ConfigAPI:
         self._conan_api.reinit()
 
     def install_package(self, require, lockfile=None, force=False, remotes=None, profile=None):
+        """ install Conan configuration from a Conan package
+
+        Calling this method will cause a reinitilization of the full ConanAPI, with possible
+        invalidation of cached information, and references to objects from the ConanAPI might
+        become dangling or outdated.
+
+        :param require: The package requirement to be installed. It can contain version range
+            expressions. If the revision is not specified, as a recipe ``requires``, it will
+            also resolve to the latest recipe-revision
+        :param lockfile: Lockfile to be used to constrain and lock the versions and recipe-revisions
+            from the input requirements, to the exact versions and revisions specified in the
+            lockfile
+        :param force: If the package has already been installed, nothing will be done unless
+            force is True
+        :param remotes: Remotes to look for the configuration package
+        :param profile: If specified, use that profile to resolve for profile-specific different
+            configurations, like depending on different settings.
+        :return: list of RecipeReferences of the installed configuration packages
+        """
         ConanOutput().warning("The 'conan config install-pkg' is experimental",
                               warn_tag="experimental")
         require = RecipeReference.loads(require)
@@ -60,6 +94,7 @@ class ConfigAPI:
 
     @staticmethod
     def load_conanconfig(path, remotes):
+        # Internal, do not document yet.
         if os.path.isdir(path):
             path = os.path.join(path, "conanconfig.yml")
         requested_requires, urls = loadconanconfig_yml(path)
@@ -71,6 +106,24 @@ class ConfigAPI:
         return requested_requires, remotes
 
     def install_conanconfig(self, path, lockfile=None, force=False, remotes=None, profile=None):
+        """ install Conan configuration from a Conan "conanconfig.yml" file
+
+        Calling this method will cause a reinitilization of the full ConanAPI, with possible
+        invalidation of cached information, and references to objects from the ConanAPI might
+        become dangling or outdated.
+
+        :param path: Path to the conanconfig.yml file containing the configuration packages
+            requirement efinitions
+        :param lockfile: Lockfile to be used to constrain and lock the versions and recipe-revisions
+            from the input requirements, to the exact versions and revisions specified in the
+            lockfile
+        :param force: If the package has already been installed, nothing will be done unless
+            force is True
+        :param remotes: Remotes to look for the configuration package
+        :param profile: If specified, use that profile to resolve for profile-specific different
+            configurations, like depending on different settings.
+        :return: list of RecipeReferences of the installed configuration packages
+        """
         ConanOutput().warning("The 'conan config install-pkg' is experimental",
                               warn_tag="experimental")
         requested_requires, remotes = self.load_conanconfig(path, remotes)
@@ -148,9 +201,12 @@ class ConfigAPI:
         saveconanconfig(config_version_file, final_config_refs)
         return final_config_refs
 
-    def fetch_packages(self, refs, lockfile=None, remotes=None, profile=None):
-        """ install configuration stored inside a Conan package
-        The installation of configuration will reinitialize the full ConanAPI
+    def fetch_packages(self, requires, lockfile=None, remotes=None, profile=None):
+        """ get and download configuration packages into the Conan cache, without installing
+        such configuration in the current Conan home.
+
+        This shouldn't be necessary for regular Conan configuration, and used at the moment
+        exclusively for the "conan lock upgrade-config" experimental command.
         """
         conan_api = self._conan_api
         remotes = conan_api.remotes.list() if remotes is None else remotes
@@ -160,7 +216,7 @@ class ConfigAPI:
 
         ConanOutput().title("Fetching requested configuration packages")
         result = []
-        for ref in refs:
+        for ref in requires:
             # Computation of a very simple graph that requires "ref"
             # Need to convert input requires to RecipeReference
             conanfile = app.loader.load_virtual(requires=[ref])
@@ -192,21 +248,33 @@ class ConfigAPI:
 
     def get(self, name, default=None, check_type=None):
         """ get the value of a global.conf item
+
+        :param name: configuration value to return
+        :param default: default value to return if the configuration doesn't contain a value
+        :param check_type: check if value is of type check_type, only if the value is defined
         """
         return self._helpers.global_conf.get(name, default=default, check_type=check_type)
 
     def show(self, pattern) -> dict:
         """ get the values of global.conf for those configurations that matches the pattern
+        that have an actual user definition.
+
+        It wont return anything not even the defaults, for not defined values
+
+        :param pattern: pattern to match against
+        :return: dict of configuration values
         """
         return self._helpers.global_conf.show(pattern)
 
     @staticmethod
-    def conf_list():
+    def conf_list() -> dict:
         """ list all the available built-in configurations
+
+        :return: A sorted dictionary with all possible built-in configurations
         """
         return BUILT_IN_CONFS.copy()
 
-    def clean(self):
+    def clean(self) -> None:
         """ reset the Conan home folder to a clean state, removing all the user
         custom configuration, custom files, and resetting modified files
         """
@@ -229,17 +297,21 @@ class ConfigAPI:
     @property
     def settings_yml(self):
         """ Get the contents of the settings.yml and user_settings.yml files,
-            which define the possible values for settings.
+        which define the possible values for settings.
 
-            Note that this is different from the settings present in a conanfile,
-            which represent the actual values for a specific package, while this
-            property represents the possible values for each setting.
+        Note that this is different from the settings present in a conanfile,
+        which represent the actual values for a specific package, while this
+        property represents the possible values for each setting.
 
-            :returns: A read-only object representing the settings scheme, with a
-                ``possible_values()`` method that returns a dictionary with the possible values for each setting,
-                and a ``fields`` property that returns an ordered list with the fields of each setting.
-                Note that it's possible to access nested settings using attribute access,
-                such as ``settings_yml.compiler.possible_values()``.
+        This is intended to be a **read-only** value, do not try to attempt to modify,
+        inject or remove settings with this attribute.
+
+        :returns: A read-only object representing the settings scheme, with a
+            ``possible_values()`` method that returns a dictionary with the possible
+            values for each setting, and a ``fields`` property that returns an ordered
+            list with the fields of each setting.
+            Note that it's possible to access nested settings using attribute access,
+            such as ``settings_yml.compiler.possible_values()``.
         """
 
         class SettingsYmlInterface:

--- a/conan/api/subapi/config.py
+++ b/conan/api/subapi/config.py
@@ -259,7 +259,8 @@ class ConfigAPI:
         """ get the values of global.conf for those configurations that matches the pattern
         that have an actual user definition.
 
-        It wont return anything not even the defaults, for not defined values
+        Values with no user definitions will be skipped from the returned value,
+        defaults for those confs won't be shown.
 
         :param pattern: pattern to match against
         :return: dict of configuration values

--- a/conan/api/subapi/config.py
+++ b/conan/api/subapi/config.py
@@ -113,7 +113,7 @@ class ConfigAPI:
         become dangling or outdated.
 
         :param path: Path to the conanconfig.yml file containing the configuration packages
-            requirement efinitions
+            requirement definitions
         :param lockfile: Lockfile to be used to constrain and lock the versions and recipe-revisions
             from the input requirements, to the exact versions and revisions specified in the
             lockfile


### PR DESCRIPTION
Changelog: Feature: Add public documentation for ``CacheAPI`` and ``ConfigAPI`` subapis.
Docs: Omit

Continuing with https://github.com/conan-io/conan/issues/14206