### PR TITLE
Fix potential `None` and `PackageType` comparison when deducing `cpp_info`

### DIFF
--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -659,7 +659,7 @@ class _Component:
             return
 
         # automatic location deduction from a single .lib=["lib"]
-        if self._type not in [PackageType.SHARED, PackageType.STATIC] and self._type is not None:
+        if self._type is not None and self._type not in [PackageType.SHARED, PackageType.STATIC]:
             raise ConanException(f"{name} has a library but .type {self._type} is not static/shared")
 
         # If no location is defined, it's time to guess the location

--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -659,7 +659,7 @@ class _Component:
             return
 
         # automatic location deduction from a single .lib=["lib"]
-        if self._type not in [None, PackageType.SHARED, PackageType.STATIC]:
+        if self._type not in [PackageType.SHARED, PackageType.STATIC] and self._type is not None:
             raise ConanException(f"{name} has a library but .type {self._type} is not static/shared")
 
         # If no location is defined, it's time to guess the location

--- a/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
@@ -393,28 +393,12 @@ def test_cmake_extra_dependencies():
 
 def test_cmake_different_component_type_package_type_regression():
     tc = TestClient()
-    dep = textwrap.dedent("""
-    from conan import ConanFile
-    from conan.tools.files import save
-    import os
-
-    class Pkg(ConanFile):
-        name = "dep"
-        version = "0.1"
-
-        def package(self):
-            save(self, os.path.join(self.package_folder, "lib", "libutils.a"), "content")
-            save(self, os.path.join(self.package_folder, "lib", "libmain.dylib"), "content")
-
-        def package_info(self):
-            self.cpp_info.components["utils"].libs = ["utils"]
-            self.cpp_info.components["utils"].type = "static-library"
-            self.cpp_info.components["main"].libs = ["main"]
-            self.cpp_info.components["main"].type = "shared-library"
-    """)
+    dep = (GenConanfile("dep", "0.1")
+           .with_package_file("libmain.so", "dynamic library")
+           .with_package_info({"components": {"main": {"libs": ["libmain.so"], "type": "'shared-library'"}}}))
     tc.save({"conanfile.py": dep})
     tc.run("create")
-    tc.run("install --requires=dep/0.1 -g CMakeConfigDeps")
+    tc.run("install --requires=dep/0.1 -g CMakeConfigDeps", assert_error=True)
     assert "None is not a valid PackageType" not in tc.out
 
 

--- a/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
@@ -394,11 +394,11 @@ def test_cmake_extra_dependencies():
 def test_cmake_component_type_none_check():
     tc = TestClient()
     dep = (GenConanfile("dep", "0.1")
-           .with_package_file("libmain.so", "dynamic library")
+           .with_package_file("lib/libmain.so", "dynamic library")
            .with_package_info({"components": {"main": {"libs": ["libmain.so"], "type": "'shared-library'"}}}))
     tc.save({"conanfile.py": dep})
     tc.run("create")
-    tc.run("install --requires=dep/0.1 -g CMakeConfigDeps", assert_error=True)
+    tc.run("install --requires=dep/0.1 -g CMakeConfigDeps")
     assert "None is not a valid PackageType" not in tc.out
 
 

--- a/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
@@ -391,6 +391,33 @@ def test_cmake_extra_dependencies():
            "             $<$<CONFIG:RELEASE>:MyOpenMPILib>)" in dep
 
 
+def test_cmake_different_component_type_package_type_regression():
+    tc = TestClient()
+    dep = textwrap.dedent("""
+    from conan import ConanFile
+    from conan.tools.files import save
+    import os
+
+    class Pkg(ConanFile):
+        name = "dep"
+        version = "0.1"
+
+        def package(self):
+            save(self, os.path.join(self.package_folder, "lib", "libutils.a"), "content")
+            save(self, os.path.join(self.package_folder, "lib", "libmain.dylib"), "content")
+
+        def package_info(self):
+            self.cpp_info.components["utils"].libs = ["utils"]
+            self.cpp_info.components["utils"].type = "static-library"
+            self.cpp_info.components["main"].libs = ["main"]
+            self.cpp_info.components["main"].type = "shared-library"
+    """)
+    tc.save({"conanfile.py": dep})
+    tc.run("create")
+    tc.run("install --requires=dep/0.1 -g CMakeConfigDeps")
+    assert "None is not a valid PackageType" not in tc.out
+
+
 def test_cmake_extra_dependencies_components():
     tc = TestClient()
     dep = textwrap.dedent("""

--- a/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
@@ -391,7 +391,7 @@ def test_cmake_extra_dependencies():
            "             $<$<CONFIG:RELEASE>:MyOpenMPILib>)" in dep
 
 
-def test_cmake_different_component_type_package_type_regression():
+def test_cmake_component_type_none_check():
     tc = TestClient()
     dep = (GenConanfile("dep", "0.1")
            .with_package_file("libmain.so", "dynamic library")


### PR DESCRIPTION
Changelog: Bugfix: Avoid potential `None` and `PackageType` comparison when deducing `cpp_info`.
Docs: Omit

Got a question from @ErniGH about a failing code they were getting in another project, traced this to a case where:

* You're calling `deduce_full_cpp_info()` - This tests uses CMakeConfigDeps, but they were calling it directly from within hook checks
* You have more than one component defined in your recipe
* You set the `type` of one of them.

The overloaded comparison for `PackageType` can't initialize an other value of `None` and breaks.

---

Maybe a better approach would be to re-think the check just above for header-only, as it makes little sense to me why this would only trigger after 2 components (because said branch is not taken)