### PR TITLE
[commands] `conan new` default template

### DIFF
--- a/conan/api/subapi/new.py
+++ b/conan/api/subapi/new.py
@@ -81,7 +81,7 @@ class NewAPI:
 
     @staticmethod
     def get_builtin_template(template_name):
-        from conan.internal.api.new.basic import basic_file
+        from conan.internal.api.new.basic import basic_file, basic_default_file
         from conan.internal.api.new.alias_new import alias_file
         from conan.internal.api.new.cmake_exe import cmake_exe_files
         from conan.internal.api.new.cmake_lib import cmake_lib_files
@@ -122,7 +122,7 @@ class NewAPI:
                          "local_recipes_index": local_recipes_index_files,
                          "qbs_lib": qbs_lib_files,
                          "workspace": workspace_files}
-        template_files = new_templates.get(template_name)
+        template_files = new_templates.get(template_name, basic_default_file)
         return template_files
 
     def get_template(self, template_folder):

--- a/conan/api/subapi/new.py
+++ b/conan/api/subapi/new.py
@@ -101,6 +101,8 @@ class NewAPI:
         from conan.internal.api.new.local_recipes_index import local_recipes_index_files
         from conan.internal.api.new.qbs_lib import qbs_lib_files
         from conan.internal.api.new.workspace import workspace_files
+        if not template_name:
+            return basic_default_file
         new_templates = {"basic": basic_file,
                          "cmake_lib": cmake_lib_files,
                          "cmake_exe": cmake_exe_files,
@@ -122,7 +124,7 @@ class NewAPI:
                          "local_recipes_index": local_recipes_index_files,
                          "qbs_lib": qbs_lib_files,
                          "workspace": workspace_files}
-        template_files = new_templates.get(template_name, basic_default_file)
+        template_files = new_templates.get(template_name)
         return template_files
 
     def get_template(self, template_folder):

--- a/conan/cli/commands/new.py
+++ b/conan/cli/commands/new.py
@@ -8,7 +8,7 @@ def new(conan_api, parser, *args):
     """
     Create a new example recipe and source files from a template.
     """
-    parser.add_argument("template", help="Template name, "
+    parser.add_argument("template", nargs="?", default="", help="Template name, "
                         "either a predefined built-in or a user-provided one. "
                         "Available built-in templates: basic, cmake_lib, cmake_exe, header_lib, "
                         "meson_lib, meson_exe, msbuild_lib, msbuild_exe, bazel_lib, bazel_exe, "

--- a/conan/internal/api/new/basic.py
+++ b/conan/internal/api/new/basic.py
@@ -104,6 +104,12 @@ class {{package_name}}Recipe(ConanFile):
         cmake.configure()
         cmake.build()
 
+    This recipe is aimed at a consumer scenario. If you want to create
+    a package, then you should add the following attributes/methods:
+    * exports_sources attribute (https://docs.conan.io/2/reference/conanfile/attributes.html#exports-sources)
+    * package method (https://docs.conan.io/2/reference/conanfile/methods/package.html)
+    * package_info method (https://docs.conan.io/2/reference/conanfile/methods/package_info.html)
+
 '''
 
 

--- a/conan/internal/api/new/basic.py
+++ b/conan/internal/api/new/basic.py
@@ -104,11 +104,11 @@ class {{package_name}}Recipe(ConanFile):
         cmake.configure()
         cmake.build()
 
-    This recipe is aimed at a consumer scenario. If you want to create
-    a package, then you should add the following attributes/methods:
-    * exports_sources attribute (https://docs.conan.io/2/reference/conanfile/attributes.html#exports-sources)
-    * package method (https://docs.conan.io/2/reference/conanfile/methods/package.html)
-    * package_info method (https://docs.conan.io/2/reference/conanfile/methods/package_info.html)
+    # This recipe is aimed at a consumer scenario. If you want to create
+    # a package, then you should add the following attributes/methods:
+    #   * exports_sources attribute (https://docs.conan.io/2/reference/conanfile/attributes.html#exports-sources)
+    #   * package method (https://docs.conan.io/2/reference/conanfile/methods/package.html)
+    #   * package_info method (https://docs.conan.io/2/reference/conanfile/methods/package_info.html)
 
 '''
 

--- a/conan/internal/api/new/basic.py
+++ b/conan/internal/api/new/basic.py
@@ -70,4 +70,42 @@ class BasicConanfile(ConanFile):
 '''
 
 
+_conanfile_default = '''from conan import ConanFile
+from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
+
+
+class {{package_name}}Recipe(ConanFile):
+    name = "{{name}}"
+    version = "{{version}}"
+    settings = "os", "compiler", "build_type", "arch"
+
+    def layout(self):
+        cmake_layout(self)
+    {% if requires is defined %}
+    def requirements(self):
+        {% for require in requires -%}
+        self.requires("{{ require }}")
+        {% endfor %}
+    {%- endif %}
+    {%- if tool_requires is defined %}
+    def build_requirements(self):
+        {% for require in tool_requires -%}
+        self.tool_requires("{{ require }}")
+        {% endfor %}
+    {%- endif %}
+    def generate(self):
+        deps = CMakeDeps(self)
+        deps.generate()
+        tc = CMakeToolchain(self)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+'''
+
+
 basic_file = {"conanfile.py": _conanfile}
+basic_default_file = {"conanfile.py": _conanfile_default}

--- a/test/functional/command/test_new.py
+++ b/test/functional/command/test_new.py
@@ -1,6 +1,11 @@
+import os
+import textwrap
+
 import pytest
 
+from conan.test.utils.mocks import ConanFileMock
 from conan.test.utils.tools import TestClient
+from conan.tools.files import replace_in_file
 
 
 @pytest.mark.tool("cmake")
@@ -12,3 +17,31 @@ def test_conan_new_compiles():
 
     tc.run("create hello -tf=")
     tc.run("create bye")
+
+
+@pytest.mark.tool("cmake")
+def test_conan_new_empty():
+    c = TestClient()
+    c.run("new")
+    cmakelists = textwrap.dedent("""
+    cmake_minimum_required(VERSION 3.15)
+    project(PackageTest CXX)
+    add_executable(example main.cpp)
+    """)
+    main = textwrap.dedent(r"""
+    #include <iostream>
+
+    int main() {
+        std::cout << "Hello World!\n";
+    }
+    """)
+    c.save({
+        "CMakeLists.txt": cmakelists,
+        "main.cpp": main,
+    })
+    replace_in_file(ConanFileMock(),
+                    os.path.join(c.current_folder, "conanfile.py"),
+                    'class mypkgRecipe(ConanFile):\n',
+                    'class mypkgRecipe(ConanFile):\n    exports_sources = "CMakelists.txt", "main.cpp"\n')
+    c.run("build")
+    assert "[100%] Built target example" in c.out

--- a/test/functional/command/test_new.py
+++ b/test/functional/command/test_new.py
@@ -1,4 +1,5 @@
 import os
+import platform
 import textwrap
 
 import pytest
@@ -44,4 +45,6 @@ def test_conan_new_empty():
                     'class mypkgRecipe(ConanFile):\n',
                     'class mypkgRecipe(ConanFile):\n    exports_sources = "CMakelists.txt", "main.cpp"\n')
     c.run("build")
-    assert "[100%] Built target example" in c.out
+
+    suffix = ".exe" if platform.system() == "Windows" else ""
+    assert os.path.exists(os.path.join(c.current_folder, "build", "Release", f"example{suffix}"))

--- a/test/functional/command/test_new.py
+++ b/test/functional/command/test_new.py
@@ -4,9 +4,7 @@ import textwrap
 
 import pytest
 
-from conan.test.utils.mocks import ConanFileMock
 from conan.test.utils.tools import TestClient
-from conan.tools.files import replace_in_file
 
 
 @pytest.mark.tool("cmake")
@@ -40,11 +38,6 @@ def test_conan_new_empty():
         "CMakeLists.txt": cmakelists,
         "main.cpp": main,
     })
-    replace_in_file(ConanFileMock(),
-                    os.path.join(c.current_folder, "conanfile.py"),
-                    'class mypkgRecipe(ConanFile):\n',
-                    'class mypkgRecipe(ConanFile):\n    exports_sources = "CMakelists.txt", "main.cpp"\n')
     c.run("build")
-
     suffix = ".exe" if platform.system() == "Windows" else ""
     assert os.path.exists(os.path.join(c.current_folder, "build", "Release", f"example{suffix}"))

--- a/test/integration/command/test_new.py
+++ b/test/integration/command/test_new.py
@@ -4,9 +4,11 @@ import textwrap
 import pytest
 
 from conan import __version__
+from conan.test.utils.mocks import ConanFileMock
 from conan.test.utils.test_files import temp_folder
 from conan.test.utils.tools import TestClient
 from conan.internal.util.files import save
+from conan.tools.files import replace_in_file
 
 
 class TestNewCommand:
@@ -76,6 +78,32 @@ class TestNewCommand:
             conanfile = c.load("conanfile.py")
             assert 'name = "mylib"' in conanfile
             assert 'version = "0.1"' in conanfile
+
+    def test_new_empty(self):
+        c = TestClient()
+        c.run("new")
+        cmakelists = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.15)
+        project(PackageTest CXX)
+        add_executable(example main.cpp)
+        """)
+        main = textwrap.dedent(r"""
+        #include <iostream>
+
+        int main() {
+            std::cout << "Hello World!\n";
+        }
+        """)
+        c.save({
+            "CMakeLists.txt": cmakelists,
+            "main.cpp": main,
+        })
+        replace_in_file(ConanFileMock(),
+                        os.path.join(c.current_folder, "conanfile.py"),
+                        'class mypkgRecipe(ConanFile):\n',
+                        'class mypkgRecipe(ConanFile):\n    exports_sources = "CMakelists.txt", "main.cpp"\n')
+        c.run("create")
+        assert "mypkg/0.1: Package folder" in c.out
 
 
 class TestNewCommandUserTemplate:

--- a/test/integration/command/test_new.py
+++ b/test/integration/command/test_new.py
@@ -4,11 +4,9 @@ import textwrap
 import pytest
 
 from conan import __version__
-from conan.test.utils.mocks import ConanFileMock
+from conan.internal.util.files import save
 from conan.test.utils.test_files import temp_folder
 from conan.test.utils.tools import TestClient
-from conan.internal.util.files import save
-from conan.tools.files import replace_in_file
 
 
 class TestNewCommand:
@@ -78,32 +76,6 @@ class TestNewCommand:
             conanfile = c.load("conanfile.py")
             assert 'name = "mylib"' in conanfile
             assert 'version = "0.1"' in conanfile
-
-    def test_new_empty(self):
-        c = TestClient()
-        c.run("new")
-        cmakelists = textwrap.dedent("""
-        cmake_minimum_required(VERSION 3.15)
-        project(PackageTest CXX)
-        add_executable(example main.cpp)
-        """)
-        main = textwrap.dedent(r"""
-        #include <iostream>
-
-        int main() {
-            std::cout << "Hello World!\n";
-        }
-        """)
-        c.save({
-            "CMakeLists.txt": cmakelists,
-            "main.cpp": main,
-        })
-        replace_in_file(ConanFileMock(),
-                        os.path.join(c.current_folder, "conanfile.py"),
-                        'class mypkgRecipe(ConanFile):\n',
-                        'class mypkgRecipe(ConanFile):\n    exports_sources = "CMakelists.txt", "main.cpp"\n')
-        c.run("create")
-        assert "mypkg/0.1: Package folder" in c.out
 
 
 class TestNewCommandUserTemplate:


### PR DESCRIPTION
Changelog: Feature: `conan new` with no positional arguments creates a default CMake basic conanfile.
Docs: https://github.com/conan-io/docs/pull/4356
