### PR TITLE
Docs for `InstallAPI`

### DIFF
--- a/conan/api/conan_api.py
+++ b/conan/api/conan_api.py
@@ -64,7 +64,8 @@ class ConanAPI:
         #: Used to get latest refs and list refs of recipes and packages
         self.list: ListAPI = ListAPI(self)
         self.profiles = ProfilesAPI(self, self._api_helpers)
-        self.install = InstallAPI(self, self._api_helpers)
+        #: Used to install binaries, sources, deploy packages and more
+        self.install: InstallAPI = InstallAPI(self, self._api_helpers)
         self.graph = GraphAPI(self, self._api_helpers)
         #: Used to export recipes and pre-compiled package binaries to the Conan cache
         self.export: ExportAPI = ExportAPI(self, self._api_helpers)

--- a/conan/api/subapi/install.py
+++ b/conan/api/subapi/install.py
@@ -1,5 +1,7 @@
 import os
+from typing import List
 
+from conan.api.model import Remote
 from conan.internal.api.install.generators import write_generators
 from conan.internal.conan_app import ConanBasicApp
 from conan.internal.deploy import do_deploys
@@ -10,16 +12,29 @@ from conan.errors import ConanInvalidConfiguration, ConanException
 
 
 class InstallAPI:
+    """ This is the InstallAPI.
+
+    It provides methods to install binaries, sources,
+    prepare the consumer folder with generators and deploy, etc., all of them
+    based on an already resolved dependency graph.
+    """
 
     def __init__(self, conan_api, helpers):
+        """ Do not instantiate directly, use the ``ConanAPI.install`` property instead"""
         self._conan_api = conan_api
         self._helpers = helpers
 
-    def install_binaries(self, deps_graph, remotes=None, return_install_error=False):
-        """ Install binaries for dependency graph
-        :param deps_graph: Dependency graph to intall packages for
-        :param remotes:
-        :param return_install_error: If True, do not raise an exception, but return it
+    def install_binaries(self, deps_graph, remotes: List[Remote] = None, return_install_error=False):
+        """ Install binaries of a dependency graph.
+
+        This is the equivalent to the ``conan install`` command, but working with an already
+        resolved dependency graph, uusually obtained from the corresponding ``GraphAPI`` methods,
+        and as such, it will first check the remotes for the requested binaries, and if not found,
+        it will build from sources if possible.
+
+        :param deps_graph: Dependency graph to install packages for
+        :param remotes: List of remotes to fetch packages from if necessary.
+        :param return_install_error: If ``True``, do not raise an exception, but return it
         """
         app = ConanBasicApp(self._conan_api)
         installer = BinaryInstaller(app, self._helpers.global_conf, app.editable_packages,
@@ -38,33 +53,62 @@ class InstallAPI:
             return e
 
     def install_system_requires(self, graph, only_info=False):
-        """ Install binaries for dependency graph
+        """ Install only the system requirements of a dependency graph.
+
+        This is a subset of install_binaries which only deals with system requirements
+        of an already resolved dependency graph,
+        usually obtained from the corresponding ``GraphAPI`` methods, but which only installs
+        system requirements if ``only_info`` is ``False``,
+        or reporting/checking them if ``only_info`` is ``True``.
+
+        :param graph: Dependency graph to install system requirements for
         :param only_info: Only allow reporting and checking, but never install
-        :param graph: Dependency graph to intall packages for
         """
         app = ConanBasicApp(self._conan_api)
         installer = BinaryInstaller(app, self._helpers.global_conf, app.editable_packages,
                                     self._helpers.hook_manager)
         installer.install_system_requires(graph, only_info)
 
-    def install_sources(self, graph, remotes):
-        """ Install sources for dependency graph of packages to BUILD or packages that match
-        tools.build:download_source conf
-        :param remotes:
-        :param graph: Dependency graph to install packages for
+    def install_sources(self, graph, remotes: List[Remote]):
+        """ Download sources in the given dependency graph.
+
+        If the ``tools.build:download_source`` conf is ``True``, sources will be downloaded for
+        every package in the graph, otherwise only the packages marked for build from source will
+        have their sources downloaded.
+
+        ``tools.build:download_source=True`` is useful when users want to inspect the source code
+        of all dependencies, even the ones that are not built from source.
+
+        After this method, the ``conanfile.source_folder`` on each node of the dependency graph
+        will be set to the folder where sources have been downloaded.
+
+        :param remotes: List of remotes where the ``exports_sources`` of the packages might be located
+        :param graph: Dependency graph to download sources from
         """
         app = ConanBasicApp(self._conan_api)
         installer = BinaryInstaller(app, self._helpers.global_conf, app.editable_packages,
                                     self._helpers.hook_manager)
         installer.install_sources(graph, remotes)
 
-    # TODO: Look for a better name
-    def install_consumer(self, deps_graph, generators=None, source_folder=None, output_folder=None,
-                         deploy=False, deploy_package=None, deploy_folder=None,
-                         envs_generation=None):
-        """ Once a dependency graph has been installed, there are things to be done, like invoking
-        generators for the root consumer.
-        This is necessary for example for conanfile.txt/py, or for "conan install <ref> -g
+    def install_consumer(self, deps_graph, generators: List[str] = None, source_folder=None,
+                         output_folder=None, deploy=False, deploy_package: List[str] = None,
+                         deploy_folder=None, envs_generation=None):
+        """ Prepare the folder of the root consumer of a dependency graph after installation
+        of the dependencies.
+
+        This ensures that the requested generators are created in the consumer folder,
+        and also handles deployment if requested.
+
+        This is necessary for example for ``conanfile.txt/py``, or for ``conan install -g ...``.
+
+        :param deps_graph: Dependency graph whose root is the consumer we want to prepare
+        :param generators: List of generators to be used in addition to the ones defined in the root conanfile, if any
+        :param source_folder: Source folder of the consumer
+        :param output_folder: Output folder of the consumer
+        :param deploy: Deployer or list of deployers to be used for deployment
+        :param deploy_package: Only deploy the packages matching these patterns (Empty for all)
+        :param deploy_folder: Folder where to deploy, by default the build folder
+        :param envs_generation: Anything other than ``None`` will activate the generation of virtual environment files for the root conanfile
         """
         root_node = deps_graph.root
         conanfile = root_node.conanfile
@@ -101,6 +145,17 @@ class InstallAPI:
         write_generators(conanfile, hook_manager, self._conan_api.home_folder,
                          envs_generation=envs_generation)
 
-    def deploy(self, graph, deployer, deploy_package=None, deploy_folder=None):
+    def deploy(self, graph, deployer: List[str], deploy_package: List[str]=None,
+               deploy_folder=None) -> None:
+        """ Run the given deployer in the dependency graph.
+
+        No checks are performed in the graph, it is assumed to be already resolved
+        and in a valid state to be deployed from.
+
+        :param graph: The dependency graph to deploy
+        :param deployer: List of deployers to be used
+        :param deploy_package: Only deploy the packages matching these patterns (Empty for all)
+        :param deploy_folder: Folder where to deploy, by default the build folder
+        """
         return do_deploys(self._conan_api.home_folder, graph, deployer,
                           deploy_package=deploy_package, deploy_folder=deploy_folder)

--- a/conan/api/subapi/install.py
+++ b/conan/api/subapi/install.py
@@ -20,7 +20,6 @@ class InstallAPI:
     """
 
     def __init__(self, conan_api, helpers):
-        """ Do not instantiate directly, use the ``ConanAPI.install`` property instead"""
         self._conan_api = conan_api
         self._helpers = helpers
 
@@ -28,9 +27,13 @@ class InstallAPI:
         """ Install binaries of a dependency graph.
 
         This is the equivalent to the ``conan install`` command, but working with an already
-        resolved dependency graph, uusually obtained from the corresponding ``GraphAPI`` methods,
-        and as such, it will first check the remotes for the requested binaries, and if not found,
-        it will build from sources if possible.
+        resolved dependency graph, usually obtained from the corresponding ``GraphAPI`` methods.
+
+        It will download the available packages from the given remotes,
+        and then build the ones that were marked for build from source.
+
+        System requirements will be installed as well, taking into account the
+        ``tools.system.package_manager:mode`` conf to determine whether to install, check or skip them.
 
         :param deps_graph: Dependency graph to install packages for
         :param remotes: List of remotes to fetch packages from if necessary.
@@ -55,14 +58,15 @@ class InstallAPI:
     def install_system_requires(self, graph, only_info=False):
         """ Install only the system requirements of a dependency graph.
 
-        This is a subset of install_binaries which only deals with system requirements
+        This is a subset of ``install_binaries`` which only deals with system requirements
         of an already resolved dependency graph,
-        usually obtained from the corresponding ``GraphAPI`` methods, but which only installs
-        system requirements if ``only_info`` is ``False``,
-        or reporting/checking them if ``only_info`` is ``True``.
+        usually obtained from the corresponding ``GraphAPI`` methods.
+
+        The ``tools.system.package_manager:mode`` conf will be taken into account to
+        determine whether to install, check or skip system requirements.
 
         :param graph: Dependency graph to install system requirements for
-        :param only_info: Only allow reporting and checking, but never install
+        :param only_info: If ``True``, only reporting and checking of whether the system requirements are installed is performed.
         """
         app = ConanBasicApp(self._conan_api)
         installer = BinaryInstaller(app, self._helpers.global_conf, app.editable_packages,
@@ -80,7 +84,7 @@ class InstallAPI:
         of all dependencies, even the ones that are not built from source.
 
         After this method, the ``conanfile.source_folder`` on each node of the dependency graph
-        will be set to the folder where sources have been downloaded.
+        for which the sources have been downloaded will be set to the folder where sources have been downloaded.
 
         :param remotes: List of remotes where the ``exports_sources`` of the packages might be located
         :param graph: Dependency graph to download sources from
@@ -99,14 +103,12 @@ class InstallAPI:
         This ensures that the requested generators are created in the consumer folder,
         and also handles deployment if requested.
 
-        This is necessary for example for ``conanfile.txt/py``, or for ``conan install -g ...``.
-
         :param deps_graph: Dependency graph whose root is the consumer we want to prepare
         :param generators: List of generators to be used in addition to the ones defined in the root conanfile, if any
         :param source_folder: Source folder of the consumer
         :param output_folder: Output folder of the consumer
         :param deploy: Deployer or list of deployers to be used for deployment
-        :param deploy_package: Only deploy the packages matching these patterns (Empty for all)
+        :param deploy_package: Only deploy the packages matching these patterns (``None`` or empty for all)
         :param deploy_folder: Folder where to deploy, by default the build folder
         :param envs_generation: Anything other than ``None`` will activate the generation of virtual environment files for the root conanfile
         """
@@ -154,7 +156,7 @@ class InstallAPI:
 
         :param graph: The dependency graph to deploy
         :param deployer: List of deployers to be used
-        :param deploy_package: Only deploy the packages matching these patterns (Empty for all)
+        :param deploy_package: Only deploy the packages matching these patterns (``None`` or empty for all)
         :param deploy_folder: Folder where to deploy, by default the build folder
         """
         return do_deploys(self._conan_api.home_folder, graph, deployer,


### PR DESCRIPTION
Changelog: Feature: Add public docs for `InstallAPI` subapi.
Docs: Omit

Added in this release too after talking with @czoido about a docs issue

I decided to document the deploy function because there's a public usage in the commands

Part of https://github.com/conan-io/conan/issues/14206 effort

<img width="3358" height="5086" alt="image" src="https://github.com/user-attachments/assets/07481acb-8422-4034-adc5-c1bf145e7ba6" />
 