### PR TITLE
Add tests for overwrite behaviour of `cmake.cmaketoolchain:extra_variables` from profile

### DIFF
--- a/test/functional/toolchains/cmake/test_cmake_extra_variables.py
+++ b/test/functional/toolchains/cmake/test_cmake_extra_variables.py
@@ -34,7 +34,7 @@ def test_package_info_extra_variables(generator):
     message(STATUS "BAR=${BAR}")
     message(STATUS "BAZ=${BAZ}")
     message(STATUS "BAR_CACHE=${BAR_CACHE}")
-    message(STATUS "BAR_CACHE=${BAR_CACHE}")
+    message(STATUS "BAZ_CACHE=${BAZ_CACHE}")
     """)
 
     conanfile = textwrap.dedent(f"""

--- a/test/functional/toolchains/cmake/test_cmake_extra_variables.py
+++ b/test/functional/toolchains/cmake/test_cmake_extra_variables.py
@@ -33,8 +33,8 @@ def test_package_info_extra_variables(generator):
     message(STATUS "FOO=${FOO}")
     message(STATUS "BAR=${BAR}")
     message(STATUS "BAZ=${BAZ}")
-    message(STATUS "BAR_C=${BAR_C}")
-    message(STATUS "BAZ_C=${BAZ_C}")
+    message(STATUS "BAR_CACHE=${BAR_CACHE}")
+    message(STATUS "BAR_CACHE=${BAR_CACHE}")
     """)
 
     conanfile = textwrap.dedent(f"""

--- a/test/functional/toolchains/cmake/test_cmake_extra_variables.py
+++ b/test/functional/toolchains/cmake/test_cmake_extra_variables.py
@@ -31,16 +31,30 @@ def test_package_info_extra_variables(generator):
     project(myproject CXX)
     find_package(dep CONFIG REQUIRED)
     message(STATUS "FOO=${FOO}")
+    message(STATUS "BAR=${BAR}")
+    message(STATUS "BAZ=${BAZ}")
+    message(STATUS "BAR_C=${BAR_C}")
+    message(STATUS "BAZ_C=${BAZ_C}")
     """)
 
     conanfile = textwrap.dedent(f"""
     from conan import ConanFile
-    from conan.tools.cmake import CMake
+    from conan.tools.cmake import CMake, {generator}, CMakeToolchain
 
     class Pkg(ConanFile):
         settings = "os", "arch", "compiler", "build_type"
-        generators = "{generator}", "CMakeToolchain"
         requires = "dep/0.1"
+
+        def generate(self):
+            deps = {generator}(self)
+            deps.generate()
+            tc = CMakeToolchain(self)
+            tc.cache_variables["BAR"] = "42"
+            tc.variables["BAZ"] = "42"
+            tc.cache_variables["BAR_CACHE"] = "42"
+            tc.variables["BAZ_CACHE"] = "42"
+            tc.generate()
+
         def build(self):
             cmake = CMake(self)
             cmake.configure()
@@ -49,6 +63,12 @@ def test_package_info_extra_variables(generator):
                  "conanfile.py": conanfile})
     conf = f"-c tools.cmake.cmakedeps:new={new_value}" if generator == "CMakeConfigDeps" else ""
     client.run(f"build . {conf} "
-               """-c tools.cmake.cmaketoolchain:extra_variables="{'FOO': '9'}" """)
+               """-c tools.cmake.cmaketoolchain:extra_variables="{'FOO': '9', 'BAR': '9', 'BAZ': '9', 'BAR_CACHE': {'value': '9', 'cache': True, 'type': 'STRING'}, 'BAZ_CACHE': {'value': '9', 'cache': True, 'type': 'STRING'}}" """)
 
     assert "-- FOO=9" in client.out
+    assert "-- BAR=9" in client.out
+    assert "-- BAZ=9" in client.out
+    # No overwrite in this case. Cache - Cache keeps the first occurrence in the file, can't override
+    # from the profile
+    assert "-- BAR_CACHE=42" in client.out
+    assert "-- BAZ_CACHE=9" in client.out

--- a/test/functional/toolchains/cmake/test_cmake_extra_variables.py
+++ b/test/functional/toolchains/cmake/test_cmake_extra_variables.py
@@ -35,6 +35,7 @@ def test_package_info_extra_variables(generator):
     message(STATUS "BAZ=${BAZ}")
     message(STATUS "BAR_CACHE=${BAR_CACHE}")
     message(STATUS "BAZ_CACHE=${BAZ_CACHE}")
+    message(STATUS "BAR_CACHE_FORCE=${BAR_CACHE_FORCE}")
     """)
 
     conanfile = textwrap.dedent(f"""
@@ -53,6 +54,7 @@ def test_package_info_extra_variables(generator):
             tc.variables["BAZ"] = "42"
             tc.cache_variables["BAR_CACHE"] = "42"
             tc.variables["BAZ_CACHE"] = "42"
+            tc.cache_variables["BAR_CACHE_FORCE"] = "42"
             tc.generate()
 
         def build(self):
@@ -63,7 +65,7 @@ def test_package_info_extra_variables(generator):
                  "conanfile.py": conanfile})
     conf = f"-c tools.cmake.cmakedeps:new={new_value}" if generator == "CMakeConfigDeps" else ""
     client.run(f"build . {conf} "
-               """-c tools.cmake.cmaketoolchain:extra_variables="{'FOO': '9', 'BAR': '9', 'BAZ': '9', 'BAR_CACHE': {'value': '9', 'cache': True, 'type': 'STRING'}, 'BAZ_CACHE': {'value': '9', 'cache': True, 'type': 'STRING'}}" """)
+               """-c tools.cmake.cmaketoolchain:extra_variables="{'FOO': '9', 'BAR': '9', 'BAZ': '9', 'BAR_CACHE': {'value': '9', 'cache': True, 'type': 'STRING'}, 'BAZ_CACHE': {'value': '9', 'cache': True, 'type': 'STRING'}, 'BAR_CACHE_FORCE': {'value': '9', 'cache': True, 'type': 'STRING', 'force': True}}" """)
 
     assert "-- FOO=9" in client.out
     assert "-- BAR=9" in client.out
@@ -72,3 +74,5 @@ def test_package_info_extra_variables(generator):
     # from the profile
     assert "-- BAR_CACHE=42" in client.out
     assert "-- BAZ_CACHE=9" in client.out
+    assert "-- BAR_CACHE_FORCE=9" in client.out
+


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Improved this test alongside @ErniGH after a question arose of overwrite behaviour from profiles to recipe-defined variables.