### PR TITLE
Refactor/remote manager flow

### DIFF
--- a/conan/internal/rest/pkg_sign.py
+++ b/conan/internal/rest/pkg_sign.py
@@ -38,9 +38,9 @@ class PkgSignaturesPlugin:
                 if pkg_bundle["upload"]:
                     _sign(pref, pkg_bundle["files"], self._cache.pkg_layout(pref).download_package())
 
-    def verify(self, ref, folder, files):
+    def verify(self, ref, folder, metadata_folder, files):
         if self._plugin_verify_function is None:
             return
-        metadata_sign = os.path.join(folder, METADATA, "sign")
+        metadata_sign = os.path.join(metadata_folder, "sign")
         self._plugin_verify_function(ref, artifacts_folder=folder, signature_folder=metadata_sign,
                                      files=files)

--- a/conan/internal/rest/remote_manager.py
+++ b/conan/internal/rest/remote_manager.py
@@ -57,15 +57,22 @@ class RemoteManager:
         assert ref.revision, "get_recipe without revision specified"
         assert ref.timestamp, "get_recipe without ref.timestamp specified"
 
+        # This fails if there is a DB entry for this ref
         layout = self._cache.create_ref_layout(ref)
 
         export_folder = layout.export()
         local_folder_remote = self._local_folder_remote(remote)
         if local_folder_remote is not None:
             local_folder_remote.get_recipe(ref, export_folder)
-            mkdir(layout.metadata())
-            return layout
+        else:
+            self._download_recipe(layout, ref, remote, metadata)
+        # Make sure that the source dir is deleted, but it seems unnecessary
+        rmdir(layout.source())
+        mkdir(layout.metadata())
 
+        return layout
+
+    def _download_recipe(self, layout, ref, remote, metadata):
         download_export = layout.download_export()
         try:
             zipped_files = self._call_remote(remote, "get_recipe", ref, download_export, metadata,
@@ -97,11 +104,6 @@ class RemoteManager:
         for file_name, file_path in zipped_files.items():  # copy CONANFILE
             shutil.move(file_path, os.path.join(export_folder, file_name))
 
-        # Make sure that the source dir is deleted
-        rmdir(layout.source())
-        mkdir(layout.metadata())
-        return layout
-
     def get_recipe_metadata(self, recipe_layout, ref, remote, metadata):
         """
         Get only the metadata for a locally existing recipe in Cache
@@ -126,17 +128,15 @@ class RemoteManager:
         local_folder_remote = self._local_folder_remote(remote)
         if local_folder_remote is not None:
             local_folder_remote.get_recipe_sources(ref, export_sources_folder)
-            return
-
-        zipped_files = self._call_remote(remote, "get_recipe_sources", ref, download_folder)
-        if not zipped_files:
-            mkdir(export_sources_folder)  # create the folder even if no source files
-            return
-
-        self._signer.verify(ref, download_folder, files=zipped_files)
-        # Only 1 file is guaranteed
-        tgz_file = next(iter(zipped_files.values()))
-        uncompress_file(tgz_file, export_sources_folder, scope=str(ref))
+        else:
+            zipped_files = self._call_remote(remote, "get_recipe_sources", ref, download_folder)
+            if not zipped_files:
+                mkdir(export_sources_folder)  # create the folder even if no source files
+            else:
+                self._signer.verify(ref, download_folder, files=zipped_files)
+                # Only 1 file is guaranteed
+                tgz_file = next(iter(zipped_files.values()))
+                uncompress_file(tgz_file, export_sources_folder, scope=str(ref))
 
     def get_package(self, pref, remote, metadata=None):
         output = ConanOutput(scope=str(pref.ref))

--- a/conan/internal/rest/remote_manager.py
+++ b/conan/internal/rest/remote_manager.py
@@ -88,7 +88,7 @@ class RemoteManager:
             if "conanmanifest.txt" not in zipped_files:
                 raise ConanException(f"Corrupted {ref} in '{remote.name}' remote: "
                                      f"no conanmanifest.txt")
-            self._signer.verify(ref, download_export, files=zipped_files)
+            self._signer.verify(ref, download_export, layout.metadata(), files=zipped_files)
         except BaseException:  # So KeyboardInterrupt also cleans things
             ConanOutput(scope=str(ref)).error(f"Error downloading from remote '{remote.name}'",
                                               error_type="exception")
@@ -133,7 +133,7 @@ class RemoteManager:
             if not zipped_files:
                 mkdir(export_sources_folder)  # create the folder even if no source files
             else:
-                self._signer.verify(ref, download_folder, files=zipped_files)
+                self._signer.verify(ref, download_folder, layout.metadata(), files=zipped_files)
                 # Only 1 file is guaranteed
                 tgz_file = next(iter(zipped_files.values()))
                 uncompress_file(tgz_file, export_sources_folder, scope=str(ref))
@@ -187,7 +187,7 @@ class RemoteManager:
 
             # This is guaranteed to exists, otherwise RestClient would have raised already
             package_file = next(f for f in zipped_files if PACKAGE_FILE_NAME in f)
-            self._signer.verify(pref, download_pkg_folder, zipped_files)
+            self._signer.verify(pref, download_pkg_folder, layout.metadata(), zipped_files)
 
             tgz_file = zipped_files.pop(package_file)
             package_folder = layout.package()

--- a/conan/internal/rest/rest_client_v2.py
+++ b/conan/internal/rest/rest_client_v2.py
@@ -244,12 +244,11 @@ class RestV2Methods:
         src_file = self._find_compressed_file(ref, files, EXPORT_SOURCES_FILE_NAME)
         if src_file is None:
             return None
-        files = [src_file, ]
 
         # If we didn't indicated reference, server got the latest, use absolute now, it's safer
-        urls = {fn: self.router.recipe_file(ref, fn) for fn in files}
-        self._download_and_save_files(urls, dest_folder, files, scope=str(ref))
-        ret = {fn: os.path.join(dest_folder, fn) for fn in files}
+        urls = {src_file: self.router.recipe_file(ref, src_file)}
+        self._download_and_save_files(urls, dest_folder, [src_file, ], scope=str(ref))
+        ret = {src_file: os.path.join(dest_folder, src_file)}
         return ret
 
     @staticmethod


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Pure refactor preparation for https://github.com/conan-io/conan/pull/19495/changes

- Small changes in ``RemoteManager`` methods flow, like using ``if-else`` structures instead of early ``return``
- Small simplification in the ``Rest`` layer for one dict comprenhension over just 1 file
- Made the ``PkgSigning`` verify function more flexible inputs, being about to have downloaded artifacts and signatures in different folders, not just in the same ``download`` folder. This allows to decouple the checking of signatures when downloading ``conan_sources.tgz`` that depend on a previous signature downloaded with the recipe, that might be in a completely different location.
