### PR TITLE
make the RemoteManager.get_package() more atomic

### DIFF
--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -209,6 +209,12 @@ class CacheAPI:
                     info = os.path.join(folder, "p", "conaninfo.txt")
                     if not os.path.exists(manifest) or not os.path.exists(info):
                         rmdir(folder)
+
+        # Temporary name (not named) until we have clarity if this is the same as the "t"
+        # temporary (for exports) or not
+        if os.path.exists(os.path.join(cache.store, "d")):
+            rmdir(os.path.join(cache.store, "d"))
+
         if backup_sources:
             backup_files = self._conan_api.cache.get_backup_sources(package_list, exclude=False,
                                                                     only_upload=False)

--- a/conan/internal/cache/cache.py
+++ b/conan/internal/cache/cache.py
@@ -15,7 +15,7 @@ from conan.errors import ConanException
 from conan.api.model import PkgReference
 from conan.api.model import RecipeReference
 from conan.internal.util.dates import revision_timestamp_now
-from conan.internal.util.files import rmdir, renamedir, mkdir
+from conan.internal.util.files import rmdir, renamedir, mkdir, atomic_replace
 
 
 class PkgCache:
@@ -183,8 +183,7 @@ class PkgCache:
 
     def create_pkg_layout(self, pref: PkgReference):
         """ called by:
-         - RemoteManager.get_package()
-         - cacje restpre
+         - cache restore
         """
         assert pref.ref.revision, "Recipe revision must be known to create the package layout"
         assert pref.package_id, "Package id must be known to create the package layout"
@@ -193,6 +192,23 @@ class PkgCache:
         self._db.create_package(package_path, pref, None)
         self._create_path(package_path, remove_contents=False)
         return PackageLayout(pref, os.path.join(self._base_folder, package_path))
+
+    def get_random_path(self):
+        random_id = str(uuid.uuid4())
+        # d=downloading area. Using short hashes to avoid lengthy paths with hyphens
+        return os.path.join(self._base_folder, "d", self._short_hash_path(random_id))
+
+    def create_atomic_pkg_layout(self, pref: PkgReference, current_folder):
+        """ called by:
+         - RemoteManager.get_package()
+        """
+        assert pref.ref.revision, "Recipe revision must be known to create the package layout"
+        assert pref.package_id, "Package id must be known to create the package layout"
+        assert pref.revision, "Package revision should be known to create the package layout"
+        package_path = self._get_path_pref(pref)
+        path = self._full_path(package_path)
+        atomic_replace(current_folder, path, f"{pref.repr_notime()} package")
+        self._db.create_package(package_path, pref, None)
 
     def update_recipe_timestamp(self, ref: RecipeReference):
         """ when the recipe already exists in cache, but we get a new timestamp from a server

--- a/conan/internal/rest/remote_manager.py
+++ b/conan/internal/rest/remote_manager.py
@@ -12,7 +12,7 @@ from conan.internal.paths import CONANINFO, CONAN_MANIFEST, PACKAGE_FILE_NAME, E
 from conan.internal.rest.rest_client_local_recipe_index import RestApiClientLocalRecipesIndex
 from conan.api.model import Remote
 from conan.api.output import ConanOutput
-from conan.internal.cache.conan_reference_layout import METADATA
+from conan.internal.cache.conan_reference_layout import METADATA, PackageLayout
 from conan.internal.rest.pkg_sign import PkgSignaturesPlugin
 from conan.internal.errors import ConanConnectionError, NotFoundException, PackageNotFoundException
 from conan.errors import ConanException
@@ -144,10 +144,10 @@ class RemoteManager:
 
         assert pref.revision is not None
 
-        pkg_layout = self._cache.create_pkg_layout(pref)
-        with pkg_layout.set_dirty_context_manager():
-            mkdir(pkg_layout.metadata())
-            self._get_package(pkg_layout, pref, remote, output, metadata)
+        pkg_layout = PackageLayout(pref, self._cache.get_random_path())
+        mkdir(pkg_layout.metadata())
+        self._get_package(pkg_layout, pref, remote, output, metadata)
+        self._cache.create_atomic_pkg_layout(pref, pkg_layout.base_folder)
 
     def get_package_metadata(self, pref, remote, metadata):
         """

--- a/conan/internal/util/files.py
+++ b/conan/internal/util/files.py
@@ -10,9 +10,19 @@ import time
 
 from contextlib import contextmanager
 
+from conan.api.output import ConanOutput
 from conan.errors import ConanException
 
 _DIRTY_FOLDER = ".dirty"
+
+
+def atomic_replace(src, dst, item):
+    try:
+        os.replace(src, dst)  # ATOMIC!!!
+    except OSError as e:
+        msg = ("The os.replace() to put this item in the package storage has failed. Maybe"
+               f"there was a concurrent process that did it first.\n    Item: {item}\n    Msg: {e}")
+        ConanOutput().warning(msg)
 
 
 def set_dirty(folder):


### PR DESCRIPTION
Changelog: Feature: Make the download of package binaries more atomic to make cancellations more robust.
Docs: Omit

Besides https://github.com/conan-io/conan/pull/19506, that is a pure refactor, and before https://github.com/conan-io/conan/pull/19495, that makes atomic also the download of the recipe, and the ``conan cache save/restore``, lets introduce the minimal change to make atomic just the download of the package binaries, to iterate for one release the ``os.replace()`` concept
