### PR TITLE
feat: conan pkglist find-remote can determine revisions

### DIFF
--- a/conan/api/subapi/list.py
+++ b/conan/api/subapi/list.py
@@ -312,9 +312,13 @@ class ListAPI:
             rev_dict["packages"][pref.package_id]["remote"] = remote
         return pkglist
 
-    def find_remotes(self, package_list, remotes):
+    def find_remotes(self, package_list, remotes, expand_revisions=False):
         """
         (Experimental) Find the remotes where the current package lists can be found
+        :param package_list: PackagesList object with recipes/packages to search for
+        :param remotes: List of Remote objects to search in
+        :param expand_revisions: If True, expand recipes/packages without revisions
+                                 to all available revisions.
         """
         result = MultiPackagesList()
         app = ConanBasicApp(self._conan_api)
@@ -328,7 +332,10 @@ class ListAPI:
                     continue
                 revisions = ref_contents.get("revisions")
                 if revisions is None:  # This is a package list just with name/version
-                    if remote_rrevs:
+                    if expand_revisions:
+                        for remote_rrev in remote_rrevs:
+                            result_pkg_list.add_ref(remote_rrev)
+                    elif remote_rrevs:
                         result_pkg_list.add_ref(ref)
                     continue
 
@@ -350,8 +357,11 @@ class ListAPI:
                             continue
                         pkg_revisions = pkgcontent.get("revisions")
                         if pkg_revisions is None:  # User provided a package_id, no prevs
-                            for remote_pref in remote_prefs:
-                                result_pkg_list.add_pref(remote_pref, pkgcontent.get("info"))
+                            if expand_revisions:
+                                for remote_pref in remote_prefs:
+                                    result_pkg_list.add_pref(remote_pref, pkgcontent.get("info"))
+                            elif remote_prefs:
+                                result_pkg_list.add_pref(pref, pkgcontent.get("info"))
                             continue
                         for pkg_revision, prev_content in pkg_revisions.items():
                             pref.revision = pkg_revision

--- a/conan/api/subapi/list.py
+++ b/conan/api/subapi/list.py
@@ -349,9 +349,9 @@ class ListAPI:
                         except NotFoundException:
                             continue
                         pkg_revisions = pkgcontent.get("revisions")
-                        if pkg_revisions is None:  # This is a package_id, no prevs
-                            if remote_prefs:
-                                result_pkg_list.add_pref(pref, pkgcontent.get("info"))
+                        if pkg_revisions is None:  # User provided a package_id, no prevs
+                            for remote_pref in remote_prefs:
+                                result_pkg_list.add_pref(remote_pref, pkgcontent.get("info"))
                             continue
                         for pkg_revision, prev_content in pkg_revisions.items():
                             pref.revision = pkg_revision

--- a/conan/cli/commands/pkglist.py
+++ b/conan/cli/commands/pkglist.py
@@ -24,13 +24,16 @@ def pkglist_find_remote(conan_api, parser, subparser, *args):
     subparser.add_argument("-r", "--remote", default=None, action="append",
                            help="Remote names. Accepts wildcards "
                                 "('*' means all the remotes available)")
+    subparser.add_argument("--expand-revisions", action='store_true', default=False,
+                           help="Expand recipes/packages without explicit revisions "
+                                "to all available revisions on the remote.")
     args = parser.parse_args(*args)
 
     listfile = make_abs_path(args.list)
     multi_pkglist = MultiPackagesList.load(listfile)
     package_list = multi_pkglist["Local Cache"]
     selected_remotes = conan_api.remotes.list(args.remote)
-    result = conan_api.list.find_remotes(package_list, selected_remotes)
+    result = conan_api.list.find_remotes(package_list, selected_remotes, args.expand_revisions)
     return {
         "results": result.serialize(),
         "conan_api": conan_api,

--- a/test/integration/command/list/test_combined_pkglist_flows.py
+++ b/test/integration/command/list/test_combined_pkglist_flows.py
@@ -231,6 +231,24 @@ class TestPkgListFindRemote:
         pkglist = json.loads(c.stdout)
         assert pkglist["default"] == expected
 
+    def test_input_only_name_version_expand_revisions(self):
+        c = TestClient(default_server_user=True, light=True)
+        c.save({"zlib/conanfile.py": GenConanfile("zlib", "1.0")})
+        c.run("create zlib")
+        c.run("upload zlib* -c -r=default")
+
+        # Create input pkglist for find-remote
+        c.run(f"list * --format=json", redirect_stdout="mylist.json")
+        pkglist = json.loads(c.load("mylist.json"))
+        expected = {"zlib/1.0": {}}
+        assert pkglist["Local Cache"] == expected
+
+        c.run("pkglist find-remote mylist.json --format=json --remote default --expand-revisions")
+        pkglist = json.loads(c.stdout)
+        assert pkglist["default"].keys() == expected.keys()
+        assert "revisions" in pkglist["default"]["zlib/1.0"]
+        assert list(pkglist["default"]["zlib/1.0"]["revisions"].keys()) == ["c570d63921c5f2070567da4bf64ff261"]
+
     def test_input_recipe_revisions(self):
         c = TestClient(default_server_user=True, light=True)
         c.save({"zlib/conanfile.py": GenConanfile("zlib", "1.0")})
@@ -258,7 +276,7 @@ class TestPkgListFindRemote:
         c.run("create zlib -s os=Linux")
         c.run("upload zlib* -c -r=default")
 
-        # Create input pkglist for find-remote
+        # Create input pkglist for find-remote - list *:* may not include package revisions
         c.run(f"list *:* --format=json", redirect_stdout="mylist.json")
 
         def _check(origin):
@@ -270,11 +288,42 @@ class TestPkgListFindRemote:
             assert list(pkgs) == ["9a4eb3c8701508aa9458b1a73d0633783ecc2270"]
             pkg = pkgs["9a4eb3c8701508aa9458b1a73d0633783ecc2270"]
             assert pkg["info"] == expected
-            assert list(pkg["revisions"]) == ["1d3c57385f4133c1fbd6d13bd538496e"]
+            assert "revisions" not in pkg
 
+        _check("Local Cache")
         c.run("pkglist find-remote mylist.json --format=json --remote default",
               redirect_stdout="mylist.json")
         _check("default")
+
+    def test_input_only_package_ids_expand_revisions(self):
+        c = TestClient(default_server_user=True, light=True)
+        c.save({"zlib/conanfile.py": GenConanfile("zlib", "1.0").with_settings("os")})
+        c.run("create zlib -s os=Linux")
+        c.run("upload zlib* -c -r=default")
+
+        # Create input pkglist for find-remote - list *:* may not include package revisions
+        c.run(f"list *:* --format=json", redirect_stdout="mylist.json")
+
+        def _check(origin):
+            pkglist = json.loads(c.load("mylist.json"))
+            revs = pkglist[origin]["zlib/1.0"]["revisions"]
+            assert list(revs) == ["1cb7410d0365f87510a6767c7bef804e"]
+            expected = {'settings': {'os': 'Linux'}}
+            pkgs = revs["1cb7410d0365f87510a6767c7bef804e"]["packages"]
+            assert list(pkgs) == ["9a4eb3c8701508aa9458b1a73d0633783ecc2270"]
+            pkg = pkgs["9a4eb3c8701508aa9458b1a73d0633783ecc2270"]
+            assert pkg["info"] == expected
+            return pkg
+
+        pkg = _check("Local Cache")
+        assert "revisions" not in pkg
+
+        c.run("pkglist find-remote mylist.json --format=json --remote default --expand-revisions",
+              redirect_stdout="mylist.json")
+        pkg = _check("default")
+        # When using --expand-revisions, package revisions should be included
+        assert "revisions" in pkg
+        assert list(pkg["revisions"]) == ["1d3c57385f4133c1fbd6d13bd538496e"]
 
     def test_graph_pkg_list_of_recipes_and_binaries(self):
         c = TestClient(default_server_user=True, light=True)

--- a/test/integration/command/list/test_combined_pkglist_flows.py
+++ b/test/integration/command/list/test_combined_pkglist_flows.py
@@ -265,9 +265,12 @@ class TestPkgListFindRemote:
             pkglist = json.loads(c.load("mylist.json"))
             revs = pkglist[origin]["zlib/1.0"]["revisions"]
             assert list(revs) == ["1cb7410d0365f87510a6767c7bef804e"]
-            info = {"info": {'settings': {'os': 'Linux'}}}
-            expected = {"9a4eb3c8701508aa9458b1a73d0633783ecc2270": info}
-            assert revs["1cb7410d0365f87510a6767c7bef804e"]["packages"] == expected
+            expected = {'settings': {'os': 'Linux'}}
+            pkgs = revs["1cb7410d0365f87510a6767c7bef804e"]["packages"]
+            assert list(pkgs) == ["9a4eb3c8701508aa9458b1a73d0633783ecc2270"]
+            pkg = pkgs["9a4eb3c8701508aa9458b1a73d0633783ecc2270"]
+            assert pkg["info"] == expected
+            assert list(pkg["revisions"]) == ["1d3c57385f4133c1fbd6d13bd538496e"]
 
         c.run("pkglist find-remote mylist.json --format=json --remote default",
               redirect_stdout="mylist.json")


### PR DESCRIPTION
This feature allows to forward the result of `conan pkglist find-remote` command to `conan download --list ...` without intermediate steps. This is of high interest if you have a pkglist with package_ids but do not know (or care) about the prevs.

Changelog: Feature: conan pkglist find-remote will list prevs if the input contains at least a package_id

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
