### PR TITLE
Populate `<library>_DEFINITIONS` legacy variables in `CMakeConfigDeps` for compatibility with old `check_symbol_exists` and similar 

### DIFF
--- a/conan/tools/cmake/cmakeconfigdeps/config.py
+++ b/conan/tools/cmake/cmakeconfigdeps/config.py
@@ -98,7 +98,7 @@ class ConfigTemplate2:
             incdirs = [relativize_path(i, self._cmakedeps._conanfile, "${CMAKE_CURRENT_LIST_DIR}")
                        for i in incdirs]
             include_dirs = ";".join(incdirs)
-            definitions = ""
+            definitions = " ".join(aggregated_cppinfo.defines)
             root_target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile)
             libraries = root_target_name or f"{pkg_name}::{pkg_name}"
 

--- a/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps2/test_cmakedeps.py
@@ -788,3 +788,15 @@ class TestLinkFeatures:
         targets = tc.load("dep-Targets-release.cmake")
         # The requirement should have the link feature info
         assert "# Requirement dep::dep -> pkg::compA (Full link: True)\n# Link feature: MYFET" in targets
+
+
+def test_legacy_defines():
+    # We used not to populate this.
+    # We do for backward compatibility with old check_symbol_exists and similar CMake code
+    tc = TestClient()
+    tc.save({"conanfile.py": GenConanfile("mypkg", "1.0")
+             .with_package_info({"defines": ["MY_DEFINE"]})})
+    tc.run("create")
+    tc.run("install --requires=mypkg/1.0 -g CMakeConfigDeps")
+    mypkg_config = tc.load("mypkg-config.cmake")
+    assert "set(mypkg_DEFINITIONS MY_DEFINE )" in mypkg_config


### PR DESCRIPTION
Changelog: Fix: Populate `<library>_DEFINITIONS` legacy variables in `CMakeConfigDeps` for compatibility with old `check_symbol_exists` and similar 
Docs: Omit

Reported by @perseoGI as a failure for llvm-core to compile with `libxml2` due to an unexpected missing symbol. While the issue turned out to be CMake picking the generated module file, we found this issue that also affected the symbol visibility.
