### PR TITLE
Be more correct in hash vs. signature terms

### DIFF
--- a/conan/internal/util/files.py
+++ b/conan/internal/util/files.py
@@ -114,15 +114,15 @@ def _generic_algorithm_sum(file_path, algorithm_name):
         return m.hexdigest()
 
 
-def check_with_algorithm_sum(algorithm_name, file_path, signature):
-    real_signature = _generic_algorithm_sum(file_path, algorithm_name)
-    if real_signature != signature.lower():
-        raise ConanException("%s signature failed for '%s' file. \n"
-                             " Provided signature: %s  \n"
-                             " Computed signature: %s" % (algorithm_name,
+def check_with_algorithm_sum(algorithm_name, file_path, provided_hash):
+    real_hash = _generic_algorithm_sum(file_path, algorithm_name)
+    if real_hash != provided_hash.lower():
+        raise ConanException("%s hash failed for '%s' file. \n"
+                             " Provided hash: %s  \n"
+                             " Computed hash: %s" % (algorithm_name,
                                                           os.path.basename(file_path),
-                                                          signature,
-                                                          real_signature))
+                                                          provided_hash,
+                                                          real_hash))
 
 
 def save(path, content, encoding="utf-8"):

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -493,36 +493,36 @@ def untargz(filename, destination=".", pattern=None, strip_root=False, extract_f
 
 def check_sha1(conanfile, file_path, signature):
     """
-    Check that the specified ``sha1`` of the ``file_path`` matches with signature.
+    Check that the specified ``SHA-1`` hash of the ``file_path`` matches the actual hash.
     If doesn’t match it will raise a ``ConanException``.
 
     :param conanfile: Conanfile object.
     :param file_path: Path of the file to check.
-    :param signature: Expected sha1sum
+    :param signature: Expected SHA-1 hash.
     """
     check_with_algorithm_sum("sha1", file_path, signature)
 
 
 def check_md5(conanfile, file_path, signature):
     """
-    Check that the specified ``md5sum`` of the ``file_path`` matches with ``signature``.
+    Check that the specified ``MD5`` hash of the ``file_path`` matches the actual hash.
     If doesn’t match it will raise a ``ConanException``.
 
     :param conanfile: The current recipe object. Always use ``self``.
     :param file_path: Path of the file to check.
-    :param signature: Expected md5sum.
+    :param signature: Expected MD5 hash.
     """
     check_with_algorithm_sum("md5", file_path, signature)
 
 
 def check_sha256(conanfile, file_path, signature):
     """
-    Check that the specified ``sha256`` of the ``file_path`` matches with signature.
+    Check that the specified ``SHA-256`` hash of the ``file_path`` matches the actual hash.
     If doesn’t match it will raise a ``ConanException``.
 
     :param conanfile: Conanfile object.
     :param file_path: Path of the file to check.
-    :param signature: Expected sha256sum
+    :param signature: Expected SHA-256 hash.
     """
     check_with_algorithm_sum("sha256", file_path, signature)
 

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -149,7 +149,7 @@ def ftp_download(conanfile, host, filename, login='', password='', secure=False)
     :param secure: Set to True to use FTP over TLS/SSL (FTPS). Defaults to False for regular FTP.
     """
     # TODO: Check if we want to join this method with download() one, based on ftp:// protocol
-    # this has been requested by some users, but the signature is a bit divergent
+    # this has been requested by some users, but the hash is a bit divergent
     import ftplib
     ftp = None
     try:

--- a/test/integration/cache/backup_sources_test.py
+++ b/test/integration/cache/backup_sources_test.py
@@ -675,7 +675,7 @@ class TestDownloadCacheBackupSources:
         self.client.save({"conanfile.py": conanfile})
         self.client.run("create .")
         assert f"Sources for {self.file_server.fake_url}/internet/myfile.txt found in remote backup {self.file_server.fake_url}/backup2/" in self.client.out
-        assert "sha256 signature failed for" in self.client.out
+        assert "sha256 hash failed for" in self.client.out
 
     def test_export_then_upload_workflow(self):
         mkdir(os.path.join(self.download_cache_folder, "s"))

--- a/test/integration/cache/download_cache_test.py
+++ b/test/integration/cache/download_cache_test.py
@@ -103,8 +103,8 @@ class TestDownloadCache:
            """ % file_server.fake_url)
         client.save({"conanfile.py": conanfile})
         client.run("source .", assert_error=True)
-        assert "ConanException: md5 signature failed for" in client.out
-        assert "Provided signature: kk" in client.out
+        assert "ConanException: md5 hash failed for" in client.out
+        assert "Provided hash: kk" in client.out
 
         # There are 2 things in the cache, not sha256, no caching
         assert 0 == len(os.listdir(tmp_folder))  # Nothing was cached

--- a/test/unittests/util/file_hashes_test.py
+++ b/test/unittests/util/file_hashes_test.py
@@ -20,11 +20,11 @@ class TestHashes:
         check_sha1(ConanFileMock(), filepath, "eb599ec83d383f0f25691c184f656d40384f9435")
         check_sha256(ConanFileMock(), filepath, "7365d029861e32c521f8089b00a6fb32daf0615025b69b599d1ce53501b845c2")
 
-        with pytest.raises(ConanException, match="md5 signature failed for 'file.txt' file."):
+        with pytest.raises(ConanException, match="md5 hash failed for 'file.txt' file."):
             check_md5(ConanFileMock(), filepath, "invalid")
 
-        with pytest.raises(ConanException, match="sha1 signature failed for 'file.txt' file."):
+        with pytest.raises(ConanException, match="sha1 hash failed for 'file.txt' file."):
             check_sha1(ConanFileMock(), filepath, "invalid")
 
-        with pytest.raises(ConanException, match="sha256 signature failed for 'file.txt' file."):
+        with pytest.raises(ConanException, match="sha256 hash failed for 'file.txt' file."):
             check_sha256(ConanFileMock(), filepath, "invalid")


### PR DESCRIPTION
Changelog: Fix: Update terminology to use “hash” instead of “signature”.
Docs: https://github.com/conan-io/docs/pull/4358

Close https://github.com/conan-io/conan/issues/19521

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [X] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
