### PR TITLE
Feature/aix c style system headers

### DIFF
--- a/conan/internal/default_settings.py
+++ b/conan/internal/default_settings.py
@@ -79,6 +79,7 @@ os:
     FreeBSD:
     SunOS:
     AIX:
+        version: ["7.1", "7.2", "7.3"]
     Arduino:
         board: [ANY]
     Emscripten:

--- a/conan/tools/cmake/cmakedeps/templates/__init__.py
+++ b/conan/tools/cmake/cmakedeps/templates/__init__.py
@@ -99,3 +99,16 @@ class CMakeDepsFileTemplate(object):
         # property because that is also an absolute name (Greetings::Greetings), it is not a namespace
         # and we don't want to split and do tricks.
         return ret or self._get_target_default_name(req, component_name=comp_name)
+
+    def _is_aix_version_le(self, major, minor):
+        """Check if AIX version is less than or equal to major.minor"""
+        try:
+            version_str = self.conanfile.settings.get_safe("os.version")
+            if not version_str:
+                return False
+            version_parts = version_str.split(".")
+            aix_major = int(version_parts[0])
+            aix_minor = int(version_parts[1]) if len(version_parts) > 1 else 0
+            return (aix_major < major) or (aix_major == major and aix_minor <= minor)
+        except (ValueError, IndexError, AttributeError):
+            return False

--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -27,6 +27,8 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
                             for components_target_name in components_targets_names]
 
         is_win = self.conanfile.settings.get_safe("os") == "Windows"
+        is_aix_gcc = (self.conanfile.settings.get_safe("os") == "AIX" and 
+                      self.conanfile.settings.get_safe("compiler") == "gcc")
         auto_link = self.cmakedeps.get_property("cmake_set_interface_link_directories",
                                                 self.conanfile, check_type=bool)
         return {"pkg_name": self.pkg_name,
@@ -36,7 +38,8 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
                 "deps_targets_names": ";".join(deps_targets_names),
                 "components_names": components_names,
                 "configuration": self.cmakedeps.configuration,
-                "set_interface_link_directories": auto_link and is_win}
+                "set_interface_link_directories": auto_link and is_win,
+                "aix_gcc_no_system_includes": is_aix_gcc}
 
     @property
     def template(self):
@@ -61,7 +64,12 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
 
         ######## Create an interface target to contain all the dependencies (frameworks, system and conan deps)
         if(NOT TARGET {{ pkg_name+'_DEPS_TARGET'}})
-            add_library({{ pkg_name+'_DEPS_TARGET'}} INTERFACE IMPORTED)
+            {% if aix_gcc_no_system_includes %}
+# using -isystem option generate error "template with C linkage"
+                add_library({{ pkg_name+'_DEPS_TARGET'}} INTERFACE)
+            {% else %}
+                add_library({{ pkg_name+'_DEPS_TARGET'}} INTERFACE IMPORTED)
+            {% endif %}
         endif()
 
         set_property(TARGET {{ pkg_name + '_DEPS_TARGET'}}
@@ -69,6 +77,11 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
                      $<$<CONFIG:{{configuration}}>:{{ pkg_var(pkg_name, 'FRAMEWORKS_FOUND', config_suffix) }}>
                      $<$<CONFIG:{{configuration}}>:{{ pkg_var(pkg_name, 'SYSTEM_LIBS', config_suffix) }}>
                      $<$<CONFIG:{{configuration}}>:{{ deps_targets_names }}>)
+        {% if aix_gcc_no_system_includes %}
+        set_property(TARGET {{ pkg_name + '_DEPS_TARGET'}}
+                     APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+                     $<$<CONFIG:{{configuration}}>:{{ pkg_var(pkg_name, 'INCLUDE_DIRS', config_suffix) }}>)
+        {% endif %}
 
         ####### Find the libraries declared in cpp_info.libs, create an IMPORTED target for each one and link the
         ####### {{pkg_name}}_DEPS_TARGET to all of them
@@ -106,9 +119,11 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
             set_property(TARGET {{root_target_name}}
                          APPEND PROPERTY INTERFACE_LINK_OPTIONS
                          $<$<CONFIG:{{configuration}}>:{{ pkg_var(pkg_name, 'LINKER_FLAGS', config_suffix) }}>)
+            {% if not aix_gcc_no_system_includes %}
             set_property(TARGET {{root_target_name}}
                          APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES
                          $<$<CONFIG:{{configuration}}>:{{ pkg_var(pkg_name, 'INCLUDE_DIRS', config_suffix) }}>)
+            {% endif %}
             # Necessary to find LINK shared libraries in Linux
             set_property(TARGET {{root_target_name}}
                          APPEND PROPERTY INTERFACE_LINK_DIRECTORIES
@@ -145,7 +160,11 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
 
                 ######## Create an interface target to contain all the dependencies (frameworks, system and conan deps)
                 if(NOT TARGET {{ pkg_name + '_' + comp_variable_name + '_DEPS_TARGET'}})
+                    {% if aix_gcc_no_system_includes %}
+                    add_library({{ pkg_name + '_' + comp_variable_name + '_DEPS_TARGET'}} INTERFACE)
+                    {% else %}
                     add_library({{ pkg_name + '_' + comp_variable_name + '_DEPS_TARGET'}} INTERFACE IMPORTED)
+                    {% endif %}
                 endif()
 
                 set_property(TARGET {{ pkg_name + '_' + comp_variable_name + '_DEPS_TARGET'}}
@@ -154,6 +173,11 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
                              $<$<CONFIG:{{configuration}}>:{{ comp_var(pkg_name, comp_variable_name, 'SYSTEM_LIBS', config_suffix) }}>
                              $<$<CONFIG:{{configuration}}>:{{ comp_var(pkg_name, comp_variable_name, 'DEPENDENCIES', config_suffix) }}>
                              )
+                {% if aix_gcc_no_system_includes %}
+                set_property(TARGET {{ pkg_name + '_' + comp_variable_name + '_DEPS_TARGET'}}
+                             APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+                             $<$<CONFIG:{{configuration}}>:{{ comp_var(pkg_name, comp_variable_name, 'INCLUDE_DIRS', config_suffix) }}>)
+                {% endif %}
 
                 ####### Find the libraries declared in cpp_info.component["xxx"].libs,
                 ####### create an IMPORTED target for each one and link the '{{pkg_name}}_{{comp_variable_name}}_DEPS_TARGET' to all of them
@@ -186,8 +210,10 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
 
                 set_property(TARGET {{ comp_target_name }} APPEND PROPERTY INTERFACE_LINK_OPTIONS
                              $<$<CONFIG:{{ configuration }}>:{{ comp_var(pkg_name, comp_variable_name, 'LINKER_FLAGS', config_suffix) }}>)
+                {% if not aix_gcc_no_system_includes %}
                 set_property(TARGET {{ comp_target_name }} APPEND PROPERTY INTERFACE_INCLUDE_DIRECTORIES
                              $<$<CONFIG:{{ configuration }}>:{{ comp_var(pkg_name, comp_variable_name, 'INCLUDE_DIRS', config_suffix) }}>)
+                {% endif %}
                 set_property(TARGET {{comp_target_name }} APPEND PROPERTY INTERFACE_LINK_DIRECTORIES
                              $<$<CONFIG:{{ configuration }}>:{{ comp_var(pkg_name, comp_variable_name, 'LIB_DIRS', config_suffix) }}>)
                 set_property(TARGET {{ comp_target_name }} APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS

--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -28,7 +28,8 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
 
         is_win = self.conanfile.settings.get_safe("os") == "Windows"
         is_aix_gcc = (self.conanfile.settings.get_safe("os") == "AIX" and 
-                      self.conanfile.settings.get_safe("compiler") == "gcc")
+                      self.conanfile.settings.get_safe("compiler") == "gcc" and
+                      self._is_aix_version_le(7, 2))
         auto_link = self.cmakedeps.get_property("cmake_set_interface_link_directories",
                                                 self.conanfile, check_type=bool)
         return {"pkg_name": self.pkg_name,


### PR DESCRIPTION
Changelog: Feature Improved AIX <7.3 support | Fix CMake templates for C style System headers

Recording change that enables me to use dependencies so far in AIX 7.2 environment.
Still hoping to upgrade to AIX 7.3 env.

Issue #18196 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
