### PR TITLE
windows atomic_replace retry

### DIFF
--- a/conan/__init__.py
+++ b/conan/__init__.py
@@ -2,5 +2,5 @@ from conan.internal.model.conan_file import ConanFile
 from conan.internal.model.workspace import Workspace
 from conan.internal.model.version import Version
 
-__version__ = '2.25.0'
+__version__ = '2.26.0-dev'
 conan_version = Version(__version__)

--- a/conan/__init__.py
+++ b/conan/__init__.py
@@ -2,5 +2,5 @@ from conan.internal.model.conan_file import ConanFile
 from conan.internal.model.workspace import Workspace
 from conan.internal.model.version import Version
 
-__version__ = '2.26.0-dev'
+__version__ = '2.25.1'
 conan_version = Version(__version__)

--- a/conan/internal/util/files.py
+++ b/conan/internal/util/files.py
@@ -10,19 +10,9 @@ import time
 
 from contextlib import contextmanager
 
-from conan.api.output import ConanOutput
 from conan.errors import ConanException
 
 _DIRTY_FOLDER = ".dirty"
-
-
-def atomic_replace(src, dst, item):
-    try:
-        os.replace(src, dst)  # ATOMIC!!!
-    except OSError as e:
-        msg = ("The os.replace() to put this item in the package storage has failed. Maybe"
-               f"there was a concurrent process that did it first.\n    Item: {item}\n    Msg: {e}")
-        ConanOutput().warning(msg)
 
 
 def set_dirty(folder):
@@ -193,6 +183,23 @@ def _change_permissions(func, path, exc_info):
 
 
 if platform.system() == "Windows":
+    def atomic_replace(src, dst, item):
+        retries = 3
+        delay = 0.5
+        for i in range(retries):
+            try:
+                os.replace(src, dst)  # ATOMIC!!!
+                return
+            except OSError as e:
+                if i == retries - 1:
+                    msg = ("The os.replace() to put this item in the package storage has failed.\n"
+                           "If you have an antivirus, try to exclude the "
+                           "Conan cache from the antivirus software."
+                           f"    Item: {item}\n    Error: {e}")
+                    raise ConanException(msg)
+                time.sleep(delay)
+
+
     def rmdir(path):
         if not os.path.isdir(path):
             return
@@ -226,6 +233,16 @@ if platform.system() == "Windows":
                                          "Close any app using it and retry.")
                 time.sleep(delay)
 else:
+    def atomic_replace(src, dst, item):
+        try:
+            os.replace(src, dst)  # ATOMIC!!!
+        except OSError as e:
+            msg = ("The os.replace() to put this item in the package storage has failed. Maybe"
+                   f"there was a concurrent process that did it first.\n"
+                   f"    Item: {item}\n    Msg: {e}")
+            raise ConanException(msg)
+
+
     def rmdir(path):
         if not os.path.isdir(path):
             return

--- a/conan/internal/util/files.py
+++ b/conan/internal/util/files.py
@@ -10,6 +10,7 @@ import time
 
 from contextlib import contextmanager
 
+from conan.api.output import ConanOutput
 from conan.errors import ConanException
 
 _DIRTY_FOLDER = ".dirty"
@@ -191,12 +192,13 @@ if platform.system() == "Windows":
                 os.replace(src, dst)  # ATOMIC!!!
                 return
             except OSError as e:
+                msg = ("The os.replace() to put this item in the package storage has failed.\n"
+                       "If you have an antivirus, try to exclude the "
+                       "Conan cache from the antivirus software."
+                       f"    Item: {item}\n    Error: {e}")
                 if i == retries - 1:
-                    msg = ("The os.replace() to put this item in the package storage has failed.\n"
-                           "If you have an antivirus, try to exclude the "
-                           "Conan cache from the antivirus software."
-                           f"    Item: {item}\n    Error: {e}")
                     raise ConanException(msg)
+                ConanOutput().warning(msg)
                 time.sleep(delay)
 
 


### PR DESCRIPTION
Changelog: Fix: Do "retry" over the ``os.replace()`` in Windows to avoid antivirus blocking issues.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19526

I have been running some tests with repeated downloads from server calling this path, with an AV enabled.

I managed to reproduce, but unfortunately only in the first iterations, after that it seems the AV learns and do not block again. Besides the code in this PR I introduced a Warning to be able to count blocking retries, and it didn't happen.
