### PR TITLE
deprecating Python 3.7

### DIFF
--- a/conan/api/conan_api.py
+++ b/conan/api/conan_api.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from conan.api.output import init_colorama
+from conan.api.output import init_colorama, ConanOutput
 from conan.api.subapi.audit import AuditAPI
 from conan.api.subapi.cache import CacheAPI
 from conan.api.subapi.command import CommandAPI
@@ -46,6 +46,9 @@ class ConanAPI:
         version = sys.version_info
         if version.major == 2 or version.minor < 7:
             raise ConanException("Conan needs Python >= 3.7")
+        if version.minor == 7:
+            ConanOutput().warning("Python 3.7 support in Conan is deprecated, please update Python",
+                                  warn_tag="deprecated")
         if cache_folder is not None and not os.path.isabs(cache_folder):
             raise ConanException("cache_folder has to be an absolute path")
 

--- a/conan/cli/printers/graph.py
+++ b/conan/cli/printers/graph.py
@@ -61,8 +61,9 @@ def print_graph_basic(graph):
 
     _format_resolved("Resolved alias", graph.aliased)
     if graph.aliased:
-        output.warning("'alias' is a Conan 1.X legacy feature, no longer recommended and "
-                       "it might be removed in 3.0.")
+        output.warning("'alias' is a Conan 1.X legacy, unsupported and undocumented feature, "
+                       "completely discouraged. "
+                       "It might be removed in future Conan versions", warn_tag="deprecated")
         output.warning("Consider using version-ranges instead.")
     _format_resolved("Resolved version ranges", graph.resolved_ranges)
     for req in graph.resolved_ranges:

--- a/test/integration/command/alias_test.py
+++ b/test/integration/command/alias_test.py
@@ -50,7 +50,7 @@ class TestConanAlias:
         client.run('remove "*" -c')
 
         client.run("install .")
-        assert "'alias' is a Conan 1.X legacy feature" in client.out
+        assert "'alias' is a Conan 1.X legacy" in client.out
         client.assert_listed_require({"hello/0.1@lasote/channel": "Downloaded (default)"})
         assert "hello/0.x@lasote/channel from" not in client.out
 


### PR DESCRIPTION
Changelog: Fix: Deprecate Python 3.7 warning for Conan.
Docs: https://github.com/conan-io/docs/pull/4381
