### PR TITLE
Add riscv64 mapping to apt & yum package manager, fixes #19559

### DIFF
--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -275,7 +275,8 @@ class Apt(_SystemPackageManagerTool):
                             "armv7": "arm",
                             "armv7hf": "armhf",
                             "armv8": "arm64",
-                            "s390x": "s390x"} if arch_names is None else arch_names
+                            "s390x": "s390x",
+                            "riscv64": "riscv64"} if arch_names is None else arch_names
 
         self._arch_separator = ":"
 
@@ -326,7 +327,8 @@ class Yum(_SystemPackageManagerTool):
                             "armv7": "armv7",
                             "armv7hf": "armv7hl",
                             "armv8": "aarch64",
-                            "s390x": "s390x"} if arch_names is None else arch_names
+                            "s390x": "s390x",
+                            "riscv64": "riscv64"} if arch_names is None else arch_names
         self._arch_separator = "."
 
 


### PR DESCRIPTION
Changelog: Bugfix: Add missing `riscv64` mappings for `yum` and `apt`.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19559

- [x] Refer to the issue that supports this Pull Request. Fixes #19559
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
_Is it needed to document this change? Didn't see a corresponding place when I browsed through it._

Did run tests related to package_manager, however even with develop2 no failure happening (after installing sudo into the container.) So both before and after the change:
```
pytest test/functional/tools/system/package_manager_test.py
========================================================= test session starts =========================================================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.6.0
rootdir: /conan
configfile: pytest.ini
plugins: xdist-3.8.0, cov-7.0.0
collected 7 items                                                                                                                     

test/functional/tools/system/package_manager_test.py ...sss.                                                                    [100%]

=============================================== 4 passed, 3 skipped in 99.13s (0:01:39) ===============================================
```
```
pytest test/integration/tools/system/package_manager_test.py
========================================================= test session starts =========================================================
platform linux -- Python 3.12.3, pytest-7.4.4, pluggy-1.6.0
rootdir: /conan
configfile: pytest.ini
plugins: xdist-3.8.0, cov-7.0.0
collected 163 items                                                                                                                   

test/integration/tools/system/package_manager_test.py ....s.................................................................... [ 44%]
..........................................................................................                                      [100%]

=================================================== 162 passed, 1 skipped in 4.52s ====================================================

```

But reruning the command that lead to my bug report, it did pass:
```
root@9aa6fa1776d0:~# conan install --requires=glfw/3.4 --build=missing

======== Input profiles ========
Profile host:
[settings]
arch=riscv64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=13
os=Linux

Profile build:
[settings]
arch=riscv64
build_type=Release
compiler=gcc
compiler.cppstd=gnu17
compiler.libcxx=libstdc++11
compiler.version=13
os=Linux


======== Computing dependency graph ========
Graph root
    cli
Requirements
    glfw/3.4#41cc24c744dc4c80571f5dd10dcd9cda - Cache
    opengl/system#cfcf523b9d2bad75cbf377f56562634c - Cache
    xorg/system#98f82cb669e4ebc6b4d9d8a4f3f1faf4 - Cache

======== Computing necessary packages ========
Connecting to remote 'conancenter' anonymously
Requirements
    glfw/3.4#41cc24c744dc4c80571f5dd10dcd9cda:5a949e16d5f85ab3d2b290695e5d58d378e422ec - Build
    opengl/system#cfcf523b9d2bad75cbf377f56562634c:da39a3ee5e6b4b0d3255bfef95601890afd80709#0ba8627bd47edc3a501e8f0eb9a79e5e - Download (conancenter)
    xorg/system#98f82cb669e4ebc6b4d9d8a4f3f1faf4:da39a3ee5e6b4b0d3255bfef95601890afd80709#0ba8627bd47edc3a501e8f0eb9a79e5e - Download (conancenter)
opengl/system: System requirements: libgl-dev already installed
xorg/system: System requirements: libx11-dev libx11-xcb-dev libfontenc-dev libice-dev libsm-dev libxau-dev libxaw7-dev libxcomposite-dev libxcursor-dev libxdamage-dev libxdmcp-dev libxext-dev libxfixes-dev libxi-dev libxinerama-dev libxkbfile-dev libxmu-dev libxmuu-dev libxpm-dev libxrandr-dev libxrender-dev libxres-dev libxss-dev libxt-dev libxtst-dev libxv-dev libxxf86vm-dev libxcb-glx0-dev libxcb-render0-dev libxcb-render-util0-dev libxcb-xkb-dev libxcb-icccm4-dev libxcb-image0-dev libxcb-keysyms1-dev libxcb-randr0-dev libxcb-shape0-dev libxcb-sync-dev libxcb-xfixes0-dev libxcb-xinerama0-dev libxcb-dri3-dev uuid-dev libxcb-cursor-dev libxcb-dri2-0-dev libxcb-dri3-dev libxcb-present-dev libxcb-composite0-dev libxcb-ewmh-dev libxcb-res0-dev already installed
xorg/system: System requirements: libxcb-util-dev already installed

======== Installing packages ========

-------- Downloading 2 packages --------
Downloading binary packages in 8 parallel threads
xorg/system: Retrieving package da39a3ee5e6b4b0d3255bfef95601890afd80709 from remote 'conancenter' 
opengl/system: Retrieving package da39a3ee5e6b4b0d3255bfef95601890afd80709 from remote 'conancenter' 
xorg/system: Package installed da39a3ee5e6b4b0d3255bfef95601890afd80709
xorg/system: Downloaded package revision 0ba8627bd47edc3a501e8f0eb9a79e5e
opengl/system: Package installed da39a3ee5e6b4b0d3255bfef95601890afd80709
opengl/system: Downloaded package revision 0ba8627bd47edc3a501e8f0eb9a79e5e
glfw/3.4: Sources downloaded from 'conancenter'
glfw/3.4: Calling source() in /root/.conan2/p/glfwe704f140af55b/s/src
glfw/3.4: Uncompressing glfw-3.4.zip to .
glfw/3.4: Unzipping 7.9MB, this can take a while


-------- Installing package glfw/3.4 (3 of 3) --------
glfw/3.4: Building from source
glfw/3.4: Package glfw/3.4:5a949e16d5f85ab3d2b290695e5d58d378e422ec
glfw/3.4: settings: os=Linux arch=riscv64 compiler=gcc compiler.version=13 build_type=Release
glfw/3.4: options: fPIC=True shared=False with_wayland=False with_x11=True
glfw/3.4: requires: opengl/system xorg/system
glfw/3.4: Copying sources to build folder
glfw/3.4: Building your package in /root/.conan2/p/b/glfw77ee428f291b1/b
glfw/3.4: Calling generate()
glfw/3.4: Generators folder: /root/.conan2/p/b/glfw77ee428f291b1/b/build/Release/generators
glfw/3.4: CMakeToolchain generated: conan_toolchain.cmake
glfw/3.4: CMakeToolchain generated: /root/.conan2/p/b/glfw77ee428f291b1/b/build/Release/generators/CMakePresets.json
glfw/3.4: CMakeToolchain generated: /root/.conan2/p/b/glfw77ee428f291b1/b/src/CMakeUserPresets.json
glfw/3.4: CMakeDeps necessary find_package() and targets for your CMakeLists.txt
    find_package(opengl_system)
    find_package(xorg)
    target_link_libraries(... opengl::opengl xorg::xorg)
glfw/3.4: Generating aggregated env files
glfw/3.4: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
glfw/3.4: Calling build()
glfw/3.4: apply_conandata_patches(): No patches defined in conandata
glfw/3.4: Running CMake.configure()
glfw/3.4: RUN: cmake -G "Unix Makefiles" -DCMAKE_TOOLCHAIN_FILE="generators/conan_toolchain.cmake" -DCMAKE_INSTALL_PREFIX="/root/.conan2/p/b/glfw77ee428f291b1/p" -DGLFW_BUILD_DOCS="OFF" -DGLFW_BUILD_EXAMPLES="OFF" -DGLFW_BUILD_TESTS="OFF" -DGLFW_INSTALL="ON" -DGLFW_BUILD_X11="ON" -DGLFW_BUILD_WAYLAND="OFF" -DCMAKE_POLICY_DEFAULT_CMP0091="NEW" -DCMAKE_BUILD_TYPE="Release" "/root/.conan2/p/b/glfw77ee428f291b1/b/src"
-- Using Conan toolchain: /root/.conan2/p/b/glfw77ee428f291b1/b/build/Release/generators/conan_toolchain.cmake
-- Conan toolchain: Setting CMAKE_POSITION_INDEPENDENT_CODE=ON (options.fPIC)
-- Conan toolchain: Setting BUILD_SHARED_LIBS = OFF
-- The C compiler identification is GNU 13.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- Including X11 support
-- Found X11: /usr/include   
-- Looking for XOpenDisplay in /usr/lib/riscv64-linux-gnu/libX11.so;/usr/lib/riscv64-linux-gnu/libXext.so
-- Looking for XOpenDisplay in /usr/lib/riscv64-linux-gnu/libX11.so;/usr/lib/riscv64-linux-gnu/libXext.so - found
-- Looking for gethostbyname
-- Looking for gethostbyname - found
-- Looking for connect
-- Looking for connect - found
-- Looking for remove
-- Looking for remove - found
-- Looking for shmat
-- Looking for shmat - found
-- Looking for IceConnectionNumber in ICE
-- Looking for IceConnectionNumber in ICE - found
-- Configuring done (6.2s)
-- Generating done (0.1s)
-- Build files have been written to: /root/.conan2/p/b/glfw77ee428f291b1/b/build/Release

glfw/3.4: Running CMake.build()
glfw/3.4: RUN: cmake --build "/root/.conan2/p/b/glfw77ee428f291b1/b/build/Release" -- -j8
[  8%] Building C object src/CMakeFiles/glfw.dir/init.c.o
[  8%] Building C object src/CMakeFiles/glfw.dir/context.c.o
[ 16%] Building C object src/CMakeFiles/glfw.dir/monitor.c.o
[ 16%] Building C object src/CMakeFiles/glfw.dir/input.c.o
[ 25%] Building C object src/CMakeFiles/glfw.dir/vulkan.c.o
[ 25%] Building C object src/CMakeFiles/glfw.dir/platform.c.o
[ 29%] Building C object src/CMakeFiles/glfw.dir/window.c.o
[ 33%] Building C object src/CMakeFiles/glfw.dir/egl_context.c.o
[ 37%] Building C object src/CMakeFiles/glfw.dir/osmesa_context.c.o
[ 41%] Building C object src/CMakeFiles/glfw.dir/null_init.c.o
[ 45%] Building C object src/CMakeFiles/glfw.dir/null_monitor.c.o
[ 50%] Building C object src/CMakeFiles/glfw.dir/null_window.c.o
[ 54%] Building C object src/CMakeFiles/glfw.dir/null_joystick.c.o
[ 58%] Building C object src/CMakeFiles/glfw.dir/posix_module.c.o
[ 62%] Building C object src/CMakeFiles/glfw.dir/posix_time.c.o
[ 66%] Building C object src/CMakeFiles/glfw.dir/posix_thread.c.o
[ 70%] Building C object src/CMakeFiles/glfw.dir/x11_init.c.o
[ 75%] Building C object src/CMakeFiles/glfw.dir/x11_monitor.c.o
[ 79%] Building C object src/CMakeFiles/glfw.dir/x11_window.c.o
[ 83%] Building C object src/CMakeFiles/glfw.dir/xkb_unicode.c.o
[ 87%] Building C object src/CMakeFiles/glfw.dir/glx_context.c.o
[ 91%] Building C object src/CMakeFiles/glfw.dir/linux_joystick.c.o
[ 95%] Building C object src/CMakeFiles/glfw.dir/posix_poll.c.o
[100%] Linking C static library libglfw3.a
[100%] Built target glfw

glfw/3.4: Package '5a949e16d5f85ab3d2b290695e5d58d378e422ec' built
glfw/3.4: Build folder /root/.conan2/p/b/glfw77ee428f291b1/b/build/Release
glfw/3.4: Generating the package
glfw/3.4: Packaging in folder /root/.conan2/p/b/glfw77ee428f291b1/p
glfw/3.4: Calling package()
glfw/3.4: Running CMake.install()
glfw/3.4: RUN: cmake --install "/root/.conan2/p/b/glfw77ee428f291b1/b/build/Release" --prefix "/root/.conan2/p/b/glfw77ee428f291b1/p"
-- Install configuration: "Release"
-- Installing: /root/.conan2/p/b/glfw77ee428f291b1/p/lib/libglfw3.a
-- Installing: /root/.conan2/p/b/glfw77ee428f291b1/p/include/GLFW
-- Installing: /root/.conan2/p/b/glfw77ee428f291b1/p/include/GLFW/glfw3.h
-- Installing: /root/.conan2/p/b/glfw77ee428f291b1/p/include/GLFW/glfw3native.h
-- Installing: /root/.conan2/p/b/glfw77ee428f291b1/p/lib/cmake/glfw3/glfw3Config.cmake
-- Installing: /root/.conan2/p/b/glfw77ee428f291b1/p/lib/cmake/glfw3/glfw3ConfigVersion.cmake
-- Installing: /root/.conan2/p/b/glfw77ee428f291b1/p/lib/cmake/glfw3/glfw3Targets.cmake
-- Installing: /root/.conan2/p/b/glfw77ee428f291b1/p/lib/cmake/glfw3/glfw3Targets-release.cmake
-- Installing: /root/.conan2/p/b/glfw77ee428f291b1/p/lib/pkgconfig/glfw3.pc

glfw/3.4: package(): Packaged 1 '.md' file: LICENSE.md
glfw/3.4: package(): Packaged 1 '.a' file: libglfw3.a
glfw/3.4: package(): Packaged 1 '.cmake' file: conan-official-glfw-targets.cmake
glfw/3.4: package(): Packaged 2 '.h' files: glfw3.h, glfw3native.h
glfw/3.4: Created package revision 65189284415aeb74929cdab79fb1fea9
glfw/3.4: Package '5a949e16d5f85ab3d2b290695e5d58d378e422ec' created
glfw/3.4: Full package reference: glfw/3.4#41cc24c744dc4c80571f5dd10dcd9cda:5a949e16d5f85ab3d2b290695e5d58d378e422ec#65189284415aeb74929cdab79fb1fea9
glfw/3.4: Package folder /root/.conan2/p/b/glfw77ee428f291b1/p
WARN: deprecated: Usage of deprecated Conan 1.X features that will be removed in Conan 2.X:
WARN: deprecated:     'cpp_info.filenames' used in: opengl/system

======== Finalizing install (deploy, generators) ========
cli: Generating aggregated env files
cli: Generated aggregated env files: ['conanbuild.sh', 'conanrun.sh']
Install finished successfully
```