### PR TITLE
revert atomic os.replace due to antivirus Win issues

### DIFF
--- a/conan/__init__.py
+++ b/conan/__init__.py
@@ -2,5 +2,5 @@ from conan.internal.model.conan_file import ConanFile
 from conan.internal.model.workspace import Workspace
 from conan.internal.model.version import Version
 
-__version__ = '2.25.1'
+__version__ = '2.25.2'
 conan_version = Version(__version__)

--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -210,11 +210,6 @@ class CacheAPI:
                     if not os.path.exists(manifest) or not os.path.exists(info):
                         rmdir(folder)
 
-        # Temporary name (not named) until we have clarity if this is the same as the "t"
-        # temporary (for exports) or not
-        if os.path.exists(os.path.join(cache.store, "d")):
-            rmdir(os.path.join(cache.store, "d"))
-
         if backup_sources:
             backup_files = self._conan_api.cache.get_backup_sources(package_list, exclude=False,
                                                                     only_upload=False)

--- a/conan/internal/cache/cache.py
+++ b/conan/internal/cache/cache.py
@@ -15,7 +15,7 @@ from conan.errors import ConanException
 from conan.api.model import PkgReference
 from conan.api.model import RecipeReference
 from conan.internal.util.dates import revision_timestamp_now
-from conan.internal.util.files import rmdir, renamedir, mkdir, atomic_replace
+from conan.internal.util.files import rmdir, renamedir, mkdir
 
 
 class PkgCache:
@@ -183,6 +183,7 @@ class PkgCache:
 
     def create_pkg_layout(self, pref: PkgReference):
         """ called by:
+         - RemoteManager.get_package()
          - cache restore
         """
         assert pref.ref.revision, "Recipe revision must be known to create the package layout"
@@ -192,23 +193,6 @@ class PkgCache:
         self._db.create_package(package_path, pref, None)
         self._create_path(package_path, remove_contents=False)
         return PackageLayout(pref, os.path.join(self._base_folder, package_path))
-
-    def get_random_path(self):
-        random_id = str(uuid.uuid4())
-        # d=downloading area. Using short hashes to avoid lengthy paths with hyphens
-        return os.path.join(self._base_folder, "d", self._short_hash_path(random_id))
-
-    def create_atomic_pkg_layout(self, pref: PkgReference, current_folder):
-        """ called by:
-         - RemoteManager.get_package()
-        """
-        assert pref.ref.revision, "Recipe revision must be known to create the package layout"
-        assert pref.package_id, "Package id must be known to create the package layout"
-        assert pref.revision, "Package revision should be known to create the package layout"
-        package_path = self._get_path_pref(pref)
-        path = self._full_path(package_path)
-        atomic_replace(current_folder, path, f"{pref.repr_notime()} package")
-        self._db.create_package(package_path, pref, None)
 
     def update_recipe_timestamp(self, ref: RecipeReference):
         """ when the recipe already exists in cache, but we get a new timestamp from a server

--- a/conan/internal/rest/remote_manager.py
+++ b/conan/internal/rest/remote_manager.py
@@ -144,10 +144,10 @@ class RemoteManager:
 
         assert pref.revision is not None
 
-        pkg_layout = PackageLayout(pref, self._cache.get_random_path())
-        mkdir(pkg_layout.metadata())
-        self._get_package(pkg_layout, pref, remote, output, metadata)
-        self._cache.create_atomic_pkg_layout(pref, pkg_layout.base_folder)
+        pkg_layout = self._cache.create_pkg_layout(pref)
+        with pkg_layout.set_dirty_context_manager():
+            mkdir(pkg_layout.metadata())
+            self._get_package(pkg_layout, pref, remote, output, metadata)
 
     def get_package_metadata(self, pref, remote, metadata):
         """

--- a/conan/internal/util/files.py
+++ b/conan/internal/util/files.py
@@ -184,24 +184,6 @@ def _change_permissions(func, path, exc_info):
 
 
 if platform.system() == "Windows":
-    def atomic_replace(src, dst, item):
-        retries = 3
-        delay = 0.5
-        for i in range(retries):
-            try:
-                os.replace(src, dst)  # ATOMIC!!!
-                return
-            except OSError as e:
-                msg = ("The os.replace() to put this item in the package storage has failed.\n"
-                       "If you have an antivirus, try to exclude the "
-                       "Conan cache from the antivirus software."
-                       f"    Item: {item}\n    Error: {e}")
-                if i == retries - 1:
-                    raise ConanException(msg)
-                ConanOutput().warning(msg)
-                time.sleep(delay)
-
-
     def rmdir(path):
         if not os.path.isdir(path):
             return
@@ -235,16 +217,6 @@ if platform.system() == "Windows":
                                          "Close any app using it and retry.")
                 time.sleep(delay)
 else:
-    def atomic_replace(src, dst, item):
-        try:
-            os.replace(src, dst)  # ATOMIC!!!
-        except OSError as e:
-            msg = ("The os.replace() to put this item in the package storage has failed. Maybe"
-                   f"there was a concurrent process that did it first.\n"
-                   f"    Item: {item}\n    Msg: {e}")
-            raise ConanException(msg)
-
-
     def rmdir(path):
         if not os.path.isdir(path):
             return


### PR DESCRIPTION
Changelog: Fix: Revert atomic ``os.replace`` for package binary downloads due to antivirus Windows issues.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19552