### PR TITLE
fix internal copy of [buildenv]

### DIFF
--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -212,8 +212,7 @@ class Environment:
 
     def copy(self):
         e = Environment()
-        # TODO: Check this, the internal list is not being copied
-        e._values = self._values.copy()
+        e._values = {k: v.copy() for k, v in self._values.items()}
         return e
 
     def __repr__(self):

--- a/test/integration/environment/test_buildenv_profile.py
+++ b/test/integration/environment/test_buildenv_profile.py
@@ -149,3 +149,35 @@ def test_buildenv_error_unset():
     env = c.load("conanbuildenv.sh")
     assert "unset CLASSPATH" in env
     assert 'export OTHERPATH=""' in env
+
+
+def test_buildenv_priority_copy():
+    # https://github.com/conan-io/conan/issues/19570
+    c = TestClient()
+    profile = textwrap.dedent("""
+        [buildenv]
+        alib/*:CUSTOM_PATH=+(path)/only_alib
+        CUSTOM_PATH=+(path)/common
+        """)
+    lib = textwrap.dedent("""
+        from conan import ConanFile
+        class AlibConan(ConanFile):
+            version = "1.0"
+
+            def build(self):
+                v = self.buildenv.vars(self).get("CUSTOM_PATH")
+                self.output.info(f"[{self.name}] CUSTOM_PATH={v}!!!")
+        """)
+    conanfile_txt = textwrap.dedent("""
+        [requires]
+        alib/1.0
+        blib/1.0
+        """)
+    c.save({"lib/conanfile.py": lib,
+            "conanfile.txt": conanfile_txt,
+            "profile": profile})
+    c.run("export lib --name=alib")
+    c.run("export lib --name=blib")
+    c.run("install . -pr=profile -s os=Windows --build=missing")
+    assert "alib/1.0: [alib] CUSTOM_PATH=/common;/only_alib!!!" in c.out
+    assert "blib/1.0: [blib] CUSTOM_PATH=/common!!!" in c.out

--- a/test/integration/environment/test_buildenv_profile.py
+++ b/test/integration/environment/test_buildenv_profile.py
@@ -1,3 +1,4 @@
+import os
 import textwrap
 
 import pytest
@@ -179,5 +180,5 @@ def test_buildenv_priority_copy():
     c.run("export lib --name=alib")
     c.run("export lib --name=blib")
     c.run("install . -pr=profile -s os=Windows --build=missing")
-    assert "alib/1.0: [alib] CUSTOM_PATH=/common;/only_alib!!!" in c.out
+    assert f"alib/1.0: [alib] CUSTOM_PATH=/common{os.pathsep}/only_alib!!!" in c.out
     assert "blib/1.0: [blib] CUSTOM_PATH=/common!!!" in c.out


### PR DESCRIPTION
Changelog: Bugfix: Fix corruption of `[buildenv]` information when using per-package patterns across multiple packages.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19570
