### PR TITLE
Keep `ordered_dict` behaviour of environment values when copying

### DIFF
--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -212,7 +212,8 @@ class Environment:
 
     def copy(self):
         e = Environment()
-        e._values = {k: v.copy() for k, v in self._values.items()}
+        for k, v in self._values.items():
+            e._values[k] = v.copy()
         return e
 
     def __repr__(self):


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

When copying an environment, the fix introduced in https://github.com/conan-io/conan/pull/19571 broke iteration order of values, which made 3.7 develop2 unittest break.

Reversing dict key/values is only supported from 3.8 onwards, even if 3.7 implemented dict ordering.