### PR TITLE
poc of using filesystem folders mtime for LRU

### DIFF
--- a/conan/internal/cache/cache.py
+++ b/conan/internal/cache/cache.py
@@ -301,16 +301,17 @@ class PkgCache:
             self._db.update_recipe_timestamp(ref)
 
     def get_recipe_lru(self, ref):
-        return self._db.get_recipe_lru(ref)
+        path = self._full_path(self._get_path(ref))
+        return os.path.getmtime(path)  # seconds since EPOCH
 
     def update_recipes_lru(self, refs):
-        self._db.update_recipes_lru(refs)
+        for r in refs:
+            path = self._full_path(self._get_path(r))
+            os.utime(path, None)
 
     def get_package_lru(self, pref):
-        return self._db.get_package_lru(pref)
-
-    def update_packages_lru(self, prefs):
-        self._db.update_packages_lru(prefs)
+        layout = self.pkg_layout(pref)  # It can be a build folder too
+        return os.path.getmtime(layout.base_folder)  # seconds since EPOCH
 
     def path_to_ref(self, path):
         try:

--- a/conan/internal/cache/db/cache_database.py
+++ b/conan/internal/cache/db/cache_database.py
@@ -40,18 +40,6 @@ class CacheDatabase:
     def update_package_timestamp(self, pref: PkgReference, path: str, build_id: str):
         self._packages.update_timestamp(pref, path=path, build_id=build_id)
 
-    def get_recipe_lru(self, ref):
-        return self._recipes.get_recipe(ref)["lru"]
-
-    def get_package_lru(self, pref: PkgReference):
-        return self._packages.get(pref)["lru"]
-
-    def update_recipes_lru(self, refs):
-        self._recipes.update_lru(refs)
-
-    def update_packages_lru(self, prefs):
-        self._packages.update_lru(prefs)
-
     def remove_recipe(self, ref: RecipeReference):
         # Removing the recipe must remove all the package binaries too from DB
         self._recipes.remove(ref)

--- a/conan/internal/cache/db/packages_table.py
+++ b/conan/internal/cache/db/packages_table.py
@@ -100,20 +100,6 @@ class PackagesDBTable(BaseDbTable):
             except sqlite3.IntegrityError:
                 raise ConanReferenceAlreadyExistsInDB(f"Reference '{repr(pref)}' already exists")
 
-    def update_lru(self, prefs):
-        # TODO: InstallGraph is dropping the pref.timestamp, cannot be checked here yet
-        # assert pref.timestamp is not None, f"PREF _TIMESSTAMP IS NONE {repr(pref)}"
-        params = [(str(pref.ref), pref.ref.revision, pref.package_id, pref.revision)
-                  for pref in prefs]
-        where_clause = (f"{self.columns.reference} = ? AND {self.columns.rrev} = ? "
-                        f"AND {self.columns.pkgid} = ? AND {self.columns.prev} = ?")
-        lru = timestamp_now()
-        query = f"UPDATE {self.table_name} " \
-                f"SET {self.columns.lru} = '{lru}' " \
-                f"WHERE {where_clause};"
-        with self.db_connection() as conn:
-            conn.executemany(query, params)
-
     def remove_build_id(self, pref):
         where_clause = self._where_clause(pref)
         query = f"UPDATE {self.table_name} " \

--- a/conan/internal/cache/db/recipes_table.py
+++ b/conan/internal/cache/db/recipes_table.py
@@ -60,16 +60,6 @@ class RecipesDBTable(BaseDbTable):
         with self.db_connection() as conn:
             conn.execute(query)
 
-    def update_lru(self, refs):
-        params = [(str(ref), ref.revision) for ref in refs]
-        where_clause = f"{self.columns.reference} = ? AND {self.columns.rrev} = ?"
-        lru = timestamp_now()
-        query = f"UPDATE {self.table_name} " \
-                f"SET {self.columns.lru} = '{lru}' " \
-                f"WHERE {where_clause};"
-        with self.db_connection() as conn:
-            conn.executemany(query, params)
-
     def remove(self, ref: RecipeReference):
         where_clause = self._where_clause(ref)
         query = f"DELETE FROM {self.table_name} " \

--- a/conan/internal/graph/installer.py
+++ b/conan/internal/graph/installer.py
@@ -251,7 +251,6 @@ class BinaryInstaller:
         handled_count = 1
 
         self._download_bulk(install_order)
-        prefs_lru = []
         for level in install_order:
             for install_reference in level:
                 for package in install_reference.packages.values():
@@ -259,10 +258,6 @@ class BinaryInstaller:
                     self._handle_package(recipe_layout, package, install_reference, handled_count,
                                          package_count)
                     handled_count += 1
-                    if package.binary == BINARY_CACHE:
-                        prefs_lru.append(package.nodes[0].pref)
-
-        self._cache.update_packages_lru(prefs_lru)
 
         MockInfoProperty.message()
 
@@ -336,6 +331,7 @@ class BinaryInstaller:
                 assert node.prev, "PREV for %s is None" % str(pref)
                 msg = f'Already installed! ({handled_count} of {total_count})'
                 node.conanfile.output.success(msg)
+                os.utime(package_layout.base_folder, None)
 
         # Make sure that all nodes with same pref compute package_info()
         pkg_folder = package_layout.package()


### PR DESCRIPTION
Changelog: Feature: Optimize LRU database updates by using filesystem folder mtimes.
Docs: Omit

For https://github.com/conan-io/conan/issues/19181


Reporting some results: In an small-medium dependency graph of 80 packages, the DB operations take approx 1 second each (1 second to update the recipes LRU, 1 second to update the package binaries LRU).
The total time for doing just a graph computation when everything is already in the cache was around 7 seconds, with the new approach it goes down to 5 seconds, as the filesystem-based LRU is extremely fast.


I am leaving all the LRU columns in the DB, no planning a migration to simplify it, it doesn't harm the extra column, even if unused, and lets avoid the pain of a DB migration.