### PR TITLE
Add detect_api.detect_emcc_compiler

### DIFF
--- a/conan/internal/api/detect/detect_api.py
+++ b/conan/internal/api/detect/detect_api.py
@@ -615,6 +615,24 @@ def detect_cl_compiler(compiler_exe="cl"):
         return None, None, None
 
 
+def detect_emcc_compiler(compiler_exe="emcc"):
+    try:
+        ret, out = detect_runner(f'"{compiler_exe}" --version')
+        if ret != 0:
+            return None, None, None
+        first_line = out.splitlines()[0]
+        if "Emscripten" not in first_line:
+            return None, None, None
+        compiler = "emcc"
+        version_match = re.search(r"[0-9]+\.[0-9]+\.[0-9]+", first_line)
+        if version_match:
+            version = version_match.group()
+            ConanOutput(scope="detect_api").info("Found %s %s" % (compiler, version))
+            return compiler, Version(version), compiler_exe
+    except (Exception,):  # to disable broad-except
+        return None, None, None
+
+
 def default_compiler_version(compiler, version):
     """ returns the default version that Conan uses in profiles, typically dropping some
     of the minor or patch digits, that do not affect binary compatibility

--- a/test/unittests/util/detect_test.py
+++ b/test/unittests/util/detect_test.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from conan.internal.api.detect.detect_api import detect_suncc_compiler, \
-    detect_intel_compiler, detect_default_compiler
+    detect_intel_compiler, detect_emcc_compiler, detect_default_compiler
 from conan.internal.api.profile.detect import detect_defaults_settings
 from conan.internal.model.version import Version
 from conan.test.utils.mocks import RedirectedTestOutput
@@ -88,6 +88,7 @@ def test_detect_cc_versioning(detect_runner_mock, version_return, expected_versi
 @pytest.mark.parametrize("function,version_return,expected_version", [
     [detect_suncc_compiler, "Sun C 5.13", ('sun-cc', Version("5.13"), 'cc')],
     [detect_intel_compiler, "Intel C++ Compiler 2025.0", ('intel-cc', Version("2025.0"), 'icx')],
+    [detect_emcc_compiler, "emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) 4.0.22 (0f3d2e62bccf8e14497ff19e05a1202c51eb0c65)", ('emcc', Version("4.0.22"), 'emcc')],
 ])
 def test_detect_compiler(function, version_return, expected_version):
     """

--- a/test/unittests/util/detect_test.py
+++ b/test/unittests/util/detect_test.py
@@ -88,7 +88,9 @@ def test_detect_cc_versioning(detect_runner_mock, version_return, expected_versi
 @pytest.mark.parametrize("function,version_return,expected_version", [
     [detect_suncc_compiler, "Sun C 5.13", ('sun-cc', Version("5.13"), 'cc')],
     [detect_intel_compiler, "Intel C++ Compiler 2025.0", ('intel-cc', Version("2025.0"), 'icx')],
-    [detect_emcc_compiler, "emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) 4.0.22 (0f3d2e62bccf8e14497ff19e05a1202c51eb0c65)", ('emcc', Version("4.0.22"), 'emcc')],
+    [detect_emcc_compiler,
+     "emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) 4.0.22 (0f3d2e62bccf8e14497ff19e05a1202c51eb0c65)",
+     ('emcc', Version("4.0.22"), 'emcc')],
 ])
 def test_detect_compiler(function, version_return, expected_version):
     """


### PR DESCRIPTION
Changelog: Feature: Add `detect_api.detect_emcc_compiler` to detect EMSDK Emscripten compiler version.
Docs: https://github.com/conan-io/docs/pull/4367

Fixes #19590

- [x] Refer to the issue that supports this Pull Request.
- ~~If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.~~
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ~~``develop``~~ `develop2` branch, documenting this one.
