### PR TITLE
Don't check for user/channel match in `<host_version>`

### DIFF
--- a/conan/internal/graph/graph_builder.py
+++ b/conan/internal/graph/graph_builder.py
@@ -372,7 +372,6 @@ class DepsGraphBuilder:
             if transitive is None:
                 raise ConanException(f"{node.ref} require '{ref}': didn't find a matching "
                                      "host dependency")
-            # Don't copy name/revision, they might be pointing to a different package
             require.ref.version = transitive.require.ref.version
 
     def _create_new_node(self, node, require, graph, profile_host, profile_build, graph_lock):

--- a/conan/internal/graph/graph_builder.py
+++ b/conan/internal/graph/graph_builder.py
@@ -374,8 +374,6 @@ class DepsGraphBuilder:
                                      "host dependency")
             # Don't copy name/revision, they might be pointing to a different package
             require.ref.version = transitive.require.ref.version
-            require.ref.user = transitive.require.ref.user
-            require.ref.channel = transitive.require.ref.channel
 
     def _create_new_node(self, node, require, graph, profile_host, profile_build, graph_lock):
         resolved = self._resolved_system(node, require, profile_build, profile_host,

--- a/conan/internal/graph/graph_builder.py
+++ b/conan/internal/graph/graph_builder.py
@@ -372,9 +372,10 @@ class DepsGraphBuilder:
             if transitive is None:
                 raise ConanException(f"{node.ref} require '{ref}': didn't find a matching "
                                      "host dependency")
-            name = require.ref.name
-            require.ref = transitive.require.ref.copy()
-            require.ref.name = name
+            # Don't copy name/revision, they might be pointing to a different package
+            require.ref.version = transitive.require.ref.version
+            require.ref.user = transitive.require.ref.user
+            require.ref.channel = transitive.require.ref.channel
 
     def _create_new_node(self, node, require, graph, profile_host, profile_build, graph_lock):
         resolved = self._resolved_system(node, require, profile_build, profile_host,

--- a/conan/internal/graph/graph_builder.py
+++ b/conan/internal/graph/graph_builder.py
@@ -369,11 +369,10 @@ class DepsGraphBuilder:
                 ref.name = tracking_ref[1][:-1]  # Remove the trailing >
             req = Requirement(ref, headers=True, libs=True, visible=True)
             transitive = node.transitive_deps.get(req)
-            if transitive is None or transitive.require.ref.user != ref.user \
-                    or transitive.require.ref.channel != ref.channel:
+            if transitive is None:
                 raise ConanException(f"{node.ref} require '{ref}': didn't find a matching "
                                      "host dependency")
-            require.ref.version = transitive.require.ref.version
+            require.ref = transitive.require.ref.copy()
 
     def _create_new_node(self, node, require, graph, profile_host, profile_build, graph_lock):
         resolved = self._resolved_system(node, require, profile_build, profile_host,

--- a/conan/internal/graph/graph_builder.py
+++ b/conan/internal/graph/graph_builder.py
@@ -372,7 +372,9 @@ class DepsGraphBuilder:
             if transitive is None:
                 raise ConanException(f"{node.ref} require '{ref}': didn't find a matching "
                                      "host dependency")
+            name = require.ref.name
             require.ref = transitive.require.ref.copy()
+            require.ref.name = name
 
     def _create_new_node(self, node, require, graph, profile_host, profile_build, graph_lock):
         resolved = self._resolved_system(node, require, profile_build, profile_host,

--- a/test/integration/build_requires/build_requires_test.py
+++ b/test/integration/build_requires/build_requires_test.py
@@ -508,7 +508,6 @@ class TestBuildTrackHost:
         c.assert_listed_require({"protobuf/1.1": "Cache"}, build=True)
 
     @pytest.mark.parametrize("host_version, assert_error, assert_msg", [
-        # Ensure we keep the original library, even if we take the version, user and channel,
         ("libgettext>", False, "gettext/0.2#d9f9eaeac9b6e403b271f04e04149df2"),
         # Error cases, just checking that we fail gracefully - no tracebacks
         ("libgettext", True, "Package 'gettext/<host_version:libgettext' not resolved"),

--- a/test/integration/build_requires/build_requires_test.py
+++ b/test/integration/build_requires/build_requires_test.py
@@ -539,13 +539,14 @@ class TestBuildTrackHost:
         Make the tool_requires follow the regular require with the expression "<host_version>"
         """
         c = TestClient(light=True)
+        user_channel_reference = f"@{requires_tag}" if requires_tag else ""
         pkg = textwrap.dedent(f"""
             from conan import ConanFile
             class ProtoBuf(ConanFile):
                 name = "pkg"
                 version = "0.1"
                 def requirements(self):
-                    self.requires("protobuf/1.0@{requires_tag}")
+                    self.requires("protobuf/1.0{user_channel_reference}")
                 def build_requirements(self):
                     self.tool_requires("protobuf/<host_version>@{tool_requires_tag}")
             """)
@@ -559,8 +560,8 @@ class TestBuildTrackHost:
         c.run(f"create protobuf --version=1.0 {user_channel}")
 
         c.run("create pkg")
-        c.assert_listed_require({f"protobuf/1.0@{requires_tag}": "Cache"})
-        c.assert_listed_require({f"protobuf/1.0@{requires_tag}": "Cache"}, build=True)
+        c.assert_listed_require({f"protobuf/1.0{user_channel_reference}": "Cache"})
+        c.assert_listed_require({f"protobuf/1.0{user_channel_reference}": "Cache"}, build=True)
 
     @pytest.mark.parametrize("shared", [True, False])
     def test_host_version_transitive_contexts(self, shared):

--- a/test/integration/build_requires/build_requires_test.py
+++ b/test/integration/build_requires/build_requires_test.py
@@ -508,6 +508,7 @@ class TestBuildTrackHost:
         c.assert_listed_require({"protobuf/1.1": "Cache"}, build=True)
 
     @pytest.mark.parametrize("host_version, assert_error, assert_msg", [
+        # Ensure we keep the original library, even if we take the version, user and channel,
         ("libgettext>", False, "gettext/0.2#d9f9eaeac9b6e403b271f04e04149df2"),
         # Error cases, just checking that we fail gracefully - no tracebacks
         ("libgettext", True, "Package 'gettext/<host_version:libgettext' not resolved"),

--- a/test/integration/build_requires/build_requires_test.py
+++ b/test/integration/build_requires/build_requires_test.py
@@ -531,6 +531,8 @@ class TestBuildTrackHost:
         assert assert_msg in tc.out
 
     @pytest.mark.parametrize("requires_tag,tool_requires_tag", [
+        ("", ""),
+        ("", "user/channel"),
         ("user/channel", "user/channel"),
         ("", "user/channel"),
         ("auser/achannel", "anotheruser/anotherchannel"),
@@ -553,16 +555,18 @@ class TestBuildTrackHost:
             """)
         c.save({"protobuf/conanfile.py": GenConanfile("protobuf"),
                 "pkg/conanfile.py": pkg})
-        if "/" in requires_tag:
-            user, channel = requires_tag.split("/", 1)
-            user_channel = f"--user={user} --channel={channel}"
-        else:
-            user_channel = ""
-        c.run(f"create protobuf --version=1.0 {user_channel}")
+        for tag in (requires_tag, tool_requires_tag):
+            if "/" in tag:
+                user, channel = tag.split("/", 1)
+                user_channel = f"--user={user} --channel={channel}"
+            else:
+                user_channel = ""
+            c.run(f"create protobuf --version=1.0 {user_channel}")
 
         c.run("create pkg")
+        expected_tool_requires_tag = f"@{tool_requires_tag}" if tool_requires_tag else ""
         c.assert_listed_require({f"protobuf/1.0{user_channel_reference}": "Cache"})
-        c.assert_listed_require({f"protobuf/1.0{user_channel_reference}": "Cache"}, build=True)
+        c.assert_listed_require({f"protobuf/1.0{expected_tool_requires_tag}": "Cache"}, build=True)
 
     @pytest.mark.parametrize("shared", [True, False])
     def test_host_version_transitive_contexts(self, shared):

--- a/test/integration/build_requires/build_requires_test.py
+++ b/test/integration/build_requires/build_requires_test.py
@@ -529,12 +529,12 @@ class TestBuildTrackHost:
         tc.run("create app", assert_error=assert_error)
         assert assert_msg in tc.out
 
-    @pytest.mark.parametrize("requires_tag,tool_requires_tag,fails", [
-        ("user/channel", "user/channel", False),
-        ("", "user/channel", True),
-        ("auser/achannel", "anotheruser/anotherchannel", True),
+    @pytest.mark.parametrize("requires_tag,tool_requires_tag", [
+        ("user/channel", "user/channel"),
+        ("", "user/channel"),
+        ("auser/achannel", "anotheruser/anotherchannel"),
     ])
-    def test_overriden_host_version_user_channel(self, requires_tag, tool_requires_tag, fails):
+    def test_overriden_host_version_user_channel(self, requires_tag, tool_requires_tag):
         """
         Make the tool_requires follow the regular require with the expression "<host_version>"
         """
@@ -558,12 +558,9 @@ class TestBuildTrackHost:
             user_channel = ""
         c.run(f"create protobuf --version=1.0 {user_channel}")
 
-        c.run("create pkg", assert_error=fails)
-        if fails:
-            assert f"pkg/0.1 require 'protobuf/<host_version>@{tool_requires_tag}': didn't find a " \
-                   "matching host dependency" in c.out
-        else:
-            assert "pkg/0.1: Package '39f6a091994d2d080081ea888d75ef65c1d04c8d' created" in c.out
+        c.run("create pkg")
+        c.assert_listed_require({f"protobuf/1.0@{requires_tag}": "Cache"})
+        c.assert_listed_require({f"protobuf/1.0@{requires_tag}": "Cache"}, build=True)
 
     @pytest.mark.parametrize("shared", [True, False])
     def test_host_version_transitive_contexts(self, shared):

--- a/test/integration/graph/test_replace_requires.py
+++ b/test/integration/graph/test_replace_requires.py
@@ -770,14 +770,16 @@ def test_host_version_replace():
     tc = TestClient(light=True)
     tc.save({"pkg/conanfile.py": GenConanfile("pkg", "0.1"),
              "conanfile.py": GenConanfile()
-                .with_requires("pkg/0.1")
+                .with_requires("pkg/0.1@user/channel")
                 .with_tool_requires("pkg/<host_version>"),
              "profile": profile})
     tc.run("create pkg")
     tc.run("create pkg --user=user --channel=channel")
 
-    tc.run("install -pr=profile", assert_error=True)
-    assert "require 'pkg/<host_version>': didn't find a matching host dependency" in tc.out
+    tc.run("install -pr=profile")
+    tc.assert_listed_require({"pkg/0.1@user/channel#485dad6cb11e2fa99d9afbe44a57a164": "Cache"})
+    tc.assert_listed_require({"pkg/0.1@user/channel#485dad6cb11e2fa99d9afbe44a57a164": "Cache"}, build=True)
+    # assert "require 'pkg/<host_version>': didn't find a matching host dependency" in tc.out
 
     profile += "\n[replace_tool_requires]\npkg/*: pkg/<host_version>@user/channel"
     tc.save({"profile": profile})

--- a/test/integration/graph/test_replace_requires.py
+++ b/test/integration/graph/test_replace_requires.py
@@ -758,3 +758,29 @@ def test_replace_requires_ranges(require, pattern, alternative, expected):
         assert f"{require}: {expected}" in c.out
     else:
         assert "Replaced requires" not in c.out
+
+
+def test_host_version_replace():
+    profile = textwrap.dedent("""
+    include(default)
+    [replace_requires]
+    pkg/*: pkg/0.1@user/channel
+    """)
+
+    tc = TestClient(light=True)
+    tc.save({"pkg/conanfile.py": GenConanfile("pkg", "0.1"),
+             "conanfile.py": GenConanfile()
+                .with_requires("pkg/0.1")
+                .with_tool_requires("pkg/<host_version>"),
+             "profile": profile})
+    tc.run("create pkg")
+    tc.run("create pkg --user=user --channel=channel")
+
+    tc.run("install -pr=profile", assert_error=True)
+    assert "require 'pkg/<host_version>': didn't find a matching host dependency" in tc.out
+
+    profile += "\n[replace_tool_requires]\npkg/*: pkg/<host_version>@user/channel"
+    tc.save({"profile": profile})
+    tc.run("install -pr=profile")
+    tc.assert_listed_require({"pkg/0.1@user/channel#485dad6cb11e2fa99d9afbe44a57a164": "Cache"})
+    tc.assert_listed_require({"pkg/0.1@user/channel#485dad6cb11e2fa99d9afbe44a57a164": "Cache"}, build=True)

--- a/test/integration/graph/test_replace_requires.py
+++ b/test/integration/graph/test_replace_requires.py
@@ -776,13 +776,24 @@ def test_host_version_replace():
     tc.run("create pkg")
     tc.run("create pkg --user=user --channel=channel")
 
+    # We did not track the user/channel, we resolve the version but keep the original user/channel
     tc.run("install -pr=profile")
     tc.assert_listed_require({"pkg/0.1@user/channel#485dad6cb11e2fa99d9afbe44a57a164": "Cache"})
-    tc.assert_listed_require({"pkg/0.1@user/channel#485dad6cb11e2fa99d9afbe44a57a164": "Cache"}, build=True)
-    # assert "require 'pkg/<host_version>': didn't find a matching host dependency" in tc.out
+    tc.assert_listed_require({"pkg/0.1#485dad6cb11e2fa99d9afbe44a57a164": "Cache"}, build=True)
 
-    profile += "\n[replace_tool_requires]\npkg/*: pkg/<host_version>@user/channel"
-    tc.save({"profile": profile})
+    # If we want to also match user/channel
+    # Solution 1: Also replace the tool_requires in your profile to use same user/channel
+    tool_profile = profile + "\n[replace_tool_requires]\npkg/*: pkg/<host_version>@user/channel"
+    tc.save({"tool_profile": tool_profile})
+    tc.run("install -pr=tool_profile")
+    tc.assert_listed_require({"pkg/0.1@user/channel#485dad6cb11e2fa99d9afbe44a57a164": "Cache"})
+    tc.assert_listed_require({"pkg/0.1@user/channel#485dad6cb11e2fa99d9afbe44a57a164": "Cache"}, build=True)
+
+    # Solution 2: Directly in the requirement
+    tc.save({"conanfile.py": GenConanfile()
+                .with_requires("pkg/0.1@user/channel")
+                .with_tool_requires("pkg/<host_version>@user/channel")})
+
     tc.run("install -pr=profile")
     tc.assert_listed_require({"pkg/0.1@user/channel#485dad6cb11e2fa99d9afbe44a57a164": "Cache"})
     tc.assert_listed_require({"pkg/0.1@user/channel#485dad6cb11e2fa99d9afbe44a57a164": "Cache"}, build=True)


### PR DESCRIPTION
Changelog: Feature: Don't check for user/channel match in ``<host_version>``.
Docs: https://github.com/conan-io/docs/pull/4382

Started as a test for replace requires with host_version chains when the user/channel didn't match, see
https://github.com/conan-io/conan/issues/19598