### PR TITLE
Fix serialization of cpp_info when it uses the type field

### DIFF
--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -127,7 +127,7 @@ class _Component:
             "requires": self._requires,
             "properties": self._properties,
             "exe": self._exe,  # single exe, incompatible with libs
-            "type": str(self._type),
+            "type": str(self._type) if self._type else None,
             "location": self._location,
             "link_location": self._link_location,
             "languages": self._languages

--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -127,7 +127,7 @@ class _Component:
             "requires": self._requires,
             "properties": self._properties,
             "exe": self._exe,  # single exe, incompatible with libs
-            "type": self._type,
+            "type": str(self._type),
             "location": self._location,
             "link_location": self._link_location,
             "languages": self._languages
@@ -137,6 +137,8 @@ class _Component:
     def deserialize(contents):
         result = _Component()
         for field, value in contents.items():
+            if field == "type":
+                value = PackageType(value) if value is not None else None
             setattr(result, f"_{field}", value)
         return result
 

--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -137,9 +137,12 @@ class _Component:
     def deserialize(contents):
         result = _Component()
         for field, value in contents.items():
-            if field == "type":
-                value = PackageType(value) if value is not None else None
-            setattr(result, f"_{field}", value)
+            if hasattr(result, field):
+                setattr(result, field, value)
+            else:
+                # If there's on setter, use the internal field, e.g, _properties which has
+                # set_property method, but not a setter
+                setattr(result, f"_{field}", value)
         return result
 
     def clone(self):

--- a/test/integration/conanfile/test_cpp_info_serialize.py
+++ b/test/integration/conanfile/test_cpp_info_serialize.py
@@ -24,6 +24,7 @@ def test_cpp_info_serialize_round_trip():
                 cpp_info.libs = ["mylib", "myother"]
                 cpp_info.libdirs = ["mylibs"]
                 cpp_info.type = "static-library"
+                cpp_info.set_property("myprop", "myvalue")
                 p = os.path.join(self.package_folder, "cpp_info.json")
                 cpp_info.save(p)
 
@@ -40,3 +41,4 @@ def test_cpp_info_serialize_round_trip():
     assert cpp_info["libdirs"][0].endswith("mylibs")
     assert cpp_info["libs"] == ["mylib", "myother"]
     assert cpp_info["type"] == "static-library"
+    assert cpp_info["properties"] == {"myprop": "myvalue"}

--- a/test/integration/conanfile/test_cpp_info_serialize.py
+++ b/test/integration/conanfile/test_cpp_info_serialize.py
@@ -23,6 +23,7 @@ def test_cpp_info_serialize_round_trip():
                 cpp_info.includedirs = ["myinc"]
                 cpp_info.libs = ["mylib", "myother"]
                 cpp_info.libdirs = ["mylibs"]
+                cpp_info.type = "static-library"
                 p = os.path.join(self.package_folder, "cpp_info.json")
                 cpp_info.save(p)
 
@@ -38,3 +39,4 @@ def test_cpp_info_serialize_round_trip():
     assert cpp_info["includedirs"][0].endswith("myinc")
     assert cpp_info["libdirs"][0].endswith("mylibs")
     assert cpp_info["libs"] == ["mylib", "myother"]
+    assert cpp_info["type"] == "static-library"

--- a/test/integration/conanfile/test_cpp_info_serialize.py
+++ b/test/integration/conanfile/test_cpp_info_serialize.py
@@ -25,6 +25,8 @@ def test_cpp_info_serialize_round_trip():
                 cpp_info.libdirs = ["mylibs"]
                 cpp_info.type = "static-library"
                 cpp_info.set_property("myprop", "myvalue")
+                cpp_info.components["comp"].libs = []
+                cpp_info.components["comp"].type = None
                 p = os.path.join(self.package_folder, "cpp_info.json")
                 cpp_info.save(p)
 
@@ -42,3 +44,6 @@ def test_cpp_info_serialize_round_trip():
     assert cpp_info["libs"] == ["mylib", "myother"]
     assert cpp_info["type"] == "static-library"
     assert cpp_info["properties"] == {"myprop": "myvalue"}
+
+    comp = graph["graph"]["nodes"]["1"]["cpp_info"]["comp"]
+    assert comp["type"] is None


### PR DESCRIPTION
Changelog: Bugfix: Fix serialization of `cpp_info` when it uses the type field.
Docs: Omit

Closes https://github.com/conan-io/conan/issues/19603, but the deserialization approach could probably be a bit better