### PR TITLE
Fix Xcode issues with the premake5 integration

### DIFF
--- a/conan/test/assets/sources.py
+++ b/conan/test/assets/sources.py
@@ -11,6 +11,10 @@ _function_cpp = r"""
 #include "{{it}}.h"
 {% endfor %}
 
+{% for it in sys_includes -%}
+#include <{{it}}.h>
+{% endfor %}
+
 int {{name}}(){
     #ifdef NDEBUG
     std::cout << "{{ msg or name }}: Release!\n";
@@ -135,6 +139,10 @@ _function_c = r"""
 #include "{{it}}.h"
 {% endfor %}
 
+{% for it in sys_includes -%}
+#include <{{it}}.h>
+{% endfor %}
+
 int {{name}}(){
     #ifdef NDEBUG
     printf("{{ msg or name }}: Release!\n");
@@ -249,6 +257,10 @@ _function_h = """
 
 {% for it in includes -%}
 #include "{{it}}.h"
+{%- endfor %}
+
+{% for it in sys_includes -%}
+#include <{{it}}.h>
 {%- endfor %}
 
 #ifdef _WIN32

--- a/conan/tools/apple/xcodebuild.py
+++ b/conan/tools/apple/xcodebuild.py
@@ -1,3 +1,6 @@
+import re
+from io import StringIO
+
 from conan.tools.apple.apple import to_apple_arch, xcodebuild_deployment_target_key
 from conan.tools.build import cmd_args_to_string
 
@@ -57,3 +60,44 @@ class XcodeBuild:
             cmd += " " + cmd_args_to_string(cli_args)
 
         self._conanfile.run(cmd)
+
+    def build_workspace(self, xcworkspace, scheme, configuration=None, cli_args=None):
+        """
+        Call to ``xcodebuild`` to build a Xcode workspace.
+
+        :param xcworkspace: the *xcworkspace* workspace to build.
+        :param scheme: the name of the scheme to build
+        :param configuration: Build configuration to use (e.g., ``Debug``, ``Release``).
+                              Defaults to the recipe's ``settings.build_type``.
+        :param cli_args: Extra options to pass directly to ``xcodebuild`` (list of strings).
+                              Examples: ``["-xcconfig", "<path/to/file.xcconfig>"]`` or custom
+                              Xcode build settings like ``["BUILD_LIBRARY_FOR_DISTRIBUTION=YES"]``.
+        :return: the return code for the launched ``xcodebuild`` command.
+        """
+        build_config = configuration or self._build_type
+        cmd = "xcodebuild -workspace '{}' -scheme {} -configuration {} -arch {} " \
+              "{} {}".format(xcworkspace, scheme, build_config, self._arch, self._sdkroot,
+                                self._verbosity)
+        deployment_target_key = xcodebuild_deployment_target_key(self._os)
+        if deployment_target_key and self._os_version:
+            cmd += f" {deployment_target_key}={self._os_version}"
+
+        if cli_args:
+            cmd += " " + cmd_args_to_string(cli_args)
+
+        self._conanfile.run(cmd)
+
+    def discover_workspace_schemes(self, xcworkspace):
+        """
+        Call to ``xcodebuild`` to discovers all schemes in a Xcode workspace
+
+        :param xcworkspace: the *xcworkspace* workspace to discover.
+        :return: ``List[str]`` of all schemes in workspace
+        """
+
+        cmd = "xcodebuild -list -workspace '{}'".format(xcworkspace)
+        output = StringIO()
+        self._conanfile.run(cmd, stdout=output)
+
+        schemesString = re.search(r"Schemes:\s*(.*)", output.getvalue().strip(), re.M | re.S).group(1)
+        return re.findall(r"\S+", schemesString)

--- a/conan/tools/premake/constants.py
+++ b/conan/tools/premake/constants.py
@@ -1,4 +1,6 @@
 # Source: https://premake.github.io/docs/architecture/
+# ! Please make sure to only take the normal "Parameters" and NOT the aliases
+#   When using aliases as cli arguments premake will reject them
 CONAN_TO_PREMAKE_ARCH = {
     "x86": "x86",
     "x86_64": "x86_64",
@@ -13,10 +15,10 @@ CONAN_TO_PREMAKE_ARCH = {
     "armv7s": "arm",
     "armv7k": "arm",
 
-    "armv8": "arm64",
-    "armv8_32": "arm64",
-    "armv8.3": "arm64",
-    "arm64ec": "arm64",
+    "armv8": "aarch64",
+    "armv8_32": "aarch64",
+    "armv8.3": "aarch64",
+    "arm64ec": "aarch64",
 
     "e2k-v2": "e2k",
     "e2k-v3": "e2k",

--- a/conan/tools/premake/premake.py
+++ b/conan/tools/premake/premake.py
@@ -7,6 +7,7 @@ from jinja2 import Template
 from conan.errors import ConanException
 from conan.tools.files import save
 from conan.tools.microsoft.msbuild import MSBuild
+from conan.tools.apple.xcodebuild import XcodeBuild
 from conan.tools.premake.toolchain import PremakeToolchain
 from conan.tools.premake.constants import CONAN_TO_PREMAKE_ARCH
 
@@ -122,6 +123,15 @@ class Premake:
                 msbuild.platform = msbuild_platform
             msbuild.build_type = build_type
             msbuild.build(sln=f"{workspace}.sln", targets=targets)
+        elif self.action.startswith("xcode"):
+            xcodeBuild = XcodeBuild(self._conanfile)
+            workspace = f'{workspace}.xcworkspace' # Workspace is not converted to lowercase
+            if not targets:
+                targets = xcodeBuild.discover_workspace_schemes(workspace)
+            else:
+                targets = [target.lower() for target in targets] # Premake converts projects to lower
+            for target in targets:
+                xcodeBuild.build_workspace(workspace, target, configuration)
         else:
             targets = "all" if targets is None else " ".join(targets)
             njobs = build_jobs(self._conanfile)

--- a/conan/tools/premake/premakedeps.py
+++ b/conan/tools/premake/premakedeps.py
@@ -62,7 +62,7 @@ if conandeps == nil then conandeps = {{}} end
 conan_premake_tmerge(conandeps, t_conandeps)
 """
 PREMAKE_TEMPLATE_ROOT_BUILD = """
-        includedirs(conandeps[conf][pkg]["includedirs"])
+        externalincludedirs(conandeps[conf][pkg]["includedirs"])
         bindirs(conandeps[conf][pkg]["bindirs"])
         defines(conandeps[conf][pkg]["defines"])
 """

--- a/test/functional/toolchains/test_premake.py
+++ b/test/functional/toolchains/test_premake.py
@@ -1,4 +1,5 @@
 import os
+import re
 import platform
 import textwrap
 
@@ -92,14 +93,109 @@ def test_premake_new_generator():
     assert "lib/0.1: Hello World Release!" in c.out
     assert "example/1.0: Hello World Release!" in c.out
 
-
 @pytest.mark.tool("premake")
 def test_premake_shared_lib():
     c = TestClient()
     c.run("new premake_lib -d name=lib -d version=0.1 -o lib")
     c.run("create lib -o '&:shared=True'")
-    assert "lib/0.1: package(): Packaged 1 '.so' file: liblib.so" in c.out
+
+    assert re.search(
+        r"lib/0\.1: package\(\): Packaged 1 '.*\.(so|dll|dylib)' file: (lib)?lib\.(so|dll|dylib)",
+        c.out,
+        re.IGNORECASE
+    )
     assert "lib/0.1: package(): Packaged 1 '.a' file: liblib.a" not in c.out
+
+
+@pytest.mark.tool("premake")
+def test_system_style_includes(matrix_client):
+    main = gen_function_cpp(name="main", sys_includes=["matrix"], calls=["matrix"])
+    premake5 = gen_premake5(
+        workspace="Consumer",
+        projects=[
+            {"name": "consumer", "files": ["src/main.cpp"], "kind": "ConsoleApp"}
+        ],
+    )
+
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.layout import basic_layout
+        from conan.tools.premake import Premake
+
+        class ConsumerRecipe(ConanFile):
+            name = "consumer"
+            version = "1.0"
+            package_type = "application"
+            settings = "os", "compiler", "build_type", "arch"
+            exports_sources = "*"
+            generators= "PremakeDeps", "PremakeToolchain"
+
+            def layout(self):
+                basic_layout(self)
+
+            def requirements(self):
+                self.requires("matrix/1.0")
+
+            def build(self):
+                premake = Premake(self)
+                premake.configure()
+                premake.build(workspace="Consumer")
+    """)
+
+    # Save and build to see if it works
+    c = matrix_client
+    c.save({"src/main.cpp": main,
+            "premake5.lua": premake5,
+            "conanfile.py": conanfile
+            })
+    c.run("build .")
+
+
+@pytest.mark.tool("premake")
+@pytest.mark.skipif(platform.system() != "Darwin",
+                    reason="Xcode is online avilible on MaxOS")
+def test_system_style_includes_xcode(matrix_client):
+    main = gen_function_cpp(name="main", sys_includes=["matrix"], calls=["matrix"])
+    premake5 = gen_premake5(
+        workspace="Consumer",
+        projects=[
+            {"name": "consumer", "files": ["src/main.cpp"], "kind": "ConsoleApp"}
+        ],
+    )
+
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.layout import basic_layout
+        from conan.tools.premake import Premake
+
+        class ConsumerRecipe(ConanFile):
+            name = "consumer"
+            version = "1.0"
+            package_type = "application"
+            settings = "os", "compiler", "build_type", "arch"
+            exports_sources = "*"
+            generators= "PremakeDeps", "PremakeToolchain"
+
+            def layout(self):
+                basic_layout(self)
+
+            def requirements(self):
+                self.requires("matrix/1.0")
+
+            def build(self):
+                premake = Premake(self)
+                premake.action = "xcode4"
+                premake.configure()
+                premake.build(workspace="Consumer")
+    """)
+
+    # Save and build to see if it works
+    c = matrix_client
+    c.save({"src/main.cpp": main,
+            "premake5.lua": premake5,
+            "conanfile.py": conanfile
+            })
+    c.run("build .")
 
 
 @pytest.mark.tool("premake")
@@ -256,6 +352,7 @@ def test_transitive_headers_not_public(transitive_libraries):
     rmdir(ConanFileMock(), os.path.join(c.current_folder, "build-release"))
     c.run("build .", assert_error=True)
     # Error should be about not finding matrix
+
 
 @pytest.mark.tool("premake")
 def test_premake_custom_configuration(transitive_libraries):


### PR DESCRIPTION
Changelog: Switch to externalincludedirs to fix macos xocde build targets (Fixes #19606 )

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
