### PR TITLE
[fix] avoid erroneously adding an extra NULL string when appending new elements to a list variable when generating sh scripts

### DIFF
--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -501,6 +501,18 @@ class EnvVars:
                     f'fi;'
                 )
             if varvalues:
+                value = value.replace(f":${varname}", f"${{{varname}+:}}${varname}")
+                value = value.replace(f"${varname}:", f"${varname}${{{varname}+:}}")
+                # Omit the colon if the variable is unset.  For example,
+                #   LD_LIBRARY_PATH=PrependedDir${LD_LIBRARY_PATH+:}$LD_LIBRARY_PATH
+                # Thus, if LD_LIBRARY_PATH is unset, the result will be:
+                #   LD_LIBRARY_PATH=PrependedDir
+                # If LD_LIBRARY_PATH is a NULL string, the result will be:
+                #   LD_LIBRARY_PATH=PrependedDir:
+                # Note that a zero-length directory name in LD_LIBRARY_PATH indicates
+                # the current working directory.  The latter is probably not what we
+                # want and dangerous in some cases.
+
                 result.append(f'export {varname}="{value}"')
             else:
                 result.append(f'unset {varname}')


### PR DESCRIPTION
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.

________

This commit does exactly what the title says.
Below is an example to explain it.

Before:

```bash
$ git clone --depth=1 --single-branch https://github.com/conan-io/examples2.git
$ cd examples2/tutorial/consuming_packages/simple_cmake_project
$ conan install . --build=missing --output-folder=build --options=\*:shared=True
$ cat ./build/conanrunenv-*-*.sh | grep '$LD_LIBRARY_PATH'
export LD_LIBRARY_PATH="/root/.conan2/p/b/zlib90a466e748ea9/p/lib:$LD_LIBRARY_PATH"
```

After:

```bash
$ git clone --depth=1 --single-branch https://github.com/conan-io/examples2.git
$ cd examples2/tutorial/consuming_packages/simple_cmake_project
$ conan install . --build=missing --output-folder=build --options=\*:shared=True
$ cat ./build/conanrunenv-*-*.sh | grep '$LD_LIBRARY_PATH'
export LD_LIBRARY_PATH="/root/.conan2/p/b/zlib90a466e748ea9/p/lib${LD_LIBRARY_PATH+:}$LD_LIBRARY_PATH"
```

_____

The previous implementation didn't account for the scenario where `LD_LIBRARY_PATH` is unset (this excludes the case where it's a NULL string, which is considered an intentional action by the user).
When adding new elements, a NULL string element was introduced, which could lead to the potential loading of arbitrary DLLs after `source conanrun.sh`.

This may cause security issues.

Also see [ld.so(8)](https://www.man7.org/linux/man-pages/man8/ld.so.8.html):

> `LD_LIBRARY_PATH`  <br />
> A list of directories in which to search for ELF libraries at execution time.  The items in the list are separated by either colons or semicolons, and there is no support for escaping either separator.  **A zero-length directory name indicates the current working directory.**
