### PR TITLE
fix repeated checking of binary compatibles

### DIFF
--- a/conan/internal/graph/graph_binaries.py
+++ b/conan/internal/graph/graph_binaries.py
@@ -264,7 +264,6 @@ class GraphBinariesAnalyzer:
     @staticmethod
     def _binary_in_cache(node, cache_latest_prev):
         assert cache_latest_prev.revision
-        assert node.binary is None
         node.binary = BINARY_CACHE
         node.binary_remote = None
         node.prev = cache_latest_prev.revision
@@ -312,6 +311,10 @@ class GraphBinariesAnalyzer:
         assert node.package_id is not None, "Node.package_id shouldn't be None"
         assert node.prev is None, "Node.prev should be None"
 
+        # Check that this same reference hasn't already been checked
+        if self._evaluate_is_cached(node):
+            return
+
         self._process_node(node, build_mode, remotes, update)
         compatibles = None
 
@@ -346,10 +349,6 @@ class GraphBinariesAnalyzer:
                                          "dependencies, this is dangerous", warn_tag="risk")
 
     def _process_node(self, node, build_mode, remotes, update):
-        # Check that this same reference hasn't already been checked
-        if self._evaluate_is_cached(node):
-            return
-
         if node.conanfile.info.invalid:
             node.binary = BINARY_INVALID
             return
@@ -384,8 +383,7 @@ class GraphBinariesAnalyzer:
             # Download/update shouldn't be checked in the servers if this is "skip-upload"
             # The binary can only be in cache or missing.
             if cache_latest_prev:
-                node.binary = BINARY_CACHE
-                node.prev = cache_latest_prev.revision
+                self._binary_in_cache(node, cache_latest_prev)
             else:
                 node.binary = BINARY_MISSING
         elif cache_latest_prev is None:  # This binary does NOT exist in the cache
@@ -442,19 +440,13 @@ class GraphBinariesAnalyzer:
                     node.binary = BINARY_UPDATE
                     output.info("Current package revision is older than the remote one")
                 else:
-                    node.binary = BINARY_CACHE
                     # The final data is the cache one, not the server one
-                    node.binary_remote = None
-                    node.prev = cache_latest_prev.revision
+                    self._binary_in_cache(node, cache_latest_prev)
                     if cache_time > node.pref_timestamp:
                         output.info("Current package revision is newer than the remote one")
-                    node.pref_timestamp = cache_time
+
         if not node.binary:
-            node.binary = BINARY_CACHE
-            node.binary_remote = None
-            node.prev = cache_latest_prev.revision
-            node.pref_timestamp = cache_latest_prev.timestamp
-            assert node.prev, "PREV for %s is None" % str(node.pref)
+            self._binary_in_cache(node, cache_latest_prev)
 
     def _config_version(self):
         config_mode = self._global_conf.get("core.package_id:config_mode", default=None)
@@ -526,7 +518,7 @@ class GraphBinariesAnalyzer:
             # Evaluate the possible nodes with repeated "prefs" that haven't been evaluated
             for pref, pref_nodes in nodes.items():
                 for n in pref_nodes[1:]:
-                    _evaluate_single(n)
+                    assert self._evaluate_is_cached(n)  # The pref is the same, must exist cached
 
         if self._warn_about_new_compatibility:
             (ConanOutput().info("\nA new experimental approach for binary compatibility detection "

--- a/conan/internal/graph/graph_binaries.py
+++ b/conan/internal/graph/graph_binaries.py
@@ -440,10 +440,10 @@ class GraphBinariesAnalyzer:
                     node.binary = BINARY_UPDATE
                     output.info("Current package revision is older than the remote one")
                 else:
-                    # The final data is the cache one, not the server one
-                    self._binary_in_cache(node, cache_latest_prev)
                     if cache_time > node.pref_timestamp:
                         output.info("Current package revision is newer than the remote one")
+                    # The final data is the cache one, not the server one
+                    self._binary_in_cache(node, cache_latest_prev)
 
         if not node.binary:
             self._binary_in_cache(node, cache_latest_prev)

--- a/test/integration/package_id/compatible_test.py
+++ b/test/integration/package_id/compatible_test.py
@@ -963,3 +963,28 @@ def test_compatibility_remove_cppstd():
     # Now we try again, this time app will find the compatible dep without cppstd
     tc.run("install --requires=dep/1.0 -pr=profile -s=compiler.cppstd=17")
     assert f"dep/1.0: Found compatible package '{dep_package_id}'" in tc.out
+
+
+def test_compatible_setting():
+    c = TestClient()
+    profile = textwrap.dedent("""
+        [settings]
+        os = Linux
+        compiler=gcc
+        compiler.version=11
+        compiler.libcxx=libstdc++
+        """)
+    pkg = GenConanfile(version="0.1").with_settings("os", "compiler").with_tool_requires("tool/0.1")
+    c.save({"tool/conanfile.py": GenConanfile("tool", "0.1").with_settings("os", "compiler"),
+            "pkg/conanfile.py": pkg,
+            "profile": profile})
+
+    c.run("export tool")
+    c.run("export pkg --name=pkga")
+    c.run("export pkg --name=pkgb")
+    c.run("export pkg --name=pkgc")
+
+    c.run("install --requires=pkga/0.1 --requires=pkgb/0.1 --requires=pkgc/0.1 "
+          "-pr:a=profile -s:a compiler.cppstd=17 --build=pkg*", assert_error=True)
+    assert str(c.out).count("tool/0.1: Main binary package "
+                            "'e297d0212cdeb8744c601b0e5ea294e62a74582f' missing") == 1


### PR DESCRIPTION
Changelog: Omit.
Docs: Omit

This is a first little step to start improving the ``GraphBinariesAnalyzer``:
- Avoid to check more than once for missing binaries compatible binaries, not really checking in remotes, but not finishing as early as possible
- Small refactor for the code when a binary is used from the cache

It will follow another with fixes for ``--build=compatible``
