### PR TITLE
fix CMake escaping

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -13,7 +13,7 @@ from conan.tools.build import build_jobs
 from conan.tools.build.flags import architecture_flag, architecture_link_flag, libcxx_flags, threads_flags
 from conan.tools.build.cross_building import cross_building
 from conan.tools.cmake.toolchain import CONAN_TOOLCHAIN_FILENAME
-from conan.tools.cmake.utils import is_multi_configuration
+from conan.tools.cmake.utils import is_multi_configuration, cmake_escape_value
 from conan.tools.intel import IntelCC
 from conan.tools.microsoft.visual import msvc_version_to_toolset_version, msvc_platform_from_arch
 from conan.internal.api.install.generators import relativize_path
@@ -1291,8 +1291,8 @@ class VariablesBlock(Block):
                 {% endfor %}
                 {% for i in range(values|count) %}{% set genexpr.str = genexpr.str + '>' %}
                 {% endfor %}
-                set({{ it }} {{ genexpr.str }} CACHE STRING
-                    "Variable {{ it }} conan-toolchain defined")
+            set({{ it }} {{ genexpr.str }} CACHE STRING
+                "Variable {{ it }} conan-toolchain defined")
             {% endfor %}
             {% endmacro %}
             # Variables
@@ -1308,8 +1308,11 @@ class VariablesBlock(Block):
             """)
 
     def context(self):
-        return {"variables": self._toolchain.variables,
-                "variables_config": self._toolchain.variables.configuration_types}
+        variables = {k: cmake_escape_value(v) for k, v in self._toolchain.variables.items()}
+        vars_config = {k: [(config, cmake_escape_value(v)) for (config, v) in configs]
+                       for k, configs in self._toolchain.variables.configuration_types.items()}
+        return {"variables": variables,
+                "variables_config": vars_config}
 
 
 class PreprocessorBlock(Block):

--- a/conan/tools/cmake/utils.py
+++ b/conan/tools/cmake/utils.py
@@ -42,6 +42,9 @@ def parse_extra_variable(source, key, value):
 
 
 def cmake_escape_value(v):
+    if not isinstance(v, str):
+        return v
+
     def _stream_chars(s):
         iterable = iter(enumerate(s))
         for i, char in iterable:

--- a/conan/tools/cmake/utils.py
+++ b/conan/tools/cmake/utils.py
@@ -42,4 +42,16 @@ def parse_extra_variable(source, key, value):
 
 
 def cmake_escape_value(v):
-    return v.replace('\\', '\\\\').replace('$', '\\$').replace('"', '\\"')
+    def _stream_chars(s):
+        iterable = iter(enumerate(s))
+        for i, char in iterable:
+            # If we see a backslash, check the next char immediately
+            if char == '\\' and i + 1 < len(s) and s[i+1] in r'\$"':
+                yield s[i:i+2]  # Yield the existing pair
+                next(iterable)   # Skip the next char in the loop
+            elif char in r'\$"':
+                yield '\\' + char  # Escape the lonely char
+            else:
+                yield char
+
+    return "".join(_stream_chars(v))

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -838,6 +838,29 @@ def test_variables_types():
     assert 'set(FOO ON CACHE BOOL "Variable FOO conan-toolchain defined")' in toolchain
 
 
+def test_variables_escaping():
+    # https://github.com/conan-io/conan/issues/19638
+    client = TestClient()
+    conanfile = textwrap.dedent(r"""
+        from conan import ConanFile
+        from conan.tools.cmake import CMakeToolchain
+
+        class Conan(ConanFile):
+            settings = "os", "arch", "compiler", "build_type"
+            def generate(self):
+                toolchain = CMakeToolchain(self)
+                toolchain.variables["FOO"] = r"D:\new\thing\path"
+                toolchain.variables.release["BAR"] = r"C:\new\thing\path"
+                toolchain.generate()
+        """)
+    client.save({"conanfile.py": conanfile})
+    client.run("install . --name=mylib --version=1.0")
+
+    toolchain = client.load("conan_toolchain.cmake")
+    assert r'set(FOO "D:\\new\\thing\\path" CACHE STRING' in toolchain
+    assert r'set(CONAN_DEF_releaseBAR "C:\\new\\thing\\path")' in toolchain
+
+
 def test_android_c_library():
     client = TestClient()
     conanfile = textwrap.dedent("""

--- a/test/unittests/tools/cmake/test_cmake_test.py
+++ b/test/unittests/tools/cmake/test_cmake_test.py
@@ -7,6 +7,7 @@ from conan.internal.model.conf import Conf
 from conan.internal.model.settings import Settings
 from conan.test.utils.mocks import ConanFileMock
 from conan.test.utils.test_files import temp_folder
+from conan.tools.cmake.utils import cmake_escape_value
 
 
 @pytest.mark.parametrize("generator,target", [
@@ -82,3 +83,24 @@ def test_run_ctest():
     cmake = CMake(conanfile)
     cmake.ctest(cli_args=["--schedule-random", "--quiet"])
     assert "--schedule-random --quiet --verbose --debug --output-junit myfile" in conanfile.command
+
+
+@pytest.mark.parametrize("input_str, expected", [
+    (r"PlainString", r"PlainString"),  # Case 1: Plain strings (No change)
+    # Case 2: Individual characters (First-time escape)
+    (r"C:\Path", r"C:\\Path"),
+    (r'He said "Hi"', r'He said \"Hi\"'),
+    (r"Cost is $10", r"Cost is \$10"),
+    # Case 3: Complex mixed strings
+    (r'Mixed \path and "quote" with $VAR', r'Mixed \\path and \"quote\" with \$VAR'),
+    # Case 4: Partial escapes (Only unescaped parts get fixed)
+    (r'\"Already" and \$Already$', r'\"Already\" and \$Already\$'),
+    # Case 5: Edge cases
+    (r'TrailingSlash\\', r'TrailingSlash\\'),
+    (r"Double\\Slash", r"Double\\Slash"),
+    (r"", r""),  # Empty string
+])
+def test_cmake_escape_correctness(input_str, expected):
+    escaped = cmake_escape_value(input_str)
+    assert escaped == expected
+    assert cmake_escape_value(escaped) == expected


### PR DESCRIPTION
Changelog: Bugfix: Correctly escape ``CMakeToolchain.variables`` for CMake syntax.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19638