### PR TITLE
feature: Add pkg sign no-op return

### DIFF
--- a/conan/internal/rest/pkg_sign.py
+++ b/conan/internal/rest/pkg_sign.py
@@ -122,7 +122,8 @@ class PkgSignaturesPlugin:
                                                 signature_folder=metadata_sign)
         if isinstance(signatures, list):
             # Save signatures file with the plugin's returned signatures data
-            _save_signatures(metadata_sign, signatures)
+            if signatures:
+                _save_signatures(metadata_sign, signatures)
         else:
             # Fallback to old behavior (plugin sign() returns None)
             ConanOutput().warning("[Package sign] The signature plugin sign() function must return "

--- a/test/integration/test_pkg_signing.py
+++ b/test/integration/test_pkg_signing.py
@@ -1,5 +1,7 @@
+import os
 import textwrap
 
+from conan.api.model import RecipeReference
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
 
@@ -268,3 +270,39 @@ def test_pkg_sign_exports_sources():
     assert "Checksum verified for file conan_package.tgz" in c.out
     c.run("install --requires=pkg/0.1 -r=default --build=pkg/0.1")
     assert "Checksum verified for file conan_sources.tgz" in c.out
+
+
+def test_pkg_sign_no_op():
+    c = TestClient()
+    c.save({"conanfile1.py": GenConanfile("pkg", "0.1"),
+            "conanfile2.py": GenConanfile("no-op", "0.1")})
+    signer = textwrap.dedent(r"""
+        def sign(ref, artifacts_folder, signature_folder, **kwargs):
+            if "pkg/0.1" in str(ref):
+                print("Signing package", str(ref))
+                # Return the pkgsign-signatures.json's content
+                return [{"method": "openssl-dgst",
+                        "provider": "conan-client",
+                        "sign_artifacts": {"manifest": "pkgsign-manifest.json",
+                                           "signature": "pkgsign-manifest.json.sig"}}]
+            else:
+                # no-op: The package should not be signed or if it is signed, it shouldn't be resigned
+                print("Skipping package", str(ref))
+                return []
+
+        """)
+    c.save_home({"extensions/plugins/sign/sign.py": signer})
+    c.run("create conanfile1.py")
+    c.run("cache sign pkg/0.1")
+    assert "Signing package pkg/0.1" in c.out
+    metadata_folder = c.cache.recipe_layout(
+        RecipeReference("pkg", "0.1", revision="485dad6cb11e2fa99d9afbe44a57a164")).metadata()
+    signatures_path = os.path.join(metadata_folder, "sign", "pkgsign-signatures.json")
+    assert os.path.exists(signatures_path)
+    c.run("create conanfile2.py")
+    c.run("cache sign no-op/0.1")
+    assert "Skipping package no-op/0.1" in c.out
+    metadata_folder = c.cache.recipe_layout(
+        RecipeReference("no-op", "0.1", revision="9f8243dd2f341b13df241e599326b3cb")).metadata()
+    signatures_path = os.path.join(metadata_folder, "sign", "pkgsign-signatures.json")
+    assert not os.path.exists(signatures_path)


### PR DESCRIPTION
Changelog: omit
Docs: omit

Add the possibility to return an empty list of signatures as a way to skip signing packages (in case the package should be skipped, or in case it is already signed and should not be resigned)

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
