### PR TITLE
Fix bare .bat invocations in tests for NoDefaultCurrentDirectoryInExePath

### DIFF
--- a/test/functional/toolchains/cmake/test_ninja.py
+++ b/test/functional/toolchains/cmake/test_ninja.py
@@ -92,11 +92,11 @@ def test_locally_build_msvc(build_type, shared, client):
     settings = "-s build_type={} -o hello/*:shared={}".format(build_type, shared)
     client.run("install . {}".format(settings))
 
-    client.run_command('conanvcvars.bat && cmake . -G "Ninja" '
+    client.run_command(r'.\conanvcvars.bat && cmake . -G "Ninja" '
                        '-DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake '
                        '-DCMAKE_BUILD_TYPE={}'.format(build_type))
 
-    client.run_command("conanvcvars.bat && ninja")
+    client.run_command(r".\conanvcvars.bat && ninja")
 
     libname = "mylibrary.dll" if shared else "mylibrary.lib"
     assert libname in client.out
@@ -136,11 +136,11 @@ def test_locally_build_msvc_toolset(client):
     client.save({"profile": profile})
     client.run("install . -pr=profile")
 
-    client.run_command('conanvcvars.bat && cmake . -G "Ninja" '
+    client.run_command(r'.\conanvcvars.bat && cmake . -G "Ninja" '
                        '-DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake '
                        '-DCMAKE_BUILD_TYPE=Release')
 
-    client.run_command("conanvcvars.bat && ninja")
+    client.run_command(r".\conanvcvars.bat && ninja")
 
     client.run_command("myapp.exe")
 

--- a/test/functional/toolchains/microsoft/test_vcvars.py
+++ b/test/functional/toolchains/microsoft/test_vcvars.py
@@ -18,9 +18,9 @@ def test_deactivate_vcvars_message():
         """)
     client.save({"conanfile.py": conanfile})
     client.run('install . -s compiler.version=194')
-    client.run_command(r'conanbuild.bat')
+    client.run_command(r'.\conanbuild.bat')
     assert "[vcvarsall.bat] Environment initialized" in client.out
-    client.run_command(r'deactivate_conanvcvars.bat')
+    client.run_command(r'.\deactivate_conanvcvars.bat')
     assert "vcvars env cannot be deactivated" in client.out
 
 

--- a/test/integration/environment/test_env.py
+++ b/test/integration/environment/test_env.py
@@ -518,7 +518,7 @@ def test_multiple_deactivate(deactivation_mode):
 
     for _ in range(2):  # Just repeat it, so we can check things keep working
         if platform.system() == "Windows":
-            cmd = "conanbuild.bat && display.bat && deactivate_conanbuild.bat && display.bat"
+            cmd = r".\conanbuild.bat && .\display.bat && .\deactivate_conanbuild.bat && .\display.bat"
         else:
             deactivate_cmd = "deactivate_conanbuild" if deactivation_mode else ". ./deactivate_conanbuild.sh"
             cmd = f'. ./conanbuild.sh && ./display.sh && {deactivate_cmd} && ./display.sh'
@@ -565,7 +565,7 @@ def test_multiple_deactivate_order(deactivation_mode):
 
     for _ in range(2):  # Just repeat it, so we can check things keep working
         if platform.system() == "Windows":
-            cmd = "conanbuild.bat && display.bat && deactivate_conanbuild.bat && display.bat"
+            cmd = r".\conanbuild.bat && .\display.bat && .\deactivate_conanbuild.bat && .\display.bat"
         else:
             deactivate_cmd = "deactivate_conanbuild" if deactivation_mode else ". ./deactivate_conanbuild.sh"
             cmd = f'. ./conanbuild.sh && ./display.sh && {deactivate_cmd} && ./display.sh'
@@ -731,7 +731,7 @@ def test_profile_build_env_spaces(deactivation_mode):
     client.run(f"install . -g VirtualBuildEnv -pr=profile {f'-c=tools.env:deactivation_mode={deactivation_mode}' if deactivation_mode else ''} ")
 
     if platform.system() == "Windows":
-        cmd = "conanbuild.bat && display.bat && deactivate_conanbuild.bat && display.bat"
+        cmd = r".\conanbuild.bat && .\display.bat && .\deactivate_conanbuild.bat && .\display.bat"
     else:
         deactivate_cmd = "deactivate_conanbuild" if deactivation_mode else ". ./deactivate_conanbuild.sh"
         cmd = f'. ./conanbuild.sh && ./display.sh && {deactivate_cmd} && ./display.sh'

--- a/test/unittests/tools/env/test_env.py
+++ b/test/unittests/tools/env/test_env.py
@@ -227,7 +227,7 @@ def test_windows_case_insensitive_bat(envvars):
     with chdir(temp_folder()):
         envvars.save_bat("test.bat")
         save("display.bat", display)
-        cmd = "test.bat && display.bat && deactivate_test.bat && display.bat"
+        cmd = r".\test.bat && .\display.bat && .\deactivate_test.bat && .\display.bat"
         check_command_output(cmd, prevenv)
 
 

--- a/test/unittests/tools/env/test_env_files.py
+++ b/test/unittests/tools/env/test_env_files.py
@@ -98,7 +98,7 @@ def test_env_files_bat(env, prevenv):
         env._subsystem = WINDOWS
         env.save_bat("test.bat")
         save("display.bat", display)
-        cmd = "test.bat && display.bat && deactivate_test.bat && display.bat"
+        cmd = r".\test.bat && .\display.bat && .\deactivate_test.bat && .\display.bat"
         check_env_files_output(cmd, prevenv)
 
 
@@ -186,7 +186,7 @@ def test_relative_paths():
         if platform.system() == "Windows":
             test_bat = load("test.bat")
             assert r'set "PATH=%~dp0\myscripts"' in test_bat
-            cmd = "test.bat && myhello.bat"
+            cmd = r".\test.bat && myhello.bat"
         else:
             test_sh = load("test.sh")
             assert 'export PATH="$script_folder/myscripts"' in test_sh


### PR DESCRIPTION
## Summary
- On security-hardened Windows machines with `NoDefaultCurrentDirectoryInExePath=1`, `cmd.exe` won't find `.bat` files in the current directory unless invoked with an explicit path prefix (e.g., `.\script.bat`).
- Prefix all bare `.bat` invocations in tests with `.\` so they work regardless of this registry setting.
- Affects 5 test files, 12 individual `.bat` call sites. No production code changes.

## Files changed
- `test/unittests/tools/env/test_env.py`
- `test/unittests/tools/env/test_env_files.py`
- `test/integration/environment/test_env.py`
- `test/functional/toolchains/microsoft/test_vcvars.py`
- `test/functional/toolchains/cmake/test_ninja.py`

## Test plan
- [x] All 9 previously-failing tests pass with the fix applied
- [ ] Full CI passes on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)