### PR TITLE
Fix Windows test environment for VS 2022 and git autocrlf

### DIFF
--- a/conan/test/utils/tools.py
+++ b/conan/test/utils/tools.py
@@ -56,7 +56,7 @@ default_profiles = {
         os=Windows
         arch=x86_64
         compiler=msvc
-        compiler.version=191
+        compiler.version=194
         compiler.runtime=dynamic
         build_type=Release
         """),

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -411,7 +411,7 @@ class TestOpenAdd:
 
         c = TestClient(servers=t1.servers, light=True)
         c.run("workspace open pkg/0.1")
-        assert c.load("pkg/conanfile.py") == conanfile
+        assert c.load("pkg/conanfile.py").replace("\r\n", "\n") == conanfile
 
         c2 = TestClient(servers=t1.servers, light=True)
         c2.save({"conanws.yml": ""})


### PR DESCRIPTION
## Summary

- Update default Windows test profile `compiler.version` from `191` (VS 2017/MSVC 19.1x) to `194` (VS 2022/MSVC 14.4x) in `conan/test/utils/tools.py`, so the test suite works out-of-the-box on machines with only VS 2022 Build Tools installed.
- Fix `test_workspace_git_scm` line ending comparison on Windows where `git core.autocrlf` converts `\n` to `\r\n` on checkout, causing the assertion to fail.

## Test plan

- [x] Verified all 9 previously-failing `.bat` tests pass on Windows with VS 2022 Build Tools
- [x] Verified `test_workspace_git_scm` passes on Windows with `core.autocrlf=true`
- [ ] CI should confirm no regressions on Linux/macOS (these changes only affect Windows behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)