### PR TITLE
Fix ``conan list --graph-context={build,host}-only`` for consumer recipes without a name

### DIFF
--- a/conan/api/model/list.py
+++ b/conan/api/model/list.py
@@ -188,7 +188,8 @@ class MultiPackagesList:
 
         pref_contexts = {}
         for node in graph["graph"]["nodes"].values():
-            if node["ref"] and node["package_id"] is not None:
+            if (node["recipe"] not in (RECIPE_CONSUMER, RECIPE_VIRTUAL)
+                and node["ref"] and node["package_id"]):
                 pref = node["ref"] + ":" + node["package_id"]
                 pref_contexts.setdefault(pref, set()).add(node['context'])
 

--- a/conan/api/model/list.py
+++ b/conan/api/model/list.py
@@ -188,7 +188,7 @@ class MultiPackagesList:
 
         pref_contexts = {}
         for node in graph["graph"]["nodes"].values():
-            if node["package_id"] is not None:
+            if node["ref"] and node["package_id"] is not None:
                 pref = node["ref"] + ":" + node["package_id"]
                 pref_contexts.setdefault(pref, set()).add(node['context'])
 

--- a/test/integration/command/list/test_combined_pkglist_flows.py
+++ b/test/integration/command/list/test_combined_pkglist_flows.py
@@ -649,3 +649,17 @@ class TestListGraphContext:
             assert "protobuf/1.0" in tc.out
             assert protobuf_build_static_pkgid not in tc.out
             assert protobuf_host_shared_pkgid in tc.out
+
+    @pytest.mark.parametrize("context", ["build-only", "host-only"])
+    def test_context_only_consumer_recipe_no_named(self, context):
+        tc = TestClient()
+        tc.save({
+            "protobuf/conanfile.py": GenConanfile("protobuf", "1.0"),
+            "consumer/conanfile.py": GenConanfile()
+                .with_tool_requires("protobuf/1.0")
+                .with_requires("protobuf/1.0")})
+
+        tc.run("create protobuf")
+        tc.run(f"graph info consumer -f=json", redirect_stdout="graph.json")
+        tc.run(f"list --graph=graph.json --graph-context={context}")
+        assert "protobuf/1.0" not in tc.out


### PR DESCRIPTION
Changelog: Bugfix: Fix ``conan list --graph-context={build,host}-only`` for consumer recipes without a name
Docs: Omit
Closes: https://github.com/conan-io/conan/issues/19656

Introduced in https://github.com/conan-io/conan/pull/19368