### PR TITLE
Fix legacy definitions syntax for ``CMakeConfigDeps``

### DIFF
--- a/conan/tools/cmake/cmakeconfigdeps/config.py
+++ b/conan/tools/cmake/cmakeconfigdeps/config.py
@@ -2,7 +2,7 @@ import textwrap
 
 import jinja2
 from jinja2 import Template
-from conan.tools.cmake.utils import parse_extra_variable
+from conan.tools.cmake.utils import parse_extra_variable, cmake_escape_value
 from conan.internal.api.install.generators import relativize_path
 
 
@@ -98,7 +98,7 @@ class ConfigTemplate2:
             incdirs = [relativize_path(i, self._cmakedeps._conanfile, "${CMAKE_CURRENT_LIST_DIR}")
                        for i in incdirs]
             include_dirs = ";".join(incdirs)
-            definitions = " ".join(aggregated_cppinfo.defines)
+            definitions = ";".join("-D" + cmake_escape_value(d) for d in aggregated_cppinfo.defines)
             root_target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile)
             libraries = root_target_name or f"{pkg_name}::{pkg_name}"
 
@@ -147,7 +147,7 @@ class ConfigTemplate2:
         set({{ prefix }}_LIBRARIES {{ libraries }} )
         {% endif %}
         {% if definitions is not none %}
-        set({{ prefix }}_DEFINITIONS {{ definitions}} )
+        set({{ prefix }}_DEFINITIONS "{{ definitions}}" )
         {% endif %}
         {% endfor %}
 

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -795,11 +795,11 @@ def test_legacy_defines():
     # We do for backward compatibility with old check_symbol_exists and similar CMake code
     tc = TestClient()
     tc.save({"conanfile.py": GenConanfile("mypkg", "1.0")
-             .with_package_info({"defines": ["MY_DEFINE"]})})
+             .with_package_info({"defines": ["MY_DEFINE", "MYVAR=1"]})})
     tc.run("create")
     tc.run("install --requires=mypkg/1.0 -g CMakeConfigDeps")
     mypkg_config = tc.load("mypkg-config.cmake")
-    assert "set(mypkg_DEFINITIONS MY_DEFINE )" in mypkg_config
+    assert 'set(mypkg_DEFINITIONS "-DMY_DEFINE;-DMYVAR=1" )' in mypkg_config
 
 
 class TestExtraFindExtraVariants:


### PR DESCRIPTION
Changelog: Fix: Fix legacy definitions syntax for ``CMakeConfigDeps``
Docs: Omit

Closes https://github.com/conan-io/conan/issues/19655. This gets this variable back to how it was in `CMakeDeps`, and makes it possible to pass the value directly to functions like `add_definitions`/arguments for `try_compile` and family (Even though the modern recommended approach is to set the imported target and let it propagate all the necessary information)