### PR TITLE
fix CMakeConfigDeps casing in-package

### DIFF
--- a/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
+++ b/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
@@ -341,13 +341,12 @@ class _PathGenerator:
                     build_dir = dep.package_folder
                 pkg_folder = build_dir.replace("\\", "/") if build_dir else None
                 if pkg_folder:
-                    f = self._cmakedeps.get_cmake_filename(dep)
-                    for filename in (f"{f}-config.cmake", f"{f}Config.cmake"):
-                        if os.path.isfile(os.path.join(pkg_folder, filename)):
-                            relative_path = relativize_path(pkg_folder, self._conanfile,
-                                                            "${CMAKE_CURRENT_LIST_DIR}")
-                            for pkg_name in pkg_names:
-                                pkg_paths[pkg_name] = relative_path
+                    if any(os.path.isfile(os.path.join(pkg_folder, f + ext)) for f in pkg_names
+                           for ext in ("-config.cmake", "Config.cmake")):
+                        relative_path = relativize_path(pkg_folder, self._conanfile,
+                                                        "${CMAKE_CURRENT_LIST_DIR}")
+                        for pkg_name in pkg_names:
+                            pkg_paths[pkg_name] = relative_path
 
                     for pkg_name in pkg_names:
                         existing_paths = pkg_paths_multi.setdefault(pkg_name, [])

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -917,6 +917,35 @@ class TestExtraFindExtraVariants:
         assert paths_content.count("list(APPEND CONAN_HellO_DIR_MULTI") == 2
         assert paths_content.count("list(APPEND CONAN_HELLO_DIR_MULTI") == 2
 
+    def test_find_file_in_package(self):
+        tc = TestClient()
+        conanfile = textwrap.dedent("""
+            import os
+            from conan import ConanFile
+            from conan.tools.files import save
+
+            class HelloConan(ConanFile):
+                name = "hello"
+                version = "1.0"
+                settings = "build_type"
+
+                def package(self):
+                    save(self, os.path.join(self.package_folder, "HellOConfig.cmake"), "")
+
+                def package_info(self):
+                    self.cpp_info.builddirs = ["."]
+                    self.cpp_info.set_property("cmake_find_mode", "none")
+                    self.cpp_info.set_property("cmake_file_name_variants", ["HellO", "HELLO"])
+            """)
+        tc.save({"conanfile.py": conanfile})
+        tc.run("create")
+        tc.run("create -s=build_type=Debug")
+        tc.run("install --requires=hello/1.0 -g CMakeConfigDeps")
+        paths_content = tc.load("conan_cmakedeps_paths.cmake")
+        assert "set(hello_DIR" in paths_content
+        assert "set(HellO_DIR" in paths_content
+        assert "set(HELLO_DIR" in paths_content
+
 
 def test_requires_only_component_target_generation():
     tc = TestClient()


### PR DESCRIPTION
Changelog:  Bugfix: Solve ``CMakeConfigDeps`` issue with in-package config.cmake files that were ignoring ``cmake_file_name_variants``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19667
