### PR TITLE
Use lazy imports to avoid circular dependency so PyInstaller bundles `conan.tools.system`

### DIFF
--- a/conan/internal/api/install/generators.py
+++ b/conan/internal/api/install/generators.py
@@ -7,7 +7,6 @@ from conan.errors import ConanException
 from conan.internal.cache.home_paths import HomePaths
 from conan.internal.errors import conanfile_exception_formatter
 from conan.internal.util.files import mkdir, chdir
-from conan.tools.env.environment import generate_aggregated_env
 
 
 _generators = {"CMakeToolchain": "conan.tools.cmake",
@@ -142,6 +141,7 @@ def write_generators(conanfile, hook_manager, home_folder, envs_generation=None)
                 env = VirtualRunEnv(conanfile)
                 env.generate()
 
+    from conan.tools.env.environment import generate_aggregated_env
     generate_aggregated_env(conanfile)
     hook_manager.execute("post_generate", conanfile=conanfile)
 

--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -9,7 +9,6 @@ from conan.internal.subsystems import deduce_subsystem, WINDOWS, subsystem_path
 from conan.errors import ConanException
 from conan.internal.model.recipe_ref import ref_matches
 from conan.internal.util.files import save
-from conan.tools.microsoft.visual import CONAN_VCVARS
 
 
 class _EnvVarPlaceHolder:
@@ -910,6 +909,7 @@ def generate_aggregated_env(conanfile):
                 content = ["@echo off"]
 
                 if deactivation_mode == "function":
+                    from conan.tools.microsoft.visual import CONAN_VCVARS
                     deactivates_var = f"_CONAN_{group}_DEACTIVATES_DIR"
                     content += [
                         f'set "{deactivates_var}=%TEMP%\\conan_{group}_%RANDOM%"',


### PR DESCRIPTION
Changelog: Fix: Use lazy imports to avoid circular dependency so PyInstaller bundles `conan.tools.system`.
Docs: Omit

When building Conan with PyInstaller (e.g. on `develop2` or release branches), [the resulting binary failed](https://github.com/conan-io/conan/actions/runs/22385855865/job/64796249682#step:5:712) with `ModuleNotFoundError: No module named 'conan.tools.system'` when running recipes that use `conan.tools.system.package_manager` (Apt, Brew, etc.). This failed only for the standalone binary generated with PyInstaller.

## Cause

PyInstaller discovers modules by importing the package during its analysis. With `--collect-submodules=conan`. Here is the warning that was triggered:

```
73 WARNING: Failed to collect submodules for 'conan.tools.system' because importing 'conan.tools.system' raised: ImportError: cannot import name 'generate_aggregated_env' from partially initialized module 'conan.tools.env.environment' (most likely due to a circular import) (/Users/runner/work/conan/conan/conan-home/p/b/conanca173c38cc51e/b/conan-src/conan/tools/env/environment.py)
```

When importing `conan.tools.system` triggers this chain:

- `conan.tools.system` → `python_manager` → `conan.tools.env.environment` → (top-level import) `conan.tools.microsoft.visual` → `conan.tools.microsoft` package → `nmakedeps` / `nmaketoolchain` → `from conan.tools.env import Environment`.

At that point `conan.tools.env` (and `environment`) is still being initialized, so Python raises `ImportError: cannot import name 'X' from partially initialized module 'conan.tools.env.environment'`. PyInstaller treats that as a failure and **does not include** `conan.tools.system` in the bundle, which leads to `ModuleNotFoundError` at runtime.

Under normal execution (pip-installed Conan), the import order is different: `conan.tools.env` is usually fully loaded before `conan.tools.system` is ever imported, so the cycle never triggers and the error does not appear.

The changes with lazy imports remove the cycle when PyInstaller imports `conan.tools.system`, so its submodules are collected correctly and the packaged binary can use `conan.tools.system.package_manager` without errors.