### PR TITLE
Representation of a cycle/loop in the graph info with a red arrow

### DIFF
--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -103,7 +103,6 @@ graph_info_html = r"""
                     if (node.test && hide_test) continue;
                     let shape = node.context == "build" || node.test ? "ellipse" : "box";
                     let label = null;
-                    const level = loop_error ? node.level : undefined;
                     if (node["name"])
                         label =  node["name"] + "/" + node["version"];
                     else if (node["ref"])
@@ -177,7 +176,6 @@ graph_info_html = r"""
                         borderWidth: borderWidth,
                         color: {border: borderColor, background: color,
                                 highlight: {background: color, border: "Blue"}},
-                        level: level
                     });
                 }
                 for (const [node_id, node] of Object.entries(graph_data["nodes"])) {
@@ -190,8 +188,12 @@ graph_info_html = r"""
                         }
                         if (loop_error && loop_error[1] == node["name"] && loop_error[0] == dep["ref"]) {
                             let target_id = targets[dep_id] || dep_id;
-                            edges.push({id: edge_counter, from: target_id, to: node_id,
-                                        color: {color: "Red", highlight: "Red"}, smooth: { enabled: true, type: 'curvedCW', roundness: 0.4 }});
+                            edges.push({id: edge_counter, from: node_id, to: target_id,
+                                        color: {color: "Red", highlight: "Red"},
+                                        smooth: { enabled: true, type: 'curvedCW', roundness: 0.4 },
+                                        arrows: "from",
+                                        label: "loop",
+                                        title: "loop"});
                             global_edges[edge_counter++] = dep;
                         }
                     }

--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -89,17 +89,21 @@ graph_info_html = r"""
                 let conflict=null;
                 let provide_conflict=null;
                 let missing_error=null;
+                let loop_error=null;
                 if (graph_data["error"] && graph_data["error"]["type"] == "conflict")
                     conflict = graph_data["error"];
                 else if (graph_data["error"] && graph_data["error"]["type"] == "provide_conflict")
                     provide_conflict = graph_data["error"];
                 else if (graph_data["error"] && graph_data["error"]["type"] == "missing")
                     missing_error = graph_data["error"];
+                else if (graph_data["error"] && graph_data["error"]["type"] == "loop")
+                    loop_error = [graph_data["error"]['node']['label'], graph_data["error"]['require']['name']];
                 for (const [node_id, node] of Object.entries(graph_data["nodes"])) {
                     if (node.context == "build" && hide_build) continue;
                     if (node.test && hide_test) continue;
                     let shape = node.context == "build" || node.test ? "ellipse" : "box";
                     let label = null;
+                    const level = loop_error ? node.level : undefined;
                     if (node["name"])
                         label =  node["name"] + "/" + node["version"];
                     else if (node["ref"])
@@ -173,6 +177,7 @@ graph_info_html = r"""
                         borderWidth: borderWidth,
                         color: {border: borderColor, background: color,
                                 highlight: {background: color, border: "Blue"}},
+                        level: level
                     });
                 }
                 for (const [node_id, node] of Object.entries(graph_data["nodes"])) {
@@ -181,6 +186,12 @@ graph_info_html = r"""
                             let target_id = targets[dep_id] || dep_id;
                             edges.push({id: edge_counter, from: node_id, to: target_id,
                                         color: {color: "SkyBlue", highlight: "Blue"}});
+                            global_edges[edge_counter++] = dep;
+                        }
+                        if (loop_error && loop_error[1] == node["name"] && loop_error[0] == dep["ref"]) {
+                            let target_id = targets[dep_id] || dep_id;
+                            edges.push({id: edge_counter, from: target_id, to: node_id,
+                                        color: {color: "Red", highlight: "Red"}, smooth: { enabled: true, type: 'curvedCW', roundness: 0.4 }});
                             global_edges[edge_counter++] = dep;
                         }
                     }

--- a/conan/internal/graph/graph.py
+++ b/conan/internal/graph/graph.py
@@ -273,7 +273,6 @@ class Node:
         result["recipe"] = self.recipe
         result["package_id"] = self.package_id
         result["prev"] = self.prev
-        result["level"] = getattr(self, "level", None)
         result["rrev"] = self.ref.revision if self.ref is not None else None
         result["rrev_timestamp"] = self.ref.timestamp if self.ref is not None else None
         result["prev_timestamp"] = self.pref_timestamp
@@ -448,9 +447,6 @@ class DepsGraph:
     def serialize(self):
         for i, n in enumerate(self.nodes):
             n.id = str(i)
-        by_levels = self.by_levels()
-        for node in self.nodes:
-            node.level = len(by_levels) - next(i for i, level in enumerate(by_levels) if node in level)
         result = OrderedDict()
         result["nodes"] = {n.id: n.serialize() for n in self.nodes}
         result["root"] = {self.root.id: repr(self.root.ref)}  # TODO: ref of consumer/virtual

--- a/conan/internal/graph/graph.py
+++ b/conan/internal/graph/graph.py
@@ -273,6 +273,7 @@ class Node:
         result["recipe"] = self.recipe
         result["package_id"] = self.package_id
         result["prev"] = self.prev
+        result["level"] = getattr(self, "level", None)
         result["rrev"] = self.ref.revision if self.ref is not None else None
         result["rrev_timestamp"] = self.ref.timestamp if self.ref is not None else None
         result["prev_timestamp"] = self.pref_timestamp
@@ -447,6 +448,9 @@ class DepsGraph:
     def serialize(self):
         for i, n in enumerate(self.nodes):
             n.id = str(i)
+        by_levels = self.by_levels()
+        for node in self.nodes:
+            node.level = len(by_levels) - next(i for i, level in enumerate(by_levels) if node in level)
         result = OrderedDict()
         result["nodes"] = {n.id: n.serialize() for n in self.nodes}
         result["root"] = {self.root.id: repr(self.root.ref)}  # TODO: ref of consumer/virtual

--- a/conan/internal/graph/graph_error.py
+++ b/conan/internal/graph/graph_error.py
@@ -43,6 +43,13 @@ class GraphLoopError(GraphError):
         self.require = require
         self.ancestor = ancestor
 
+    def serialize(self):
+        return {"type": "loop",
+                "require": {**self.require.serialize(), "name": str(self.require.ref).split("/")[0]},
+                "node": self.node.serialize(),
+                "ancestor": self.ancestor.serialize()
+                }
+
     def __str__(self):
         return "There is a cycle/loop in the graph:\n" \
                f"    Initial ancestor: {self.ancestor}\n" \

--- a/test/integration/command/info/test_graph_info_graphical.py
+++ b/test/integration/command/info/test_graph_info_graphical.py
@@ -173,7 +173,7 @@ def test_graph_conflict_loop():
     c.run("export lib_c")
     c.run("graph info lib_x --format=html", assert_error=True, redirect_stdout="graph.html")
     # checked manually
-    c.open("graph.html")
+    #c.open("graph.html")
 
 def test_graph_missing_error():
     c = TestClient()

--- a/test/integration/command/info/test_graph_info_graphical.py
+++ b/test/integration/command/info/test_graph_info_graphical.py
@@ -160,7 +160,8 @@ def test_graph_conflict_diamond():
     # check that it doesn't crash
     assert "ERROR: Version conflict: Conflict between math/1.0.1 and math/1.0 in the graph." in c.out
 
-def test_graph_conflict_diamond():
+
+def test_graph_conflict_loop():
     c = TestClient()
     c.save({"lib_a/conanfile.py": GenConanfile("lib_a", "1.0").with_requires("lib_b/1.0"),
             "lib_b/conanfile.py": GenConanfile("lib_b", "1.0").with_requires("lib_c/1.0"),
@@ -171,8 +172,8 @@ def test_graph_conflict_diamond():
     c.run("export lib_b")
     c.run("export lib_c")
     c.run("graph info lib_x --format=html", assert_error=True, redirect_stdout="graph.html")
-    # check that it doesn't crash, tested manually
-    assert "ERROR: There is a cycle/loop in the graph" in c.out
+    # checked manually
+    c.open("graph.html")
 
 def test_graph_missing_error():
     c = TestClient()

--- a/test/integration/command/info/test_graph_info_graphical.py
+++ b/test/integration/command/info/test_graph_info_graphical.py
@@ -162,7 +162,7 @@ def test_graph_conflict_diamond():
 
 
 def test_graph_conflict_loop():
-    c = TestClient()
+    c = TestClient(light=True)
     c.save({"lib_a/conanfile.py": GenConanfile("lib_a", "1.0").with_requires("lib_b/1.0"),
             "lib_b/conanfile.py": GenConanfile("lib_b", "1.0").with_requires("lib_c/1.0"),
             "lib_c/conanfile.py": GenConanfile("lib_c", "1.0").with_requires("lib_a/1.0"),

--- a/test/integration/command/info/test_graph_info_graphical.py
+++ b/test/integration/command/info/test_graph_info_graphical.py
@@ -160,6 +160,19 @@ def test_graph_conflict_diamond():
     # check that it doesn't crash
     assert "ERROR: Version conflict: Conflict between math/1.0.1 and math/1.0 in the graph." in c.out
 
+def test_graph_conflict_diamond():
+    c = TestClient()
+    c.save({"lib_a/conanfile.py": GenConanfile("lib_a", "1.0").with_requires("lib_b/1.0"),
+            "lib_b/conanfile.py": GenConanfile("lib_b", "1.0").with_requires("lib_c/1.0"),
+            "lib_c/conanfile.py": GenConanfile("lib_c", "1.0").with_requires("lib_a/1.0"),
+            "lib_x/conanfile.py": GenConanfile("lib_x", "1.0").with_requires("lib_a/1.0"),
+            })
+    c.run("export lib_a")
+    c.run("export lib_b")
+    c.run("export lib_c")
+    c.run("graph info lib_x --format=html", assert_error=True, redirect_stdout="graph.html")
+    # check that it doesn't crash, tested manually
+    assert "ERROR: There is a cycle/loop in the graph" in c.out
 
 def test_graph_missing_error():
     c = TestClient()


### PR DESCRIPTION
Changelog: Feature: Show cycles/loops in ``conan graph info --format=html`` with a red arrow.
Docs: Omit

Close: https://github.com/conan-io/conan/issues/19678

# Examples of the new line:

Test case:
<img width="287" height="547" alt="Screenshot 2026-03-04 at 12 24 07" src="https://github.com/user-attachments/assets/c315fb3b-992f-45e5-91b7-989363910cd4" />

Complex graph:
<img width="376" height="408" alt="Screenshot 2026-03-04 at 12 23 57" src="https://github.com/user-attachments/assets/05983e87-f217-42b3-b918-e32ba42bace3" />



- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
