### PR TITLE
fix win_bash_true with scope=run

### DIFF
--- a/conan/internal/model/conan_file.py
+++ b/conan/internal/model/conan_file.py
@@ -384,7 +384,8 @@ class ConanFile:
         env = [env] if env and isinstance(env, str) else (env or [])
         assert isinstance(env, list), "env argument to ConanFile.run() should be a list"
         envfiles_folder = self.generators_folder or os.getcwd()
-        wrapped_cmd = command_env_wrapper(self, command, env, envfiles_folder=envfiles_folder)
+        wrapped_cmd = command_env_wrapper(self, command, env, envfiles_folder=envfiles_folder,
+                                          scope=scope)
         from conan.internal.util.runners import conan_run
         if not quiet:
             ConanOutput().info(f"{self.display_name}: RUN: {command}", fg=Color.BRIGHT_BLUE)

--- a/test/functional/toolchains/gnu/autotools/test_win_bash.py
+++ b/test/functional/toolchains/gnu/autotools/test_win_bash.py
@@ -144,8 +144,9 @@ def test_autotools_bash_complete_clang(frontend, runtime, build_type):
     check_vs_runtime("main.exe", client, "17", build_type=build_type, static_runtime=static_runtime)
 
 
+@pytest.mark.parametrize("scope", ["build", "run"])
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows")
-def test_add_msys2_path_automatically():
+def test_add_msys2_path_automatically(scope):
     """ Check that commands like ar, autoconf, etc, that are in the /usr/bin folder together
     with the bash.exe, can be automaticallly used when running in windows bash, without user
     extra addition to [buildenv] of that msys64/usr/bin path
@@ -164,21 +165,25 @@ def test_add_msys2_path_automatically():
             tools.microsoft.bash:path={}
             """.format(bash_path))})
 
-    conanfile = textwrap.dedent("""
+    conanfile = textwrap.dedent(f"""
         from conan import ConanFile
 
         class HelloConan(ConanFile):
             name = "hello"
             version = "0.1"
 
-            win_bash = True
+            def configure(self):
+                if "{scope}" == "build":
+                    self.win_bash = True
+                else:
+                    self.win_bash_run = True
 
             def build(self):
-                self.run("ar -h")
+                self.run("ar -h", scope="{scope}")
                 """)
 
     client.save({"conanfile.py": conanfile})
-    client.run("create .")
+    client.run("build .")
     assert "ar.exe" in client.out
 
 


### PR DESCRIPTION
Changelog: Bugfix: Define correct bash usage for ``win_bash_run=True`` with ``self.run(..., scope="run")``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/13692
