### PR TITLE
implicit C linkage support by CXX projects in CMakeConfigDeps

### DIFF
--- a/conan/tools/cmake/cmakeconfigdeps/target_configuration.py
+++ b/conan/tools/cmake/cmakeconfigdeps/target_configuration.py
@@ -408,6 +408,12 @@ class TargetConfigurationTemplate2:
 
         {% if lib_info.get("link_languages") %}
         get_property(_languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+        if("CXX" IN_LIST _languages)
+            list(APPEND _languages "C")
+        endif()
+        if("CUDA" IN_LIST _languages)
+            list(APPEND _languages "C" "CXX")
+        endif()
         {% for lang in lib_info["link_languages"] %}
         if(NOT "{{lang}}" IN_LIST _languages)
             message(SEND_ERROR

--- a/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new_cpp_linkage.py
+++ b/test/functional/toolchains/cmake/cmakedeps2/test_cmakeconfigdeps_new_cpp_linkage.py
@@ -2,8 +2,117 @@ import platform
 import textwrap
 import pytest
 
+from conan.test.assets.sources import gen_function_c, gen_function_h
+from conan.test.utils.tools import TestClient
 
-new_value = "will_break_next"
+
+@pytest.mark.tool("cmake")
+def test_cxx_only_project_links_c_library():
+    """
+    When the consumer enables only CXX (project(myapp CXX)), the generated CMake config
+    must not SEND_ERROR for a dependency with C linkage. CXX implies C linkage support,
+    so the template adds "C" to the enabled languages check when "CXX" is present.
+    """
+    c = TestClient()
+    # C library package: builds a static C lib, declares languages = "C" so link_languages = ["C"]
+    hello_c = gen_function_c(name="hello")
+    hello_h = gen_function_h(name="hello")
+    hello_cmake = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.15)
+        project(hello C)
+        add_library(hello STATIC src/hello.c)
+        target_include_directories(hello PUBLIC
+          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+          $<INSTALL_INTERFACE:include>)
+        install(TARGETS hello
+          ARCHIVE DESTINATION lib
+          INCLUDES DESTINATION include)
+        install(FILES include/hello.h DESTINATION include)
+        """)
+    hello_conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.cmake import CMake, cmake_layout
+
+        class Clib(ConanFile):
+            name = "hello"
+            version = "0.1"
+            settings = "os", "compiler", "build_type", "arch"
+            package_type = "static-library"
+            generators = "CMakeToolchain"
+            exports_sources = "CMakeLists.txt", "src/*", "include/*"
+            languages = "C"
+
+            def layout(self):
+                cmake_layout(self)
+
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+                cmake.build()
+
+            def package(self):
+                cmake = CMake(self)
+                cmake.install()
+
+            def package_info(self):
+                self.cpp_info.libs = ["hello"]
+        """)
+    c.save({
+        "hello/conanfile.py": hello_conanfile,
+        "hello/CMakeLists.txt": hello_cmake,
+        "hello/src/hello.c": hello_c,
+        "hello/include/hello.h": hello_h,
+    })
+    c.run("create hello")
+
+    # Consumer: project(CXX) only - no C in project(). Links to C library.
+    consumer_cmake = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.15)
+        project(myapp CXX)
+
+        find_package(hello CONFIG REQUIRED)
+
+        add_executable(app main.cpp)
+        target_link_libraries(app PRIVATE hello::hello)
+        """)
+    main_cpp = textwrap.dedent("""
+        extern "C" {
+            #include "hello.h"
+        }
+        int main() {
+            hello();
+        }
+        """)
+    consumer_conanfile = textwrap.dedent("""\
+        import os
+        from conan import ConanFile
+        from conan.tools.cmake import CMake, cmake_layout
+
+        class Recipe(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+            package_type = "application"
+            generators = "CMakeToolchain", "CMakeConfigDeps"
+            requires = "hello/0.1"
+
+            def layout(self):
+                cmake_layout(self)
+
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+                cmake.build()
+                self.run(os.path.join(self.cpp.build.bindir, "app"), env="conanrun")
+        """)
+    c.save({
+        "consumer/conanfile.py": consumer_conanfile,
+        "consumer/CMakeLists.txt": consumer_cmake,
+        "consumer/main.cpp": main_cpp,
+    })
+    c.run("build consumer")
+
+    # If the fix were missing, CMake configure would SEND_ERROR: "Target hello::hello has C
+    # linkage but C not enabled in project()". So reaching here and running the app proves the fix.
+    assert "hello: Release!" in c.out
 
 
 @pytest.mark.skipif(platform.system() == "Windows", reason="Windows doesn't fail to link")
@@ -28,7 +137,7 @@ def test_auto_cppstd(matrix_c_interface_client):
         class Recipe(ConanFile):
             settings = "os", "compiler", "build_type", "arch"
             package_type = "application"
-            generators = "CMakeToolchain", "CMakeDeps"
+            generators = "CMakeToolchain", "CMakeConfigDeps"
             requires = "matrix/0.1"
 
             def layout(self):
@@ -50,5 +159,5 @@ def test_auto_cppstd(matrix_c_interface_client):
     c.save({"conanfile.py": conanfile,
             "CMakeLists.txt": consumer,
             "app.c": app}, clean_first=True)
-    c.run(f"build . -c tools.cmake.cmakedeps:new={new_value}")
+    c.run(f"build .")
     assert "Hello Matrix!" in c.out


### PR DESCRIPTION
Changelog: Fix: Relax the ``CMakeConfigDeps`` requirement to explicitly declare the CMake ``C`` language in ``CXX`` projects when linking C dependencies, since this is already implicit in CMake.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19702