### PR TITLE
Add support for Clang version 22

### DIFF
--- a/conan/internal/default_settings.py
+++ b/conan/internal/default_settings.py
@@ -141,7 +141,7 @@ compiler:
         version: ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0",
                   "5.0", "6.0", "7.0", "7.1",
                   "8", "9", "10", "11", "12", "13", "14", "15", "16", "17",
-                  "18", "19", "20", "21"]
+                  "18", "19", "20", "21", "22"]
         libcxx: [null, libstdc++, libstdc++11, libc++, c++_shared, c++_static]
         cppstd: [null, 98, gnu98, 11, gnu11, 14, gnu14, 17, gnu17, 20, gnu20, 23, gnu23, 26, gnu26]
         runtime: [null, static, dynamic]


### PR DESCRIPTION
Changelog: Feature: Add support for Clang 22.
Docs: Omit

https://releases.llvm.org/22.1.0/tools/clang/docs/ReleaseNotes.html

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
