### PR TITLE
Fix missing libraries in legacy `<packagename>_LIBRARIES` variable definition

### DIFF
--- a/conan/tools/cmake/cmakeconfigdeps/config.py
+++ b/conan/tools/cmake/cmakeconfigdeps/config.py
@@ -99,9 +99,17 @@ class ConfigTemplate2:
                        for i in incdirs]
             include_dirs = ";".join(incdirs)
             definitions = ";".join("-D" + cmake_escape_value(d) for d in aggregated_cppinfo.defines)
-            root_target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile)
-            libraries = root_target_name or f"{pkg_name}::{pkg_name}"
 
+            libraries = []
+            if self._full_cpp_info.has_components:
+                for component in self._full_cpp_info.components.keys():
+                    root_target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile,
+                                                                    comp_name=component)
+                    libraries.append(root_target_name or f"{pkg_name}::{component}")
+            else:
+                root_target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile)
+                libraries.append(root_target_name or f"{pkg_name}::{pkg_name}")
+        libraries = " ".join(libraries) if libraries else ""
         return {"additional_variables_prefixes": prefixes,
                 "version": self._conanfile.ref.version,
                 "include_dirs": include_dirs,

--- a/conan/tools/cmake/cmakeconfigdeps/config.py
+++ b/conan/tools/cmake/cmakeconfigdeps/config.py
@@ -103,7 +103,8 @@ class ConfigTemplate2:
             libraries = []
             if self._full_cpp_info.has_components:
                 for component in self._full_cpp_info.components.keys():
-                    root_target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile,
+                    root_target_name = self._cmakedeps.get_property("cmake_target_name",
+                                                                    self._conanfile,
                                                                     comp_name=component)
                     libraries.append(root_target_name or f"{pkg_name}::{component}")
             else:

--- a/conan/tools/cmake/cmakeconfigdeps/config.py
+++ b/conan/tools/cmake/cmakeconfigdeps/config.py
@@ -110,7 +110,7 @@ class ConfigTemplate2:
             else:
                 root_target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile)
                 libraries.append(root_target_name or f"{pkg_name}::{pkg_name}")
-        libraries = " ".join(libraries) if libraries else ""
+            libraries = " ".join(libraries) if libraries else ""
         return {"additional_variables_prefixes": prefixes,
                 "version": self._conanfile.ref.version,
                 "include_dirs": include_dirs,

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -790,16 +790,33 @@ class TestLinkFeatures:
         assert "# Requirement dep::dep -> pkg::compA (Full link: True)\n# Link feature: MYFET" in targets
 
 
-def test_legacy_defines():
-    # We used not to populate this.
-    # We do for backward compatibility with old check_symbol_exists and similar CMake code
-    tc = TestClient()
-    tc.save({"conanfile.py": GenConanfile("mypkg", "1.0")
-             .with_package_info({"defines": ["MY_DEFINE", "MYVAR=1"]})})
-    tc.run("create")
-    tc.run("install --requires=mypkg/1.0 -g CMakeConfigDeps")
-    mypkg_config = tc.load("mypkg-config.cmake")
-    assert 'set(mypkg_DEFINITIONS "-DMY_DEFINE;-DMYVAR=1" )' in mypkg_config
+class TestLegacyVariables:
+    def test_legacy_defines(self):
+        # We used not to populate this.
+        # We do for backward compatibility with old check_symbol_exists and similar CMake code
+        tc = TestClient()
+        tc.save({"conanfile.py": GenConanfile("mypkg", "1.0")
+                 .with_package_info({"defines": ["MY_DEFINE", "MYVAR=1"]})})
+        tc.run("create")
+        tc.run("install --requires=mypkg/1.0 -g CMakeConfigDeps")
+        mypkg_config = tc.load("mypkg-config.cmake")
+        assert 'set(mypkg_DEFINITIONS "-DMY_DEFINE;-DMYVAR=1" )' in mypkg_config
+
+    def test_legacy_libraries(self):
+        tc = TestClient()
+        tc.save({"conanfile.py": GenConanfile("mypkg", "1.0")
+                 .with_package_file("lib/mylib1.a", "library")
+                 .with_package_file("lib/mylib2.a", "library")
+                 .with_package_info({"components": {"mypkg": {"libs": ["mylib1"]},
+                                                    "lib2": {"libs": ["mylib2"]}}})
+        })
+        tc.run("create")
+        tc.run("install --requires=mypkg/1.0 -g CMakeConfigDeps")
+        mypkg_config = tc.load("mypkg-config.cmake")
+        # If there's no interface global target
+        # mypkg::lib2 is not added to the list of libraries
+        assert "set(mypkg_LIBRARIES mypkg::mypkg mypkg::lib2 )" in mypkg_config
+
 
 
 class TestExtraFindExtraVariants:

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -796,11 +796,13 @@ class TestLegacyVariables:
         # We do for backward compatibility with old check_symbol_exists and similar CMake code
         tc = TestClient()
         tc.save({"conanfile.py": GenConanfile("mypkg", "1.0")
-                 .with_package_info({"defines": ["MY_DEFINE", "MYVAR=1"]})})
+                 .with_package_info({"components": {"mypkg": {"defines": ["MY_DEFINE", "MYVAR=1"]},
+                                                    "lib2": {"defines": ["MY_DEFINE2", "MYVAR2=1"]}}})
+                 .with_package_info()})
         tc.run("create")
         tc.run("install --requires=mypkg/1.0 -g CMakeConfigDeps")
         mypkg_config = tc.load("mypkg-config.cmake")
-        assert 'set(mypkg_DEFINITIONS "-DMY_DEFINE;-DMYVAR=1" )' in mypkg_config
+        assert 'set(mypkg_DEFINITIONS "-DMY_DEFINE2;-DMYVAR2=1;-DMY_DEFINE;-DMYVAR=1" )' in mypkg_config
 
     def test_legacy_libraries(self):
         tc = TestClient()

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -791,7 +791,7 @@ class TestLinkFeatures:
 
 
 class TestLegacyVariables:
-    def test_legacy_definesself(self):
+    def test_legacy_defines(self):
         # We used not to populate this.
         # We do for backward compatibility with old check_symbol_exists and similar CMake code
         tc = TestClient()

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -829,7 +829,6 @@ class TestLegacyVariables:
         assert "set(mypkg_LIBRARIES mypkg::mypkg mypkg::lib2 )" in mypkg_config
 
 
-
 class TestExtraFindExtraVariants:
     def test_generated_dir_entries(self):
         tc = TestClient()

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -791,14 +791,23 @@ class TestLinkFeatures:
 
 
 class TestLegacyVariables:
-    def test_legacy_defines(self):
+    def test_legacy_definesself(self):
         # We used not to populate this.
         # We do for backward compatibility with old check_symbol_exists and similar CMake code
         tc = TestClient()
         tc.save({"conanfile.py": GenConanfile("mypkg", "1.0")
+                .with_package_info({"defines": ["MY_DEFINE", "MYVAR=1"]})})
+        tc.run("create")
+        tc.run("install --requires=mypkg/1.0 -g CMakeConfigDeps")
+        mypkg_config = tc.load("mypkg-config.cmake")
+        assert 'set(mypkg_DEFINITIONS "-DMY_DEFINE;-DMYVAR=1" )' in mypkg_config
+
+    def test_legacy_defines_multiple_components(self):
+        tc = TestClient()
+        tc.save({"conanfile.py": GenConanfile("mypkg", "1.0")
                  .with_package_info({"components": {"mypkg": {"defines": ["MY_DEFINE", "MYVAR=1"]},
                                                     "lib2": {"defines": ["MY_DEFINE2", "MYVAR2=1"]}}})
-                 .with_package_info()})
+                 })
         tc.run("create")
         tc.run("install --requires=mypkg/1.0 -g CMakeConfigDeps")
         mypkg_config = tc.load("mypkg-config.cmake")


### PR DESCRIPTION
Changelog: Fix: Fix missing libraries in legacy ``<packagename>_LIBRARIES`` variable definition in ``CMakeConfigDeps`` generator.
Docs: Omit