### PR TITLE
show transitive html

### DIFF
--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -36,6 +36,10 @@ graph_info_html = r"""
                     <label for="show_test_requires">Show test-requires</label>
                 </div>
                 <div>
+                    <input type="checkbox" onchange="switchTransitive()" id="show_transitive_requires"/>
+                    <label for="show_transitive_requires">Show transitive-requires</label>
+                </div>
+                <div>
                     <input type="checkbox" onchange="collapsePackages()" id="collapse_packages"/>
                     <label for="collapse_packages">Group packages</label>
                 </div>
@@ -63,6 +67,7 @@ graph_info_html = r"""
             const graph_data = {{ deps_graph | tojson }};
             let hide_build = false;
             let hide_test = false;
+            let show_transitive = false;
             let search_pkgs = null;
             let focus_search = false;
             let excluded_pkgs = null;
@@ -184,6 +189,13 @@ graph_info_html = r"""
                             let target_id = targets[dep_id] || dep_id;
                             edges.push({id: edge_counter, from: node_id, to: target_id,
                                         color: {color: "SkyBlue", highlight: "Blue"}});
+                            global_edges[edge_counter++] = dep;
+                        }
+                        if (show_transitive && dep.direct === false){
+                            let target_id = targets[dep_id] || dep_id;
+                            edges.push({id: edge_counter, from: node_id, to: target_id,
+                                        color: {color: "LightGray", highlight: "Gray"},
+                                        dashes: true});
                             global_edges[edge_counter++] = dep;
                         }
                         if (loop_error && loop_error[1] == node["name"] && loop_error[0] == dep["ref"]) {
@@ -379,6 +391,10 @@ graph_info_html = r"""
             }
             function switchTest() {
                 hide_test = !hide_test;
+                draw();
+            }
+            function switchTransitive() {
+                show_transitive = !show_transitive;
                 draw();
             }
             function collapsePackages() {


### PR DESCRIPTION
Changelog: Feature: The HTML graph representation learned to show transitive requirements.
Docs: Omit


<img width="380" height="447" alt="image" src="https://github.com/user-attachments/assets/b723909e-7d84-4294-88e8-eecb9c9947db" />
