### PR TITLE
remove alias support

### DIFF
--- a/conan/internal/graph/graph_builder.py
+++ b/conan/internal/graph/graph_builder.py
@@ -1,3 +1,4 @@
+import os
 from collections import deque
 
 from conan.internal.cache.conan_reference_layout import BasicLayout
@@ -20,6 +21,7 @@ from conan.internal.model.version_range import VersionRange
 
 
 class DepsGraphBuilder:
+    ALLOW_ALIAS = False
 
     def __init__(self, proxy, loader, resolver, cache, remotes, update, check_update, global_conf):
         self._proxy = proxy
@@ -219,6 +221,8 @@ class DepsGraphBuilder:
             result.append(require)
             alias = require.alias  # alias needs to be processed this early
             if alias is not None:
+                if not DepsGraphBuilder.ALLOW_ALIAS and os.getenv("CONAN_ALLOW_ALIAS") != "will_break_next":
+                    raise ConanException(f"Alias requirements have been removed: '{node}' requiring: '{alias}'")
                 resolved = False
                 if graph_lock is not None:
                     resolved = graph_lock.replace_alias(require, alias)

--- a/test/functional/revisions_test.py
+++ b/test/functional/revisions_test.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 import pytest
 from unittest.mock import patch
 
+from conan.internal.graph.graph_builder import DepsGraphBuilder
 from conan.test.utils.env import environment_update
 from conan.internal.errors import RecipeNotFoundException
 from conan.api.model import RecipeReference
@@ -22,6 +23,9 @@ def _create(c_v2, ref, conanfile=None, args=None, assert_error=False):
     if not assert_error:
         pref = c_v2.created_package_reference(str(ref))
         return pref
+
+
+DepsGraphBuilder.ALLOW_ALIAS = True
 
 
 @pytest.mark.artifactory_ready

--- a/test/integration/command/alias_test.py
+++ b/test/integration/command/alias_test.py
@@ -2,7 +2,10 @@ import os
 import textwrap
 
 from conan.api.model import RecipeReference
+from conan.internal.graph.graph_builder import DepsGraphBuilder
 from conan.test.utils.tools import TestClient, GenConanfile
+
+DepsGraphBuilder.ALLOW_ALIAS = True
 
 
 class TestConanAlias:

--- a/test/integration/graph/core/test_alias.py
+++ b/test/integration/graph/core/test_alias.py
@@ -1,7 +1,10 @@
+from conan.internal.graph.graph_builder import DepsGraphBuilder
 from conan.test.assets.genconanfile import GenConanfile
 from test.integration.graph.core.graph_manager_base import GraphManagerTest
 from test.integration.graph.core.graph_manager_test import _check_transitive
 from conan.test.utils.tools import TestClient
+
+DepsGraphBuilder.ALLOW_ALIAS = True
 
 
 class TestAlias(GraphManagerTest):

--- a/test/integration/lockfile/test_lock_alias.py
+++ b/test/integration/lockfile/test_lock_alias.py
@@ -2,8 +2,11 @@ import os
 
 import pytest
 
+from conan.internal.graph.graph_builder import DepsGraphBuilder
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
+
+DepsGraphBuilder.ALLOW_ALIAS = True
 
 
 @pytest.mark.parametrize("requires", ["requires", "tool_requires"])


### PR DESCRIPTION
Changelog: Feature: Legacy Conan 1.X alias support has been removed.
Docs: Omit

