### PR TITLE
Only group build packages in `conan graph info .. -f=html`

### DIFF
--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -87,7 +87,7 @@ graph_info_html = r"""
             function define_data(){
                 let nodes = [];
                 let edges = [];
-                let collapsed_packages = {};
+                let collapsed_packages = {"build": {}, "host": {}};
                 let targets = {};
                 global_edges = {};
                 let edge_counter = 0;
@@ -114,11 +114,11 @@ graph_info_html = r"""
                         label = node["ref"];
                     else
                         label = node.recipe == "Consumer"? "conanfile": "CLI";
-                    if (collapse_packages && node.context == "build") {
-                        let existing = collapsed_packages[label];
+                    if (collapse_packages) {
+                        let existing = collapsed_packages[node.context][label];
                         targets[node_id] = existing;
                         if (existing) continue;
-                        collapsed_packages[label] = node_id;
+                        collapsed_packages[node.context][label] = node_id;
                     }
                     if (excluded_pkgs) {
                         let patterns = excluded_pkgs.split(',')

--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -114,7 +114,7 @@ graph_info_html = r"""
                         label = node["ref"];
                     else
                         label = node.recipe == "Consumer"? "conanfile": "CLI";
-                    if (collapse_packages) {
+                    if (collapse_packages && node.context == "build") {
                         let existing = collapsed_packages[label];
                         targets[node_id] = existing;
                         if (existing) continue;


### PR DESCRIPTION
Changelog: Fix: Only group build packages in ``conan graph info .. -f=html``.
Docs: Omit

Before, we would only get 1 protobuf, and a phantom abseil root
<img width="1076" height="704" alt="Captura de pantalla 2026-03-12 a las 13 14 52" src="https://github.com/user-attachments/assets/15086def-ee80-4962-90ec-af3b8d0c0413" />



After, we can see both protobufs, each with is corresponding abseil requirement
<img width="702" height="528" alt="image" src="https://github.com/user-attachments/assets/c66ebdd9-4aad-42ad-9f0d-6c15753e72a2" />
