### PR TITLE
moving collaborators from ConanApp to ApiHelpers

### DIFF
--- a/conan/api/conan_api.py
+++ b/conan/api/conan_api.py
@@ -21,6 +21,8 @@ from conan.api.subapi.remotes import RemotesAPI
 from conan.api.subapi.remove import RemoveAPI
 from conan.api.subapi.upload import UploadAPI
 from conan.errors import ConanException
+from conan.internal.api.remotes.localdb import LocalDB
+from conan.internal.cache.cache import PkgCache
 from conan.internal.cache.home_paths import HomePaths
 from conan.internal.hook_manager import HookManager
 from conan.internal.model.conf import load_global_conf, ConfDefinition, CORE_CONF_PATTERN
@@ -28,7 +30,9 @@ from conan.internal.model.settings import load_settings_yml
 from conan.internal.paths import get_conan_user_home
 from conan.internal.api.migrations import ClientMigrator
 from conan.internal.model.version_range import validate_conan_version
+from conan.internal.rest.auth_manager import ConanApiAuthManager
 from conan.internal.rest.conan_requester import ConanRequester
+from conan.internal.rest.remote_manager import RemoteManager
 
 
 class ConanAPI:
@@ -107,18 +111,22 @@ class ConanAPI:
         # Migration system
         # TODO: A prettier refactoring of migrators would be nice
         from conan import conan_version
-        migrator = ClientMigrator(self.cache_folder, conan_version)
+        migrator = ClientMigrator(self._home_folder, conan_version)
         migrator.migrate()
 
     class _ApiHelpers:
+        # This is an internal implementation detail of Conan, DO NOT USE
         def __init__(self, conan_api):
             self._conan_api = conan_api
             self._cli_core_confs = None
             self._init_global_conf()
+            # TODO: Make uniform lazy vs non lazy collaborators
             self.hook_manager = HookManager(HomePaths(self._conan_api.home_folder).hooks_path)
             # Wraps an http_requester to inject proxies, certs, etc
             self._requester = ConanRequester(self.global_conf, self._conan_api.home_folder)
+            self.cache = PkgCache(self._conan_api.home_folder, self.global_conf)
             self._settings_yml = None
+            self._remote_manager = None
 
         def set_core_confs(self, core_confs):
             confs = ConfDefinition()
@@ -145,12 +153,25 @@ class ConanAPI:
             self.hook_manager.reinit()
             self._requester = ConanRequester(self.global_conf, self._conan_api.home_folder)
             self._settings_yml = None
+            self.cache = PkgCache(self._conan_api.home_folder, self.global_conf)
+            self._remote_manager = None
 
         @property
         def settings_yml(self):
             if self._settings_yml is None:
                 self._settings_yml = load_settings_yml(self._conan_api.home_folder)
             return self._settings_yml
+
+        @property
+        def remote_manager(self):
+            if self._remote_manager is None:
+                home_folder = self._conan_api.home_folder
+                localdb = LocalDB(home_folder)
+                requester = self._conan_api._api_helpers.requester  # noqa
+                auth_manager = ConanApiAuthManager(requester, self._conan_api.home_folder, localdb,
+                                                   self.global_conf)
+                self._remote_manager = RemoteManager(self.cache, auth_manager, home_folder)
+            return self._remote_manager
 
         @property
         def requester(self):

--- a/conan/api/conan_api.py
+++ b/conan/api/conan_api.py
@@ -78,7 +78,7 @@ class ConanAPI:
         #: Used to upload recipes and packages to remotes
         self.upload: UploadAPI = UploadAPI(self, self._api_helpers)
         #: Used to download recipes and packages from remotes
-        self.download: DownloadAPI = DownloadAPI(self)
+        self.download: DownloadAPI = DownloadAPI(self, self._api_helpers)
         #: Used to interact wit the packages storage cache
         self.cache: CacheAPI = CacheAPI(self, self._api_helpers)
         #: Used to read and manage lockfile files

--- a/conan/api/conan_api.py
+++ b/conan/api/conan_api.py
@@ -66,14 +66,14 @@ class ConanAPI:
         self.remotes: RemotesAPI = RemotesAPI(self, self._api_helpers)
         self.command = CommandAPI(self)
         #: Used to get latest refs and list refs of recipes and packages
-        self.list: ListAPI = ListAPI(self)
+        self.list: ListAPI = ListAPI(self, self._api_helpers)
         self.profiles = ProfilesAPI(self, self._api_helpers)
         #: Used to install binaries, sources, deploy packages and more
         self.install: InstallAPI = InstallAPI(self, self._api_helpers)
         self.graph = GraphAPI(self, self._api_helpers)
         #: Used to export recipes and pre-compiled package binaries to the Conan cache
         self.export: ExportAPI = ExportAPI(self, self._api_helpers)
-        self.remove = RemoveAPI(self)
+        self.remove = RemoveAPI(self, self._api_helpers)
         self.new = NewAPI(self)
         #: Used to upload recipes and packages to remotes
         self.upload: UploadAPI = UploadAPI(self, self._api_helpers)

--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -195,7 +195,9 @@ class CacheAPI:
                 "https://docs.conan.io/2/reference/extensions/package_signing.html.")
 
         app = ConanApp(self._conan_api)
-        preparator = PackagePreparator(app, self._api_helpers.global_conf)
+        preparator = PackagePreparator(app, self._api_helpers.cache,
+                                       self._api_helpers.remote_manager,
+                                       self._api_helpers.global_conf)
         # Some packages can have missing sources/exports_sources
         enabled_remotes = self._conan_api.remotes.list()
         preparator.prepare(package_list, enabled_remotes, None, force=True)

--- a/conan/api/subapi/config.py
+++ b/conan/api/subapi/config.py
@@ -213,6 +213,7 @@ class ConfigAPI:
         profile_host = profile_build = profile or conan_api.profiles.get_profile([])
 
         app = ConanApp(self._conan_api)
+        cache = self._helpers.cache
 
         ConanOutput().title("Fetching requested configuration packages")
         result = []
@@ -225,7 +226,7 @@ class ConfigAPI:
                              recipe=RECIPE_VIRTUAL)
             root_node.is_conf = True
             update = ["*"]
-            builder = DepsGraphBuilder(app.proxy, app.loader, app.range_resolver, app.cache, remotes,
+            builder = DepsGraphBuilder(app.proxy, app.loader, app.range_resolver, cache, remotes,
                                        update, update, self._helpers.global_conf)
             deps_graph = builder.load_graph(root_node, profile_host, profile_build, lockfile)
 

--- a/conan/api/subapi/download.py
+++ b/conan/api/subapi/download.py
@@ -4,7 +4,6 @@ from typing import Optional, List
 
 from conan.api.model import Remote, PackagesList
 from conan.api.output import ConanOutput
-from conan.internal.conan_app import ConanBasicApp
 from conan.errors import ConanException
 from conan.api.model import PkgReference
 from conan.api.model import RecipeReference
@@ -13,38 +12,39 @@ from conan.api.model import RecipeReference
 class DownloadAPI:
     """ This API is used to download recipes and packages from a remote server."""
 
-    def __init__(self, conan_api):
+    def __init__(self, conan_api, api_helpers):
         self._conan_api = conan_api
+        self._api_helpers = api_helpers
 
     def recipe(self, ref: RecipeReference, remote: Remote, metadata: Optional[List[str]] = None):
         """Download the recipe specified in the ref from the remote.
         If the recipe is already in the cache it will be skipped,
         but the specified metadata will be downloaded."""
         output = ConanOutput()
-        app = ConanBasicApp(self._conan_api)
         assert ref.revision, f"Reference '{ref}' must have revision"
         try:
-            recipe_layout = app.cache.recipe_layout(ref)  # raises if not found
+            recipe_layout = self._api_helpers.cache.recipe_layout(ref)  # raises if not found
         except ConanException:
             pass
         else:
             output.info(f"Skip recipe {ref.repr_notime()} download, already in cache")
             if metadata:
-                app.remote_manager.get_recipe_metadata(recipe_layout, ref, remote, metadata)
+                self._api_helpers.remote_manager.get_recipe_metadata(recipe_layout, ref, remote,
+                                                                     metadata)
             return False
 
         output.info(f"Downloading recipe '{ref.repr_notime()}'")
         if ref.timestamp is None:  # we didnt obtain the timestamp before (in general it should be)
             # Respect the timestamp of the server, the ``get_recipe()`` doesn't do it internally
             # Best would be that ``get_recipe()`` returns the timestamp in the same call
-            server_ref = app.remote_manager.get_recipe_revision(ref, remote)
+            server_ref = self._api_helpers.remote_manager.get_recipe_revision(ref, remote)
             assert server_ref == ref
             ref.timestamp = server_ref.timestamp
-        recipe_layout = app.remote_manager.get_recipe(ref, remote, metadata)
+        recipe_layout = self._api_helpers.remote_manager.get_recipe(ref, remote, metadata)
 
         # Download the sources too, don't be lazy
         output.info(f"Downloading '{str(ref)}' sources")
-        app.remote_manager.get_recipe_sources(ref, recipe_layout, remote)
+        self._api_helpers.remote_manager.get_recipe_sources(ref, recipe_layout, remote)
         return True
 
     def package(self, pref: PkgReference, remote: Remote, metadata: Optional[List[str]] = None):
@@ -53,28 +53,28 @@ class DownloadAPI:
         If the package is already in the cache it will be skipped,
         but the specified metadata will be downloaded."""
         output = ConanOutput()
-        app = ConanBasicApp(self._conan_api)
+
         try:
-            app.cache.recipe_layout(pref.ref)  # raises if not found
+            self._api_helpers.cache.recipe_layout(pref.ref)  # raises if not found
         except ConanException:
             raise ConanException("The recipe of the specified package "
                                  "doesn't exist, download it first")
 
-        skip_download = app.cache.exists_prev(pref)
+        skip_download = self._api_helpers.cache.exists_prev(pref)
         if skip_download:
             output.info(f"Skip package {pref.repr_notime()} download, already in cache")
             if metadata:
-                app.remote_manager.get_package_metadata(pref, remote, metadata)
+                self._api_helpers.remote_manager.get_package_metadata(pref, remote, metadata)
             return False
 
         if pref.timestamp is None:  # we didn't obtain the timestamp before (in general it should be)
             # Respect the timestamp of the server
-            server_pref = app.remote_manager.get_package_revision(pref, remote)
+            server_pref = self._api_helpers.remote_manager.get_package_revision(pref, remote)
             assert server_pref == pref
             pref.timestamp = server_pref.timestamp
 
         output.info(f"Downloading package '{pref.repr_notime()}'")
-        app.remote_manager.get_package(pref, remote, metadata)
+        self._api_helpers.remote_manager.get_package(pref, remote, metadata)
         return True
 
     def download_full(self, package_list: PackagesList, remote: Remote,
@@ -94,7 +94,8 @@ class DownloadAPI:
                     pkg_dict.pop("upload-urls", None)
 
         t = time.time()
-        parallel = self._conan_api.config.get("core.download:parallel", default=1, check_type=int)
+        parallel = self._api_helpers.global_conf.get("core.download:parallel", default=1,
+                                                     check_type=int)
         thread_pool = ThreadPool(parallel) if parallel > 1 else None
         if not thread_pool or len(package_list._data) <= 1:  # FIXME: Iteration when multiple rrevs
             _download_pkglist(package_list)

--- a/conan/api/subapi/export.py
+++ b/conan/api/subapi/export.py
@@ -46,7 +46,7 @@ class ExportAPI:
         ConanOutput().title("Exporting recipe to the cache")
         app = ConanApp(self._conan_api)
         hook_manager = self._helpers.hook_manager
-        return cmd_export(app.loader, app.cache, hook_manager, self._helpers.global_conf, path,
+        return cmd_export(app.loader,self._helpers.cache, hook_manager, self._helpers.global_conf, path,
                           name, version, user, channel, graph_lock=lockfile, remotes=remotes)
 
     def export_pkg_graph(self, path, ref: RecipeReference, profile_host, profile_build,

--- a/conan/api/subapi/graph.py
+++ b/conan/api/subapi/graph.py
@@ -188,7 +188,8 @@ class GraphAPI:
         assert profile_build is not None
 
         remotes = remotes or []
-        builder = DepsGraphBuilder(app.proxy, app.loader, app.range_resolver, app.cache, remotes,
+        cache = self._conan_api._api_helpers.cache # noqa
+        builder = DepsGraphBuilder(app.proxy, app.loader, app.range_resolver, cache, remotes,
                                    update, check_update, self._conan_api._api_helpers.global_conf)
         deps_graph = builder.load_graph(root_node, profile_host, profile_build, lockfile)
         return deps_graph
@@ -213,8 +214,10 @@ class GraphAPI:
         :param tested_graph: In case of a "test_package", the graph being tested
         """
         ConanOutput().title("Computing necessary packages")
-        conan_app = ConanBasicApp(self._conan_api)
-        binaries_analyzer = GraphBinariesAnalyzer(conan_app, self._conan_api._api_helpers.global_conf,
+        binaries_analyzer = GraphBinariesAnalyzer(self._helpers.cache,
+                                                  self._helpers.remote_manager,
+                                                  self._conan_api.home_folder,
+                                                  self._helpers.global_conf,
                                                   self._helpers.hook_manager)
         binaries_analyzer.evaluate_graph(graph, build_mode, lockfile, remotes, update,
                                          build_modes_test, tested_graph)

--- a/conan/api/subapi/graph.py
+++ b/conan/api/subapi/graph.py
@@ -1,5 +1,5 @@
 from conan.api.output import ConanOutput
-from conan.internal.conan_app import ConanApp, ConanBasicApp
+from conan.internal.conan_app import ConanApp
 from conan.internal.model.recipe_ref import ref_matches
 from conan.internal.graph.graph import Node, RECIPE_CONSUMER, CONTEXT_HOST, RECIPE_VIRTUAL, \
     CONTEXT_BUILD, BINARY_MISSING, DepsGraph

--- a/conan/api/subapi/install.py
+++ b/conan/api/subapi/install.py
@@ -40,7 +40,7 @@ class InstallAPI:
         :param return_install_error: If ``True``, do not raise an exception, but return it
         """
         app = ConanBasicApp(self._conan_api)
-        installer = BinaryInstaller(app, self._helpers.global_conf, app.editable_packages,
+        installer = BinaryInstaller(self._conan_api, self._helpers.global_conf, app.editable_packages,
                                     self._helpers.hook_manager)
         install_graph = InstallGraph(deps_graph)
         install_graph.raise_errors()
@@ -69,7 +69,7 @@ class InstallAPI:
         :param only_info: If ``True``, only reporting and checking of whether the system requirements are installed is performed.
         """
         app = ConanBasicApp(self._conan_api)
-        installer = BinaryInstaller(app, self._helpers.global_conf, app.editable_packages,
+        installer = BinaryInstaller(self._conan_api, self._helpers.global_conf, app.editable_packages,
                                     self._helpers.hook_manager)
         installer.install_system_requires(graph, only_info)
 
@@ -90,7 +90,7 @@ class InstallAPI:
         :param graph: Dependency graph to download sources from
         """
         app = ConanBasicApp(self._conan_api)
-        installer = BinaryInstaller(app, self._helpers.global_conf, app.editable_packages,
+        installer = BinaryInstaller(self._conan_api, self._helpers.global_conf, app.editable_packages,
                                     self._helpers.hook_manager)
         installer.install_sources(graph, remotes)
 

--- a/conan/api/subapi/list.py
+++ b/conan/api/subapi/list.py
@@ -5,7 +5,6 @@ from typing import Dict
 from conan.api.model import PackagesList, MultiPackagesList, ListPattern, Remote
 from conan.api.output import ConanOutput, TimedOutput
 from conan.internal.api.list.query_parse import filter_package_configs
-from conan.internal.conan_app import ConanBasicApp
 from conan.internal.model.recipe_ref import ref_matches
 from conan.internal.paths import CONANINFO
 from conan.internal.errors import NotFoundException
@@ -47,18 +46,18 @@ class ListAPI:
     """ Get references from the recipes and packages in the cache or a remote
     """
 
-    def __init__(self, conan_api):
+    def __init__(self, conan_api, api_helpers):
         self._conan_api = conan_api
+        self._api_helpers = api_helpers
 
     def latest_recipe_revision(self, ref: RecipeReference, remote: Remote = None):
         """ For a given recipe reference, return the latest revision of the recipe in the remote,
         or in the local cache if no remote is specified, or ``None`` if the recipe does not exist."""
         assert ref.revision is None, "latest_recipe_revision: ref already have a revision"
-        app = ConanBasicApp(self._conan_api)
         if remote:
-            ret = app.remote_manager.get_latest_recipe_revision(ref, remote=remote)
+            ret = self._api_helpers.remote_manager.get_latest_recipe_revision(ref, remote=remote)
         else:
-            ret = app.cache.get_latest_recipe_revision(ref)
+            ret = self._api_helpers.cache.get_latest_recipe_revision(ref)
 
         return ret
 
@@ -66,11 +65,10 @@ class ListAPI:
         """ For a given recipe reference, return all the revisions of the recipe in the remote,
         or in the local cache if no remote is specified"""
         assert ref.revision is None, "recipe_revisions: ref already have a revision"
-        app = ConanBasicApp(self._conan_api)
         if remote:
-            results = app.remote_manager.get_recipe_revisions(ref, remote=remote)
+            results = self._api_helpers.remote_manager.get_recipe_revisions(ref, remote=remote)
         else:
-            results = app.cache.get_recipe_revisions(ref)
+            results = self._api_helpers.cache.get_recipe_revisions(ref)
 
         return results
 
@@ -80,33 +78,30 @@ class ListAPI:
         #  is used as an "exists" check too in other places, lets respect the None return
         assert pref.revision is None, "latest_package_revision: ref already have a revision"
         assert pref.package_id is not None, "package_id must be defined"
-        app = ConanBasicApp(self._conan_api)
         if remote:
-            ret = app.remote_manager.get_latest_package_revision(pref, remote=remote)
+            ret = self._api_helpers.remote_manager.get_latest_package_revision(pref, remote=remote)
         else:
-            ret = app.cache.get_latest_package_revision(pref)
+            ret = self._api_helpers.cache.get_latest_package_revision(pref)
         return ret
 
     def package_revisions(self, pref: PkgReference, remote=None):
         assert pref.ref.revision is not None, "package_revisions requires a recipe revision, " \
                                               "check latest first if needed"
-        app = ConanBasicApp(self._conan_api)
         if remote:
-            results = app.remote_manager.get_package_revisions(pref, remote=remote)
+            results = self._api_helpers.remote_manager.get_package_revisions(pref, remote=remote)
         else:
-            results = app.cache.get_package_revisions(pref)
+            results = self._api_helpers.cache.get_package_revisions(pref)
         return results
 
     def _packages_configurations(self, ref: RecipeReference,
                                  remote=None) -> Dict[PkgReference, dict]:
         assert ref.revision is not None and ref.revision != "latest", \
             "packages: ref should have a revision. Check latest if needed."
-        app = ConanBasicApp(self._conan_api)
         if not remote:
-            prefs = app.cache.get_package_references(ref)
-            packages = _get_cache_packages_binary_info(app.cache, prefs)
+            prefs = self._api_helpers.cache.get_package_references(ref)
+            packages = _get_cache_packages_binary_info(self._api_helpers.cache, prefs)
         else:
-            packages = app.remote_manager.search_packages(remote, ref)
+            packages = self._api_helpers.remote_manager.search_packages(remote, ref)
         return packages
 
     @staticmethod
@@ -182,13 +177,13 @@ class ListAPI:
         select_bundle = PackagesList()
         # Avoid doing a ``search`` of recipes if it is an exact ref and it will be used later
         search_ref = pattern.search_ref
-        app = ConanBasicApp(self._conan_api)
+        cache = self._api_helpers.cache
         limit_time = _timelimit(lru) if lru else None
         out = ConanOutput()
         remote_name = "local cache" if not remote else remote.name
         if search_ref:
-            refs = _search_recipes(app, search_ref, remote=remote)
-            global_conf = self._conan_api._api_helpers.global_conf  # noqa
+            refs = _search_recipes(self._api_helpers, search_ref, remote=remote)
+            global_conf = self._api_helpers.global_conf  # noqa
             resolve_prereleases = global_conf.get("core.version_ranges:resolve_prereleases")
             refs = pattern.filter_versions(refs, resolve_prereleases)
             pattern.check_refs(refs)
@@ -219,7 +214,7 @@ class ListAPI:
                 rrevs = list(reversed(rrevs))  # Order older revisions first
 
             if lru and pattern.package_id is None:  # Filter LRUs
-                rrevs = [r for r in rrevs if app.cache.get_recipe_lru(r) < limit_time]
+                rrevs = [r for r in rrevs if cache.get_recipe_lru(r) < limit_time]
 
             for rr in rrevs:
                 select_bundle.add_ref(rr)
@@ -261,7 +256,7 @@ class ListAPI:
                     prefs = new_prefs
 
                 if lru:  # Filter LRUs
-                    prefs = [r for r in prefs if app.cache.get_package_lru(r) < limit_time]
+                    prefs = [r for r in prefs if cache.get_package_lru(r) < limit_time]
 
                 # Packages dict has been listed, even if empty
                 select_bundle.recipe_dict(rrev)["packages"] = {}
@@ -317,13 +312,13 @@ class ListAPI:
         (Experimental) Find the remotes where the current package lists can be found
         """
         result = MultiPackagesList()
-        app = ConanBasicApp(self._conan_api)
+        remote_manager = self._api_helpers.remote_manager
         for r in remotes:
             result_pkg_list = PackagesList()
             for ref, ref_contents in package_list.serialize().items():
                 ref = RecipeReference.loads(ref)
                 try:
-                    remote_rrevs = app.remote_manager.get_recipe_revisions(ref, remote=r)
+                    remote_rrevs = remote_manager.get_recipe_revisions(ref, remote=r)
                 except NotFoundException:
                     continue
                 revisions = ref_contents.get("revisions")
@@ -551,16 +546,16 @@ def _get_cache_packages_binary_info(cache, prefs) -> Dict[PkgReference, dict]:
     return result
 
 
-def _search_recipes(app, query: str, remote=None):
+def _search_recipes(api_helpers, query: str, remote=None):
     only_none_user_channel = False
     if query and query.endswith("@"):
         only_none_user_channel = True
         query = query[:-1]
 
     if remote:
-        refs = app.remote_manager.search_recipes(remote, query)
+        refs = api_helpers.remote_manager.search_recipes(remote, query)
     else:
-        refs = app.cache.search_recipes(query)
+        refs = api_helpers.cache.search_recipes(query)
     ret = []
     for r in refs:
         if not only_none_user_channel or (r.user is None and r.channel is None):

--- a/conan/api/subapi/list.py
+++ b/conan/api/subapi/list.py
@@ -340,7 +340,7 @@ class ListAPI:
                     for pkgid, pkgcontent in packages.items():
                         pref = PkgReference(ref, pkgid)
                         try:
-                            remote_prefs = app.remote_manager.get_package_revisions(pref, remote=r)
+                            remote_prefs = remote_manager.get_package_revisions(pref, remote=r)
                         except NotFoundException:
                             continue
                         pkg_revisions = pkgcontent.get("revisions")

--- a/conan/api/subapi/remotes.py
+++ b/conan/api/subapi/remotes.py
@@ -7,7 +7,6 @@ from urllib.parse import urlparse
 from conan.api.model import Remote, LOCAL_RECIPES_INDEX
 from conan.api.output import ConanOutput
 from conan.internal.cache.home_paths import HomePaths
-from conan.internal.conan_app import ConanBasicApp
 from conan.internal.rest.remote_credentials import RemoteCredentials
 from conan.internal.rest.rest_client_local_recipe_index import add_local_recipes_index_remote, \
     remove_local_recipes_index_remote
@@ -228,8 +227,7 @@ class RemotesAPI:
         :param username: the user login as ``str``
         :param password: password ``str``
         """
-        app = ConanBasicApp(self._conan_api)
-        app.remote_manager.authenticate(remote, username, password)
+        self._api_helpers.remote_manager.authenticate(remote, username, password)
 
     def login(self, remotes, username=None, password=None):
         creds = RemoteCredentials(self._conan_api.cache_folder, self._api_helpers.global_conf)
@@ -271,7 +269,6 @@ class RemotesAPI:
     def user_auth(self, remote: Remote, with_user=False, force=False):
         # TODO: Review
         localdb = LocalDB(self._home_folder)
-        app = ConanBasicApp(self._conan_api)
         if with_user:
             user, token, _ = localdb.get_login(remote.url)
             if not user:
@@ -279,7 +276,7 @@ class RemotesAPI:
                 user = os.getenv(var_name, None) or os.getenv("CONAN_LOGIN_USERNAME", None)
             if not user:
                 return
-        app.remote_manager.check_credentials(remote, force)
+        self._api_helpers.remote_manager.check_credentials(remote, force)
         user, token, _ = localdb.get_login(remote.url)
         return user
 

--- a/conan/api/subapi/remove.py
+++ b/conan/api/subapi/remove.py
@@ -1,53 +1,51 @@
 from typing import Optional
 
 from conan.api.model import Remote
-from conan.internal.conan_app import ConanBasicApp
 from conan.api.model import PkgReference
 from conan.api.model import RecipeReference
 
 
 class RemoveAPI:
 
-    def __init__(self, conan_api):
+    def __init__(self, conan_api, api_helpers):
         self._conan_api = conan_api
+        self._api_helpers = api_helpers
 
     def recipe(self, ref: RecipeReference, remote: Optional[Remote] = None):
         assert ref.revision, "Recipe revision cannot be None to remove a recipe"
         """Removes the recipe (or recipe revision if present) and all the packages (with all prev)"""
-        app = ConanBasicApp(self._conan_api)
+
         if remote:
-            app.remote_manager.remove_recipe(ref, remote)
+            self._api_helpers.remote_manager.remove_recipe(ref, remote)
         else:
             self.all_recipe_packages(ref)
-            recipe_layout = app.cache.recipe_layout(ref)
-            app.cache.remove_recipe_layout(recipe_layout)
+            recipe_layout = self._api_helpers.cache.recipe_layout(ref)
+            self._api_helpers.cache.remove_recipe_layout(recipe_layout)
 
     def all_recipe_packages(self, ref: RecipeReference, remote: Optional[Remote] = None):
         assert ref.revision, "Recipe revision cannot be None to remove a recipe"
         """Removes all the packages from the provided reference"""
-        app = ConanBasicApp(self._conan_api)
+
         if remote:
-            app.remote_manager.remove_all_packages(ref, remote)
+            self._api_helpers.remote_manager.remove_all_packages(ref, remote)
         else:
             # Remove all the prefs with all the prevs
-            self._remove_all_local_packages(app, ref)
+            self._remove_all_local_packages(ref)
 
-    @staticmethod
-    def _remove_all_local_packages(app, ref):
+    def _remove_all_local_packages(self, ref):
         # Get all the prefs and all the prevs
-        pkg_ids = app.cache.get_package_references(ref, only_latest_prev=False)
+        pkg_ids = self._api_helpers.cache.get_package_references(ref, only_latest_prev=False)
         for pref in pkg_ids:
-            package_layout = app.cache.pkg_layout(pref)
-            app.cache.remove_package_layout(package_layout)
+            package_layout = self._api_helpers.cache.pkg_layout(pref)
+            self._api_helpers.cache.remove_package_layout(package_layout)
 
     def package(self, pref: PkgReference, remote: Optional[Remote]):
         assert pref.ref.revision, "Recipe revision cannot be None to remove a package"
         assert pref.revision, "Package revision cannot be None to remove a package"
 
-        app = ConanBasicApp(self._conan_api)
         if remote:
             # FIXME: Create a "packages" method to optimize remote remove?
-            app.remote_manager.remove_packages([pref], remote)
+            self._api_helpers.remote_manager.remove_packages([pref], remote)
         else:
-            package_layout = app.cache.pkg_layout(pref)
-            app.cache.remove_package_layout(package_layout)
+            package_layout = self._api_helpers.cache.pkg_layout(pref)
+            self._api_helpers.cache.remove_package_layout(package_layout)

--- a/conan/api/subapi/report.py
+++ b/conan/api/subapi/report.py
@@ -98,7 +98,8 @@ def _configure_source(conan_api, hook_manager, conanfile_path, ref, remotes):
         with conanfile_exception_formatter(conanfile, "layout"):
             conanfile.layout()
 
-    recipe_layout = app.cache.recipe_layout(ref)
+    cache = conan_api._api_helpers.cache # noqa
+    recipe_layout = cache.recipe_layout(ref)
     export_source_folder = recipe_layout.export_sources()
     source_folder = recipe_layout.source()
 

--- a/conan/api/subapi/upload.py
+++ b/conan/api/subapi/upload.py
@@ -38,7 +38,7 @@ class UploadAPI:
         """
         app = ConanApp(self._conan_api)
         for ref, _ in package_list.items():
-            layout = app.cache.recipe_layout(ref)
+            layout = self._api_helpers.cache.recipe_layout(ref)
             conanfile_path = layout.conanfile()
             conanfile = app.loader.load_basic(conanfile_path, remotes=enabled_remotes)
             if conanfile.upload_policy == "skip":
@@ -46,7 +46,7 @@ class UploadAPI:
                                    "because upload_policy='skip'")
                 package_list.recipe_dict(ref)["packages"] = {}
 
-        UploadUpstreamChecker(app).check(package_list, remote, force)
+        UploadUpstreamChecker(self._api_helpers.remote_manager).check(package_list, remote, force)
 
     def prepare(self, package_list: PackagesList, enabled_remotes: List[Remote],
                 metadata: List[str] = None):
@@ -64,18 +64,19 @@ class UploadAPI:
         if metadata and metadata != [''] and '' in metadata:
             raise ConanException("Empty string and patterns can not be mixed for metadata.")
         app = ConanApp(self._conan_api)
-        preparator = PackagePreparator(app, self._api_helpers.global_conf)
+        preparator = PackagePreparator(app, self._api_helpers.cache,
+                                       self._api_helpers.remote_manager,
+                                       self._api_helpers.global_conf)
         preparator.prepare(package_list, enabled_remotes, metadata)
-        signer = PkgSignaturesPlugin(app.cache, app.cache_folder)
+        signer = PkgSignaturesPlugin(self._api_helpers.cache, self._conan_api.home_folder)
         if signer.is_sign_configured:
             ConanOutput().warning("[Package sign] Implicitly signing packages in the upload "
                                   "command has been removed. Use 'conan cache sign' command before "
                                   "uploading instead.", warn_tag="deprecated")
 
     def _upload(self, package_list, remote):
-        app = ConanApp(self._conan_api)
-        app.remote_manager.check_credentials(remote)
-        executor = UploadExecutor(app)
+        self._api_helpers.remote_manager.check_credentials(remote)
+        executor = UploadExecutor(self._api_helpers.remote_manager)
         executor.upload(package_list, remote)
 
     def upload_full(self, package_list: PackagesList, remote: Remote, enabled_remotes: List[Remote],

--- a/conan/api/subapi/workspace.py
+++ b/conan/api/subapi/workspace.py
@@ -159,7 +159,8 @@ class WorkspaceAPI:
             conanfile.output.warning("conandata doesn't contain 'scm' information\n"
                                      "doing a local copy!!!")
             shutil.copytree(layout.export(), dst_path)
-            retrieve_exports_sources(app.remote_manager, layout, conanfile, ref, remotes)
+            remote_manager = self._conan_api._api_helpers.remote_manager # noqa
+            retrieve_exports_sources(remote_manager, layout, conanfile, ref, remotes)
             export_sources = layout.export_sources()
             if os.path.exists(export_sources):
                 conanfile.output.warning("There are export-sources, copying them, but the location"

--- a/conan/internal/api/uploader.py
+++ b/conan/internal/api/uploader.py
@@ -26,8 +26,8 @@ class UploadUpstreamChecker:
     This is completely irrespective of the actual package contents, it only uses the local
     computed revision and the remote one
     """
-    def __init__(self, app: ConanApp):
-        self._app = app
+    def __init__(self, remote_manager):
+        self._remote_manager = remote_manager
 
     def check(self, package_list, remote, force):
         for ref, packages in package_list.items():
@@ -43,7 +43,7 @@ class UploadUpstreamChecker:
         try:
             assert ref.revision
             # TODO: It is a bit ugly, interface-wise to ask for revisions to check existence
-            server_ref = self._app.remote_manager.get_recipe_revision(ref, remote)
+            server_ref = self._remote_manager.get_recipe_revision(ref, remote)
             assert server_ref  # If successful (not raising NotFoundException), this will exist
         except NotFoundException:
             ref_bundle["force_upload"] = False
@@ -64,7 +64,7 @@ class UploadUpstreamChecker:
 
         try:
             # TODO: It is a bit ugly, interface-wise to ask for revisions to check existence
-            server_revisions = self._app.remote_manager.get_package_revision(pref, remote)
+            server_revisions = self._remote_manager.get_package_revision(pref, remote)
             assert server_revisions
         except NotFoundException:
             prev_bundle["force_upload"] = False
@@ -104,8 +104,10 @@ def get_compress_level(compressformat, global_conf):
 
 
 class PackagePreparator:
-    def __init__(self, app: ConanApp, global_conf):
+    def __init__(self, app: ConanApp, cache, remote_manager, global_conf):
         self._app = app
+        self._remote_manager = remote_manager
+        self._cache = cache
         self._global_conf = global_conf
         compressformat = self._global_conf.get("core.upload:compression_format", default="gz",
                                                choices=COMPRESSIONS)
@@ -116,7 +118,7 @@ class PackagePreparator:
     def prepare(self, pkg_list, enabled_remotes, metadata, force=False):
         local_url = self._global_conf.get("core.scm:local_url", choices=["allow", "block"])
         for ref, packages in pkg_list.items():
-            recipe_layout = self._app.cache.recipe_layout(ref)
+            recipe_layout = self._cache.recipe_layout(ref)
             conanfile_path = recipe_layout.conanfile()
             conanfile = self._app.loader.load_basic(conanfile_path)
             url = conanfile.conan_data.get("scm", {}).get("url") if conanfile.conan_data else None
@@ -154,7 +156,7 @@ class PackagePreparator:
         - compress the artifacts in conan_export.tgz and conan_export_sources.tgz
         """
         try:
-            retrieve_exports_sources(self._app.remote_manager, recipe_layout, conanfile, ref,
+            retrieve_exports_sources(self._remote_manager, recipe_layout, conanfile, ref,
                                      remotes)
             cache_files = self._compress_recipe_files(recipe_layout, ref)
             ref_bundle["files"] = cache_files
@@ -199,7 +201,7 @@ class PackagePreparator:
     def _prepare_package(self, pref, prev_bundle, metadata, force=False):
         pkg_layout = None
         if prev_bundle.get("upload") or force:
-            pkg_layout = self._app.cache.pkg_layout(pref)
+            pkg_layout = self._cache.pkg_layout(pref)
             if pkg_layout.package_is_dirty():
                 raise ConanException(f"Package {pref} is corrupted, aborting upload.\n"
                                      f"Remove it with 'conan remove {pref}'")
@@ -208,7 +210,7 @@ class PackagePreparator:
 
         # Package metadata files too
         if metadata != [""] and (metadata or prev_bundle.get("upload")):
-            pkg_layout = pkg_layout or self._app.cache.pkg_layout(pref)
+            pkg_layout = pkg_layout or self._cache.pkg_layout(pref)
             metadata_folder = pkg_layout.metadata()
             files = _metadata_files(metadata_folder, metadata)
             if files:
@@ -280,8 +282,8 @@ class UploadExecutor:
     been computed and are passed in the ``upload_data`` parameter, so this executor is also
     agnostic about which files are transferred
     """
-    def __init__(self, app: ConanApp):
-        self._app = app
+    def __init__(self, remote_manager):
+        self._remote_manager = remote_manager
 
     def upload(self, upload_data, remote):
         for ref, packages in upload_data.items():
@@ -300,7 +302,7 @@ class UploadExecutor:
         output.info(f"Uploading recipe '{ref.repr_notime()}' ({_total_size(cache_files)})")
 
         t1 = time.time()
-        self._app.remote_manager.upload_recipe(ref, cache_files, remote)
+        self._remote_manager.upload_recipe(ref, cache_files, remote)
 
         duration = time.time() - t1
         output.debug(f"Upload {ref} in {duration} time")
@@ -315,7 +317,7 @@ class UploadExecutor:
         output.info(f"Uploading package '{pref.repr_notime()}' ({_total_size(cache_files)})")
 
         t1 = time.time()
-        self._app.remote_manager.upload_package(pref, cache_files, remote)
+        self._remote_manager.upload_package(pref, cache_files, remote)
         duration = time.time() - t1
         output.debug(f"Upload {pref} in {duration} time")
 

--- a/conan/internal/conan_app.py
+++ b/conan/internal/conan_app.py
@@ -44,8 +44,8 @@ class ConanBasicApp:
         # TODO: Remove this global_conf from here
         global_conf = conan_api._api_helpers.global_conf  # noqa
         # TODO: Temporary while refactoring, remove i nthe future
-        self.cache = conan_api._api_helpers.cache # noqa
-        self.remote_manager = conan_api._api_helpers.remote_manager  # noqa
+        self._cache = conan_api._api_helpers.cache # noqa
+        self._remote_manager = conan_api._api_helpers.remote_manager  # noqa
         self._global_conf = global_conf
         self.cache_folder = conan_api.home_folder
         global_editables = conan_api.local.editable_packages
@@ -60,13 +60,13 @@ class ConanApp(ConanBasicApp):
         """
         super().__init__(conan_api)
         legacy_update = self._global_conf.get("core:update_policy", choices=["legacy"])
-        self.proxy = ConanProxy(self.cache, self.remote_manager, self.editable_packages,
+        self.proxy = ConanProxy(self._cache, self._remote_manager, self.editable_packages,
                                 legacy_update=legacy_update)
-        self.range_resolver = RangeResolver(self.cache, self.remote_manager, self._global_conf,
+        self.range_resolver = RangeResolver(self._cache, self._remote_manager, self._global_conf,
                                             self.editable_packages)
         cmd_wrap = CmdWrapper(HomePaths(self.cache_folder).wrapper_path)
         requester = conan_api._api_helpers.requester  # noqa
-        conanfile_helpers = ConanFileHelpers(requester, cmd_wrap, self._global_conf, self.cache,
+        conanfile_helpers = ConanFileHelpers(requester, cmd_wrap, self._global_conf, self._cache,
                                              self.cache_folder, conan_api)
         pyreq_loader = PyRequireLoader(self.proxy, self.range_resolver, self._global_conf)
         self.loader = ConanFileLoader(pyreq_loader, conanfile_helpers)

--- a/conan/internal/conan_app.py
+++ b/conan/internal/conan_app.py
@@ -4,13 +4,11 @@ from conan.internal.api.local.editable import EditablePackages
 from conan.internal.cache.cache import PkgCache
 from conan.internal.cache.home_paths import HomePaths
 from conan.internal.model.conf import ConfDefinition
-from conan.internal.rest.auth_manager import ConanApiAuthManager
 from conan.internal.graph.proxy import ConanProxy
 from conan.internal.graph.python_requires import PyRequireLoader
 from conan.internal.graph.range_resolver import RangeResolver
 from conan.internal.loader import ConanFileLoader, load_python_file
 from conan.internal.rest.remote_manager import RemoteManager
-from conan.internal.api.remotes.localdb import LocalDB
 
 
 class CmdWrapper:
@@ -28,12 +26,13 @@ class CmdWrapper:
 
 
 class ConanFileHelpers:
-    def __init__(self, requester, cmd_wrapper, global_conf, cache, home_folder):
+    def __init__(self, requester, cmd_wrapper, global_conf, cache, home_folder, conan_api):
         self.requester = requester
         self.cmd_wrapper = cmd_wrapper
         self.global_conf = global_conf
         self.cache = cache
         self.home_folder = home_folder
+        self.conan_api = conan_api  # Might be None for local-recipes-index
 
 
 class ConanBasicApp:
@@ -44,17 +43,11 @@ class ConanBasicApp:
         """
         # TODO: Remove this global_conf from here
         global_conf = conan_api._api_helpers.global_conf  # noqa
+        # TODO: Temporary while refactoring, remove i nthe future
+        self.cache = conan_api._api_helpers.cache # noqa
+        self.remote_manager = conan_api._api_helpers.remote_manager  # noqa
         self._global_conf = global_conf
-        self.conan_api = conan_api
-        cache_folder = conan_api.home_folder
-        self.cache_folder = cache_folder
-        self.cache = PkgCache(self.cache_folder, global_conf)
-        # Wraps RestApiClient to add authentication support (same interface)
-        localdb = LocalDB(cache_folder)
-        requester = conan_api._api_helpers.requester  # noqa
-        auth_manager = ConanApiAuthManager(requester, cache_folder, localdb, global_conf)
-        # Handle remote connections
-        self.remote_manager = RemoteManager(self.cache, auth_manager, cache_folder)
+        self.cache_folder = conan_api.home_folder
         global_editables = conan_api.local.editable_packages
         ws_editables = conan_api.workspace.packages()
         self.editable_packages = global_editables.update_copy(ws_editables)
@@ -67,14 +60,16 @@ class ConanApp(ConanBasicApp):
         """
         super().__init__(conan_api)
         legacy_update = self._global_conf.get("core:update_policy", choices=["legacy"])
-        self.proxy = ConanProxy(self, self.editable_packages, legacy_update=legacy_update)
-        self.range_resolver = RangeResolver(self, self._global_conf, self.editable_packages)
-
-        self.pyreq_loader = PyRequireLoader(self, self._global_conf)
+        self.proxy = ConanProxy(self.cache, self.remote_manager, self.editable_packages,
+                                legacy_update=legacy_update)
+        self.range_resolver = RangeResolver(self.cache, self.remote_manager, self._global_conf,
+                                            self.editable_packages)
         cmd_wrap = CmdWrapper(HomePaths(self.cache_folder).wrapper_path)
         requester = conan_api._api_helpers.requester  # noqa
-        conanfile_helpers = ConanFileHelpers(requester, cmd_wrap, self._global_conf, self.cache, self.cache_folder)
-        self.loader = ConanFileLoader(self.pyreq_loader, conanfile_helpers)
+        conanfile_helpers = ConanFileHelpers(requester, cmd_wrap, self._global_conf, self.cache,
+                                             self.cache_folder, conan_api)
+        pyreq_loader = PyRequireLoader(self.proxy, self.range_resolver, self._global_conf)
+        self.loader = ConanFileLoader(pyreq_loader, conanfile_helpers)
 
 
 class LocalRecipesIndexApp:
@@ -89,8 +84,9 @@ class LocalRecipesIndexApp:
         self.cache = PkgCache(cache_folder, self.global_conf)
         self.remote_manager = RemoteManager(self.cache, auth_manager=None, home_folder=cache_folder)
         editable_packages = EditablePackages()
-        self.proxy = ConanProxy(self, editable_packages)
-        self.range_resolver = RangeResolver(self, self.global_conf, editable_packages)
-        pyreq_loader = PyRequireLoader(self, self.global_conf)
-        helpers = ConanFileHelpers(None, CmdWrapper(""), self.global_conf, self.cache, cache_folder)
+        self.proxy = ConanProxy(self.cache, self.remote_manager, editable_packages)
+        self.range_resolver = RangeResolver(self.cache, self.remote_manager, self.global_conf,
+                                            editable_packages)
+        pyreq_loader = PyRequireLoader(self.proxy, self.range_resolver, self.global_conf)
+        helpers = ConanFileHelpers(None, CmdWrapper(""), self.global_conf, self.cache, cache_folder, None)
         self.loader = ConanFileLoader(pyreq_loader, helpers)

--- a/conan/internal/graph/graph_binaries.py
+++ b/conan/internal/graph/graph_binaries.py
@@ -21,15 +21,15 @@ from conan.internal.model.pkg_type import PackageType
 
 class GraphBinariesAnalyzer:
 
-    def __init__(self, conan_app, global_conf, hook_manager):
-        self._cache = conan_app.cache
-        self._home_folder = conan_app.cache_folder
+    def __init__(self, cache, remote_manager, home_folder, global_conf, hook_manager):
+        self._cache = cache
+        self._home_folder = home_folder
         self._global_conf = global_conf
-        self._remote_manager = conan_app.remote_manager
+        self._remote_manager = remote_manager
         self._hook_manager = hook_manager
         # These are the nodes with pref (not including PREV) that have been evaluated
         self._evaluated = {}  # {pref: [nodes]}
-        compat_folder = HomePaths(conan_app.cache_folder).compatibility_plugin_path
+        compat_folder = HomePaths(home_folder).compatibility_plugin_path
         self._compatibility = BinaryCompatibility(compat_folder, hook_manager)
         unknown_mode = global_conf.get("core.package_id:default_unknown_mode", default="semver_mode")
         non_embed = global_conf.get("core.package_id:default_non_embed_mode", default="minor_mode")

--- a/conan/internal/graph/installer.py
+++ b/conan/internal/graph/installer.py
@@ -34,11 +34,11 @@ def build_id(conan_file):
 
 class _PackageBuilder:
 
-    def __init__(self, app, hook_manager):
-        self._cache = app.cache
+    def __init__(self, cache, remote_manager, cache_folder, hook_manager):
+        self._cache = cache
         self._hook_manager = hook_manager
-        self._remote_manager = app.remote_manager
-        self._home_folder = app.cache_folder
+        self._remote_manager = remote_manager
+        self._home_folder = cache_folder
 
     def _get_build_folder(self, conanfile, package_layout):
         # Build folder can use a different package_ID if build_id() is defined.
@@ -165,14 +165,14 @@ class BinaryInstaller:
     locally in case they are not found in remotes
     """
 
-    def __init__(self, app, global_conf, editable_packages, hook_manager):
-        self._app = app
+    def __init__(self, api, global_conf, editable_packages, hook_manager):
+        helpers = api._api_helpers  # noqa
         self._editable_packages = editable_packages
-        self._cache = app.cache
-        self._remote_manager = app.remote_manager
+        self._cache = helpers.cache
+        self._remote_manager = helpers.remote_manager
         self._hook_manager = hook_manager
         self._global_conf = global_conf
-        self._home_folder = app.cache_folder
+        self._home_folder = api.home_folder
 
     def _install_source(self, node, remotes, need_conf=False):
         conanfile = node.conanfile
@@ -394,7 +394,8 @@ class BinaryInstaller:
         with pkg_layout.package_lock():
             pkg_layout.package_remove()
             with pkg_layout.set_dirty_context_manager():
-                builder = _PackageBuilder(self._app, self._hook_manager)
+                builder = _PackageBuilder(self._cache, self._remote_manager, self._home_folder,
+                                          self._hook_manager)
                 pref = builder.build_package(node, recipe_layout, pkg_layout)
             assert node.prev, "Node PREV shouldn't be empty"
             assert node.pref.revision, "Node PREF revision shouldn't be empty"

--- a/conan/internal/graph/proxy.py
+++ b/conan/internal/graph/proxy.py
@@ -8,11 +8,11 @@ from conan.errors import ConanException
 
 
 class ConanProxy:
-    def __init__(self, conan_app, editable_packages, legacy_update=None):
+    def __init__(self, cache, remote_manager, editable_packages, legacy_update=None):
         # collaborators
         self._editable_packages = editable_packages
-        self._cache = conan_app.cache
-        self._remote_manager = conan_app.remote_manager
+        self._cache = cache
+        self._remote_manager = remote_manager
         self._resolved = {}  # Cache of the requested recipes to optimize calls
         self._legacy_update = legacy_update
 

--- a/conan/internal/graph/python_requires.py
+++ b/conan/internal/graph/python_requires.py
@@ -65,9 +65,9 @@ class PyRequires:
 
 
 class PyRequireLoader:
-    def __init__(self, conan_app, global_conf):
-        self._proxy = conan_app.proxy
-        self._range_resolver = conan_app.range_resolver
+    def __init__(self, proxy, range_resolver, global_conf):
+        self._proxy = proxy
+        self._range_resolver = range_resolver
         self._cached_py_requires = {}
         self._resolve_prereleases = global_conf.get("core.version_ranges:resolve_prereleases")
 

--- a/conan/internal/graph/range_resolver.py
+++ b/conan/internal/graph/range_resolver.py
@@ -7,10 +7,10 @@ from conan.internal.model.version_range import VersionRange
 
 class RangeResolver:
 
-    def __init__(self, conan_app, global_conf, editable_packages):
-        self._cache = conan_app.cache
+    def __init__(self, cache, remote_manager, global_conf, editable_packages):
+        self._cache = cache
         self._editable_packages = editable_packages
-        self._remote_manager = conan_app.remote_manager
+        self._remote_manager = remote_manager
         self._cached_cache = {}  # Cache caching of search result, so invariant wrt installations
         self._cached_remote_found = {}  # dict {ref (pkg/*): {remote_name: results (pkg/1, pkg/2)}}
         self.resolved_ranges = {}

--- a/conan/internal/model/workspace.py
+++ b/conan/internal/model/workspace.py
@@ -118,7 +118,7 @@ class Workspace:
         from conan.internal.conan_app import ConanFileHelpers, CmdWrapper
         cmd_wrap = CmdWrapper(HomePaths(self._conan_api.home_folder).wrapper_path)
         helpers = ConanFileHelpers(None, cmd_wrap, self._conan_api._api_helpers.global_conf,
-                                   cache=None, home_folder=self._conan_api.home_folder)
+                                   cache=None, home_folder=self._conan_api.home_folder, conan_api=self._conan_api)
         loader = ConanFileLoader(pyreq_loader=None, conanfile_helpers=helpers)
         conanfile = loader.load_named(conanfile_path, name=None, version=None, user=None,
                                       channel=None, remotes=None, graph_lock=None)

--- a/conan/internal/rest/remote_manager.py
+++ b/conan/internal/rest/remote_manager.py
@@ -12,7 +12,7 @@ from conan.internal.paths import CONANINFO, CONAN_MANIFEST, PACKAGE_FILE_NAME, E
 from conan.internal.rest.rest_client_local_recipe_index import RestApiClientLocalRecipesIndex
 from conan.api.model import Remote
 from conan.api.output import ConanOutput
-from conan.internal.cache.conan_reference_layout import METADATA, PackageLayout
+from conan.internal.cache.conan_reference_layout import METADATA
 from conan.internal.rest.pkg_sign import PkgSignaturesPlugin
 from conan.internal.errors import ConanConnectionError, NotFoundException, PackageNotFoundException
 from conan.errors import ConanException

--- a/conan/test/utils/mocks.py
+++ b/conan/test/utils/mocks.py
@@ -72,7 +72,7 @@ class ConanFileMock(ConanFile):
         self.win_bash = None
         self.command = None
         self._commands = []
-        self._conan_helpers = ConanFileHelpers(None, None, self.conf, None, None)
+        self._conan_helpers = ConanFileHelpers(None, None, self.conf, None, None, None)
 
     def run(self, *args, **kwargs):
         self.command = args[0]

--- a/test/integration/cache/storage_path_test.py
+++ b/test/integration/cache/storage_path_test.py
@@ -22,7 +22,7 @@ def test_storage_path():
 def test_wrong_home_error():
     client = TestClient(light=True)
     client.save_home({"global.conf": "core.cache:storage_path=//"})
-    client.run("list *")
+    client.run("list *", assert_error=True)
     assert "Couldn't initialize storage in" in client.out
 
 


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Pure internal refactor.

This is something that has been architecturally pending for some time, to get rid of ``ConanBasicApp`` and ``ConanApp``, to move collaborators to the Api ``ApiHelpers`` class. This allows better caching when desired. We already moved some collaborators in the past, this PR moves ``PkgCache`` and ``RemoteManager``

This will also be preparation in case we want to move forward https://github.com/conan-io/conan/pull/19730 