### PR TITLE
fix CMakeConfigDeps .set_property context

### DIFF
--- a/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
+++ b/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
@@ -165,7 +165,11 @@ class CMakeConfigDeps:
 
     def get_property(self, prop, dep, comp_name=None, check_type=None):
         dep_name = dep.ref.name
-        build_suffix = "&build" if dep.context == "build" else ""
+        # Find the requirement that points to this "dep".
+        # TODO: It would probably be more explicit if it was an argument as "dep", but to keep
+        #   diff minimal
+        require = next(iter(r for r, d in self._conanfile.dependencies.items() if d is dep))
+        build_suffix = "&build" if require.build else ""
         dep_comp = f"{str(dep_name)}::{comp_name}" if comp_name else f"{str(dep_name)}"
         try:
             value = self._properties[f"{dep_comp}{build_suffix}"][prop]

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -802,6 +802,34 @@ def test_legacy_defines():
     assert 'set(mypkg_DEFINITIONS "-DMY_DEFINE;-DMYVAR=1" )' in mypkg_config
 
 
+class TestPropertiesBuildContext:
+    def test_property_build_context(self):
+        c = TestClient()
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            from conan.tools.cmake import CMakeConfigDeps
+
+            class PackageConan(ConanFile):
+                name = "package"
+                settings = "os", "arch", "compiler", "build_type"
+
+                def requirements(self):
+                    self.requires("zlib/1.3.1")
+
+                def generate(self):
+                    deps = CMakeConfigDeps(self)
+                    deps.set_property("zlib", "cmake_file_name", "MyZlibName")
+                    deps.generate()
+            """)
+        c.save({"zlib/conanfile.py": GenConanfile("zlib", "1.3.1"),
+                "pkg/conanfile.py": conanfile})
+        c.run("create zlib")
+        c.run("install pkg --build-require")
+        assert "find_package(MyZlibName)" in c.out
+        config = c.load("pkg/MyZlibNameConfig.cmake")
+        assert 'set(MyZlibName_VERSION_STRING "1.3.1")' in config
+
+
 class TestExtraFindExtraVariants:
     def test_generated_dir_entries(self):
         tc = TestClient()


### PR DESCRIPTION
Changelog: Fix: Correct definition of ``set_property()`` in ``CMakeConfigDeps`` for build context.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19759