### PR TITLE
CMakeToolchain: disable CMake package registry exports

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -578,9 +578,6 @@ class FindFiles(Block):
 
         # Disable CMake package registry to avoid polluting the user package registry
         # with Conan-generated builds.
-        if(NOT DEFINED CMAKE_EXPORT_NO_PACKAGE_REGISTRY)
-            set(CMAKE_EXPORT_NO_PACKAGE_REGISTRY ON)
-        endif()
         if(NOT DEFINED CMAKE_EXPORT_PACKAGE_REGISTRY)
             set(CMAKE_EXPORT_PACKAGE_REGISTRY OFF)
         endif()

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -576,12 +576,6 @@ class FindFiles(Block):
         set(CMAKE_FIND_PACKAGE_PREFER_CONFIG {{ find_package_prefer_config }})
         {% endif %}
 
-        # Disable CMake package registry to avoid polluting the user package registry
-        # with Conan-generated builds.
-        if(NOT DEFINED CMAKE_EXPORT_PACKAGE_REGISTRY)
-            set(CMAKE_EXPORT_PACKAGE_REGISTRY OFF)
-        endif()
-
         # Definition of CMAKE_MODULE_PATH
         {% if build_paths %}
         list(PREPEND CMAKE_MODULE_PATH {{ build_paths }})
@@ -1265,6 +1259,13 @@ class OutputDirsBlock(Block):
     def template(self):
         return textwrap.dedent("""\
            # Definition of CMAKE_INSTALL_XXX folders
+
+           # Ensure export(PACKAGE) honors CMAKE_EXPORT_PACKAGE_REGISTRY even if the
+           # project sets cmake_minimum_required() lower than 3.15.
+           cmake_policy(SET CMP0090 NEW)
+           if(NOT DEFINED CMAKE_EXPORT_PACKAGE_REGISTRY)
+               set(CMAKE_EXPORT_PACKAGE_REGISTRY OFF)
+           endif()
 
            {% if package_folder %}
            set(CMAKE_INSTALL_PREFIX "{{package_folder}}")

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -576,6 +576,15 @@ class FindFiles(Block):
         set(CMAKE_FIND_PACKAGE_PREFER_CONFIG {{ find_package_prefer_config }})
         {% endif %}
 
+        # Disable CMake package registry to avoid polluting the user package registry
+        # with Conan-generated builds.
+        if(NOT DEFINED CMAKE_EXPORT_NO_PACKAGE_REGISTRY)
+            set(CMAKE_EXPORT_NO_PACKAGE_REGISTRY ON)
+        endif()
+        if(NOT DEFINED CMAKE_EXPORT_PACKAGE_REGISTRY)
+            set(CMAKE_EXPORT_PACKAGE_REGISTRY OFF)
+        endif()
+
         # Definition of CMAKE_MODULE_PATH
         {% if build_paths %}
         list(PREPEND CMAKE_MODULE_PATH {{ build_paths }})

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -433,6 +433,9 @@ def test_disable_package_registry():
     client.save({"conanfile.txt": "[generators]\nCMakeToolchain"})
     client.run("install .")
     toolchain = client.load("conan_toolchain.cmake")
+    before_output_dirs, output_dirs_block = toolchain.split("########## 'output_dirs' block #############\n", 1)
+    assert "CMAKE_EXPORT_PACKAGE_REGISTRY" not in before_output_dirs
+    assert "cmake_policy(SET CMP0090 NEW)" in output_dirs_block
     assert "set(CMAKE_EXPORT_PACKAGE_REGISTRY OFF)" in toolchain
 
 

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -429,7 +429,7 @@ def test_runtime_lib_dirs_multiconf(lib_dir_setup):
 
 def test_disable_package_registry():
     # https://github.com/conan-io/conan/issues/19749
-    client = TestClient()
+    client = TestClient(light=True)
     client.save({"conanfile.txt": "[generators]\nCMakeToolchain"})
     client.run("install .")
     toolchain = client.load("conan_toolchain.cmake")

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -433,7 +433,6 @@ def test_disable_package_registry():
     client.save({"conanfile.txt": "[generators]\nCMakeToolchain"})
     client.run("install .")
     toolchain = client.load("conan_toolchain.cmake")
-    assert "set(CMAKE_EXPORT_NO_PACKAGE_REGISTRY ON)" in toolchain
     assert "set(CMAKE_EXPORT_PACKAGE_REGISTRY OFF)" in toolchain
 
 

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -427,6 +427,16 @@ def test_runtime_lib_dirs_multiconf(lib_dir_setup):
     assert "<CONFIG:Debug>" in runtime_lib_dirs
 
 
+def test_disable_package_registry():
+    # https://github.com/conan-io/conan/issues/19749
+    client = TestClient()
+    client.save({"conanfile.txt": "[generators]\nCMakeToolchain"})
+    client.run("install .")
+    toolchain = client.load("conan_toolchain.cmake")
+    assert "set(CMAKE_EXPORT_NO_PACKAGE_REGISTRY ON)" in toolchain
+    assert "set(CMAKE_EXPORT_PACKAGE_REGISTRY OFF)" in toolchain
+
+
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only OSX")
 def test_cmaketoolchain_cmake_system_processor_cross_apple():
     """


### PR DESCRIPTION
Changelog: Feature: Disable CMake user package registry exports by default (`cmake_policy(SET CMP0090 NEW)` and `CMAKE_EXPORT_PACKAGE_REGISTRY OFF` when unset).
Docs: Omit

### Summary
This restores Conan 1 behavior from #3070 for Conan 2 CMakeToolchain: prevent CMake from writing package entries to the user package registry by default.

### Changes
- Set CMAKE_EXPORT_NO_PACKAGE_REGISTRY to ON in the generated toolchain when not already defined
- Set CMAKE_EXPORT_PACKAGE_REGISTRY to OFF in the generated toolchain when not already defined
- Added integration test coverage for generated conan_toolchain.cmake

### Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest test/integration/toolchains/cmake/test_cmaketoolchain.py -k "disable_package_registry or runtime_lib_dirs_single_conf" -q

Closes #19749