### PR TITLE
Add cve version info in `conan audit` results

### DIFF
--- a/conan/cli/commands/audit.py
+++ b/conan/cli/commands/audit.py
@@ -14,7 +14,6 @@ from conan.cli.formatters.audit.vulnerabilities import text_vuln_formatter, json
 from conan.cli.printers import print_profiles
 from conan.cli.printers.graph import print_graph_basic
 from conan.errors import ConanException
-from conan.internal.util.files import load
 
 
 def _add_provider_arg(subparser):
@@ -134,7 +133,8 @@ def audit_list(conan_api: ConanAPI, parser, subparser, *args):
             ConanOutput().warning("Nothing to list, package list does not contain recipe revisions")
     elif args.sbom:
         sbom_file = make_abs_path(args.sbom)
-        sbom = json.loads(load(sbom_file))
+        with open(sbom_file, 'r') as f:
+            sbom = json.load(f)
         if sbom.get("bomFormat") != "CycloneDX":
             raise ConanException(f"Unsupported SBOM format, only CycloneDX is supported.")
         purls = [component["purl"] for component in sbom["components"]]

--- a/conan/cli/formatters/audit/vulnerabilities.py
+++ b/conan/cli/formatters/audit/vulnerabilities.py
@@ -246,18 +246,20 @@ vuln_html = """
             {{ vuln.package }}
           </td>
           <td>
-            <span style="display: none">{{ vuln.score }}</span>
-            {% if vuln.withdrawn %}
-                <span style="color: #00ced1; font-weight: bold;">[WITHDRAWN]</span><br>
-            {% endif %}
-            {{ vuln.vuln_id }}
-            <br>
+            <span style="display: none">{{ vuln.preferred_score }}</span>
             {% if vuln.severity not in ['N/A', ''] %}
-              <span class="severity-badge severity-{{ severity_label }}">{{ severity_label }}</span>
+              <span class="severity-badge severity-{{ severity_label }}">{{ severity_label }} {% if vuln.preferred_score %}({{ vuln.preferred_score }}){% endif %}</span>
             {% else %}
               {{ vuln.severity }}
             {% endif %}
-            {{ vuln.score }}
+            <br>
+            <br>
+            {% if vuln.withdrawn %}
+                <span style="color: #00ced1; font-weight: bold;">[WITHDRAWN]</span><br>
+            {% endif %}
+            <b>{{ vuln.vuln_id }}</b>
+            {% if vuln.score_v3 %}<br/>CVSS <i>v3</i>: {{ vuln.score_v3 }}{% endif %}
+            {% if vuln.score_v4 %}<br/>CVSS <i>v4</i>: {{ vuln.score_v4 }}{% endif %}
           </td>
           <td>
             {% for research in vuln.advisories %}
@@ -359,16 +361,13 @@ def html_vuln_formatter(result):
                 sev = node.get("severity", "Medium")
                 sev = f"{severity_order.get(sev, 2)} - {sev}"
                 cvss = node.get("cvss", {})
-                score_txt = ""
+                preferred_score = cvss.get("preferredBaseScore")
+                score_v3 = 0
+                score_v4 = 0
                 if "v3" in cvss and cvss["v3"].get("baseScore", 0) > 0:
-                    score = cvss["v3"].get("baseScore", 0)
-                    score_txt = f", CVSS (v3): {score}"
+                    score_v3 = cvss["v3"].get("baseScore", 0)
                 if "v4" in cvss and cvss["v4"].get("baseScore", 0) > 0:
-                    score = cvss["v4"].get("baseScore", 0)
-                    score_txt = f", CVSS (v4): {score}"
-                if not score_txt:
-                    score = cvss.get("preferredBaseScore")
-                    score_txt = f", CVSS: {score}" if score else ""
+                    score_v4 = cvss["v4"].get("baseScore", 0)
                 aliases = node.get("aliases", [])
                 references = node.get("references", [])
                 desc = node.get("description", "")
@@ -384,7 +383,9 @@ def html_vuln_formatter(result):
                     "vuln_id": name,
                     "aliases": aliases,
                     "severity": sev,
-                    "score": score_txt,
+                    "preferred_score": preferred_score,
+                    "score_v3": score_v3,
+                    "score_v4": score_v4,
                     "description": desc,
                     "references": references,
                     "withdrawn": withdrawn,

--- a/conan/cli/formatters/audit/vulnerabilities.py
+++ b/conan/cli/formatters/audit/vulnerabilities.py
@@ -73,16 +73,14 @@ def text_vuln_formatter(result):
             sev = node.get("severity", "Medium")
             sev_color = severity_colors.get(sev, Color.BRIGHT_YELLOW)
             cvss = node.get("cvss", {})
-            score_txt = ""
+            preferred_score = cvss.get("preferredBaseScore")
+            score_txt = f" - {preferred_score}" if preferred_score else ""
             if "v3" in cvss and cvss["v3"].get("baseScore", 0) > 0:
-                score = cvss["v3"].get("baseScore", 0)
-                score_txt = f", CVSS (v3): {score}"
+                score_v3 = cvss["v3"].get("baseScore", 0)
+                score_txt += f" - {score_v3} (v3)"
             if "v4" in cvss and cvss["v4"].get("baseScore", 0) > 0:
-                score = cvss["v4"].get("baseScore", 0)
-                score_txt = f", CVSS (v4): {score}"
-            if not score_txt:
-                score = cvss.get("preferredBaseScore")
-                score_txt = f", CVSS: {score}" if score else ""
+                score_v4 = cvss["v4"].get("baseScore", 0)
+                score_txt += f" - {score_v4} (v4)"
             desc = node.get("description", "")
             desc = (desc[:240] + "...") if len(desc) > 240 else desc
             desc_wrapped = wrap_and_indent(desc)

--- a/conan/cli/formatters/audit/vulnerabilities.py
+++ b/conan/cli/formatters/audit/vulnerabilities.py
@@ -75,12 +75,6 @@ def text_vuln_formatter(result):
             cvss = node.get("cvss", {})
             preferred_score = cvss.get("preferredBaseScore")
             score_txt = f" - {preferred_score}" if preferred_score else ""
-            if "v3" in cvss and cvss["v3"].get("baseScore", 0) > 0:
-                score_v3 = cvss["v3"].get("baseScore", 0)
-                score_txt += f" - {score_v3} (v3)"
-            if "v4" in cvss and cvss["v4"].get("baseScore", 0) > 0:
-                score_v4 = cvss["v4"].get("baseScore", 0)
-                score_txt += f" - {score_v4} (v4)"
             desc = node.get("description", "")
             desc = (desc[:240] + "...") if len(desc) > 240 else desc
             desc_wrapped = wrap_and_indent(desc)
@@ -134,6 +128,17 @@ def text_vuln_formatter(result):
                 if fixVersions:
                     cli_out_write(f"  fixed in version(s): ", endline="", fg=Color.BRIGHT_BLUE)
                     cli_out_write(', '.join(fixVersions))
+
+            if "v3" in cvss and cvss["v3"].get("baseScore", 0) > 0:
+                score_v3 = cvss["v3"].get("baseScore", 0)
+                if score_v3:
+                    cli_out_write(f"  CVSS v3: ", endline="", fg=Color.BRIGHT_BLUE)
+                    cli_out_write(score_v3)
+            if "v4" in cvss and cvss["v4"].get("baseScore", 0) > 0:
+                score_v4 = cvss["v4"].get("baseScore", 0)
+                if score_v4:
+                    cli_out_write(f"  CVSS v4: ", endline="", fg=Color.BRIGHT_BLUE)
+                    cli_out_write(score_v4)
             cli_out_write("")
 
     color_for_total = Color.BRIGHT_RED if total_vulns else Color.BRIGHT_GREEN

--- a/conan/cli/formatters/audit/vulnerabilities.py
+++ b/conan/cli/formatters/audit/vulnerabilities.py
@@ -72,8 +72,17 @@ def text_vuln_formatter(result):
             name = node["name"]
             sev = node.get("severity", "Medium")
             sev_color = severity_colors.get(sev, Color.BRIGHT_YELLOW)
-            score = node.get("cvss", {}).get("preferredBaseScore")
-            score_txt = f", CVSS: {score}" if score else ""
+            cvss = node.get("cvss", {})
+            score_txt = ""
+            if "v4" in cvss and cvss["v4"].get("baseScore", 0) > 0:
+                score = cvss["v4"].get("baseScore", 0)
+                score_txt = f", CVSS (v4): {score}"
+            if "v3" in cvss and cvss["v3"].get("baseScore", 0) > 0:
+                score = cvss["v3"].get("baseScore", 0)
+                score_txt = f", CVSS (v3): {score}"
+            if not score_txt:
+                score = cvss.get("preferredBaseScore")
+                score_txt = f", CVSS: {score}" if score else ""
             desc = node.get("description", "")
             desc = (desc[:240] + "...") if len(desc) > 240 else desc
             desc_wrapped = wrap_and_indent(desc)
@@ -349,8 +358,17 @@ def html_vuln_formatter(result):
                 name = node.get("name")
                 sev = node.get("severity", "Medium")
                 sev = f"{severity_order.get(sev, 2)} - {sev}"
-                score = node.get("cvss", {}).get("preferredBaseScore")
-                score_txt = f"CVSS: {score}" if score else "-"
+                cvss = node.get("cvss", {})
+                score_txt = ""
+                if "v4" in cvss and cvss["v4"].get("baseScore", 0) > 0:
+                    score = cvss["v4"].get("baseScore", 0)
+                    score_txt = f", CVSS (v4): {score}"
+                if "v3" in cvss and cvss["v3"].get("baseScore", 0) > 0:
+                    score = cvss["v3"].get("baseScore", 0)
+                    score_txt = f", CVSS (v3): {score}"
+                if not score_txt:
+                    score = cvss.get("preferredBaseScore")
+                    score_txt = f", CVSS: {score}" if score else ""
                 aliases = node.get("aliases", [])
                 references = node.get("references", [])
                 desc = node.get("description", "")

--- a/conan/cli/formatters/audit/vulnerabilities.py
+++ b/conan/cli/formatters/audit/vulnerabilities.py
@@ -74,12 +74,12 @@ def text_vuln_formatter(result):
             sev_color = severity_colors.get(sev, Color.BRIGHT_YELLOW)
             cvss = node.get("cvss", {})
             score_txt = ""
-            if "v4" in cvss and cvss["v4"].get("baseScore", 0) > 0:
-                score = cvss["v4"].get("baseScore", 0)
-                score_txt = f", CVSS (v4): {score}"
             if "v3" in cvss and cvss["v3"].get("baseScore", 0) > 0:
                 score = cvss["v3"].get("baseScore", 0)
                 score_txt = f", CVSS (v3): {score}"
+            if "v4" in cvss and cvss["v4"].get("baseScore", 0) > 0:
+                score = cvss["v4"].get("baseScore", 0)
+                score_txt = f", CVSS (v4): {score}"
             if not score_txt:
                 score = cvss.get("preferredBaseScore")
                 score_txt = f", CVSS: {score}" if score else ""
@@ -360,12 +360,12 @@ def html_vuln_formatter(result):
                 sev = f"{severity_order.get(sev, 2)} - {sev}"
                 cvss = node.get("cvss", {})
                 score_txt = ""
-                if "v4" in cvss and cvss["v4"].get("baseScore", 0) > 0:
-                    score = cvss["v4"].get("baseScore", 0)
-                    score_txt = f", CVSS (v4): {score}"
                 if "v3" in cvss and cvss["v3"].get("baseScore", 0) > 0:
                     score = cvss["v3"].get("baseScore", 0)
                     score_txt = f", CVSS (v3): {score}"
+                if "v4" in cvss and cvss["v4"].get("baseScore", 0) > 0:
+                    score = cvss["v4"].get("baseScore", 0)
+                    score_txt = f", CVSS (v4): {score}"
                 if not score_txt:
                     score = cvss.get("preferredBaseScore")
                     score_txt = f", CVSS: {score}" if score else ""

--- a/conan/internal/api/audit/providers.py
+++ b/conan/internal/api/audit/providers.py
@@ -148,6 +148,12 @@ class PrivateProvider:
                             severity
                             cvss {{
                                 preferredBaseScore
+                                v3 {{
+                                  baseScore
+                                }}
+                                v4 {{
+                                  baseScore
+                                }}
                             }}
                             aliases
                             withdrawn

--- a/test/integration/command/test_audit.py
+++ b/test/integration/command/test_audit.py
@@ -479,7 +479,7 @@ def test_audit_scan_threshold_error(severity_level, threshold, should_fail):
         severity_param = "" if threshold is None else f"-sl {threshold}"
         tc.run(f"audit scan --requires=foobar/0.1.0 {severity_param}", assert_error=should_fail)
         assert "foobar/0.1.0 1 vulnerability found" in tc.out
-        assert f"CVSS: {severity_level}" in tc.out
+        assert f"Critical - {severity_level}" in tc.out
         if should_fail:
             if threshold is None:
                 threshold = "9.0"
@@ -528,6 +528,88 @@ def test_audit_scan_context_filter(package_context, filter_context):
             assert "Requesting vulnerability info for: zlib/1.2.11" in tc.out
         else:
             assert "Requesting vulnerability info for: zlib/1.2.11" not in tc.out
+
+
+@pytest.mark.parametrize("score", [
+    {
+        "preferredBaseScore": 8.9,
+    },
+    {
+        "preferredBaseScore": 8.9,
+        "v3": {
+            "baseScore": 8.9
+        }
+    },
+    {
+        "preferredBaseScore": 8.9,
+        "v3": {
+            "baseScore": 8.9
+        },
+        "v4": {
+            "baseScore": 5.6
+        }
+    },
+])
+@pytest.mark.parametrize("out", ["html", "text"])
+def test_audit_cvss_versions(score, out):
+    """In case the severity level is equal or higher than the found for a CVE,
+           the command should output the information as usual, and exit with non-success code error.
+        """
+    successful_response = {
+        "data": {
+            "query": {
+                "vulnerabilities": {
+                    "totalCount": 1,
+                    "edges": [
+                        {
+                            "node": {
+                                "name": "CVE-2023-45853",
+                                "description": "Zip vulnerability",
+                                "severity": "Critical",
+                                "cvss": score,
+                                "aliases": [
+                                    "CVE-2023-45853",
+                                    "JFSA-2023-000272529"
+                                ],
+                                "advisories": [
+                                    {
+                                        "name": "CVE-2023-45853"
+                                    },
+                                    {
+                                        "name": "JFSA-2023-000272529"
+                                    }
+                                ],
+                                "references": [
+                                    "https://pypi.org/project/pyminizip/#history",
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+    tc = TestClient(light=True)
+
+    tc.save({"conanfile.py": GenConanfile("foobar", "0.1.0")})
+    tc.run("export .")
+    tc.run("audit provider auth conancenter --token=valid_token")
+
+    with proxy_response(200, successful_response):
+        tc.run(f"audit scan --requires=foobar/0.1.0 -f={out}")
+        print(score)
+        if "v4" in score:
+            assert str(score["v4"]["baseScore"]) in tc.out
+        if "v3" in score:
+            assert str(score["v3"]["baseScore"]) in tc.out
+
+        if out == "text":
+            assert "foobar/0.1.0 1 vulnerability found" in tc.out
+            assert f"Critical - {score['preferredBaseScore']}" in tc.out
+        else:
+            assert "CVE-2023-45853" in tc.out
+            assert f"Critical ({score['preferredBaseScore']})" in tc.out
 
 
 class TestAuditApiBranchouts:

--- a/test/integration/command/test_audit.py
+++ b/test/integration/command/test_audit.py
@@ -598,7 +598,6 @@ def test_audit_cvss_versions(score, out):
 
     with proxy_response(200, successful_response):
         tc.run(f"audit scan --requires=foobar/0.1.0 -f={out}")
-        print(score)
         if "v4" in score:
             assert str(score["v4"]["baseScore"]) in tc.out
         if "v3" in score:

--- a/test/integration/command/test_audit.py
+++ b/test/integration/command/test_audit.py
@@ -598,17 +598,20 @@ def test_audit_cvss_versions(score, out):
 
     with proxy_response(200, successful_response):
         tc.run(f"audit scan --requires=foobar/0.1.0 -f={out}")
-        if "v4" in score:
-            assert str(score["v4"]["baseScore"]) in tc.out
-        if "v3" in score:
-            assert str(score["v3"]["baseScore"]) in tc.out
-
         if out == "text":
             assert "foobar/0.1.0 1 vulnerability found" in tc.out
             assert f"Critical - {score['preferredBaseScore']}" in tc.out
+            if "v4" in score:
+                assert f'CVSS v4: {score["v4"]["baseScore"]}' in tc.out
+            if "v3" in score:
+                assert f'CVSS v3: {score["v3"]["baseScore"]}' in tc.out
         else:
             assert "CVE-2023-45853" in tc.out
             assert f"Critical ({score['preferredBaseScore']})" in tc.out
+            if "v4" in score:
+                assert f'CVSS <i>v4</i>: {score["v4"]["baseScore"]}' in tc.out
+            if "v3" in score:
+                assert f'CVSS <i>v3</i>: {score["v3"]["baseScore"]}' in tc.out
 
 
 class TestAuditApiBranchouts:


### PR DESCRIPTION
Changelog: Feature: Feature: Add CVE version info to ``conan audit`` results.
Docs: Omit

I'll add a test to show that old queries are supported
