### PR TITLE
Fix/nmake

### DIFF
--- a/conan/tools/microsoft/nmakedeps.py
+++ b/conan/tools/microsoft/nmakedeps.py
@@ -21,9 +21,10 @@ def format_defines(defines):
             # https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables
             macro, value = define.split("=", 1)
             if value and not is_hex_or_numeric(value):
+                # value quotes are escaped
                 value = f'\\"{value}\\"'
             define = f"{macro}#{value}"
-        formated_defines.append(f"/D\"{define}\"")
+        formated_defines.append(f'/D"{define}"')
     return formated_defines
 
 

--- a/conan/tools/microsoft/nmakedeps.py
+++ b/conan/tools/microsoft/nmakedeps.py
@@ -5,6 +5,28 @@ from conan.tools import CppInfo
 from conan.tools.env import Environment
 
 
+def format_defines(defines):
+    def is_hex_or_numeric(s):
+        try:
+            # Check for Hexadecimal (base 16)
+            int(s, 16)
+            return True
+        except ValueError:
+            return False
+
+    formated_defines = []
+    for define in defines:
+        if "=" in define:
+            # CL env-var can't accept '=' sign in /D option, it can be replaced by '#' sign:
+            # https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables
+            macro, value = define.split("=", 1)
+            if value and not is_hex_or_numeric(value):
+                value = f'\\"{value}\\"'
+            define = f"{macro}#{value}"
+        formated_defines.append(f"/D\"{define}\"")
+    return formated_defines
+
+
 class NMakeDeps:
 
     def __init__(self, conanfile):
@@ -45,20 +67,10 @@ class NMakeDeps:
             ret.extend([format_lib(lib) for lib in cpp_info.system_libs or []])
             link_args = " ".join(ret)
 
-            def format_define(define):
-                if "=" in define:
-                    # CL env-var can't accept '=' sign in /D option, it can be replaced by '#' sign:
-                    # https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables
-                    macro, value = define.split("=", 1)
-                    if value and not value.isnumeric():
-                        value = f'\"{value}\"'
-                    define = f"{macro}#{value}"
-                return f"/D\"{define}\""
-
             cl_flags = [f'-I"{p}"' for p in cpp_info.includedirs or []]
             cl_flags.extend(cpp_info.cflags or [])
             cl_flags.extend(cpp_info.cxxflags or [])
-            cl_flags.extend([format_define(define) for define in cpp_info.defines or []])
+            cl_flags.extend(format_defines(cpp_info.defines or []))
 
             env = Environment()
             env.append("CL", " ".join(cl_flags))

--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -2,6 +2,7 @@
 from conan.internal import check_duplicated_generator
 from conan.tools.build.flags import build_type_flags, cppstd_flag, build_type_link_flags
 from conan.tools.env import Environment
+from conan.tools.microsoft.nmakedeps import format_defines
 from conan.tools.microsoft.visual import msvc_runtime_flag, VCVars
 
 
@@ -28,20 +29,6 @@ class NMakeToolchain:
     @staticmethod
     def _format_options(options):
         return [f"{opt[0].replace('-', '/')}{opt[1:]}" for opt in options if len(opt) > 1]
-
-    @staticmethod
-    def _format_defines(defines):
-        formated_defines = []
-        for define in defines:
-            if "=" in define:
-                # CL env-var can't accept '=' sign in /D option, it can be replaced by '#' sign:
-                # https://learn.microsoft.com/en-us/cpp/build/reference/cl-environment-variables
-                macro, value = define.split("=", 1)
-                if value and not value.isnumeric():
-                    value = f'\\"{value}\\"'
-                define = f"{macro}#{value}"
-            formated_defines.append(f"/D\"{define}\"")
-        return formated_defines
 
     @property
     def _cl(self):
@@ -71,7 +58,7 @@ class NMakeToolchain:
         defines.extend(self.extra_defines)
 
         return (["/nologo"] + self._format_options(bt_flags + rt_flags + cflags + cxxflags) +
-                self._format_defines(defines))
+                format_defines(defines))
 
     @property
     def _link(self):

--- a/test/functional/toolchains/test_nmake_toolchain.py
+++ b/test/functional/toolchains/test_nmake_toolchain.py
@@ -15,7 +15,7 @@ from conan.test.utils.tools import TestClient
         ("msvc", "191", "dynamic", "14", "Release", [], [], [], [], []),
         ("msvc", "191", "dynamic", "14", "Release",
          ["TEST_DEFINITION1", "TEST_DEFINITION2=0", "TEST_DEFINITION3=", "TEST_DEFINITION4=TestPpdValue4",
-          "TEST_DEFINITION5=__declspec(dllexport)", "TEST_DEFINITION6=foo bar"],
+          "TEST_DEFINITION5=__declspec(dllexport)", "TEST_DEFINITION6=foo bar", "TEST_WINVER=0x0601"],
          ["/GL"], ["/GL"], ["/LTCG"], ["/LTCG"]),
         ("msvc", "191", "static", "17", "Debug", [], [], [], [], []),
     ],
@@ -86,6 +86,9 @@ def test_toolchain_nmake(compiler, version, runtime, cppstd, build_type,
     client.run(f"build . {settings} {conf}")
     client.run_command("simple.exe")
     assert "dep/1.0" in client.out
+    # It is printed as an integer number by default
+    if "TEST_WINVER" in conf_preprocessors:
+        conf_preprocessors["TEST_WINVER"] = 1537
     check_exe_run(client.out, "main", "msvc", version, build_type, "x86_64", cppstd,
                   conf_preprocessors)
 

--- a/test/integration/toolchains/microsoft/test_nmakedeps.py
+++ b/test/integration/toolchains/microsoft/test_nmakedeps.py
@@ -40,18 +40,16 @@ def test_nmakedeps():
                " -g NMakeDeps -s build_type=Release -s arch=x86_64")
     # Checking that NMakeDeps builds correctly .bat file
     bat_file = client.load("conannmakedeps.bat")
-    print(bat_file)
     # Checking that defines are added to CL
     for flag in (
         r'/D"TEST_DEFINITION1"', '/D"TEST_DEFINITION2#0"',
-        r'/D"TEST_DEFINITION3#"', '/D"TEST_DEFINITION4#"foo""',
-        r'/D"TEST_DEFINITION5#"__declspec\(dllexport\)""',
-        r'/D"TEST_DEFINITION6#"foo bar""',
+        r'/D"TEST_DEFINITION3#"', r'/D"TEST_DEFINITION4#\"foo\""',
+        r'/D"TEST_DEFINITION5#\"__declspec(dllexport)\""',
+        r'/D"TEST_DEFINITION6#\"foo bar\""',
         r'/D"TEST_DEFINITION7#7"',
         r'/D"TEST_WINVER#0x0601"'
     ):
-        print("TESTING", flag)
-        assert re.search(fr'set "CL=%CL%.*\s{flag}(?:\s|")', bat_file)
+        assert flag in bat_file
     # Checking that libs and system libs are added to _LINK_
     for flag in (r"pkg-1\.lib", r"pkg-2\.lib", r"pkg-3\.lib", r"pkg-4\.lib", r"ws2_32\.lib"):
         assert re.search(fr'set "_LINK_=%_LINK_%.*\s{flag}(?:\s|")', bat_file)

--- a/test/integration/toolchains/microsoft/test_nmakedeps.py
+++ b/test/integration/toolchains/microsoft/test_nmakedeps.py
@@ -31,7 +31,8 @@ def test_nmakedeps():
                 self.cpp_info.components["pkg-4"].defines = ["TEST_DEFINITION4=foo",
                                                             "TEST_DEFINITION5=__declspec(dllexport)",
                                                             "TEST_DEFINITION6=foo bar",
-                                                            "TEST_DEFINITION7=7"]
+                                                            "TEST_DEFINITION7=7",
+                                                            "TEST_WINVER=0x0601"]
     """)
     client.save({"conanfile.py": conanfile})
     client.run("create . -s arch=x86_64")
@@ -39,14 +40,17 @@ def test_nmakedeps():
                " -g NMakeDeps -s build_type=Release -s arch=x86_64")
     # Checking that NMakeDeps builds correctly .bat file
     bat_file = client.load("conannmakedeps.bat")
+    print(bat_file)
     # Checking that defines are added to CL
     for flag in (
         r'/D"TEST_DEFINITION1"', '/D"TEST_DEFINITION2#0"',
         r'/D"TEST_DEFINITION3#"', '/D"TEST_DEFINITION4#"foo""',
         r'/D"TEST_DEFINITION5#"__declspec\(dllexport\)""',
         r'/D"TEST_DEFINITION6#"foo bar""',
-        r'/D"TEST_DEFINITION7#7"'
+        r'/D"TEST_DEFINITION7#7"',
+        r'/D"TEST_WINVER#0x0601"'
     ):
+        print("TESTING", flag)
         assert re.search(fr'set "CL=%CL%.*\s{flag}(?:\s|")', bat_file)
     # Checking that libs and system libs are added to _LINK_
     for flag in (r"pkg-1\.lib", r"pkg-2\.lib", r"pkg-3\.lib", r"pkg-4\.lib", r"ws2_32\.lib"):


### PR DESCRIPTION
Changelog: Fix: Allow ``NMake`` integrations to handle defines such as ``WINVER=0x0601`` as numeric, not strings.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19769
