### PR TITLE
short form for --update-requires

### DIFF
--- a/conan/cli/commands/lock.py
+++ b/conan/cli/commands/lock.py
@@ -180,11 +180,11 @@ def lock_upgrade(conan_api, parser, subparser, *args):
     given a conanfile or a reference.
     """
     common_graph_args(subparser)
-    subparser.add_argument('--update-requires', action="append",
+    subparser.add_argument('-ur', '--update-requires', action="append",
                            help='Update requires from lockfile')
-    subparser.add_argument('--update-build-requires', action="append",
+    subparser.add_argument('-ubr', '--update-build-requires', action="append",
                            help='Update build-requires from lockfile')
-    subparser.add_argument('--update-python-requires', action="append",
+    subparser.add_argument('-upr', '--update-python-requires', action="append",
                            help='Update python-requires from lockfile')
     subparser.add_argument('--build-require', action='store_true', default=False,
                            help='Whether the provided reference is a build-require')

--- a/test/integration/lockfile/test_user_overrides.py
+++ b/test/integration/lockfile/test_user_overrides.py
@@ -419,7 +419,7 @@ class TestLockUpgrade:
         c.run(f"export libb --version=1.2")
         c.run(f"export libc --version=1.1")
         c.run(f"export libd --version=1.1")
-        c.run("lock upgrade . --update-requires=liba/1.0 --update-requires=libb/[*] --update-build-requires=libc/[*] --update-python-requires=libd/1.0")
+        c.run("lock upgrade . -ur=liba/1.0 -ur=libb/[*] -ubr=libc/[*] -upr=libd/1.0")
         lock = c.load("conan.lock")
         assert "liba/1.9" in lock
         assert "libb/1.1" in lock


### PR DESCRIPTION
Changelog: Fix: Add ``-ur/-ubr/-upr`` for ``conan lock upgrade`` as short forms for ``--update-requires``, etc.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19622