### PR TITLE
avoid casing errors while looking for version ranges

### DIFF
--- a/conan/internal/cache/cache.py
+++ b/conan/internal/cache/cache.py
@@ -201,13 +201,13 @@ class PkgCache:
         assert ref.timestamp
         self._db.update_recipe_timestamp(ref)
 
-    def search_recipes(self, pattern=None, ignorecase=True):
+    def search_recipes(self, pattern=None):
         # Conan references in main storage
         if pattern:
             if isinstance(pattern, RecipeReference):
                 pattern = repr(pattern)
             pattern = translate(pattern)
-            pattern = re.compile(pattern, re.IGNORECASE if ignorecase else 0)
+            pattern = re.compile(pattern)
 
         return self._db.list_references(pattern)
 

--- a/test/integration/conanfile/conanfile_errors_test.py
+++ b/test/integration/conanfile/conanfile_errors_test.py
@@ -137,6 +137,16 @@ class TestConanfileErrors:
         client.run("export .", assert_error=True)
         assert "Duplicated requirement" in client.out
 
+    @pytest.mark.parametrize("version", ["0.1", "[*]"])
+    def test_error_requirement_casing(self, version):
+        # https://github.com/conan-io/conan/issues/19796
+        c = TestClient(light=True)
+        c.save({"mypkg/conanfile.py": GenConanfile("mypkg", "0.1"),
+                "app/conanfile.py": GenConanfile("app", "0.1").with_requires(f"myPkg/{version}")})
+        c.run("create mypkg")
+        c.run("install app", assert_error=True)
+        assert f"ERROR: Package 'myPkg/{version}' not resolved" in c.out
+
 
 class TestWrongMethods:
     # https://github.com/conan-io/conan/issues/12961


### PR DESCRIPTION
Changelog: Fix: Avoid subtle errors with casing errors like ``requires("myPkg/[*]")`` using version ranges.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19796