### PR TITLE
Fix syntax error in Python <3.9

### DIFF
--- a/test/integration/command/remote/test_remote_users.py
+++ b/test/integration/command/remote/test_remote_users.py
@@ -362,8 +362,8 @@ class TestRemoteAuth:
         c = TestClient(light=True, servers=servers,
                        inputs=["lasote", "mypass", "danimtb", "passpass", "lasote", "mypass"])
 
-        with (patch("conan.internal.rest.rest_client_v2.RestV2Methods.check_credentials")
-              as check_credentials_mock):
+        with patch("conan.internal.rest.rest_client_v2.RestV2Methods.check_credentials") \
+             as check_credentials_mock:
             c.run("remote auth --force *")
             check_credentials_mock.assert_called_with(True)
 
@@ -375,8 +375,8 @@ class TestRemoteAuth:
         c = TestClient(light=True, servers=servers,
                        inputs=["lasote", "mypass", "danimtb", "passpass", "lasote", "mypass"])
 
-        with (patch("conan.internal.rest.rest_client_v2.RestV2Methods.check_credentials")
-              as check_credentials_mock):
+        with patch("conan.internal.rest.rest_client_v2.RestV2Methods.check_credentials") \
+             as check_credentials_mock:
             c.run("remote auth *")
             check_credentials_mock.assert_called_with(False)
 


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Python <3.9 does not allow parens in the context manager line, use a \ instead