### PR TITLE
fix powershell unset (and other possible unsets too)

### DIFF
--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -387,7 +387,9 @@ class Conf:
         conf_value = self._values.get(conf_name)
         if conf_value:
             v = conf_value.value
-            if choices is not None and v not in choices and v is not None:
+            if v is None:  # value was unset
+                return default
+            if choices is not None and v not in choices:
                 raise ConanException(f"Unknown value '{v}' for '{conf_name}'")
             # Some smart conversions
             if check_type is bool and not isinstance(v, bool):
@@ -398,9 +400,9 @@ class Conf:
                 raise ConanException(f"[conf] {conf_name} must be a boolean-like object "
                                      f"(true/false, 1/0, on/off) and value '{v}' does not match it.")
             elif check_type is str and not isinstance(v, str):
+                # TODO: this would be converting things like lists to strings without
+                #   proper error, is it worth trying to change it?
                 return str(v)
-            elif v is None:  # value was unset
-                return default
             elif (check_type is not None and not isinstance(v, check_type) or
                   check_type is int and isinstance(v, bool)):
                 raise ConanException(f"[conf] {conf_name} must be a "

--- a/test/functional/toolchains/env/test_virtualenv_powershell.py
+++ b/test/functional/toolchains/env/test_virtualenv_powershell.py
@@ -260,3 +260,15 @@ def test_verbosity_flag():
 
     assert "/verbosity:Detailed" in tc.out
     assert "-verbosity:Detailed" not in tc.out
+
+
+def test_powershell_deactivation():
+    # https://github.com/conan-io/conan/issues/19819
+    c = TestClient(light=True)
+    c.save({"conanfile.txt": ""})
+    c.run('install . -c tools.env.virtualenv:powershell=!')
+    files = os.listdir(c.current_folder)
+    assert "conanrun.ps1" not in files
+    assert "conanbuild.ps1" not in files
+    assert "conanrunenv.ps1" not in files
+    assert "conanbuildenv.ps1" not in files


### PR DESCRIPTION
Changelog: Bugfix: Solve incorrect ``.ps1`` file generation when unsetting the conf with ``-c tools.env.virtualenv:powershell=!``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19819
