### PR TITLE
Undefined locale for list html

### DIFF
--- a/conan/cli/formatters/list/search_table_html.py
+++ b/conan/cli/formatters/list/search_table_html.py
@@ -50,7 +50,7 @@ list_packages_html_template = r"""
                 second: "2-digit",
                 hour12: false
             };
-            return new Date(timeStamp * 1000).toLocaleDateString('en', options);
+            return new Date(timeStamp * 1000).toLocaleDateString(undefined, options);
         }
 
         function getInfoFieldsBadges(info) {


### PR DESCRIPTION
Changelog: Fix: Use user locale in `conan list ... -f=html` output.
Docs: Omit

Closes https://github.com/conan-io/conan/issues/19827.

Valid as per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleDateString
