### PR TITLE
Stop build requirements with ``run=False`` from propagating their bindirs to path

### DIFF
--- a/conan/tools/env/virtualbuildenv.py
+++ b/conan/tools/env/virtualbuildenv.py
@@ -63,8 +63,9 @@ class VirtualBuildEnv:
             if build_require.runenv_info:
                 self._buildenv.compose_env(build_require.runenv_info)
             # Then the implicit
-            os_name = self._conanfile.settings_build.get_safe("os")
-            self._buildenv.compose_env(runenv_from_cpp_info(build_require, os_name))
+            if require.run:
+                os_name = self._conanfile.settings_build.get_safe("os")
+                self._buildenv.compose_env(runenv_from_cpp_info(build_require, os_name))
 
         # Requires in host context can also bring some direct buildenv_info
         host_requires = self._conanfile.dependencies.host.topological_sort

--- a/test/integration/build_requires/build_requires_test.py
+++ b/test/integration/build_requires/build_requires_test.py
@@ -768,3 +768,46 @@ def test_transitive_build_scripts_library_error():
     c.run("install --requires=tool/0.1", assert_error=True)
     assert ("ERROR: Package 'tool/0.1' with type 'build-scripts' cannot have "
             "a 'static-library' dependency to 'dep/0.1'") in c.out
+
+
+def test_build_run_false():
+    tc = TestClient(light=True)
+    cmake = textwrap.dedent("""
+    from conan import ConanFile
+    from conan.tools.files import save
+    import os
+
+    class CMake(ConanFile):
+        name = "mycmake"
+        version = "1.0"
+        settings = "os"
+
+        def package(self):
+            echo = "echo MYCMAKE!!!"
+            save(self, os.path.join(self.package_folder, "bin", "mycmake.sh"), echo)
+            save(self, os.path.join(self.package_folder, "bin", "mycmake.bat"), echo)
+            os.chmod(os.path.join(self.package_folder, "bin", "mycmake.sh"), 0o777)
+    """)
+
+    consumer = textwrap.dedent("""
+    from conan import ConanFile
+    import platform
+
+    class Pkg(ConanFile):
+        name = "pkg"
+        version = "0.1"
+        settings = "os"
+
+        def build_requirements(self):
+            self.tool_requires("mycmake/1.0", run=False)
+
+        def build(self):
+            cmd = "mycmake.bat" if platform.system() == "Windows" else "mycmake.sh"
+            self.run(cmd)
+    """)
+    tc.save({"consumer/conanfile.py": consumer,
+             "cmake/conanfile.py": cmake})
+    tc.run("create cmake")
+    tc.run("create consumer", assert_error=True)
+    assert "MYCMAKE!!!" not in tc.out
+    assert "Error in build() method" in tc.out

--- a/test/integration/graph/test_require_same_pkg_versions.py
+++ b/test/integration/graph/test_require_same_pkg_versions.py
@@ -27,6 +27,7 @@ def test_require_different_versions():
     wine = textwrap.dedent("""
         import os, platform
         from conan import ConanFile
+        from conan.tools.env import VirtualBuildEnv
         from conan.tools.files import save, chdir
         class Pkg(ConanFile):
             name = "wine"
@@ -36,10 +37,15 @@ def test_require_different_versions():
                 self.tool_requires("gcc/2.0", run=False)
 
             def generate(self):
+                venv = VirtualBuildEnv(self)
                 gcc1 = self.dependencies.build["gcc/1.0"]
                 assert gcc1.ref.version == "1.0"
                 gcc2 = self.dependencies.build["gcc/2.0"]
                 assert gcc2.ref.version == "2.0"
+                env = venv.environment()
+                env.prepend_path("PATH", gcc1.cpp_info.bindir)
+                env.prepend_path("PATH", gcc2.cpp_info.bindir)
+                venv.generate()
 
             def build(self):
                 ext = "bat" if platform.system() == "Windows" else "sh"

--- a/test/integration/graph/test_require_same_pkg_versions.py
+++ b/test/integration/graph/test_require_same_pkg_versions.py
@@ -81,12 +81,19 @@ def test_require_different_versions_profile_override():
     wine = textwrap.dedent("""
         import os, platform
         from conan import ConanFile
+        from conan.tools.env import VirtualBuildEnv
         from conan.tools.files import save, chdir
         class Pkg(ConanFile):
             name = "wine"
             version = "1.0"
             def build_requirements(self):
                 self.tool_requires("gcc/1.0", run=False)
+
+            def generate(self):
+                venv = VirtualBuildEnv(self)
+                gcc1 = self.dependencies.build["gcc/1.0"]
+                venv.environment().prepend_path("PATH", gcc1.cpp_info.bindir)
+                venv.generate()
 
             def build(self):
                 ext = "bat" if platform.system() == "Windows" else "sh"

--- a/test/integration/graph/test_require_same_pkg_versions.py
+++ b/test/integration/graph/test_require_same_pkg_versions.py
@@ -155,6 +155,7 @@ def test_require_different_options():
     wine = textwrap.dedent("""
         import os, platform
         from conan import ConanFile
+        from conan.tools.env import VirtualBuildEnv
         from conan.tools.files import save, chdir
         class Pkg(ConanFile):
             name = "wine"
@@ -164,10 +165,16 @@ def test_require_different_options():
                 self.tool_requires("gcc/1.0", run=False, options={"myoption": 2})
 
             def generate(self):
+                venv = VirtualBuildEnv(self)
                 gcc1 = self.dependencies.build.get("gcc", options={"myoption": 1})
                 assert gcc1.options.myoption == "1"
                 gcc2 = self.dependencies.build.get("gcc", options={"myoption": 2})
                 assert gcc2.options.myoption == "2"
+                env = venv.environment()
+                env.prepend_path("PATH", gcc1.cpp_info.bindir)
+                env.prepend_path("PATH", gcc2.cpp_info.bindir)
+                venv.generate()
+
 
             def build(self):
                 ext = "bat" if platform.system() == "Windows" else "sh"


### PR DESCRIPTION
Changelog: Bugifx: Stop build requirements with ``run=False`` from propagating their bindirs to path
Docs: Omit

Nothing was noted in https://github.com/conan-io/conan/pull/10076 when this was introduced.

Reported by @aagor in https://github.com/conan-io/conan/pull/19751#issuecomment-4190787050, thanks!