### PR TITLE
finalize() output folder should be printed only once

### DIFF
--- a/conan/internal/graph/installer.py
+++ b/conan/internal/graph/installer.py
@@ -487,4 +487,4 @@ class BinaryInstaller:
                                                'finalize'):
                         conanfile.finalize()
 
-            conanfile.output.success(f"Finalized folder {finalize_folder}")
+                conanfile.output.success(f"Finalized folder {finalize_folder}")

--- a/test/integration/conanfile/test_finalize_method.py
+++ b/test/integration/conanfile/test_finalize_method.py
@@ -319,6 +319,27 @@ class TestToolRequiresFlows:
         assert "There are corrupted artifacts" not in tc.out
 
 
+    def test_multiple_instances_of_finalized_package(self):
+        tc = TestClient(light=True)
+        tc.save({"tool/conanfile.py": GenConanfile("tool", "1.0")
+                    .with_package_type("application")
+                    .with_finalize("self.output.info('RUNNING MY FINALIZE')"),
+                "liba/conanfile.py": GenConanfile("liba", "1.0").with_tool_requires("tool/1.0"),
+                "libb/conanfile.py": GenConanfile("libb", "1.0").with_tool_requires("tool/1.0"),
+                "consumer/conanfile.py": GenConanfile("consummer", "1.0")
+                    .with_requires("liba/1.0")
+                    .with_requires("libb/1.0")})
+
+        tc.run("export tool")
+        tc.run("export liba")
+        tc.run("export libb")
+        tc.run("install consumer -c:a tools.graph:skip_binaries=False -b missing")
+
+        # The finalize() method of the tool should only be called once, even if multiple packages depend on it
+        assert tc.out.count("RUNNING MY FINALIZE") == 1
+        # Finalize folder conan output should be printed only once
+        assert tc.out.count("Finalized folder ") == 1
+
 class TestRemoteFlows:
 
     @pytest.fixture


### PR DESCRIPTION
Changelog: Fix: `finalize()` output folder should be printed only once
Docs: omit

Close https://github.com/conan-io/conan/issues/19833

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
