### PR TITLE
Poc/editable refactor

### DIFF
--- a/conan/api/subapi/install.py
+++ b/conan/api/subapi/install.py
@@ -3,7 +3,6 @@ from typing import List
 
 from conan.api.model import Remote
 from conan.internal.api.install.generators import write_generators
-from conan.internal.conan_app import ConanBasicApp
 from conan.internal.deploy import do_deploys
 
 from conan.internal.graph.install_graph import InstallGraph
@@ -39,9 +38,7 @@ class InstallAPI:
         :param remotes: List of remotes to fetch packages from if necessary.
         :param return_install_error: If ``True``, do not raise an exception, but return it
         """
-        app = ConanBasicApp(self._conan_api)
-        installer = BinaryInstaller(self._conan_api, self._helpers.global_conf, app.editable_packages,
-                                    self._helpers.hook_manager)
+        installer = BinaryInstaller(self._conan_api, self._helpers.global_conf, self._helpers.hook_manager)
         install_graph = InstallGraph(deps_graph)
         install_graph.raise_errors()
         install_order = install_graph.install_order()
@@ -68,9 +65,7 @@ class InstallAPI:
         :param graph: Dependency graph to install system requirements for
         :param only_info: If ``True``, only reporting and checking of whether the system requirements are installed is performed.
         """
-        app = ConanBasicApp(self._conan_api)
-        installer = BinaryInstaller(self._conan_api, self._helpers.global_conf, app.editable_packages,
-                                    self._helpers.hook_manager)
+        installer = BinaryInstaller(self._conan_api, self._helpers.global_conf, self._helpers.hook_manager)
         installer.install_system_requires(graph, only_info)
 
     def install_sources(self, graph, remotes: List[Remote]):
@@ -89,9 +84,7 @@ class InstallAPI:
         :param remotes: List of remotes where the ``exports_sources`` of the packages might be located
         :param graph: Dependency graph to download sources from
         """
-        app = ConanBasicApp(self._conan_api)
-        installer = BinaryInstaller(self._conan_api, self._helpers.global_conf, app.editable_packages,
-                                    self._helpers.hook_manager)
+        installer = BinaryInstaller(self._conan_api, self._helpers.global_conf, self._helpers.hook_manager)
         installer.install_sources(graph, remotes)
 
     def install_consumer(self, deps_graph, generators: List[str] = None, source_folder=None,

--- a/conan/internal/api/local/editable.py
+++ b/conan/internal/api/local/editable.py
@@ -49,11 +49,6 @@ class EditablePackages:
         _tmp.revision = None
         return self._edited_refs.get(_tmp)
 
-    def get_path(self, ref):
-        editable = self.get(ref)
-        if editable is not None:
-            return editable["path"]
-
     def add(self, ref, path, output_folder=None):
         assert isinstance(ref, RecipeReference)
         _tmp = copy.copy(ref)

--- a/conan/internal/cache/conan_reference_layout.py
+++ b/conan/internal/cache/conan_reference_layout.py
@@ -31,11 +31,12 @@ class LayoutBase:
 
 
 class BasicLayout(LayoutBase):
+    # For editables and platform_requires
+
     def __init__(self, ref, base_folder, editable_output_folder=None):
         super().__init__(ref, base_folder)
         self.editable_output_folder = editable_output_folder
 
-    # For editables and platform_requires
     def conanfile(self):
         # the full conanfile path (including other other.py names) for editables
         # None for platform_requires

--- a/conan/internal/cache/conan_reference_layout.py
+++ b/conan/internal/cache/conan_reference_layout.py
@@ -31,6 +31,10 @@ class LayoutBase:
 
 
 class BasicLayout(LayoutBase):
+    def __init__(self, ref, base_folder, editable_output_folder=None):
+        super().__init__(ref, base_folder)
+        self.editable_output_folder = editable_output_folder
+
     # For editables and platform_requires
     def conanfile(self):
         # the full conanfile path (including other other.py names) for editables

--- a/conan/internal/graph/graph.py
+++ b/conan/internal/graph/graph.py
@@ -71,6 +71,7 @@ class Node:
         self.is_conf = False
         self.replaced_requires = {}  # To track the replaced requires for self.edges[old-ref]
         self.skipped_build_requires = False
+        self.editable_output_folder = None  # In case this node is editable
 
     @property
     def dependencies(self):

--- a/conan/internal/graph/graph_builder.py
+++ b/conan/internal/graph/graph_builder.py
@@ -290,8 +290,6 @@ class DepsGraphBuilder:
         dep_conanfile = self._loader.load_conanfile(conanfile_path, ref=ref, graph_lock=graph_lock,
                                                     remotes=self._remotes, update=self._update,
                                                     check_update=self._check_update)
-        if getattr(layout, "editable_output_folder", None):
-            dep_conanfile.editable_output_folder = layout.editable_output_folder
         return layout, dep_conanfile, recipe_status, remote
 
     @staticmethod
@@ -420,6 +418,8 @@ class DepsGraphBuilder:
         new_node = Node(new_ref, dep_conanfile, context=context, test=require.test or node.test)
         new_node.recipe = recipe_status
         new_node.remote = remote
+        if isinstance(layout, BasicLayout):  # Store the editable_output_folder for BinaryInstaller
+            new_node.editable_output_folder = layout.editable_output_folder
 
         down_options = self._compute_down_options(node, require, new_ref)
 

--- a/conan/internal/graph/graph_builder.py
+++ b/conan/internal/graph/graph_builder.py
@@ -290,6 +290,8 @@ class DepsGraphBuilder:
         dep_conanfile = self._loader.load_conanfile(conanfile_path, ref=ref, graph_lock=graph_lock,
                                                     remotes=self._remotes, update=self._update,
                                                     check_update=self._check_update)
+        if getattr(layout, "editable_output_folder", None):
+            dep_conanfile.editable_output_folder = layout.editable_output_folder
         return layout, dep_conanfile, recipe_status, remote
 
     @staticmethod

--- a/conan/internal/graph/installer.py
+++ b/conan/internal/graph/installer.py
@@ -351,12 +351,9 @@ class BinaryInstaller:
         # It will only run generation
         node = install_node.nodes[0]
         conanfile = node.conanfile
-        ref = node.ref
-        editable = self._editable_packages.get(ref)
-        conanfile_path = editable["path"]
-        output_folder = editable.get("output_folder")
 
-        base_path = os.path.dirname(conanfile_path)
+        output_folder = conanfile.editable_output_folder
+        base_path = conanfile.recipe_folder
 
         conanfile.folders.set_base_folders(base_path, output_folder)
 

--- a/conan/internal/graph/installer.py
+++ b/conan/internal/graph/installer.py
@@ -165,9 +165,8 @@ class BinaryInstaller:
     locally in case they are not found in remotes
     """
 
-    def __init__(self, api, global_conf, editable_packages, hook_manager):
+    def __init__(self, api, global_conf, hook_manager):
         helpers = api._api_helpers  # noqa
-        self._editable_packages = editable_packages
         self._cache = helpers.cache
         self._remote_manager = helpers.remote_manager
         self._hook_manager = hook_manager
@@ -352,7 +351,7 @@ class BinaryInstaller:
         node = install_node.nodes[0]
         conanfile = node.conanfile
 
-        output_folder = conanfile.editable_output_folder
+        output_folder = node.editable_output_folder
         base_path = conanfile.recipe_folder
 
         conanfile.folders.set_base_folders(base_path, output_folder)

--- a/conan/internal/graph/proxy.py
+++ b/conan/internal/graph/proxy.py
@@ -32,9 +32,12 @@ class ConanProxy:
     def _get_recipe(self, reference, remotes, update, check_update):
         output = ConanOutput(scope=str(reference))
 
-        conanfile_path = self._editable_packages.get_path(reference)
-        if conanfile_path is not None:
-            return BasicLayout(reference, conanfile_path), RECIPE_EDITABLE, None
+        editable = self._editable_packages.get(reference)
+        if editable is not None:
+            path = editable["path"]
+            output_folder = editable["output_folder"]
+            return BasicLayout(reference, path,
+                               editable_output_folder=output_folder), RECIPE_EDITABLE, None
 
         # check if it there's any revision of this recipe in the local cache
         try:

--- a/conan/internal/graph/proxy.py
+++ b/conan/internal/graph/proxy.py
@@ -35,9 +35,8 @@ class ConanProxy:
         editable = self._editable_packages.get(reference)
         if editable is not None:
             path = editable["path"]
-            output_folder = editable["output_folder"]
-            return BasicLayout(reference, path,
-                               editable_output_folder=output_folder), RECIPE_EDITABLE, None
+            output_folder = editable.get("output_folder")
+            return BasicLayout(reference, path, output_folder), RECIPE_EDITABLE, None
 
         # check if it there's any revision of this recipe in the local cache
         try:


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Internal refactor.

Avoid passing "editable" information to ``BinaryInstaller`` just to retrieve the "output_folder". When the editables resolve in ``ConanProxy``, the necessary information for editable installation is already stored in the ``Node``.

Preparation and simplification for: https://github.com/conan-io/conan/pull/19797
