### PR TITLE
detect_libcxx: Remove temporary directory usage

### DIFF
--- a/conan/internal/api/detect/detect_api.py
+++ b/conan/internal/api/detect/detect_api.py
@@ -223,29 +223,28 @@ def detect_libcxx(compiler, version, compiler_exe=None):
         main = textwrap.dedent("""
             #include <string>
 
-            using namespace std;
             static_assert(sizeof(std::string) != sizeof(void*), "using libstdc++");
             int main(){}
             """)
-        t = tempfile.mkdtemp()
-        filename = os.path.join(t, "main.cpp")
-        save(filename, main)
-        old_path = os.getcwd()
-        os.chdir(t)
-        try:
-            error, out_str = detect_runner(f'"{executable}" main.cpp -std=c++11')
-            if error:
-                if "using libstdc++" in out_str:
-                    output.info("gcc C++ standard library: libstdc++")
-                    return "libstdc++"
-                # Other error, but can't know, lets keep libstdc++11
-                output.warning("compiler.libcxx check error: %s" % out_str)
-                output.warning("Couldn't deduce compiler.libcxx for gcc>=5.1, assuming libstdc++11")
-            else:
-                output.info("gcc C++ standard library: libstdc++11")
-            return "libstdc++11"
-        finally:
-            os.chdir(old_path)
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as t:
+            filename = os.path.join(t, "main.cpp")
+            save(filename, main)
+            old_path = os.getcwd()
+            os.chdir(t)
+            try:
+                error, out_str = detect_runner(f'"{executable}" main.cpp -std=c++11')
+                if error:
+                    if "using libstdc++" in out_str:
+                        output.info("gcc C++ standard library: libstdc++")
+                        return "libstdc++"
+                    # Other error, but can't know, lets keep libstdc++11
+                    output.warning("compiler.libcxx check error: %s" % out_str)
+                    output.warning("Couldn't deduce compiler.libcxx for gcc>=5.1, assuming libstdc++11")
+                else:
+                    output.info("gcc C++ standard library: libstdc++11")
+                return "libstdc++11"
+            finally:
+                os.chdir(old_path)
 
         # This is not really a detection in most cases
         # Get compiler C++ stdlib

--- a/conan/internal/api/detect/detect_api.py
+++ b/conan/internal/api/detect/detect_api.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import re
+import subprocess
 import tempfile
 import textwrap
 
@@ -226,25 +227,22 @@ def detect_libcxx(compiler, version, compiler_exe=None):
             static_assert(sizeof(std::string) != sizeof(void*), "using libstdc++");
             int main(){}
             """)
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as t:
-            filename = os.path.join(t, "main.cpp")
-            save(filename, main)
-            old_path = os.getcwd()
-            os.chdir(t)
-            try:
-                error, out_str = detect_runner(f'"{executable}" main.cpp -std=c++11')
-                if error:
-                    if "using libstdc++" in out_str:
-                        output.info("gcc C++ standard library: libstdc++")
-                        return "libstdc++"
-                    # Other error, but can't know, lets keep libstdc++11
-                    output.warning("compiler.libcxx check error: %s" % out_str)
-                    output.warning("Couldn't deduce compiler.libcxx for gcc>=5.1, assuming libstdc++11")
-                else:
-                    output.info("gcc C++ standard library: libstdc++11")
-                return "libstdc++11"
-            finally:
-                os.chdir(old_path)
+        # -fsyntax-only to omit the output and stop early (but enough for our static_assert).
+        # -xc++ and - to tell the compiler to compile code from stdin and treat it as C++.
+        completed_process = subprocess.run([executable, "-std=c++11", "-fsyntax-only", "-xc++", "-"],
+                                           input=main, stdout=subprocess.PIPE,
+                                           stderr=subprocess.STDOUT, text=True)
+        error, out_str = completed_process.returncode, completed_process.stdout
+        if error:
+            if "using libstdc++" in out_str:
+                output.info("gcc C++ standard library: libstdc++")
+                return "libstdc++"
+            # Other error, but can't know, lets keep libstdc++11
+            output.warning("compiler.libcxx check error: %s" % out_str)
+            output.warning("Couldn't deduce compiler.libcxx for gcc>=5.1, assuming libstdc++11")
+        else:
+            output.info("gcc C++ standard library: libstdc++11")
+        return "libstdc++11"
 
         # This is not really a detection in most cases
         # Get compiler C++ stdlib


### PR DESCRIPTION
`detect_libcxx` tries to detect the C++ standard library implementation.

When running `conan profile detect`, a temporary folder is created, where a minimal C++ translation unit is stored. This unit gets compiled in order to test which standard library is in use.
Due to the use of `tempfile.mkdtemp()`,
cleanup must be done manually, but was omitted.

The temporary directory was used for two purposes:
* Storing the input file (`main.cpp`).
* Storing the output file (`a.out`).

Both of these can be quite easily replaced:
* The input can be passed via stdin to the compiler.
  `-xc++` is necessary to tell the compiler which language the input is,
  as autodetection from filename doesn't work anymore.
  `-` is used to tell the compiler to use stdin.
* The output can be omitted by using `-fsyntax-only`,
  which tells the compiler to stop early and don't write output at all.
  The output is not relevant anyway, only the returncode and error
  message was used.

Together, the whole chdir and temporary file logic is obsolete and
can be removed.

Remove unnecessary using-directive for `std` namespace, too.

Changelog: omit
Docs: omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
