### PR TITLE
Refactor/ordered dict

### DIFF
--- a/conan/cli/formatters/graph/graph_info_text.py
+++ b/conan/cli/formatters/graph/graph_info_text.py
@@ -1,5 +1,4 @@
 import fnmatch
-from collections import OrderedDict
 
 from conan.api.model import RecipeReference
 from conan.api.output import ConanOutput, cli_out_write
@@ -29,7 +28,7 @@ def filter_graph(graph, package_filter=None, field_filter=None):
             field_filter.append("ref")
         result = {}
         for id_, n in graph["nodes"].items():
-            new_node = OrderedDict((k, v) for k, v in n.items() if k in field_filter)
+            new_node = {k: v for k, v in n.items() if k in field_filter}
             result[id_] = new_node
         graph["nodes"] = result
     return graph

--- a/conan/internal/graph/compatibility.py
+++ b/conan/internal/graph/compatibility.py
@@ -135,7 +135,7 @@ class BinaryCompatibility:
         if not compat_infos:
             return {}
 
-        result = OrderedDict()
+        result = {}
         original_info = conanfile.info
         original_settings = conanfile.settings
         original_settings_target = conanfile.settings_target

--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -7,8 +7,6 @@ import os
 import fnmatch
 import textwrap
 
-from collections import OrderedDict
-
 from jinja2 import Environment, FileSystemLoader
 
 from conan.errors import ConanException
@@ -345,19 +343,10 @@ class Conf:
 
     def __init__(self):
         # It being ordered allows for Windows case-insensitive composition
-        self._values = OrderedDict()  # {var_name: [] of values, including separators}
+        self._values = {}  # {var_name: [] of values, including separators}
 
     def __bool__(self):
         return bool(self._values)
-
-    def __repr__(self):
-        return "Conf: " + repr(self._values)
-
-    def __eq__(self, other):
-        """
-        :type other: Conf
-        """
-        return other._values == self._values
 
     def clear(self):
         self._values.clear()
@@ -429,13 +418,12 @@ class Conf:
 
     def copy(self):
         c = Conf()
-        c._values = OrderedDict((k, v.copy()) for k, v in self._values.items())
+        c._values = {k: v.copy() for k, v in self._values.items()}
         return c
 
     def filter_core(self):
         c = Conf()
-        c._values = OrderedDict((k, v.copy()) for k, v in self._values.items()
-                                if not CORE_CONF_PATTERN.match(k))
+        c._values = {k: v.copy() for k, v in self._values.items() if not CORE_CONF_PATTERN.match(k)}
         return c
 
     def dumps(self):
@@ -600,10 +588,7 @@ class ConfDefinition:
                ("=!", "unset"), ("*=", "update"), ("=", "define"))
 
     def __init__(self):
-        self._pattern_confs = OrderedDict()
-
-    def __repr__(self):
-        return "ConfDefinition: " + repr(self._pattern_confs)
+        self._pattern_confs = {}
 
     def __bool__(self):
         return bool(self._pattern_confs)

--- a/conan/internal/model/lockfile.py
+++ b/conan/internal/model/lockfile.py
@@ -1,7 +1,6 @@
 import fnmatch
 import json
 import os
-from collections import OrderedDict
 
 from conan.api.output import ConanOutput
 from conan.internal.graph.graph import RECIPE_VIRTUAL, RECIPE_CONSUMER, CONTEXT_BUILD, Overrides
@@ -21,7 +20,7 @@ class _LockRequires:
     otherwise it could be a bare list
     """
     def __init__(self):
-        self._requires = OrderedDict()  # {require: package_ids}
+        self._requires = {}  # {require: package_ids}
 
     def refs(self):
         return self._requires.keys()
@@ -53,9 +52,9 @@ class _LockRequires:
             old_package_ids = self._requires.pop(ref, None)  # Get existing one
             if old_package_ids is not None:
                 if package_ids is not None:
-                    package_ids = old_package_ids.update(package_ids)
-                else:
-                    package_ids = old_package_ids
+                    assert isinstance(old_package_ids, dict)
+                    old_package_ids.update(package_ids)
+                package_ids = old_package_ids
             self._requires[ref] = package_ids
         else:  # Manual addition of something without revision
             existing = {r: r for r in self._requires}.get(ref)
@@ -77,7 +76,7 @@ class _LockRequires:
                         remove.append(k)
         else:
             remove = [k for k in self._requires if k.matches(pattern, False)]
-        self._requires = OrderedDict((k, v) for k, v in self._requires.items() if k not in remove)
+        self._requires = {k: v for k, v in self._requires.items() if k not in remove}
         return remove
 
     def update(self, refs, name):
@@ -96,7 +95,7 @@ class _LockRequires:
         self.sort()
 
     def sort(self):
-        self._requires = OrderedDict(reversed(sorted(self._requires.items())))
+        self._requires = dict(reversed(sorted(self._requires.items())))
 
     def merge(self, other):
         """

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -1,7 +1,6 @@
 import os
 import re
 import textwrap
-from collections import OrderedDict
 
 from jinja2 import Template
 
@@ -130,7 +129,7 @@ class XcodeDeps:
         """
         def _merged_vars(name):
             merged = [var for cpp_info in transitive_cpp_infos for var in getattr(cpp_info, name)]
-            return list(OrderedDict.fromkeys(merged).keys())
+            return list(dict.fromkeys(merged).keys())
 
         # TODO: Investigate if paths can be made relative to "root" folder
         fields = {
@@ -292,8 +291,8 @@ class XcodeDeps:
                     _transitive_components(comp_cpp_info)
 
                     # remove duplicates
-                    transitive_internal = list(OrderedDict.fromkeys(transitive_internal).keys())
-                    transitive_external = list(OrderedDict.fromkeys(transitive_external).keys())
+                    transitive_internal = list(dict.fromkeys(transitive_internal).keys())
+                    transitive_external = list(dict.fromkeys(transitive_external).keys())
 
                     # In case dep is editable and package_folder=None
                     pkg_folder = dep.package_folder or dep.recipe_folder

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -1,7 +1,6 @@
 import os
 import re
 import textwrap
-from collections import OrderedDict
 
 from jinja2 import Template
 
@@ -13,7 +12,7 @@ from conan.tools.build import build_jobs
 from conan.tools.build.flags import architecture_flag, architecture_link_flag, libcxx_flags, threads_flags
 from conan.tools.build.cross_building import cross_building
 from conan.tools.cmake.toolchain import CONAN_TOOLCHAIN_FILENAME
-from conan.tools.cmake.utils import is_multi_configuration, cmake_escape_value
+from conan.tools.cmake.utils import is_multi_configuration
 from conan.tools.intel import IntelCC
 from conan.tools.microsoft.visual import msvc_version_to_toolset_version, msvc_platform_from_arch
 from conan.internal.api.install.generators import relativize_path
@@ -1390,7 +1389,7 @@ class PreprocessorBlock(Block):
 
 class ToolchainBlocks:
     def __init__(self, conanfile, toolchain, items=None):
-        self._blocks = OrderedDict()
+        self._blocks = {}
         self._conanfile = conanfile
         self._toolchain = toolchain
         if items:
@@ -1416,14 +1415,14 @@ class ToolchainBlocks:
         self._conanfile.output.warning("CMakeToolchain.select is deprecated. Use blocks.enabled()"
                                        " instead", warn_tag="deprecated")
         to_keep = [name] + list(args) + ["variables", "preprocessor"]
-        self._blocks = OrderedDict((k, v) for k, v in self._blocks.items() if k in to_keep)
+        self._blocks = {k: v for k, v in self._blocks.items() if k in to_keep}
 
     def enabled(self, name, *args):
         """
         keep the blocks provided as arguments, remove the others
         """
         to_keep = [name] + list(args)
-        self._blocks = OrderedDict((k, v) for k, v in self._blocks.items() if k in to_keep)
+        self._blocks = {k: v for k, v in self._blocks.items() if k in to_keep}
 
     def __setitem__(self, name, block_type):
         # Create a new class inheriting Block with the elements of the provided one
@@ -1438,7 +1437,7 @@ class ToolchainBlocks:
                                           check_type=list)
         if blocks is not None:
             try:
-                new_blocks = OrderedDict((b, self._blocks[b]) for b in blocks)
+                new_blocks = {b: self._blocks[b] for b in blocks}
             except KeyError as e:
                 raise ConanException(f"Block {e} defined in tools.cmake.cmaketoolchain"
                                      f":enabled_blocks doesn't exist in {list(self._blocks.keys())}")

--- a/test/integration/lockfile/test_lock_packages.py
+++ b/test/integration/lockfile/test_lock_packages.py
@@ -27,6 +27,13 @@ def test_lock_packages(requires):
     lock = client.load("consumer/conan.lock")
     assert NO_SETTINGS_PACKAGE_ID in lock
 
+    # Just repeat
+    client.run("lock create consumer/conanfile.txt --lockfile-packages")
+    assert "ERROR: The --lockfile-packages arg is private and shouldn't be used" in client.out
+    assert "pkg/0.1#" in client.out
+    lock = client.load("consumer/conan.lock")
+    assert NO_SETTINGS_PACKAGE_ID in lock
+
     with environment_update({"MYVAR": "MYVALUE2"}):
         client.run("create pkg --name=pkg --version=0.1")
     prev2 = client.created_package_revision("pkg/0.1")


### PR DESCRIPTION
Changelog: Omit
Docs: Omit


This should be an internal refactor, dropping OrderedDict in favor of regular dict (ordered from Python 3.7), for simplicity and performance.

I haven't done all, I have started with the "lower risk" ones, there are some OrderedDict more in the core of dependencies, that better be reviewed twice and carefully. Lets start with these only, and in the next iterations we will continue.


