### PR TITLE
Core: replaced internal usage of colorama with rich

### DIFF
--- a/conan/api/conan_api.py
+++ b/conan/api/conan_api.py
@@ -1,7 +1,6 @@
 import os
 import sys
 
-from conan.api.output import init_colorama
 from conan.api.subapi.audit import AuditAPI
 from conan.api.subapi.cache import CacheAPI
 from conan.api.subapi.command import CommandAPI
@@ -59,7 +58,6 @@ class ConanAPI:
         if cache_folder is not None and not os.path.isabs(cache_folder):
             raise ConanException("cache_folder has to be an absolute path")
 
-        init_colorama(sys.stderr)
         # Deprecated, but still used internally, prefer home_folder
         self.cache_folder = cache_folder or get_conan_user_home()
         self._home_folder = self.cache_folder

--- a/conan/api/output.py
+++ b/conan/api/output.py
@@ -4,8 +4,7 @@ import sys
 import time
 from threading import Lock
 
-import colorama
-from colorama import Fore, Style
+from rich.console import Console
 
 from conan.errors import ConanException
 
@@ -20,44 +19,34 @@ LEVEL_TRACE = 10  # -vvv Fine-grained messages with very low-level implementatio
 
 
 class Color:
-    """ Wrapper around colorama colors that are undefined in importing
-    """
-    RED = Fore.RED  # @UndefinedVariable
-    WHITE = Fore.WHITE  # @UndefinedVariable
-    CYAN = Fore.CYAN  # @UndefinedVariable
-    GREEN = Fore.GREEN  # @UndefinedVariable
-    MAGENTA = Fore.MAGENTA  # @UndefinedVariable
-    BLUE = Fore.BLUE  # @UndefinedVariable
-    YELLOW = Fore.YELLOW  # @UndefinedVariable
-    BLACK = Fore.BLACK  # @UndefinedVariable
+    """Rich style strings for foreground/background"""
 
-    BRIGHT_RED = Style.BRIGHT + Fore.RED  # @UndefinedVariable
-    BRIGHT_BLUE = Style.BRIGHT + Fore.BLUE  # @UndefinedVariable
-    BRIGHT_YELLOW = Style.BRIGHT + Fore.YELLOW  # @UndefinedVariable
-    BRIGHT_GREEN = Style.BRIGHT + Fore.GREEN  # @UndefinedVariable
-    BRIGHT_CYAN = Style.BRIGHT + Fore.CYAN  # @UndefinedVariable
-    BRIGHT_WHITE = Style.BRIGHT + Fore.WHITE  # @UndefinedVariable
-    BRIGHT_MAGENTA = Style.BRIGHT + Fore.MAGENTA  # @UndefinedVariable
+    RED = "red"
+    WHITE = "white"
+    CYAN = "cyan"
+    GREEN = "green"
+    MAGENTA = "magenta"
+    BLUE = "blue"
+    YELLOW = "yellow"
+    BLACK = "black"
+
+    BRIGHT_RED = "bright_red"
+    BRIGHT_BLUE = "bright_blue"
+    BRIGHT_YELLOW = "bright_yellow"
+    BRIGHT_GREEN = "bright_green"
+    BRIGHT_CYAN = "bright_cyan"
+    BRIGHT_WHITE = "bright_white"
+    BRIGHT_MAGENTA = "bright_magenta"
 
 
 if os.environ.get("CONAN_COLOR_DARK"):
-    Color.WHITE = Fore.BLACK
-    Color.CYAN = Fore.BLUE
-    Color.YELLOW = Fore.MAGENTA
-    Color.BRIGHT_WHITE = Fore.BLACK
-    Color.BRIGHT_CYAN = Fore.BLUE
-    Color.BRIGHT_YELLOW = Fore.MAGENTA
-    Color.BRIGHT_GREEN = Fore.GREEN
-
-
-def init_colorama(stream):
-    import colorama
-    if _color_enabled(stream):
-        if os.getenv("CLICOLOR_FORCE", "0") != "0":
-            # Otherwise it is not really forced if colorama doesn't feel it
-            colorama.init(strip=False, convert=False)
-        else:
-            colorama.init()
+    Color.WHITE = "black"
+    Color.CYAN = "blue"
+    Color.YELLOW = "magenta"
+    Color.BRIGHT_WHITE = "black"
+    Color.BRIGHT_CYAN = "blue"
+    Color.BRIGHT_YELLOW = "bright_magenta"
+    Color.BRIGHT_GREEN = "green"
 
 
 def _color_enabled(stream):
@@ -84,6 +73,14 @@ def _color_enabled(stream):
     return hasattr(stream, "isatty") and stream.isatty()
 
 
+def _create_style(fg, bg, use_color):
+    if not use_color:
+        return None
+    if fg and bg:
+        return f"{fg} on {bg}"
+    return fg or bg or None
+
+
 class ConanOutput:
     """ A singleton class to handle output messages in Conan.
 
@@ -105,6 +102,22 @@ class ConanOutput:
     # Flag to enable/disable new ConanOutput contextual behavior
     _scoped_recipe_output = None
     lock = Lock()
+    _console = None
+    _console_stream_id = None
+
+    @classmethod
+    def _get_console(cls):
+        stream = sys.stderr
+        if cls._console is None or cls._console_stream_id != id(stream):
+            cls._console_stream_id = id(stream)
+            cls._console = Console(
+                file=stream,
+                stderr=True,
+                color_system="auto" if _color_enabled(stream) else None,
+                soft_wrap=True,
+                emoji=False,
+            )
+        return cls._console
 
     def __init__(self, scope: str = ""):
         """ Initialize the ConanOutput instance.
@@ -115,9 +128,8 @@ class ConanOutput:
         """
         self.stream = sys.stderr
         self._scope = scope
-        # FIXME:  This is needed because in testing we are redirecting the sys.stderr to a buffer
-        #         stream to capture it, so colorama is not there to strip the color bytes
         self._color = _color_enabled(self.stream)
+        self._console = ConanOutput._get_console()
         if not scope:
             ConanOutput._last_scope_header = None
 
@@ -194,16 +206,10 @@ class ConanOutput:
     def write(self, data, fg=None, bg=None, newline=False):
         if self._conan_output_level > LEVEL_NOTICE:
             return self
-        if self._color and (fg or bg):
-            data = "%s%s%s%s" % (fg or '', bg or '', data, Style.RESET_ALL)
-
-        if newline:
-            data = "%s\n" % data
-
+        end = "\n" if newline else ""
         with self.lock:
-            self.stream.write(data)
+            self._console.out(data, style=_create_style(fg, bg, self._color), highlight=False, end=end)
             self.stream.flush()
-
         return self
 
     def box(self, msg: str):
@@ -231,26 +237,15 @@ class ConanOutput:
             if self._scope != ConanOutput._last_scope_header:
                 self.writeln(f"{self._scope}:", fg=Color.BRIGHT_BLUE)
                 ConanOutput._last_scope_header = self._scope
-            if self._color:
-                ret = f"  {fg or ''}{bg or ''}{msg}{Style.RESET_ALL}"
-            else:
-                ret = f"  {msg}"
+            ret = f"  {msg}"
         elif self._scope:
-            if self._color:
-                ret = f"{fg or ''}{bg or ''}{self._scope}: {msg}{Style.RESET_ALL}"
-            else:
-                ret = f"{self._scope}: {msg}"
+            ret = f"{self._scope}: {msg}"
         else:
-            if self._color:
-                ret = f"{fg or ''}{bg or ''}{msg}{Style.RESET_ALL}"
-            else:
-                ret = msg
+            ret = msg
 
-        if newline:
-            ret = f"{ret}\n"
-
+        end = "\n" if newline else ""
         with self.lock:
-            self.stream.write(ret)
+            self._console.out(ret, style=_create_style(fg, bg, self._color), highlight=False, end=end)
             self.stream.flush()
 
     def trace(self, msg: str):
@@ -387,19 +382,21 @@ def cli_out_write(data, fg=None, bg=None, endline="\n", indentation=0):
     """
     Output to be used by formatters to dump information to stdout
     """
-    if (fg or bg) and _color_enabled(sys.stdout):  # need color
-        data = f"{' ' * indentation}{fg or ''}{bg or ''}{data}{Style.RESET_ALL}{endline}"
-        sys.stdout.write(data)
-    else:
-        data = f"{' ' * indentation}{data}{endline}"
-        if sys.stdout.isatty():
-            # https://github.com/conan-io/conan/issues/17245 avoid colorama crash and overhead
-            # skip deinit/reinit if stdout is not a TTY to preserve redirected output to file
-            colorama.deinit()
-            sys.stdout.write(data)
-            colorama.reinit()
-        else:
-            sys.stdout.write(data)
+    stream = sys.stdout
+    if getattr(cli_out_write, "_console", None) is None \
+            or cli_out_write._console_stream_id != id(stream):
+        cli_out_write._console_stream_id = id(stream)
+        cli_out_write._console = Console(
+            file=stream,
+            stderr=False,
+            color_system="auto" if _color_enabled(stream) else None,
+            soft_wrap=True,
+            emoji=False,
+        )
+    text = f"{' ' * indentation}{data}"
+    use_color = (fg or bg) and _color_enabled(stream)
+    cli_out_write._console.out(text, style=_create_style(fg, bg, use_color), highlight=False, end=endline)
+    stream.flush()
 
 
 class TimedOutput:

--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -1,6 +1,6 @@
 requests>=2.25, <3.0.0
 urllib3>=1.26.6, <3.0
-rich>=13.7.0, <13.9.0
+rich>=14.3.4, <15
 PyYAML>=6.0, <7.0
 patch-ng>=1.18.0, <1.19
 fasteners>=0.15

--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -1,6 +1,6 @@
 requests>=2.25, <3.0.0
 urllib3>=1.26.6, <3.0
-colorama>=0.4.3, <0.5.0
+rich>=13.7.0, <13.9.0
 PyYAML>=6.0, <7.0
 patch-ng>=1.18.0, <1.19
 fasteners>=0.15

--- a/test/functional/tools/scm/test_git.py
+++ b/test/functional/tools/scm/test_git.py
@@ -1295,7 +1295,7 @@ class TestGitTreelessRemote:
         client.save({"conanfile.py": self.conanfile.format(url=url)})
         client.run("export .")
         # We expect [tree:0] for regular git remote command. Requires Git +2.43
-        assert f"git remote: origin\t{url} (fetch) [tree:0]" in client.out
+        assert f"git remote: origin     {url} (fetch) [tree:0]" in client.out
         # Then get_remote_url filters it to only the URL
         assert f"get_remote_url(): {url} ===" in client.out
 

--- a/test/functional/tools/system/python_manager_test.py
+++ b/test/functional/tools/system/python_manager_test.py
@@ -46,7 +46,7 @@ def test_empty_pyenv():
     c.run("build")
     # Test that some Conan common deps are not in this pip list
     assert "requests" not in c.out
-    assert "colorama" not in c.out
+    assert "rich" not in c.out
     assert "Jinja2" not in c.out
     assert "PyJWT" not in c.out
     ext = ".bat" if platform.system() == "Windows" else ".sh"

--- a/test/unittests/client/conan_output_test.py
+++ b/test/unittests/client/conan_output_test.py
@@ -1,10 +1,9 @@
-import sys
 from unittest import mock
 
 import pytest
 import textwrap
 
-from conan.api.output import ConanOutput, init_colorama
+from conan.api.output import ConanOutput
 from conan.test.utils.mocks import RedirectedTestOutput
 from conan.test.utils.tools import redirect_output
 
@@ -14,28 +13,21 @@ class TestConanOutput:
     @pytest.mark.parametrize("isatty, env", [(True, {"NO_COLOR": "1"}),
                                              (True, {"NO_COLOR": "0"})])
     def test_output_color_prevent_strip(self, isatty, env):
-        with mock.patch("colorama.init") as init:
-            with mock.patch("sys.stderr.isatty", return_value=isatty), \
-                 mock.patch.dict("os.environ", env, clear=True):
-                init_colorama(sys.stderr)
-                out = ConanOutput()
-                assert out.color is False
-                init.assert_not_called()
+        with mock.patch("sys.stderr.isatty", return_value=isatty), \
+             mock.patch.dict("os.environ", env, clear=True):
+            out = ConanOutput()
+            assert out.color is False
 
 
 @pytest.mark.parametrize("force", ["1", "0", "foo"])
 def test_output_forced(force):
     env = {"CLICOLOR_FORCE": force}
     forced = force != "0"
-    with mock.patch("colorama.init") as init:
-        with mock.patch("sys.stderr.isatty", return_value=False), \
-             mock.patch.dict("os.environ", env, clear=True):
-            init_colorama(sys.stderr)
-            out = ConanOutput()
+    with mock.patch("sys.stderr.isatty", return_value=False), \
+         mock.patch.dict("os.environ", env, clear=True):
+        out = ConanOutput()
 
-            assert out.color is forced
-            if not forced:
-                init.assert_not_called()
+        assert out.color is forced
 
 
 def test_output_chainable():


### PR DESCRIPTION
Changelog: omit
Docs: omit

**We can merge this PR when we deprecate Python 3.7**
Not before, as the last version supporting Python 3.7 has a bug related to soft_wrap and trimming white spaces. 
