### PR TITLE
Inline transitive dependencies to avoid Xcode recursion crashes

### DIFF
--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -242,7 +242,7 @@ class XcodeDeps:
         return result
 
     @staticmethod
-    def _collect_all_transitive(cpp_info, pkg_dep, all_deps, collected, visited):
+    def _collect_all_transitive(cpp_info, pkg_dep, all_deps, collected, visited=None):
         """Recursively collect all transitive CppInfo objects (internal and external)
         into a flat list.
 
@@ -250,8 +250,10 @@ class XcodeDeps:
         :param pkg_dep: dependency object owning the cpp_info
         :param all_deps: dict {ref.name: dep} of all available host/test deps
         :param collected: output list accumulating the CppInfo objects
-        :param visited: set of id(cpp_info) already processed
+        :param visited: set of id(cpp_info) already processed (created automatically)
         """
+        if visited is None:
+            visited = set()
 
         key = id(cpp_info)
         if key in visited:
@@ -321,7 +323,7 @@ class XcodeDeps:
 
                     transitive_internal = []
                     self._collect_all_transitive(comp_cpp_info, dep, all_deps,
-                                                 transitive_internal, set())
+                                                 transitive_internal)
 
                     # In case dep is editable and package_folder=None
                     pkg_folder = dep.package_folder or dep.recipe_folder
@@ -334,7 +336,7 @@ class XcodeDeps:
             else:
                 transitive_internal = []
                 self._collect_all_transitive(dep.cpp_info, dep, all_deps,
-                                             transitive_internal, set())
+                                             transitive_internal)
                 # In case dep is editable and package_folder=None
                 pkg_folder = dep.package_folder or dep.recipe_folder
                 root_content = self.get_content_for_component(require, dep_name, dep_name, pkg_folder,

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -244,7 +244,14 @@ class XcodeDeps:
     @staticmethod
     def _collect_all_transitive(cpp_info, pkg_dep, all_deps, collected, visited):
         """Recursively collect all transitive CppInfo objects (internal and external)
-        into a flat list."""
+        into a flat list.
+
+        :param cpp_info: current CppInfo being processed (root or component)
+        :param pkg_dep: dependency object owning the cpp_info
+        :param all_deps: dict {ref.name: dep} of all available host/test deps
+        :param collected: output list accumulating the CppInfo objects
+        :param visited: set of id(cpp_info) already processed
+        """
 
         key = id(cpp_info)
         if key in visited:

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -259,10 +259,8 @@ class XcodeDeps:
         visited.add(key)
         collected.append(cpp_info)
 
-        requires = cpp_info.requires or []
-
-        if requires:
-            for req in requires:
+        if cpp_info.requires:
+            for req in cpp_info.requires:
                 if "::" not in req:
                     XcodeDeps._collect_all_transitive(
                         pkg_dep.cpp_info.components.get(req), pkg_dep,

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -267,16 +267,8 @@ class XcodeDeps:
                     XcodeDeps._follow_external(req, transitive_deps, collected, visited)
         elif not pkg_dep.cpp_info.has_components and cpp_info is pkg_dep.cpp_info:
             for _, d in pkg_dep.dependencies.direct_host.items():
-                ext_dep = transitive_deps.get(d.ref.name)
-                if ext_dep is None:
-                    continue
-                if ext_dep.cpp_info.has_components:
-                    for comp in ext_dep.cpp_info.get_sorted_components().values():
-                        XcodeDeps._collect_all_transitive(comp, ext_dep, transitive_deps,
-                                                          collected, visited)
-                else:
-                    XcodeDeps._collect_all_transitive(ext_dep.cpp_info, ext_dep,
-                                                      transitive_deps, collected, visited)
+                XcodeDeps._follow_external(f"{d.ref.name}::{d.ref.name}",
+                                           transitive_deps, collected, visited)
 
     @staticmethod
     def _follow_external(req, transitive_deps, collected, visited):
@@ -327,26 +319,24 @@ class XcodeDeps:
                     transitive_internal = []
                     self._collect_all_transitive(comp_cpp_info, dep, transitive_deps,
                                                  transitive_internal, set())
-                    transitive_external = []
 
                     # In case dep is editable and package_folder=None
                     pkg_folder = dep.package_folder or dep.recipe_folder
                     component_content = self.get_content_for_component(require, dep_name, comp_name,
                                                                        pkg_folder,
                                                                        transitive_internal,
-                                                                       transitive_external)
+                                                                       [])
                     include_components_names.append((dep_name, comp_name))
                     result.update(component_content)
             else:
                 transitive_internal = []
                 self._collect_all_transitive(dep.cpp_info, dep, transitive_deps,
                                              transitive_internal, set())
-                transitive_external = []
                 # In case dep is editable and package_folder=None
                 pkg_folder = dep.package_folder or dep.recipe_folder
                 root_content = self.get_content_for_component(require, dep_name, dep_name, pkg_folder,
                                                               transitive_internal,
-                                                              transitive_external)
+                                                              [])
                 include_components_names.append((dep_name, dep_name))
                 result.update(root_content)
 

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -279,6 +279,8 @@ class XcodeDeps:
 
         ext_pkg, ext_comp = req.split("::", 1)
         ext_dep = all_deps.get(ext_pkg)
+        if ext_dep is None:  # skipped or not visible dependency
+            return
 
         if not ext_dep.cpp_info.has_components:
             # Package without components: use root cpp_info directly

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -243,7 +243,7 @@ class XcodeDeps:
         return result
 
     @staticmethod
-    def _collect_all_transitive(cpp_info, pkg_dep, visible_deps, collected, visited):
+    def _collect_all_transitive(cpp_info, pkg_dep, transitive_deps, collected, visited):
         """Recursively collect CppInfo objects from a component and all its transitive
         dependencies, both within the same package (internal) and across packages (external).
         This produces a flat list of CppInfos that can be merged into a single props file,
@@ -261,42 +261,42 @@ class XcodeDeps:
                 if "::" not in req:
                     ci = pkg_dep.cpp_info.components.get(req)
                     if ci:
-                        XcodeDeps._collect_all_transitive(ci, pkg_dep, visible_deps,
+                        XcodeDeps._collect_all_transitive(ci, pkg_dep, transitive_deps,
                                                           collected, visited)
                 else:
-                    XcodeDeps._follow_external(req, visible_deps, collected, visited)
+                    XcodeDeps._follow_external(req, transitive_deps, collected, visited)
         elif not pkg_dep.cpp_info.has_components and cpp_info is pkg_dep.cpp_info:
             for _, d in pkg_dep.dependencies.direct_host.items():
-                ext_dep = visible_deps.get(d.ref.name)
+                ext_dep = transitive_deps.get(d.ref.name)
                 if ext_dep is None:
                     continue
                 if ext_dep.cpp_info.has_components:
                     for comp in ext_dep.cpp_info.get_sorted_components().values():
-                        XcodeDeps._collect_all_transitive(comp, ext_dep, visible_deps,
+                        XcodeDeps._collect_all_transitive(comp, ext_dep, transitive_deps,
                                                           collected, visited)
                 else:
                     XcodeDeps._collect_all_transitive(ext_dep.cpp_info, ext_dep,
-                                                      visible_deps, collected, visited)
+                                                      transitive_deps, collected, visited)
 
     @staticmethod
-    def _follow_external(req, visible_deps, collected, visited):
+    def _follow_external(req, transitive_deps, collected, visited):
         """Resolve and follow an external requirement (pkg::comp)."""
         ext_pkg, ext_comp = req.split("::", 1)
-        ext_dep = visible_deps.get(ext_pkg)
+        ext_dep = transitive_deps.get(ext_pkg)
         if ext_dep is None:
             return
 
         if not ext_dep.cpp_info.has_components:
-            XcodeDeps._collect_all_transitive(ext_dep.cpp_info, ext_dep, visible_deps,
+            XcodeDeps._collect_all_transitive(ext_dep.cpp_info, ext_dep, transitive_deps,
                                               collected, visited)
         elif ext_pkg == ext_comp:
             for comp in ext_dep.cpp_info.get_sorted_components().values():
-                XcodeDeps._collect_all_transitive(comp, ext_dep, visible_deps,
+                XcodeDeps._collect_all_transitive(comp, ext_dep, transitive_deps,
                                                   collected, visited)
         else:
             ci = ext_dep.cpp_info.components.get(ext_comp)
             if ci:
-                XcodeDeps._collect_all_transitive(ci, ext_dep, visible_deps,
+                XcodeDeps._collect_all_transitive(ci, ext_dep, transitive_deps,
                                                   collected, visited)
 
     def _content(self):
@@ -313,9 +313,8 @@ class XcodeDeps:
             dep_name = _format_name(dep.ref.name)
 
             include_components_names = []
-            visible_deps = {}
-            for _, d in get_transitive_requires(self._conanfile, dep).items():
-                visible_deps[d.ref.name] = d
+            transitive_deps = {d.ref.name: d for _, d in
+                               get_transitive_requires(self._conanfile, dep).items()}
             if dep.cpp_info.has_components:
 
                 sorted_components = dep.cpp_info.get_sorted_components().items()
@@ -323,7 +322,7 @@ class XcodeDeps:
                     comp_name = _format_name(comp_name)
 
                     transitive_internal = []
-                    self._collect_all_transitive(comp_cpp_info, dep, visible_deps,
+                    self._collect_all_transitive(comp_cpp_info, dep, transitive_deps,
                                                  transitive_internal, set())
                     transitive_external = []
 
@@ -337,7 +336,7 @@ class XcodeDeps:
                     result.update(component_content)
             else:
                 transitive_internal = []
-                self._collect_all_transitive(dep.cpp_info, dep, visible_deps,
+                self._collect_all_transitive(dep.cpp_info, dep, transitive_deps,
                                              transitive_internal, set())
                 transitive_external = []
                 # In case dep is editable and package_folder=None

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -260,10 +260,9 @@ class XcodeDeps:
         if requires:
             for req in requires:
                 if "::" not in req:
-                    ci = pkg_dep.cpp_info.components.get(req)
-                    if ci:
-                        XcodeDeps._collect_all_transitive(ci, pkg_dep, transitive_deps,
-                                                          collected, visited)
+                    XcodeDeps._collect_all_transitive(
+                        pkg_dep.cpp_info.components.get(req), pkg_dep,
+                        transitive_deps, collected, visited)
                 else:
                     XcodeDeps._follow_external(req, transitive_deps, collected, visited)
         elif not pkg_dep.cpp_info.has_components and cpp_info is pkg_dep.cpp_info:
@@ -289,17 +288,19 @@ class XcodeDeps:
             return
 
         if not ext_dep.cpp_info.has_components:
+            # Package without components: use root cpp_info directly
             XcodeDeps._collect_all_transitive(ext_dep.cpp_info, ext_dep, transitive_deps,
                                               collected, visited)
         elif ext_pkg == ext_comp:
+            # Dependency on the whole package (pkg::pkg): collect all its components
             for comp in ext_dep.cpp_info.get_sorted_components().values():
                 XcodeDeps._collect_all_transitive(comp, ext_dep, transitive_deps,
                                                   collected, visited)
         else:
-            ci = ext_dep.cpp_info.components.get(ext_comp)
-            if ci:
-                XcodeDeps._collect_all_transitive(ci, ext_dep, transitive_deps,
-                                                  collected, visited)
+            # Dependency on a specific component (pkg::comp)
+            XcodeDeps._collect_all_transitive(
+                ext_dep.cpp_info.components.get(ext_comp), ext_dep,
+                transitive_deps, collected, visited)
 
     def _content(self):
         result = {}

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -311,40 +311,44 @@ class XcodeDeps:
         host_req = self._conanfile.dependencies.host
         test_req = self._conanfile.dependencies.test
         requires = list(host_req.items()) + list(test_req.items())
-
         for require, dep in requires:
 
             dep_name = _format_name(dep.ref.name)
 
+            include_components_names = []
             visible_deps = {}
             for _, d in get_transitive_requires(self._conanfile, dep).items():
                 visible_deps[d.ref.name] = d
                 visible_deps[_format_name(d.ref.name)] = d
-
-            include_components_names = []
             if dep.cpp_info.has_components:
+
                 sorted_components = dep.cpp_info.get_sorted_components().items()
                 for comp_name, comp_cpp_info in sorted_components:
                     comp_name = _format_name(comp_name)
 
-                    collected = []
+                    transitive_internal = []
                     self._collect_all_transitive(comp_cpp_info, dep, visible_deps,
-                                                 collected, set())
+                                                 transitive_internal, set())
+                    transitive_external = []
 
+                    # In case dep is editable and package_folder=None
                     pkg_folder = dep.package_folder or dep.recipe_folder
                     component_content = self.get_content_for_component(require, dep_name, comp_name,
                                                                        pkg_folder,
-                                                                       collected, [])
+                                                                       transitive_internal,
+                                                                       transitive_external)
                     include_components_names.append((dep_name, comp_name))
                     result.update(component_content)
             else:
-                collected = []
+                transitive_internal = []
                 self._collect_all_transitive(dep.cpp_info, dep, visible_deps,
-                                             collected, set())
-
+                                             transitive_internal, set())
+                transitive_external = []
+                # In case dep is editable and package_folder=None
                 pkg_folder = dep.package_folder or dep.recipe_folder
-                root_content = self.get_content_for_component(require, dep_name, dep_name,
-                                                              pkg_folder, collected, [])
+                root_content = self.get_content_for_component(require, dep_name, dep_name, pkg_folder,
+                                                              transitive_internal,
+                                                              transitive_external)
                 include_components_names.append((dep_name, dep_name))
                 result.update(root_content)
 

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -7,7 +7,6 @@ from jinja2 import Template
 
 from conan.internal import check_duplicated_generator
 from conan.errors import ConanException
-from conan.internal.model.dependencies import get_transitive_requires
 from conan.internal.util.files import load, save
 from conan.tools.apple.apple import _to_apple_arch
 
@@ -243,7 +242,7 @@ class XcodeDeps:
         return result
 
     @staticmethod
-    def _collect_all_transitive(cpp_info, pkg_dep, transitive_deps, collected, visited):
+    def _collect_all_transitive(cpp_info, pkg_dep, all_deps, collected, visited):
         """Recursively collect all transitive CppInfo objects (internal and external)
         into a flat list."""
 
@@ -260,37 +259,37 @@ class XcodeDeps:
                 if "::" not in req:
                     XcodeDeps._collect_all_transitive(
                         pkg_dep.cpp_info.components.get(req), pkg_dep,
-                        transitive_deps, collected, visited)
+                        all_deps, collected, visited)
                 else:
-                    XcodeDeps._follow_external(req, transitive_deps, collected, visited)
+                    XcodeDeps._follow_external(req, all_deps, collected, visited)
         elif not pkg_dep.cpp_info.has_components and cpp_info is pkg_dep.cpp_info:
             for _, d in pkg_dep.dependencies.direct_host.items():
                 XcodeDeps._follow_external(f"{d.ref.name}::{d.ref.name}",
-                                           transitive_deps, collected, visited)
+                                           all_deps, collected, visited)
 
     @staticmethod
-    def _follow_external(req, transitive_deps, collected, visited):
+    def _follow_external(req, all_deps, collected, visited):
         """Resolve and follow an external requirement (pkg::comp)."""
 
         ext_pkg, ext_comp = req.split("::", 1)
-        ext_dep = transitive_deps.get(ext_pkg)
+        ext_dep = all_deps.get(ext_pkg)
         if ext_dep is None:
             return
 
         if not ext_dep.cpp_info.has_components:
             # Package without components: use root cpp_info directly
-            XcodeDeps._collect_all_transitive(ext_dep.cpp_info, ext_dep, transitive_deps,
+            XcodeDeps._collect_all_transitive(ext_dep.cpp_info, ext_dep, all_deps,
                                               collected, visited)
         elif ext_pkg == ext_comp:
             # Dependency on the whole package (pkg::pkg): collect all its components
             for comp in ext_dep.cpp_info.get_sorted_components().values():
-                XcodeDeps._collect_all_transitive(comp, ext_dep, transitive_deps,
+                XcodeDeps._collect_all_transitive(comp, ext_dep, all_deps,
                                                   collected, visited)
         else:
             # Dependency on a specific component (pkg::comp)
             XcodeDeps._collect_all_transitive(
                 ext_dep.cpp_info.components.get(ext_comp), ext_dep,
-                transitive_deps, collected, visited)
+                all_deps, collected, visited)
 
     def _content(self):
         result = {}
@@ -301,13 +300,12 @@ class XcodeDeps:
         host_req = self._conanfile.dependencies.host
         test_req = self._conanfile.dependencies.test
         requires = list(host_req.items()) + list(test_req.items())
+        all_deps = {dep.ref.name: dep for _, dep in requires}
         for require, dep in requires:
 
             dep_name = _format_name(dep.ref.name)
 
             include_components_names = []
-            transitive_deps = {d.ref.name: d for _, d in
-                               get_transitive_requires(self._conanfile, dep).items()}
             if dep.cpp_info.has_components:
 
                 sorted_components = dep.cpp_info.get_sorted_components().items()
@@ -315,7 +313,7 @@ class XcodeDeps:
                     comp_name = _format_name(comp_name)
 
                     transitive_internal = []
-                    self._collect_all_transitive(comp_cpp_info, dep, transitive_deps,
+                    self._collect_all_transitive(comp_cpp_info, dep, all_deps,
                                                  transitive_internal, set())
 
                     # In case dep is editable and package_folder=None
@@ -328,7 +326,7 @@ class XcodeDeps:
                     result.update(component_content)
             else:
                 transitive_internal = []
-                self._collect_all_transitive(dep.cpp_info, dep, transitive_deps,
+                self._collect_all_transitive(dep.cpp_info, dep, all_deps,
                                              transitive_internal, set())
                 # In case dep is editable and package_folder=None
                 pkg_folder = dep.package_folder or dep.recipe_folder

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -268,7 +268,7 @@ class XcodeDeps:
                         all_deps, collected, visited)
                 else:
                     XcodeDeps._resolve_external(req, all_deps, collected, visited)
-        elif not pkg_dep.cpp_info.has_components and cpp_info is pkg_dep.cpp_info:
+        elif not pkg_dep.cpp_info.has_components:
             for _, d in pkg_dep.dependencies.direct_host.items():
                 XcodeDeps._resolve_external(f"{d.ref.name}::{d.ref.name}",
                                            all_deps, collected, visited)

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 
 from jinja2 import Template
 
+from conan.api.output import ConanOutput
 from conan.internal import check_duplicated_generator
 from conan.errors import ConanException
 from conan.internal.model.dependencies import get_transitive_requires
@@ -242,6 +243,77 @@ class XcodeDeps:
         result[file_dep_name] = dep_content
         return result
 
+    @staticmethod
+    def _collect_all_transitive(cpp_info, pkg_dep, all_deps_by_name, collected, visited):
+        """Recursively collect CppInfo objects from a component and all its transitive
+        dependencies, both within the same package (internal) and across packages (external).
+        This produces a flat list of CppInfos that can be merged into a single props file,
+        eliminating the need for inter-package #include chains in xcconfig files."""
+        key = id(cpp_info)
+        if key in visited:
+            return
+        visited.add(key)
+        collected.append(cpp_info)
+        output = ConanOutput(scope="XcodeDeps")
+
+        requires = cpp_info.requires or []
+
+        if requires:
+            for req in requires:
+                if "::" not in req:
+                    ci = pkg_dep.cpp_info.components.get(req)
+                    if ci:
+                        XcodeDeps._collect_all_transitive(ci, pkg_dep, all_deps_by_name,
+                                                          collected, visited)
+                else:
+                    XcodeDeps._follow_external(req, all_deps_by_name, collected,
+                                               visited, output)
+        elif not pkg_dep.cpp_info.has_components and cpp_info is pkg_dep.cpp_info:
+            # No-component package without explicit cpp_info.requires:
+            # implicitly depends on all its visible direct host dependencies
+            for _, d in pkg_dep.dependencies.direct_host.items():
+                ext_dep = (all_deps_by_name.get(d.ref.name)
+                           or all_deps_by_name.get(_format_name(d.ref.name)))
+                if ext_dep is None:
+                    continue
+                if ext_dep.cpp_info.has_components:
+                    for comp in ext_dep.cpp_info.get_sorted_components().values():
+                        XcodeDeps._collect_all_transitive(comp, ext_dep, all_deps_by_name,
+                                                          collected, visited)
+                else:
+                    XcodeDeps._collect_all_transitive(ext_dep.cpp_info, ext_dep,
+                                                      all_deps_by_name,
+                                                      collected, visited)
+
+    @staticmethod
+    def _follow_external(req, all_deps_by_name, collected, visited, output):
+        """Resolve and follow an external requirement (pkg::comp)."""
+        ext_pkg, ext_comp = req.split("::", 1)
+        ext_dep = (all_deps_by_name.get(ext_pkg)
+                   or all_deps_by_name.get(_format_name(ext_pkg)))
+        if ext_dep is None:
+            output.warning(f"XcodeDeps: dependency '{ext_pkg}' not found in graph, "
+                           f"skipping '{req}'")
+            return
+
+        if not ext_dep.cpp_info.has_components:
+            XcodeDeps._collect_all_transitive(ext_dep.cpp_info, ext_dep, all_deps_by_name,
+                                              collected, visited)
+        elif ext_pkg == ext_comp or _format_name(ext_pkg) == _format_name(ext_comp):
+            for comp in ext_dep.cpp_info.get_sorted_components().values():
+                XcodeDeps._collect_all_transitive(comp, ext_dep, all_deps_by_name,
+                                                  collected, visited)
+        else:
+            ci = (ext_dep.cpp_info.components.get(ext_comp)
+                  or ext_dep.cpp_info.components.get(_format_name(ext_comp)))
+            if ci is None:
+                output.warning(
+                    f"XcodeDeps: component '{ext_comp}' not found in '{ext_pkg}', "
+                    f"skipping. Available: {list(ext_dep.cpp_info.components.keys())}")
+                return
+            XcodeDeps._collect_all_transitive(ci, ext_dep, all_deps_by_name,
+                                              collected, visited)
+
     def _content(self):
         result = {}
 
@@ -251,75 +323,42 @@ class XcodeDeps:
         host_req = self._conanfile.dependencies.host
         test_req = self._conanfile.dependencies.test
         requires = list(host_req.items()) + list(test_req.items())
+
         for require, dep in requires:
 
             dep_name = _format_name(dep.ref.name)
 
-            include_components_names = []
-            transitive_requires = [r for r, _ in
-                                   get_transitive_requires(self._conanfile, dep).items()]
-            if dep.cpp_info.has_components:
-                transitive_dep_names = [_format_name(dep.ref.name) for dep in transitive_requires]
+            # TODO: discuss if we should skip generating xcconfig files for transitive-only
+            # deps, since their data is now inlined and their files are never #include'd.
+            visible_deps = {}
+            for _, d in get_transitive_requires(self._conanfile, dep).items():
+                visible_deps[d.ref.name] = d
+                visible_deps[_format_name(d.ref.name)] = d
 
+            include_components_names = []
+            if dep.cpp_info.has_components:
                 sorted_components = dep.cpp_info.get_sorted_components().items()
                 for comp_name, comp_cpp_info in sorted_components:
                     comp_name = _format_name(comp_name)
 
-                    # returns: ("list of cpp infos from required components in same package",
-                    #           "list of names from required components from other packages")
-                    def _get_component_requires(component):
-                        requires_external = [(req.split("::")[0], req.split("::")[1]) for req in
-                                             component.requires if "::" in req
-                                             and req.split("::")[0] in transitive_dep_names]
-                        requires_internal = [dep.cpp_info.components.get(req) for req in
-                                             component.requires if "::" not in req]
-                        return requires_internal, requires_external
+                    collected = []
+                    self._collect_all_transitive(comp_cpp_info, dep, visible_deps,
+                                                 collected, set())
 
-                    # these are the transitive dependencies between components of the same package
-                    transitive_internal = []
-                    # these are the transitive dependencies to components from other packages
-                    transitive_external = []
-
-                    # return the internal cpp_infos and external components names
-                    def _transitive_components(component):
-                        requires_internal, requires_external = _get_component_requires(component)
-                        transitive_internal.append(component)
-                        transitive_internal.extend(requires_internal)
-                        transitive_external.extend(requires_external)
-                        for treq in requires_internal:
-                            _transitive_components(treq)
-
-                    _transitive_components(comp_cpp_info)
-
-                    # remove duplicates
-                    transitive_internal = list(OrderedDict.fromkeys(transitive_internal).keys())
-                    transitive_external = list(OrderedDict.fromkeys(transitive_external).keys())
-
-                    # In case dep is editable and package_folder=None
                     pkg_folder = dep.package_folder or dep.recipe_folder
                     component_content = self.get_content_for_component(require, dep_name, comp_name,
                                                                        pkg_folder,
-                                                                       transitive_internal,
-                                                                       transitive_external)
+                                                                       collected, [])
                     include_components_names.append((dep_name, comp_name))
                     result.update(component_content)
             else:
-                public_deps = []
-                for r, d in dep.dependencies.direct_host.items():
-                    if r not in transitive_requires:
-                        continue
-                    if d.cpp_info.has_components:
-                        sorted_components = d.cpp_info.get_sorted_components().items()
-                        for comp_name, comp_cpp_info in sorted_components:
-                            public_deps.append((_format_name(d.ref.name), _format_name(comp_name)))
-                    else:
-                        public_deps.append((_format_name(d.ref.name),) * 2)
+                collected = []
+                self._collect_all_transitive(dep.cpp_info, dep, visible_deps,
+                                             collected, set())
 
-                required_components = dep.cpp_info.required_components if dep.cpp_info.required_components else public_deps
-                # In case dep is editable and package_folder=None
                 pkg_folder = dep.package_folder or dep.recipe_folder
-                root_content = self.get_content_for_component(require, dep_name, dep_name, pkg_folder, [dep.cpp_info],
-                                                              required_components)
+                root_content = self.get_content_for_component(require, dep_name, dep_name,
+                                                              pkg_folder, collected, [])
                 include_components_names.append((dep_name, dep_name))
                 result.update(root_content)
 

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -5,7 +5,6 @@ from collections import OrderedDict
 
 from jinja2 import Template
 
-from conan.api.output import ConanOutput
 from conan.internal import check_duplicated_generator
 from conan.errors import ConanException
 from conan.internal.model.dependencies import get_transitive_requires
@@ -244,7 +243,7 @@ class XcodeDeps:
         return result
 
     @staticmethod
-    def _collect_all_transitive(cpp_info, pkg_dep, all_deps_by_name, collected, visited):
+    def _collect_all_transitive(cpp_info, pkg_dep, visible_deps, collected, visited):
         """Recursively collect CppInfo objects from a component and all its transitive
         dependencies, both within the same package (internal) and across packages (external).
         This produces a flat list of CppInfos that can be merged into a single props file,
@@ -254,7 +253,6 @@ class XcodeDeps:
             return
         visited.add(key)
         collected.append(cpp_info)
-        output = ConanOutput(scope="XcodeDeps")
 
         requires = cpp_info.requires or []
 
@@ -263,56 +261,46 @@ class XcodeDeps:
                 if "::" not in req:
                     ci = pkg_dep.cpp_info.components.get(req)
                     if ci:
-                        XcodeDeps._collect_all_transitive(ci, pkg_dep, all_deps_by_name,
+                        XcodeDeps._collect_all_transitive(ci, pkg_dep, visible_deps,
                                                           collected, visited)
                 else:
-                    XcodeDeps._follow_external(req, all_deps_by_name, collected,
-                                               visited, output)
+                    XcodeDeps._follow_external(req, visible_deps, collected, visited)
         elif not pkg_dep.cpp_info.has_components and cpp_info is pkg_dep.cpp_info:
-            # No-component package without explicit cpp_info.requires:
-            # implicitly depends on all its visible direct host dependencies
             for _, d in pkg_dep.dependencies.direct_host.items():
-                ext_dep = (all_deps_by_name.get(d.ref.name)
-                           or all_deps_by_name.get(_format_name(d.ref.name)))
+                ext_dep = (visible_deps.get(d.ref.name)
+                           or visible_deps.get(_format_name(d.ref.name)))
                 if ext_dep is None:
                     continue
                 if ext_dep.cpp_info.has_components:
                     for comp in ext_dep.cpp_info.get_sorted_components().values():
-                        XcodeDeps._collect_all_transitive(comp, ext_dep, all_deps_by_name,
+                        XcodeDeps._collect_all_transitive(comp, ext_dep, visible_deps,
                                                           collected, visited)
                 else:
                     XcodeDeps._collect_all_transitive(ext_dep.cpp_info, ext_dep,
-                                                      all_deps_by_name,
-                                                      collected, visited)
+                                                      visible_deps, collected, visited)
 
     @staticmethod
-    def _follow_external(req, all_deps_by_name, collected, visited, output):
+    def _follow_external(req, visible_deps, collected, visited):
         """Resolve and follow an external requirement (pkg::comp)."""
         ext_pkg, ext_comp = req.split("::", 1)
-        ext_dep = (all_deps_by_name.get(ext_pkg)
-                   or all_deps_by_name.get(_format_name(ext_pkg)))
+        ext_dep = (visible_deps.get(ext_pkg)
+                   or visible_deps.get(_format_name(ext_pkg)))
         if ext_dep is None:
-            output.warning(f"XcodeDeps: dependency '{ext_pkg}' not found in graph, "
-                           f"skipping '{req}'")
             return
 
         if not ext_dep.cpp_info.has_components:
-            XcodeDeps._collect_all_transitive(ext_dep.cpp_info, ext_dep, all_deps_by_name,
+            XcodeDeps._collect_all_transitive(ext_dep.cpp_info, ext_dep, visible_deps,
                                               collected, visited)
         elif ext_pkg == ext_comp or _format_name(ext_pkg) == _format_name(ext_comp):
             for comp in ext_dep.cpp_info.get_sorted_components().values():
-                XcodeDeps._collect_all_transitive(comp, ext_dep, all_deps_by_name,
+                XcodeDeps._collect_all_transitive(comp, ext_dep, visible_deps,
                                                   collected, visited)
         else:
             ci = (ext_dep.cpp_info.components.get(ext_comp)
                   or ext_dep.cpp_info.components.get(_format_name(ext_comp)))
-            if ci is None:
-                output.warning(
-                    f"XcodeDeps: component '{ext_comp}' not found in '{ext_pkg}', "
-                    f"skipping. Available: {list(ext_dep.cpp_info.components.keys())}")
-                return
-            XcodeDeps._collect_all_transitive(ci, ext_dep, all_deps_by_name,
-                                              collected, visited)
+            if ci:
+                XcodeDeps._collect_all_transitive(ci, ext_dep, visible_deps,
+                                                  collected, visited)
 
     def _content(self):
         result = {}

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -127,7 +127,7 @@ class XcodeDeps:
         """
         def _merged_vars(name):
             merged = [var for cpp_info in transitive_cpp_infos for var in getattr(cpp_info, name)]
-            return list(dict.fromkeys(merged))
+            return list(dict.fromkeys(merged).keys())
 
         # TODO: Investigate if paths can be made relative to "root" folder
         fields = {

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -305,6 +305,9 @@ class XcodeDeps:
         test_req = self._conanfile.dependencies.test
         requires = list(host_req.items()) + list(test_req.items())
         all_deps = {dep.ref.name: dep for _, dep in requires}
+
+        # TODO: since transitive data is now inlined, xcconfig files for transitive deps
+        # are no longer included automatically. Consider generating only for direct deps.
         for require, dep in requires:
 
             dep_name = _format_name(dep.ref.name)

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -244,10 +244,8 @@ class XcodeDeps:
 
     @staticmethod
     def _collect_all_transitive(cpp_info, pkg_dep, transitive_deps, collected, visited):
-        """Recursively collect CppInfo objects from a component and all its transitive
-        dependencies, both within the same package (internal) and across packages (external).
-        This produces a flat list of CppInfos that can be merged into a single props file,
-        eliminating the need for inter-package #include chains in xcconfig files."""
+        """Recursively collect all transitive CppInfo objects (internal and external)
+        into a flat list."""
 
         key = id(cpp_info)
         if key in visited:

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -316,8 +316,6 @@ class XcodeDeps:
 
             dep_name = _format_name(dep.ref.name)
 
-            # TODO: discuss if we should skip generating xcconfig files for transitive-only
-            # deps, since their data is now inlined and their files are never #include'd.
             visible_deps = {}
             for _, d in get_transitive_requires(self._conanfile, dep).items():
                 visible_deps[d.ref.name] = d

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -267,8 +267,7 @@ class XcodeDeps:
                     XcodeDeps._follow_external(req, visible_deps, collected, visited)
         elif not pkg_dep.cpp_info.has_components and cpp_info is pkg_dep.cpp_info:
             for _, d in pkg_dep.dependencies.direct_host.items():
-                ext_dep = (visible_deps.get(d.ref.name)
-                           or visible_deps.get(_format_name(d.ref.name)))
+                ext_dep = visible_deps.get(d.ref.name)
                 if ext_dep is None:
                     continue
                 if ext_dep.cpp_info.has_components:
@@ -283,21 +282,19 @@ class XcodeDeps:
     def _follow_external(req, visible_deps, collected, visited):
         """Resolve and follow an external requirement (pkg::comp)."""
         ext_pkg, ext_comp = req.split("::", 1)
-        ext_dep = (visible_deps.get(ext_pkg)
-                   or visible_deps.get(_format_name(ext_pkg)))
+        ext_dep = visible_deps.get(ext_pkg)
         if ext_dep is None:
             return
 
         if not ext_dep.cpp_info.has_components:
             XcodeDeps._collect_all_transitive(ext_dep.cpp_info, ext_dep, visible_deps,
                                               collected, visited)
-        elif ext_pkg == ext_comp or _format_name(ext_pkg) == _format_name(ext_comp):
+        elif ext_pkg == ext_comp:
             for comp in ext_dep.cpp_info.get_sorted_components().values():
                 XcodeDeps._collect_all_transitive(comp, ext_dep, visible_deps,
                                                   collected, visited)
         else:
-            ci = (ext_dep.cpp_info.components.get(ext_comp)
-                  or ext_dep.cpp_info.components.get(_format_name(ext_comp)))
+            ci = ext_dep.cpp_info.components.get(ext_comp)
             if ci:
                 XcodeDeps._collect_all_transitive(ci, ext_dep, visible_deps,
                                                   collected, visited)
@@ -319,7 +316,6 @@ class XcodeDeps:
             visible_deps = {}
             for _, d in get_transitive_requires(self._conanfile, dep).items():
                 visible_deps[d.ref.name] = d
-                visible_deps[_format_name(d.ref.name)] = d
             if dep.cpp_info.has_components:
 
                 sorted_components = dep.cpp_info.get_sorted_components().items()

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -279,8 +279,6 @@ class XcodeDeps:
 
         ext_pkg, ext_comp = req.split("::", 1)
         ext_dep = all_deps.get(ext_pkg)
-        if ext_dep is None:
-            return
 
         if not ext_dep.cpp_info.has_components:
             # Package without components: use root cpp_info directly

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -248,6 +248,7 @@ class XcodeDeps:
         dependencies, both within the same package (internal) and across packages (external).
         This produces a flat list of CppInfos that can be merged into a single props file,
         eliminating the need for inter-package #include chains in xcconfig files."""
+
         key = id(cpp_info)
         if key in visited:
             return
@@ -281,6 +282,7 @@ class XcodeDeps:
     @staticmethod
     def _follow_external(req, transitive_deps, collected, visited):
         """Resolve and follow an external requirement (pkg::comp)."""
+
         ext_pkg, ext_comp = req.split("::", 1)
         ext_dep = transitive_deps.get(ext_pkg)
         if ext_dep is None:

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -262,18 +262,19 @@ class XcodeDeps:
         if cpp_info.requires:
             for req in cpp_info.requires:
                 if "::" not in req:
+                    # Internal component from the same package
                     XcodeDeps._collect_all_transitive(
                         pkg_dep.cpp_info.components.get(req), pkg_dep,
                         all_deps, collected, visited)
                 else:
-                    XcodeDeps._follow_external(req, all_deps, collected, visited)
+                    XcodeDeps._resolve_external(req, all_deps, collected, visited)
         elif not pkg_dep.cpp_info.has_components and cpp_info is pkg_dep.cpp_info:
             for _, d in pkg_dep.dependencies.direct_host.items():
-                XcodeDeps._follow_external(f"{d.ref.name}::{d.ref.name}",
+                XcodeDeps._resolve_external(f"{d.ref.name}::{d.ref.name}",
                                            all_deps, collected, visited)
 
     @staticmethod
-    def _follow_external(req, all_deps, collected, visited):
+    def _resolve_external(req, all_deps, collected, visited):
         """Resolve and follow an external requirement (pkg::comp)."""
 
         ext_pkg, ext_comp = req.split("::", 1)

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -226,17 +226,17 @@ class XcodeDeps:
                                                GLOBAL_XCCONFIG_TEMPLATE,
                                                [self.general_name])
 
-    def get_content_for_component(self, require, pkg_name, component_name, package_folder, transitive_internal, transitive_external):
+    def _get_content_for_component(self, require, pkg_name, component_name, package_folder, transitive_cpp_infos):
         result = {}
 
         conf_name = _xcconfig_settings_filename(self._conanfile.settings, self.configuration)
 
         props_name = "conan_{}_{}{}.xcconfig".format(pkg_name, component_name, conf_name)
-        result[props_name] = self._conf_xconfig_file(require, pkg_name, component_name, package_folder, transitive_internal)
+        result[props_name] = self._conf_xconfig_file(require, pkg_name, component_name, package_folder, transitive_cpp_infos)
 
         # The entry point for each package
         file_dep_name = "conan_{}_{}.xcconfig".format(pkg_name, component_name)
-        dep_content = self._dep_xconfig_file(pkg_name, component_name, file_dep_name, props_name, transitive_external)
+        dep_content = self._dep_xconfig_file(pkg_name, component_name, file_dep_name, props_name, [])
 
         result[file_dep_name] = dep_content
         return result
@@ -321,27 +321,25 @@ class XcodeDeps:
                 for comp_name, comp_cpp_info in sorted_components:
                     comp_name = _format_name(comp_name)
 
-                    transitive_internal = []
+                    transitive_cpp_infos = []
                     self._collect_all_transitive(comp_cpp_info, dep, all_deps,
-                                                 transitive_internal)
+                                                 transitive_cpp_infos)
 
                     # In case dep is editable and package_folder=None
                     pkg_folder = dep.package_folder or dep.recipe_folder
-                    component_content = self.get_content_for_component(require, dep_name, comp_name,
-                                                                       pkg_folder,
-                                                                       transitive_internal,
-                                                                       [])
+                    component_content = self._get_content_for_component(require, dep_name, comp_name,
+                                                                        pkg_folder,
+                                                                        transitive_cpp_infos)
                     include_components_names.append((dep_name, comp_name))
                     result.update(component_content)
             else:
-                transitive_internal = []
+                transitive_cpp_infos = []
                 self._collect_all_transitive(dep.cpp_info, dep, all_deps,
-                                             transitive_internal)
+                                             transitive_cpp_infos)
                 # In case dep is editable and package_folder=None
                 pkg_folder = dep.package_folder or dep.recipe_folder
-                root_content = self.get_content_for_component(require, dep_name, dep_name, pkg_folder,
-                                                              transitive_internal,
-                                                              [])
+                root_content = self._get_content_for_component(require, dep_name, dep_name, pkg_folder,
+                                                               transitive_cpp_infos)
                 include_components_names.append((dep_name, dep_name))
                 result.update(root_content)
 

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -305,12 +305,15 @@ class XcodeDeps:
         # All components are included in the conan_pkgname.xcconfig file
         host_req = self._conanfile.dependencies.host
         test_req = self._conanfile.dependencies.test
-        requires = list(host_req.items()) + list(test_req.items())
-        all_deps = {dep.ref.name: dep for _, dep in requires}
+        all_deps = {dep.ref.name: dep
+                    for _, dep in list(host_req.items()) + list(test_req.items())}
 
-        # TODO: since transitive data is now inlined, xcconfig files for transitive deps
-        # are no longer included automatically. Consider generating only for direct deps.
-        for require, dep in requires:
+        # TODO: Discuss behavior change, only direct deps generate xcconfig files now,
+        # since transitive data is inlined into each component's props file.
+        direct_deps = self._conanfile.dependencies.filter({"direct": True,
+                                                           "build": False,
+                                                           "skip": False})
+        for require, dep in direct_deps.items():
 
             dep_name = _format_name(dep.ref.name)
 

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -1,8 +1,6 @@
 import os
 import re
 import textwrap
-from collections import OrderedDict
-
 from jinja2 import Template
 
 from conan.internal import check_duplicated_generator
@@ -129,7 +127,7 @@ class XcodeDeps:
         """
         def _merged_vars(name):
             merged = [var for cpp_info in transitive_cpp_infos for var in getattr(cpp_info, name)]
-            return list(OrderedDict.fromkeys(merged).keys())
+            return list(dict.fromkeys(merged))
 
         # TODO: Investigate if paths can be made relative to "root" folder
         fields = {

--- a/conan/tools/apple/xcodedeps.py
+++ b/conan/tools/apple/xcodedeps.py
@@ -308,8 +308,6 @@ class XcodeDeps:
         all_deps = {dep.ref.name: dep
                     for _, dep in list(host_req.items()) + list(test_req.items())}
 
-        # TODO: Discuss behavior change, only direct deps generate xcconfig files now,
-        # since transitive data is inlined into each component's props file.
         direct_deps = self._conanfile.dependencies.filter({"direct": True,
                                                            "build": False,
                                                            "skip": False})

--- a/test/functional/toolchains/apple/test_xcodedeps_components.py
+++ b/test/functional/toolchains/apple/test_xcodedeps_components.py
@@ -188,7 +188,8 @@ def test_xcodedeps_components():
     client.run("install --requires=chat/1.0@ -g XcodeDeps --output-folder=conan "
                "-s build_type=Debug --build=missing")
     chat_xcconfig = client.load(os.path.join("conan", "conan_chat_chat.xcconfig"))
-    assert '#include "conan_network_client_test__.xcconfig"' in chat_xcconfig
+    # External deps are now inlined into the props file, no #include in wrapper
+    assert '#include "conan_network_client_test__.xcconfig"' not in chat_xcconfig
     assert '#include "conan_network_server.xcconfig"' not in chat_xcconfig
     assert '#include "conan_network_network.xcconfig"' not in chat_xcconfig
     host_arch = client.get_default_host_profile().settings['arch']
@@ -270,14 +271,28 @@ def test_cpp_info_require_whole_package():
     client.run("install --requires=libb/1.0 -g XcodeDeps -of=libb")
 
     libb_xcconfig = client.load(os.path.join("libb", "conan_libb_libb.xcconfig"))
-    assert '#include "conan_liba.xcconfig"' in libb_xcconfig
+    # External deps are now inlined into the props file, no #include in wrapper
+    assert '#include "conan_liba.xcconfig"' not in libb_xcconfig
     assert '#include "conan_liba_liba.xcconfig"' not in libb_xcconfig
+
+    # Verify liba data is inlined in libb's props file
+    host_arch = client.get_default_host_profile().settings['arch']
+    arch = "arm64" if host_arch == "armv8" else host_arch
+    libb_props = client.load(os.path.join("libb", f"conan_libb_libb_release_{arch}.xcconfig"))
+    assert "cmp1" in libb_props
+    assert "cmp2" in libb_props
 
     client.run("install --requires=libc/1.0 -g XcodeDeps -of=libc")
 
     libc_comp1_xcconfig = client.load(os.path.join("libc", "conan_libc_cmp1.xcconfig"))
-    assert '#include "conan_liba.xcconfig"' in libc_comp1_xcconfig
+    # External deps are now inlined into the props file, no #include in wrapper
+    assert '#include "conan_liba.xcconfig"' not in libc_comp1_xcconfig
     assert '#include "conan_liba_liba.xcconfig"' not in libc_comp1_xcconfig
+
+    # Verify liba data is inlined in libc cmp1's props file
+    libc_cmp1_props = client.load(os.path.join("libc", f"conan_libc_cmp1_release_{arch}.xcconfig"))
+    assert "cmp1" in libc_cmp1_props
+    assert "cmp2" in libc_cmp1_props
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")

--- a/test/functional/toolchains/apple/test_xcodedeps_components.py
+++ b/test/functional/toolchains/apple/test_xcodedeps_components.py
@@ -188,7 +188,6 @@ def test_xcodedeps_components():
     client.run("install --requires=chat/1.0@ -g XcodeDeps --output-folder=conan "
                "-s build_type=Debug --build=missing")
     chat_xcconfig = client.load(os.path.join("conan", "conan_chat_chat.xcconfig"))
-    # External deps are now inlined into the props file, no #include in wrapper
     assert '#include "conan_network_client_test__.xcconfig"' not in chat_xcconfig
     assert '#include "conan_network_server.xcconfig"' not in chat_xcconfig
     assert '#include "conan_network_network.xcconfig"' not in chat_xcconfig
@@ -271,11 +270,9 @@ def test_cpp_info_require_whole_package():
     client.run("install --requires=libb/1.0 -g XcodeDeps -of=libb")
 
     libb_xcconfig = client.load(os.path.join("libb", "conan_libb_libb.xcconfig"))
-    # External deps are now inlined into the props file, no #include in wrapper
     assert '#include "conan_liba.xcconfig"' not in libb_xcconfig
     assert '#include "conan_liba_liba.xcconfig"' not in libb_xcconfig
 
-    # Verify liba data is inlined in libb's props file
     host_arch = client.get_default_host_profile().settings['arch']
     arch = "arm64" if host_arch == "armv8" else host_arch
     libb_props = client.load(os.path.join("libb", f"conan_libb_libb_release_{arch}.xcconfig"))
@@ -285,11 +282,9 @@ def test_cpp_info_require_whole_package():
     client.run("install --requires=libc/1.0 -g XcodeDeps -of=libc")
 
     libc_comp1_xcconfig = client.load(os.path.join("libc", "conan_libc_cmp1.xcconfig"))
-    # External deps are now inlined into the props file, no #include in wrapper
     assert '#include "conan_liba.xcconfig"' not in libc_comp1_xcconfig
     assert '#include "conan_liba_liba.xcconfig"' not in libc_comp1_xcconfig
 
-    # Verify liba data is inlined in libc cmp1's props file
     libc_cmp1_props = client.load(os.path.join("libc", f"conan_libc_cmp1_release_{arch}.xcconfig"))
     assert "cmp1" in libc_cmp1_props
     assert "cmp2" in libc_cmp1_props

--- a/test/integration/toolchains/apple/test_xcodedeps.py
+++ b/test/integration/toolchains/apple/test_xcodedeps.py
@@ -207,7 +207,6 @@ def test_xcodedeps_aggregate_components():
         assert f"conan_libb_libb_comp{index}.xcconfig" in lib_entry
 
     component7_entry = client.load("conan_libb_libb_comp7.xcconfig")
-    # External deps are now inlined into the props file, no #include in wrapper
     assert '#include "conan_liba.xcconfig"' not in component7_entry
 
     arch_setting = client.get_default_host_profile().settings['arch']
@@ -452,7 +451,6 @@ def test_xcodedeps_cppinfo_requires():
     So we will only link against the components specified in the cpp_info.requires of lib_b and lib_c
     """
 
-    # Verify component data is inlined in the props files, not in wrapper #includes
     arch_setting = client.get_default_host_profile().settings['arch']
     arch = "arm64" if arch_setting == "armv8" else arch_setting
 
@@ -509,11 +507,9 @@ def test_dependency_of_dependency_components():
 
     lib_b_xconfig = client.load("conan_lib_b_lib_b.xcconfig")
 
-    # External deps are now inlined into the props file, no #include in wrapper
     assert '#include "conan_lib_c_cmp1.xcconfig"' not in lib_b_xconfig
     assert '#include "conan_lib_c_lib_c.xcconfig"' not in lib_b_xconfig
 
-    # Verify lib_c's component data is inlined in lib_b's props file
     arch_setting = client.get_default_host_profile().settings['arch']
     arch = "arm64" if arch_setting == "armv8" else arch_setting
     lib_b_props = client.load(f"conan_lib_b_lib_b_release_{arch}.xcconfig")
@@ -584,17 +580,14 @@ def test_correctly_handle_transitive_components():
     assert '#include "conan_has_components.xcconfig"' not in conandeps
     assert '#include "conan_uses_components.xcconfig"' in conandeps
     conan_uses_xcconfig = client.load("conan_uses_components_uses_components.xcconfig")
-    # External deps are now inlined into the props file, no #include in wrapper
     assert '#include "conan_has_components_first.xcconfig"' not in conan_uses_xcconfig
     assert '#include "conan_has_components_second.xcconfig"' not in conan_uses_xcconfig
 
-    # Verify that 'first' component data is inlined in uses_components' props file
     arch_setting = client.get_default_host_profile().settings['arch']
     arch = "arm64" if arch_setting == "armv8" else arch_setting
     uses_props = client.load(f"conan_uses_components_uses_components_release_{arch}.xcconfig")
     assert "-lfirst" in uses_props
     assert "-luses_only_first" in uses_props
-    # 'second' component should NOT be inlined (not required)
     assert "donottouch" not in uses_props
 
 
@@ -645,7 +638,6 @@ def test_dont_add_skipped_xcconfigs_when_required_by_components():
     client.run("install --requires=regular_lib/1.0 -g XcodeDeps")
 
     conandeps = client.load("conan_regular_lib_component.xcconfig")
-    # External deps are now inlined into the props file, no #include in wrapper
     assert '#include "conan_header_skip.xcconfig"' not in conandeps
     assert '#include "conan_header_transitive.xcconfig"' not in conandeps
 

--- a/test/integration/toolchains/apple/test_xcodedeps.py
+++ b/test/integration/toolchains/apple/test_xcodedeps.py
@@ -517,6 +517,84 @@ def test_dependency_of_dependency_components():
     assert "include_cmp2" in lib_b_props
 
 
+def test_diamond_dependency_components():
+    """
+    Diamond: lib_e (with components core, utils) is reached through two paths.
+    lib_c::cmp1 depends only on lib_e::core, lib_d depends on all of lib_e.
+
+    lib_a -> lib_b -> lib_c (cmp1 -> lib_e::core) -> lib_e (core, utils)
+                   -> lib_d (-> lib_e::lib_e)      -> lib_e (core, utils)
+    """
+    client = TestClient()
+    lib_a = GenConanfile("lib_a", "1.0").with_require("lib_b/1.0").with_settings("os", "arch", "build_type", "compiler")
+
+    lib_b = textwrap.dedent("""
+        from conan import ConanFile
+        class lib_bConan(ConanFile):
+            name = "lib_b"
+            version = "1.0"
+            settings = "os", "compiler", "build_type", "arch"
+            requires = "lib_c/1.0", "lib_d/1.0"
+        """)
+
+    lib_c = textwrap.dedent("""
+        from conan import ConanFile
+        class lib_cConan(ConanFile):
+            name = "lib_c"
+            version = "1.0"
+            settings = "os", "compiler", "build_type", "arch"
+            requires = "lib_e/1.0"
+            def package_info(self):
+                self.cpp_info.components["cmp1"].includedirs = ["include_cmp1"]
+                self.cpp_info.components["cmp1"].requires = ["lib_e::core"]
+        """)
+
+    lib_d = textwrap.dedent("""
+        from conan import ConanFile
+        class lib_dConan(ConanFile):
+            name = "lib_d"
+            version = "1.0"
+            settings = "os", "compiler", "build_type", "arch"
+            requires = "lib_e/1.0"
+        """)
+
+    lib_e = textwrap.dedent("""
+        from conan import ConanFile
+        class lib_eConan(ConanFile):
+            name = "lib_e"
+            version = "1.0"
+            settings = "os", "compiler", "build_type", "arch"
+            def package_info(self):
+                self.cpp_info.components["core"].includedirs = ["include_e_core"]
+                self.cpp_info.components["utils"].includedirs = ["include_e_utils"]
+        """)
+
+    client.save({
+        'conanfile.py': lib_a,
+        'lib_b/conanfile.py': lib_b,
+        'lib_c/conanfile.py': lib_c,
+        'lib_d/conanfile.py': lib_d,
+        'lib_e/conanfile.py': lib_e,
+    })
+
+    client.run("create lib_e")
+    client.run("create lib_d")
+    client.run("create lib_c")
+    client.run("create lib_b")
+    client.run("install . -g XcodeDeps")
+
+    arch_setting = client.get_default_host_profile().settings['arch']
+    arch = "arm64" if arch_setting == "armv8" else arch_setting
+
+    # lib_b inlines everything: lib_c::cmp1, lib_d, and all of lib_e
+    lib_b_props = client.load(f"conan_lib_b_lib_b_release_{arch}.xcconfig")
+    assert "include_cmp1" in lib_b_props
+    assert "include_e_core" in lib_b_props
+    assert "include_e_utils" in lib_b_props
+    # lib_e::core appears only once despite being reached via both lib_c and lib_d
+    assert lib_b_props.count("include_e_core") == 1
+
+
 def test_skipped_not_included():
     # https://github.com/conan-io/conan/issues/13818
     client = TestClient()

--- a/test/integration/toolchains/apple/test_xcodedeps.py
+++ b/test/integration/toolchains/apple/test_xcodedeps.py
@@ -597,6 +597,18 @@ def test_diamond_dependency_components():
     # math::vectors appears only once despite being reached via both graphics and audio
     assert engine_props.count("include_vectors") == 1
 
+    # graphics::client inlines common (internal) and math::vectors (external)
+    # but NOT math::matrices (only depends on math::vectors, not all of math)
+    graphics_client_props = client.load(f"conan_graphics_client_release_{arch}.xcconfig")
+    assert "include_common" in graphics_client_props
+    assert "include_vectors" in graphics_client_props
+    assert "include_matrices" not in graphics_client_props
+
+    # audio inlines all of math (vectors + matrices) via implicit dependency
+    audio_props = client.load(f"conan_audio_audio_release_{arch}.xcconfig")
+    assert "include_vectors" in audio_props
+    assert "include_matrices" in audio_props
+
 
 def test_skipped_not_included():
     # https://github.com/conan-io/conan/issues/13818

--- a/test/integration/toolchains/apple/test_xcodedeps.py
+++ b/test/integration/toolchains/apple/test_xcodedeps.py
@@ -520,10 +520,11 @@ def test_dependency_of_dependency_components():
 def test_diamond_dependency_components():
     """
     Diamond: lib_e (with components core, utils) is reached through two paths.
-    lib_c::cmp1 depends only on lib_e::core, lib_d depends on all of lib_e.
+    lib_c has internal component deps (cmp1 -> base) and external (cmp1 -> lib_e::core).
+    lib_d depends on all of lib_e.
 
-    lib_a -> lib_b -> lib_c (cmp1 -> lib_e::core) -> lib_e (core, utils)
-                   -> lib_d (-> lib_e::lib_e)      -> lib_e (core, utils)
+    lib_a -> lib_b -> lib_c (cmp1 -> base, lib_e::core) -> lib_e (core, utils)
+                   -> lib_d                              -> lib_e (core, utils)
     """
     client = TestClient()
     lib_a = GenConanfile("lib_a", "1.0").with_require("lib_b/1.0").with_settings("os", "arch", "build_type", "compiler")
@@ -545,8 +546,9 @@ def test_diamond_dependency_components():
             settings = "os", "compiler", "build_type", "arch"
             requires = "lib_e/1.0"
             def package_info(self):
+                self.cpp_info.components["base"].includedirs = ["include_base"]
                 self.cpp_info.components["cmp1"].includedirs = ["include_cmp1"]
-                self.cpp_info.components["cmp1"].requires = ["lib_e::core"]
+                self.cpp_info.components["cmp1"].requires = ["base", "lib_e::core"]
         """)
 
     lib_d = textwrap.dedent("""
@@ -586,8 +588,9 @@ def test_diamond_dependency_components():
     arch_setting = client.get_default_host_profile().settings['arch']
     arch = "arm64" if arch_setting == "armv8" else arch_setting
 
-    # lib_b inlines everything: lib_c::cmp1, lib_d, and all of lib_e
+    # lib_b inlines everything: lib_c (base, cmp1), lib_d, and all of lib_e
     lib_b_props = client.load(f"conan_lib_b_lib_b_release_{arch}.xcconfig")
+    assert "include_base" in lib_b_props
     assert "include_cmp1" in lib_b_props
     assert "include_e_core" in lib_b_props
     assert "include_e_utils" in lib_b_props

--- a/test/integration/toolchains/apple/test_xcodedeps.py
+++ b/test/integration/toolchains/apple/test_xcodedeps.py
@@ -519,83 +519,83 @@ def test_dependency_of_dependency_components():
 
 def test_diamond_dependency_components():
     """
-    Diamond: lib_e (with components core, utils) is reached through two paths.
-    lib_c has internal component deps (cmp1 -> base) and external (cmp1 -> lib_e::core).
-    lib_d depends on all of lib_e.
+    Diamond: math (with components vectors, matrices) is reached through two paths.
+    graphics has internal component deps (client -> common) and external (client -> math::vectors).
+    audio depends on all of math.
 
-    lib_a -> lib_b -> lib_c (cmp1 -> base, lib_e::core) -> lib_e (core, utils)
-                   -> lib_d                              -> lib_e (core, utils)
+    app -> engine -> graphics (client -> common, math::vectors) -> math (vectors, matrices)
+                  -> audio                                      -> math (vectors, matrices)
     """
     client = TestClient()
-    lib_a = GenConanfile("lib_a", "1.0").with_require("lib_b/1.0").with_settings("os", "arch", "build_type", "compiler")
+    app = GenConanfile("app", "1.0").with_require("engine/1.0").with_settings("os", "arch", "build_type", "compiler")
 
-    lib_b = textwrap.dedent("""
+    engine = textwrap.dedent("""
         from conan import ConanFile
-        class lib_bConan(ConanFile):
-            name = "lib_b"
+        class EngineConan(ConanFile):
+            name = "engine"
             version = "1.0"
             settings = "os", "compiler", "build_type", "arch"
-            requires = "lib_c/1.0", "lib_d/1.0"
+            requires = "graphics/1.0", "audio/1.0"
         """)
 
-    lib_c = textwrap.dedent("""
+    graphics = textwrap.dedent("""
         from conan import ConanFile
-        class lib_cConan(ConanFile):
-            name = "lib_c"
+        class GraphicsConan(ConanFile):
+            name = "graphics"
             version = "1.0"
             settings = "os", "compiler", "build_type", "arch"
-            requires = "lib_e/1.0"
+            requires = "math/1.0"
             def package_info(self):
-                self.cpp_info.components["base"].includedirs = ["include_base"]
-                self.cpp_info.components["cmp1"].includedirs = ["include_cmp1"]
-                self.cpp_info.components["cmp1"].requires = ["base", "lib_e::core"]
+                self.cpp_info.components["common"].includedirs = ["include_common"]
+                self.cpp_info.components["client"].includedirs = ["include_client"]
+                self.cpp_info.components["client"].requires = ["common", "math::vectors"]
         """)
 
-    lib_d = textwrap.dedent("""
+    audio = textwrap.dedent("""
         from conan import ConanFile
-        class lib_dConan(ConanFile):
-            name = "lib_d"
+        class AudioConan(ConanFile):
+            name = "audio"
             version = "1.0"
             settings = "os", "compiler", "build_type", "arch"
-            requires = "lib_e/1.0"
+            requires = "math/1.0"
         """)
 
-    lib_e = textwrap.dedent("""
+    math = textwrap.dedent("""
         from conan import ConanFile
-        class lib_eConan(ConanFile):
-            name = "lib_e"
+        class MathConan(ConanFile):
+            name = "math"
             version = "1.0"
             settings = "os", "compiler", "build_type", "arch"
             def package_info(self):
-                self.cpp_info.components["core"].includedirs = ["include_e_core"]
-                self.cpp_info.components["utils"].includedirs = ["include_e_utils"]
+                self.cpp_info.components["vectors"].includedirs = ["include_vectors"]
+                self.cpp_info.components["matrices"].includedirs = ["include_matrices"]
         """)
 
     client.save({
-        'conanfile.py': lib_a,
-        'lib_b/conanfile.py': lib_b,
-        'lib_c/conanfile.py': lib_c,
-        'lib_d/conanfile.py': lib_d,
-        'lib_e/conanfile.py': lib_e,
+        'conanfile.py': app,
+        'engine/conanfile.py': engine,
+        'graphics/conanfile.py': graphics,
+        'audio/conanfile.py': audio,
+        'math/conanfile.py': math,
     })
 
-    client.run("create lib_e")
-    client.run("create lib_d")
-    client.run("create lib_c")
-    client.run("create lib_b")
+    client.run("create math")
+    client.run("create audio")
+    client.run("create graphics")
+    client.run("create engine")
     client.run("install . -g XcodeDeps")
 
     arch_setting = client.get_default_host_profile().settings['arch']
     arch = "arm64" if arch_setting == "armv8" else arch_setting
 
-    # lib_b inlines everything: lib_c (base, cmp1), lib_d, and all of lib_e
-    lib_b_props = client.load(f"conan_lib_b_lib_b_release_{arch}.xcconfig")
-    assert "include_base" in lib_b_props
-    assert "include_cmp1" in lib_b_props
-    assert "include_e_core" in lib_b_props
-    assert "include_e_utils" in lib_b_props
-    # lib_e::core appears only once despite being reached via both lib_c and lib_d
-    assert lib_b_props.count("include_e_core") == 1
+    # engine inlines everything: graphics (common, client), audio, and all of math
+    engine_props = client.load(f"conan_engine_engine_release_{arch}.xcconfig")
+    assert "include_common" in engine_props
+    assert "include_client" in engine_props
+    assert "include_vectors" in engine_props
+    assert "include_matrices" in engine_props
+    # math::vectors appears only once despite being reached via both graphics and audio
+    assert engine_props.count("include_vectors") == 1
 
 
 def test_skipped_not_included():

--- a/test/integration/toolchains/apple/test_xcodedeps.py
+++ b/test/integration/toolchains/apple/test_xcodedeps.py
@@ -738,6 +738,6 @@ def test_dont_add_skipped_xcconfigs_when_required_by_components():
     skip_files = [f for f in os.listdir(client.current_folder) if 'header_skip' in f and f.endswith('.xcconfig')]
     assert len(skip_files) == 0, f"Header skip files should not be generated: {skip_files}"
 
-    # Verify that header_transitive xcconfig files ARE generated (transitive dependency)
+    # Transitive deps no longer generate their own xcconfig files (data is inlined)
     transitive_files = [f for f in os.listdir(client.current_folder) if 'header_transitive' in f and f.endswith('.xcconfig')]
-    assert len(transitive_files) > 0, f"Header transitive files should be generated: {transitive_files}"
+    assert len(transitive_files) == 0, f"Header transitive files should not be generated: {transitive_files}"

--- a/test/integration/toolchains/apple/test_xcodedeps.py
+++ b/test/integration/toolchains/apple/test_xcodedeps.py
@@ -588,26 +588,21 @@ def test_diamond_dependency_components():
     arch_setting = client.get_default_host_profile().settings['arch']
     arch = "arm64" if arch_setting == "armv8" else arch_setting
 
-    # engine inlines everything: graphics (common, client), audio, and all of math
+    # engine is the only direct dep of app — its props file must inline everything:
+    # graphics (common, client), audio, and all of math (vectors, matrices)
     engine_props = client.load(f"conan_engine_engine_release_{arch}.xcconfig")
     assert "include_common" in engine_props
     assert "include_client" in engine_props
     assert "include_vectors" in engine_props
     assert "include_matrices" in engine_props
-    # math::vectors appears only once despite being reached via both graphics and audio
+    # math::vectors is reached via both graphics and audio, but appears only once
     assert engine_props.count("include_vectors") == 1
 
-    # graphics::client inlines common (internal) and math::vectors (external)
-    # but NOT math::matrices (only depends on math::vectors, not all of math)
-    graphics_client_props = client.load(f"conan_graphics_client_release_{arch}.xcconfig")
-    assert "include_common" in graphics_client_props
-    assert "include_vectors" in graphics_client_props
-    assert "include_matrices" not in graphics_client_props
-
-    # audio inlines all of math (vectors + matrices) via implicit dependency
-    audio_props = client.load(f"conan_audio_audio_release_{arch}.xcconfig")
-    assert "include_vectors" in audio_props
-    assert "include_matrices" in audio_props
+    # no inter-package #includes in engine wrapper
+    engine_xcconfig = client.load("conan_engine_engine.xcconfig")
+    assert '#include "conan_graphics' not in engine_xcconfig
+    assert '#include "conan_audio' not in engine_xcconfig
+    assert '#include "conan_math' not in engine_xcconfig
 
 
 def test_skipped_not_included():

--- a/test/integration/toolchains/apple/test_xcodedeps.py
+++ b/test/integration/toolchains/apple/test_xcodedeps.py
@@ -207,7 +207,8 @@ def test_xcodedeps_aggregate_components():
         assert f"conan_libb_libb_comp{index}.xcconfig" in lib_entry
 
     component7_entry = client.load("conan_libb_libb_comp7.xcconfig")
-    assert '#include "conan_liba.xcconfig"' in component7_entry
+    # External deps are now inlined into the props file, no #include in wrapper
+    assert '#include "conan_liba.xcconfig"' not in component7_entry
 
     arch_setting = client.get_default_host_profile().settings['arch']
     arch = "arm64" if arch_setting == "armv8" else arch_setting
@@ -401,10 +402,10 @@ def test_xcodedeps_cppinfo_requires():
             version = "1.0"
             settings = "os", "compiler", "build_type", "arch"
             def package_info(self):
-                self.cpp_info.components["cmp1"].includedirs = ["include"]
-                self.cpp_info.components["cmp2"].includedirs = ["include"]
-                self.cpp_info.components["cmp3"].includedirs = ["include"]
-                self.cpp_info.components["cmp4"].includedirs = ["include"]
+                self.cpp_info.components["cmp1"].includedirs = ["include_cmp1"]
+                self.cpp_info.components["cmp2"].includedirs = ["include_cmp2"]
+                self.cpp_info.components["cmp3"].includedirs = ["include_cmp3"]
+                self.cpp_info.components["cmp4"].includedirs = ["include_cmp4"]
         """)
 
     lib = textwrap.dedent("""
@@ -451,21 +452,21 @@ def test_xcodedeps_cppinfo_requires():
     So we will only link against the components specified in the cpp_info.requires of lib_b and lib_c
     """
 
-    lib_b = client.load(os.path.join("consumer", "conan_lib_b_lib_b.xcconfig"))
+    # Verify component data is inlined in the props files, not in wrapper #includes
+    arch_setting = client.get_default_host_profile().settings['arch']
+    arch = "arm64" if arch_setting == "armv8" else arch_setting
 
-    # check that nothing from other components than the specified in the cpp_info.requires
-    # from lib_b and lib_c exist in the xcconfig that adds the includes from components
-    assert "cmp1" in lib_b
-    assert "cmp2" not in lib_b
-    assert "cmp3" not in lib_b
-    assert "cmp4" not in lib_b
+    lib_b_props = client.load(os.path.join("consumer", f"conan_lib_b_lib_b_release_{arch}.xcconfig"))
+    assert "include_cmp1" in lib_b_props
+    assert "include_cmp2" not in lib_b_props
+    assert "include_cmp3" not in lib_b_props
+    assert "include_cmp4" not in lib_b_props
 
-    lib_c = client.load(os.path.join("consumer", "conan_lib_c_lib_c.xcconfig"))
-
-    assert "cmp1" not in lib_c
-    assert "cmp2" in lib_c
-    assert "cmp3" not in lib_c
-    assert "cmp4" not in lib_c
+    lib_c_props = client.load(os.path.join("consumer", f"conan_lib_c_lib_c_release_{arch}.xcconfig"))
+    assert "include_cmp1" not in lib_c_props
+    assert "include_cmp2" in lib_c_props
+    assert "include_cmp3" not in lib_c_props
+    assert "include_cmp4" not in lib_c_props
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
@@ -508,9 +509,16 @@ def test_dependency_of_dependency_components():
 
     lib_b_xconfig = client.load("conan_lib_b_lib_b.xcconfig")
 
-    assert '#include "conan_lib_c_cmp1.xcconfig"' in lib_b_xconfig
-    assert '#include "conan_lib_c_cmp1.xcconfig"' in lib_b_xconfig
+    # External deps are now inlined into the props file, no #include in wrapper
+    assert '#include "conan_lib_c_cmp1.xcconfig"' not in lib_b_xconfig
     assert '#include "conan_lib_c_lib_c.xcconfig"' not in lib_b_xconfig
+
+    # Verify lib_c's component data is inlined in lib_b's props file
+    arch_setting = client.get_default_host_profile().settings['arch']
+    arch = "arm64" if arch_setting == "armv8" else arch_setting
+    lib_b_props = client.load(f"conan_lib_b_lib_b_release_{arch}.xcconfig")
+    assert "include_cmp1" in lib_b_props
+    assert "include_cmp2" in lib_b_props
 
 
 def test_skipped_not_included():
@@ -576,8 +584,18 @@ def test_correctly_handle_transitive_components():
     assert '#include "conan_has_components.xcconfig"' not in conandeps
     assert '#include "conan_uses_components.xcconfig"' in conandeps
     conan_uses_xcconfig = client.load("conan_uses_components_uses_components.xcconfig")
-    assert '#include "conan_has_components_first.xcconfig"' in conan_uses_xcconfig
+    # External deps are now inlined into the props file, no #include in wrapper
+    assert '#include "conan_has_components_first.xcconfig"' not in conan_uses_xcconfig
     assert '#include "conan_has_components_second.xcconfig"' not in conan_uses_xcconfig
+
+    # Verify that 'first' component data is inlined in uses_components' props file
+    arch_setting = client.get_default_host_profile().settings['arch']
+    arch = "arm64" if arch_setting == "armv8" else arch_setting
+    uses_props = client.load(f"conan_uses_components_uses_components_release_{arch}.xcconfig")
+    assert "-lfirst" in uses_props
+    assert "-luses_only_first" in uses_props
+    # 'second' component should NOT be inlined (not required)
+    assert "donottouch" not in uses_props
 
 
 def test_dont_add_skipped_xcconfigs_when_required_by_components():
@@ -627,8 +645,9 @@ def test_dont_add_skipped_xcconfigs_when_required_by_components():
     client.run("install --requires=regular_lib/1.0 -g XcodeDeps")
 
     conandeps = client.load("conan_regular_lib_component.xcconfig")
+    # External deps are now inlined into the props file, no #include in wrapper
     assert '#include "conan_header_skip.xcconfig"' not in conandeps
-    assert '#include "conan_header_transitive.xcconfig"' in conandeps
+    assert '#include "conan_header_transitive.xcconfig"' not in conandeps
 
     # Verify that header_skip xcconfig files are NOT generated (skipped dependency)
     skip_files = [f for f in os.listdir(client.current_folder) if 'header_skip' in f and f.endswith('.xcconfig')]

--- a/test/integration/toolchains/apple/test_xcodedeps.py
+++ b/test/integration/toolchains/apple/test_xcodedeps.py
@@ -519,12 +519,12 @@ def test_dependency_of_dependency_components():
 
 def test_diamond_dependency_components():
     """
-    Diamond: math (with components vectors, matrices) is reached through two paths.
-    graphics has internal component deps (client -> common) and external (client -> math::vectors).
-    audio depends on all of math.
+    Diamond: math (with components vectors, matrices, geometry) is reached through two paths.
+    graphics::client requires math::vectors. audio::audio requires math::matrices.
+    geometry is not required by anyone and must not be inlined.
 
-    app -> engine -> graphics (client -> common, math::vectors) -> math (vectors, matrices)
-                  -> audio                                      -> math (vectors, matrices)
+    app -> engine -> graphics (client -> common, math::vectors) -> math (vectors, matrices, geometry)
+                  -> audio (requires math::matrices)            -> math (vectors, matrices, geometry)
     """
     client = TestClient()
     app = GenConanfile("app", "1.0").with_require("engine/1.0").with_settings("os", "arch", "build_type", "compiler")
@@ -558,6 +558,9 @@ def test_diamond_dependency_components():
             version = "1.0"
             settings = "os", "compiler", "build_type", "arch"
             requires = "math/1.0"
+            def package_info(self):
+                self.cpp_info.includedirs = ["include_audio"]
+                self.cpp_info.requires = ["math::matrices"]
         """)
 
     math = textwrap.dedent("""
@@ -569,6 +572,7 @@ def test_diamond_dependency_components():
             def package_info(self):
                 self.cpp_info.components["vectors"].includedirs = ["include_vectors"]
                 self.cpp_info.components["matrices"].includedirs = ["include_matrices"]
+                self.cpp_info.components["geometry"].includedirs = ["include_geometry"]
         """)
 
     client.save({
@@ -589,14 +593,15 @@ def test_diamond_dependency_components():
     arch = "arm64" if arch_setting == "armv8" else arch_setting
 
     # engine is the only direct dep of app — its props file must inline everything:
-    # graphics (common, client), audio, and all of math (vectors, matrices)
+    # graphics (common, client), audio, math::vectors (via graphics), math::matrices (via audio)
     engine_props = client.load(f"conan_engine_engine_release_{arch}.xcconfig")
     assert "include_common" in engine_props
     assert "include_client" in engine_props
+    assert "include_audio" in engine_props
     assert "include_vectors" in engine_props
     assert "include_matrices" in engine_props
-    # math::vectors is reached via both graphics and audio, but appears only once
-    assert engine_props.count("include_vectors") == 1
+    # math::geometry is not required by anyone, so it must NOT be inlined
+    assert "include_geometry" not in engine_props
 
     # no inter-package #includes in engine wrapper
     engine_xcconfig = client.load("conan_engine_engine.xcconfig")


### PR DESCRIPTION
Changelog: Fix: Inline transitive dependencies to avoid Xcode recursion crashes.
Docs: https://github.com/conan-io/docs/pull/4435
Closes: https://github.com/conan-io/conan/issues/19821

When projects have deep dependency trees with many components, XcodeDeps generates a large number of `xcconfig` files with nested `#include` chains. This causes Xcode's `SWBBuildService` to crash due to recursion depth, since `xcconfig` files lack include guards.

This PR changes XcodeDeps to inline all transitive `CppInfo` data (include dirs, libs, flags, etc.) directly into each component's conditional props file, eliminating inter-package `#include` directives. 

Additionally, xcconfig files are now only generated for direct dependencies, since transitive data is already inlined.
