### PR TITLE
Avoid detecting default package manager when overrided from profile

### DIFF
--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -26,7 +26,7 @@ class _SystemPackageManagerTool:
         :param conanfile: The current recipe object. Always use ``self``.
         """
         self._conanfile = conanfile
-        self._active_tool = self._conanfile.conf.get("tools.system.package_manager:tool", default=self.get_default_tool())
+        self._active_tool = self._conanfile.conf.get("tools.system.package_manager:tool") or self.get_default_tool()
         self._sudo = self._conanfile.conf.get("tools.system.package_manager:sudo", default=False, check_type=bool)
         self._sudo_askpass = self._conanfile.conf.get("tools.system.package_manager:sudo_askpass", default=False, check_type=bool)
         self._mode = self._conanfile.conf.get("tools.system.package_manager:mode", default=self.mode_check)

--- a/test/integration/tools/system/package_manager_test.py
+++ b/test/integration/tools/system/package_manager_test.py
@@ -84,6 +84,18 @@ def test_package_manager_distro(distro, tool):
                 assert tool == manager.get_default_tool()
 
 
+def test_conf_tool_skips_default_detection_message_on_unknown_distro():
+    """If ``tools.system.package_manager:tool`` is set, ``get_default_tool`` shall never be invoked"""
+    with mock.patch('conan.ConanFile.context', new_callable=PropertyMock) as context_mock:
+        context_mock.return_value = "host"
+        conanfile = ConanFileMock()
+        conanfile.settings = Settings()
+        conanfile.conf.define("tools.system.package_manager:tool", "apt-get")
+        with mock.patch.object(_SystemPackageManagerTool, "get_default_tool") as get_default_mock:
+            Apt(conanfile)
+        get_default_mock.assert_not_called()
+
+
 @pytest.mark.parametrize("sudo, sudo_askpass, expected_str", [
     (True, True, "sudo -A "),
     (True, False, "sudo "),


### PR DESCRIPTION
Changelog: Feature: Avoid detecting default package manager when overridden from profile 
Docs: omit

`ConfigAPI.get()` method does not provide a lazy callable default argument. So, in the case of the current code:

```py
self._conanfile.conf.get("tools.system.package_manager:tool", default=self.get_default_tool())
```
the `get_default_tool()` method is always called, no matter if the Conan configuration variable is present in the profiles. 
To avoid modifying the `ConfigAPI`, just call the method only if the config is not defined.

Added a test which detects if the method is called if the configuration is present in the conanfile.
 
Close https://github.com/conan-io/conan/issues/19812

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
