### PR TITLE
Add `--strict` flag to `conan remote auth`

### DIFF
--- a/conan/cli/commands/remote.py
+++ b/conan/cli/commands/remote.py
@@ -284,6 +284,8 @@ def remote_auth(conan_api, parser, subparser, *args):
     no CONAN_LOGIN* and CONAN_PASSWORD* variables available which could be used.
     Usually you'd use this method over conan remote login for scripting which needs to run in CI
     and locally.
+    By default, this command returns exit code 0 even if authentication fails for some remotes.
+    Use --strict to return exit code 1 if authentication fails for any remote.
     """
     subparser.add_argument("remote", help="Pattern or name of the remote/s to authenticate against."
                                           " The pattern uses 'fnmatch' style wildcards.")
@@ -296,6 +298,8 @@ def remote_auth(conan_api, parser, subparser, *args):
                                 "instance has anonymous access enabled and Conan would not ask "
                                 "for username and password even for non-anonymous repositories "
                                 "if not yet authenticated.")
+    subparser.add_argument("--strict", action="store_true",
+                           help="Return exit code 1 if authentication fails for any remote.")
     args = parser.parse_args(*args)
     remotes = conan_api.remotes.list(pattern=args.remote)
     if not remotes:
@@ -307,6 +311,11 @@ def remote_auth(conan_api, parser, subparser, *args):
             results[r.name] = {"user": conan_api.remotes.user_auth(r, args.with_user, args.force)}
         except Exception as e:
             results[r.name] = {"error": str(e)}
+
+    if args.strict:
+        failed = [name for name, v in results.items() if "error" in v]
+        if failed:
+            raise ConanException("Authentication error in remotes: {}".format(", ".join(failed)))
     return results
 
 

--- a/test/integration/command/remote/test_remote_users.py
+++ b/test/integration/command/remote/test_remote_users.py
@@ -467,12 +467,19 @@ class TestRemoteAuth:
         c.run("remote auth * --strict")
         assert "user: myuser" in c.out
 
-        # Partial failure -> exit != 0, reports failed remotes
+        # Partial failure without --strict -> exit 0
         c2 = TestClient(light=True, servers=servers,
                         inputs=["myuser", "mypassword",
                                 "wrong", "wrong", "wrong", "wrong", "wrong", "wrong"])
-        c2.run("remote auth * --strict", assert_error=True)
-        assert "Authentication error in remotes: bad" in c2.out
+        c2.run("remote auth *")
+        assert "error" in c2.out
+
+        # Partial failure with --strict -> exit != 0
+        c3 = TestClient(light=True, servers=servers,
+                        inputs=["myuser", "mypassword",
+                                "wrong", "wrong", "wrong", "wrong", "wrong", "wrong"])
+        c3.run("remote auth * --strict", assert_error=True)
+        assert "Authentication error in remotes: bad" in c3.out
 
     def test_auth_after_logout(self):
         server = TestServer(users={"myuser": "password"})

--- a/test/integration/command/remote/test_remote_users.py
+++ b/test/integration/command/remote/test_remote_users.py
@@ -456,6 +456,24 @@ class TestRemoteAuth:
         c.run("remote auth *")
         assert "error: Too many failed login attempts, bye!" in c.out
 
+    def test_remote_auth_strict(self):
+        servers = {
+            "good": TestServer(users={"myuser": "mypassword"}),
+            "bad": TestServer(users={"myuser": "mypassword"}),
+        }
+        # All succeed -> exit 0
+        c = TestClient(light=True, servers=servers,
+                       inputs=["myuser", "mypassword", "myuser", "mypassword"])
+        c.run("remote auth * --strict")
+        assert "user: myuser" in c.out
+
+        # Partial failure -> exit != 0, reports failed remotes
+        c2 = TestClient(light=True, servers=servers,
+                        inputs=["myuser", "mypassword",
+                                "wrong", "wrong", "wrong", "wrong", "wrong", "wrong"])
+        c2.run("remote auth * --strict", assert_error=True)
+        assert "Authentication error in remotes: bad" in c2.out
+
     def test_auth_after_logout(self):
         server = TestServer(users={"myuser": "password"})
         c = TestClient(light=True, servers={"default": server}, inputs=["myuser", "password"]*2)


### PR DESCRIPTION
Changelog: Feature: Add --strict flag to `conan remote auth`.
Docs: https://github.com/conan-io/docs/pull/4434

Closes: https://github.com/conan-io/conan/issues/19813

- Add `--strict` flag to `conan remote auth` that returns exit code 1 if authentication fails for any matched remote
- Without `--strict`, the command keeps the current behavior (exit 0 even if some remotes fail)
