### PR TITLE
Deprecate `build_requires`, fix `VirtualBuildEnv`'s bindir propagation based on requirement `run` trait 

### DIFF
--- a/conan/internal/methods.py
+++ b/conan/internal/methods.py
@@ -132,6 +132,11 @@ def run_configure_method(conanfile, down_options, profile_options, ref):
         with conanfile_exception_formatter(conanfile, "build_requirements"):
             conanfile.build_requirements()
 
+    if conanfile.build_requires._called:  # noqa
+        conanfile.output.warning(
+            "build_requires is deprecated, prefer to use tool_requires with correct traits",
+            warn_tag="deprecated")
+
 
 def auto_shared_fpic_config_options(conanfile):
     if conanfile.settings.get_safe("os") == "Windows":

--- a/conan/internal/model/conan_file.py
+++ b/conan/internal/model/conan_file.py
@@ -105,6 +105,10 @@ class ConanFile:
             self.settings = [self.settings]
         self.requires = Requirements(self.requires, self.build_requires, self.test_requires,
                                      self.tool_requires)
+        if self.build_requires:
+            self.output.warning(
+                "build_requires is deprecated, prefer to use tool_requires with correct traits",
+                warn_tag="deprecated")
 
         self.options = Options(self.options or {}, self.default_options)
 

--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -21,7 +21,7 @@ required_conan_version_msg = """\
 Raise if current version does not match the defined range.
 Applies the following behaviors based on the minimum specified version:
    - If required_conan_version>=2.28, bugfix https://github.com/conan-io/conan/pull/19705 for transitive static libraries package_id
-   - If required_conan_version>=2.28, bugfix https://github.com/conan-io/conan/pull/19849 for VirtualBuildEnv path propagation based on requirement run trait
+   - If required_conan_version>=2.28, bugfix https://github.com/conan-io/conan/pull/19849 for VirtualBuildEnv bindir path propagation based on requirement run trait
    These behaviors also apply for 'required_conan_version' in recipes, but the global one has precedence.
 """
 

--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -19,8 +19,11 @@ from conan.internal.util.files import load, save
 
 required_conan_version_msg = """\
 Raise if current version does not match the defined range.
-   - If required_conan_version>=2.28, bugfix https://github.com/conan-io/conan/pull/19705 for transitive static libraries package_id is applied
-   These behaviors also apply for 'required_conan_version' in recipes, but the global one has precedence."""
+Applies the following behaviors based on the minimum specified version:
+   - If required_conan_version>=2.28, bugfix https://github.com/conan-io/conan/pull/19705 for transitive static libraries package_id
+   - If required_conan_version>=2.28, bugfix https://github.com/conan-io/conan/pull/19849 for VirtualBuildEnv path propagation based on requirement run trait
+   These behaviors also apply for 'required_conan_version' in recipes, but the global one has precedence.
+"""
 
 BUILT_IN_CONFS = {
     "core:required_conan_version": required_conan_version_msg,

--- a/conan/internal/model/requires.py
+++ b/conan/internal/model/requires.py
@@ -418,9 +418,11 @@ class BuildRequirements:
     # Just a wrapper around requires for backwards compatibility with self.build_requires() syntax
     def __init__(self, requires):
         self._requires = requires
+        self._called = False
 
     def __call__(self, ref, package_id_mode=None, visible=False, run=None, options=None,
                  override=None):
+        self._called = True
         # TODO: Check which arguments could be user-defined
         self._requires.build_require(ref, package_id_mode=package_id_mode, visible=visible, run=run,
                                      options=options, override=override)
@@ -513,7 +515,6 @@ class Requirements:
     def values(self):
         return self._requires.values()
 
-    # TODO: Plan the interface for smooth transition from 1.X
     def __call__(self, str_ref, **kwargs):
         if str_ref is None:
             return

--- a/conan/tools/env/virtualbuildenv.py
+++ b/conan/tools/env/virtualbuildenv.py
@@ -100,7 +100,10 @@ class VirtualBuildEnv:
 def _compute_propagate_run(conanfile):
     from conan.tools.scm import Version
     from conan.internal.model.version_range import VersionRange
-    global_required_conan = conanfile._conan_helpers.global_conf.get("core:required_conan_version")  # noqa
+    try:
+        global_required_conan = conanfile._conan_helpers.global_conf.get("core:required_conan_version")  # noqa
+    except AttributeError:
+        return False  # This can happen for virtual conanfiles without helpers
     recipe_require_conan_version = global_required_conan or conanfile._conan_required_version  # noqa
     if recipe_require_conan_version:
         version_range = VersionRange(recipe_require_conan_version)

--- a/conan/tools/env/virtualbuildenv.py
+++ b/conan/tools/env/virtualbuildenv.py
@@ -97,7 +97,7 @@ class VirtualBuildEnv:
         build_env.vars(self._conanfile, scope=scope).save_script(self._filename)
 
 
-def _compute_propagate_run(conanfile):
+def _skip_propagate_run(conanfile):
     from conan.tools.scm import Version
     from conan.internal.model.version_range import VersionRange
     try:

--- a/conan/tools/env/virtualbuildenv.py
+++ b/conan/tools/env/virtualbuildenv.py
@@ -63,7 +63,7 @@ class VirtualBuildEnv:
             if build_require.runenv_info:
                 self._buildenv.compose_env(build_require.runenv_info)
             # Then the implicit
-            if require.run or _propagate_run(self_conanfile):
+            if require.run or _propagate_run(self._conanfile):
                 os_name = self._conanfile.settings_build.get_safe("os")
                 self._buildenv.compose_env(runenv_from_cpp_info(build_require, os_name))
 

--- a/conan/tools/env/virtualbuildenv.py
+++ b/conan/tools/env/virtualbuildenv.py
@@ -63,8 +63,13 @@ class VirtualBuildEnv:
             if build_require.runenv_info:
                 self._buildenv.compose_env(build_require.runenv_info)
             # Then the implicit
-            os_name = self._conanfile.settings_build.get_safe("os")
-            self._buildenv.compose_env(runenv_from_cpp_info(build_require, os_name))
+            propagate_runenv = True
+            if _compute_propagate_run(self._conanfile):
+                if not require.run:
+                    propagate_runenv = False
+            if propagate_runenv:
+                os_name = self._conanfile.settings_build.get_safe("os")
+                self._buildenv.compose_env(runenv_from_cpp_info(build_require, os_name))
 
         # Requires in host context can also bring some direct buildenv_info
         host_requires = self._conanfile.dependencies.host.topological_sort
@@ -90,3 +95,17 @@ class VirtualBuildEnv:
         check_duplicated_generator(self, self._conanfile)
         build_env = self.environment()
         build_env.vars(self._conanfile, scope=scope).save_script(self._filename)
+
+
+def _compute_propagate_run(conanfile):
+    # fix for transitive static libraries
+    from conan.tools.scm import Version
+    from conan.internal.model.version_range import VersionRange
+    global_required_conan = conanfile._conan_helpers.global_conf.get("core:required_conan_version")  # noqa
+    recipe_require_conan_version = global_required_conan or conanfile._conan_required_version  # noqa
+    if recipe_require_conan_version:
+        version_range = VersionRange(recipe_require_conan_version)
+        for conditions in version_range.condition_sets:
+            conditions.prerelease = True
+        return not version_range.contains(Version("2.27.9"), resolve_prerelease=None)
+    return False

--- a/conan/tools/env/virtualbuildenv.py
+++ b/conan/tools/env/virtualbuildenv.py
@@ -63,7 +63,7 @@ class VirtualBuildEnv:
             if build_require.runenv_info:
                 self._buildenv.compose_env(build_require.runenv_info)
             # Then the implicit
-            if require.run or not _skip_propagate_run(self_conanfile):
+            if require.run or _propagate_run(self_conanfile):
                 os_name = self._conanfile.settings_build.get_safe("os")
                 self._buildenv.compose_env(runenv_from_cpp_info(build_require, os_name))
 
@@ -93,17 +93,17 @@ class VirtualBuildEnv:
         build_env.vars(self._conanfile, scope=scope).save_script(self._filename)
 
 
-def _skip_propagate_run(conanfile):
+def _propagate_run(conanfile):
     from conan.tools.scm import Version
     from conan.internal.model.version_range import VersionRange
     try:
         global_required_conan = conanfile._conan_helpers.global_conf.get("core:required_conan_version")  # noqa
     except AttributeError:
-        return False  # This can happen for virtual conanfiles without helpers
+        return True  # This can happen for virtual conanfiles without helpers
     recipe_require_conan_version = global_required_conan or conanfile._conan_required_version  # noqa
     if recipe_require_conan_version:
         version_range = VersionRange(recipe_require_conan_version)
         for conditions in version_range.condition_sets:
             conditions.prerelease = True
-        return not version_range.contains(Version("2.27.9"), resolve_prerelease=None)
-    return False
+        return version_range.contains(Version("2.27.9"), resolve_prerelease=None)
+    return True

--- a/conan/tools/env/virtualbuildenv.py
+++ b/conan/tools/env/virtualbuildenv.py
@@ -63,11 +63,7 @@ class VirtualBuildEnv:
             if build_require.runenv_info:
                 self._buildenv.compose_env(build_require.runenv_info)
             # Then the implicit
-            propagate_runenv = True
-            if _compute_propagate_run(self._conanfile):
-                if not require.run:
-                    propagate_runenv = False
-            if propagate_runenv:
+            if require.run or not _skip_propagate_run(self_conanfile):
                 os_name = self._conanfile.settings_build.get_safe("os")
                 self._buildenv.compose_env(runenv_from_cpp_info(build_require, os_name))
 

--- a/conan/tools/env/virtualbuildenv.py
+++ b/conan/tools/env/virtualbuildenv.py
@@ -98,7 +98,6 @@ class VirtualBuildEnv:
 
 
 def _compute_propagate_run(conanfile):
-    # fix for transitive static libraries
     from conan.tools.scm import Version
     from conan.internal.model.version_range import VersionRange
     global_required_conan = conanfile._conan_helpers.global_conf.get("core:required_conan_version")  # noqa

--- a/test/integration/build_requires/build_requires_test.py
+++ b/test/integration/build_requires/build_requires_test.py
@@ -768,3 +768,59 @@ def test_transitive_build_scripts_library_error():
     c.run("install --requires=tool/0.1", assert_error=True)
     assert ("ERROR: Package 'tool/0.1' with type 'build-scripts' cannot have "
             "a 'static-library' dependency to 'dep/0.1'") in c.out
+
+
+@pytest.mark.parametrize("min_conan_version, should_propagate", [
+    (None, True),
+    ("*", True),
+    (">=2.5", True),
+    (">=2.28", False),
+])
+def test_build_run_false(min_conan_version, should_propagate):
+    required_conan_version_line = ""
+    if min_conan_version:
+        required_conan_version_line = f"required_conan_version='{min_conan_version}'"
+    tc = TestClient(light=True)
+    cmake = textwrap.dedent("""
+    from conan import ConanFile
+    from conan.tools.files import save
+    import os
+
+    class CMake(ConanFile):
+        name = "mycmake"
+        version = "1.0"
+        settings = "os"
+
+        def package(self):
+            echo = "echo MYCMAKE!!!"
+            save(self, os.path.join(self.package_folder, "bin", "mycmake.sh"), echo)
+            save(self, os.path.join(self.package_folder, "bin", "mycmake.bat"), echo)
+            os.chmod(os.path.join(self.package_folder, "bin", "mycmake.sh"), 0o777)
+    """)
+
+    consumer = textwrap.dedent(f"""
+    from conan import ConanFile
+    import platform
+    {required_conan_version_line}
+
+    class Pkg(ConanFile):
+        name = "pkg"
+        version = "0.1"
+        settings = "os"
+
+        def build_requirements(self):
+            self.tool_requires("mycmake/1.0", run=False)
+
+        def build(self):
+            cmd = "mycmake.bat" if platform.system() == "Windows" else "mycmake.sh"
+            self.run(cmd)
+    """)
+    tc.save({"consumer/conanfile.py": consumer,
+             "cmake/conanfile.py": cmake})
+    tc.run("create cmake")
+    tc.run("create consumer", assert_error=not should_propagate)
+    if should_propagate:
+        assert "MYCMAKE!!!" in tc.out
+    else:
+        assert "MYCMAKE!!!" not in tc.out
+        assert "Error in build() method" in tc.out

--- a/test/integration/build_requires/build_requires_test.py
+++ b/test/integration/build_requires/build_requires_test.py
@@ -780,7 +780,7 @@ def test_build_run_false(min_conan_version, should_propagate):
     required_conan_version_line = ""
     if min_conan_version:
         required_conan_version_line = f"required_conan_version='{min_conan_version}'"
-    tc = TestClient(light=True)
+    tc = TestClient()
     cmake = textwrap.dedent("""
     from conan import ConanFile
     from conan.tools.files import save

--- a/test/integration/graph/test_require_same_pkg_versions.py
+++ b/test/integration/graph/test_require_same_pkg_versions.py
@@ -13,7 +13,7 @@ def test_require_different_versions(min_conan_version):
 
     https://github.com/conan-io/conan/issues/13521
     """
-    c = TestClient(light=True)
+    c = TestClient()
     required_conan_version_line = ""
     if min_conan_version:
         required_conan_version_line = f"required_conan_version='{min_conan_version}'"

--- a/test/integration/graph/test_require_same_pkg_versions.py
+++ b/test/integration/graph/test_require_same_pkg_versions.py
@@ -1,17 +1,22 @@
 import re
 import textwrap
+import pytest
 
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
 
 
-def test_require_different_versions():
+@pytest.mark.parametrize("min_conan_version", [None, ">=2.28"])
+def test_require_different_versions(min_conan_version):
     """ this test demostrates that it is possible to tool_require different versions
     of the same thing, deactivating run=False (as long as their executables are not called the same)
 
     https://github.com/conan-io/conan/issues/13521
     """
-    c = TestClient()
+    c = TestClient(light=True)
+    required_conan_version_line = ""
+    if min_conan_version:
+        required_conan_version_line = f"required_conan_version='{min_conan_version}'"
     gcc = textwrap.dedent(r"""
         import os
         from conan import ConanFile
@@ -24,10 +29,13 @@ def test_require_different_versions():
                 save(self, os.path.join(self.package_folder, "bin", f"mygcc{self.version}.sh"), echo)
                 os.chmod(os.path.join(self.package_folder, "bin", f"mygcc{self.version}.sh"), 0o777)
             """)
-    wine = textwrap.dedent("""
+    wine = textwrap.dedent(f"""
         import os, platform
         from conan import ConanFile
         from conan.tools.files import save, chdir
+        from conan.tools.env import VirtualBuildEnv
+        {required_conan_version_line}
+
         class Pkg(ConanFile):
             name = "wine"
             version = "1.0"
@@ -40,11 +48,19 @@ def test_require_different_versions():
                 assert gcc1.ref.version == "1.0"
                 gcc2 = self.dependencies.build["gcc/2.0"]
                 assert gcc2.ref.version == "2.0"
+                # In the new behaviour enabled in newer versions,
+                # we have a way to bring back both bindirs to the path
+                if {bool(required_conan_version_line)}:
+                    venv = VirtualBuildEnv(self)
+                    env = venv.environment()
+                    env.prepend_path("PATH", gcc1.cpp_info.bindir)
+                    env.prepend_path("PATH", gcc2.cpp_info.bindir)
+                    venv.generate()
 
             def build(self):
                 ext = "bat" if platform.system() == "Windows" else "sh"
-                self.run(f"mygcc1.0.{ext}")
-                self.run(f"mygcc2.0.{ext}")
+                self.run(f"mygcc1.0.{{ext}}")
+                self.run(f"mygcc2.0.{{ext}}")
             """)
     c.save({"gcc/conanfile.py": gcc,
             "wine/conanfile.py": wine})


### PR DESCRIPTION
Changelog: Fix: Deprecate ``build_requires``, use ``tool_requires`` instead
Changelog: Bugfix: Change propagation on bindirs for ``VirtualBuildEnv`` respecting requirement ``run`` trait, based on the new ``required_conan_version=">=2.28"`` recipe version or ``global.conf`` using ``core:policies=["required_conan_version>=2.28"]``
Docs: https://github.com/conan-io/docs/pull/4431


<img width="1060" height="224" alt="image" src="https://github.com/user-attachments/assets/3c259915-89c5-454c-ba62-95b402d1f5ac" />
