### PR TITLE
Allow patterns in `--update` flag

### DIFF
--- a/conan/cli/args.py
+++ b/conan/cli/args.py
@@ -54,10 +54,12 @@ def add_common_install_arguments(parser):
                                  help='Do not use remote, resolve exclusively in the cache')
 
     update_help = ("Will install newer versions and/or revisions in the local cache "
-                   "for the given reference name, or all references in the graph if no argument is supplied. "
+                   "for the given references whose name matches the given pattern, "
+                   "or all references in the graph if no argument is supplied. "
                    "When using version ranges, it will install the latest version that "
                    "satisfies the range. It will update to the "
-                   "latest revision for the resolved version range.")
+                   "latest revision for the resolved version range. "
+                   "The consumer pattern (&) has no effect, and users should not specify versions.")
 
     group.add_argument("-u", "--update", action="append", nargs="?", help=update_help, const="*")
     add_profiles_args(parser)

--- a/conan/internal/graph/proxy.py
+++ b/conan/internal/graph/proxy.py
@@ -1,3 +1,5 @@
+from fnmatch import fnmatch
+
 from conan.api.output import ConanOutput
 from conan.internal.cache.conan_reference_layout import BasicLayout
 from conan.internal.graph.graph import (RECIPE_DOWNLOADED, RECIPE_INCACHE, RECIPE_NEWER,
@@ -180,4 +182,5 @@ def should_update_reference(reference, update):
     if isinstance(update, bool):
         return update
     # Legacy syntax had --update without pattern, it manifests as a "*" pattern
-    return any(name == "*" or reference.name == name for name in update)
+    return any(fnmatch(reference.name, pattern)
+               for pattern in update)

--- a/test/integration/cache/cache2_update_test.py
+++ b/test/integration/cache/cache2_update_test.py
@@ -443,9 +443,6 @@ class TestUpdateFlows:
 
 @pytest.mark.parametrize("update,result",
                          [
-                             # Not a real pattern, works to support legacy syntax
-                             ["*", {"liba/1.1": "Downloaded (default)",
-                                    "libb/1.1": "Downloaded (default)"}],
                              ["libc", {"liba/1.0": "Cache",
                                        "libb/1.0": "Cache"}],
                              ["liba", {"liba/1.1": "Downloaded (default)",
@@ -458,11 +455,17 @@ class TestUpdateFlows:
                                                                             "libb/1.0": "Cache"}],
                              ["", {"liba/1.0": "Cache",
                                    "libb/1.0": "Cache"}],
-                             # Patterns not supported, only full name match
-                             ["lib*", {"liba/1.0": "Cache",
-                                       "libb/1.0": "Cache"}],
-                             ["liba/*", {"liba/1.0": "Cache",
-                                         "libb/1.0": "Cache"}],
+                             # Patterns supported
+                             ["*", {"liba/1.1": "Downloaded (default)",
+                                    "libb/1.1": "Downloaded (default)"}],
+                             ["lib*", {"liba/1.1": "Downloaded (default)",
+                                       "libb/1.1": "Downloaded (default)"}],
+                             # But not version ones
+                             # ["liba/*", {"liba/1.1": "Downloaded (default)",
+                             #             "libb/1.0": "Cache"}],
+                             # But not consumer
+                             ["&", {"liba/1.0": "Cache",
+                                    "libb/1.0": "Cache"}],
                              # None only passes legacy --update without args,
                              # to ensure it works, it should be the same as passing *
                              [None, {"liba/1.1": "Downloaded (default)",

--- a/test/integration/cache/cache2_update_test.py
+++ b/test/integration/cache/cache2_update_test.py
@@ -443,6 +443,8 @@ class TestUpdateFlows:
 
 @pytest.mark.parametrize("update,result",
                          [
+                             ["*", {"liba/1.1": "Downloaded (default)",
+                                    "libb/1.1": "Downloaded (default)"}],
                              ["libc", {"liba/1.0": "Cache",
                                        "libb/1.0": "Cache"}],
                              ["liba", {"liba/1.1": "Downloaded (default)",
@@ -455,17 +457,11 @@ class TestUpdateFlows:
                                                                             "libb/1.0": "Cache"}],
                              ["", {"liba/1.0": "Cache",
                                    "libb/1.0": "Cache"}],
-                             # Patterns supported
-                             ["*", {"liba/1.1": "Downloaded (default)",
-                                    "libb/1.1": "Downloaded (default)"}],
+                             # Patterns supported, but only on name
                              ["lib*", {"liba/1.1": "Downloaded (default)",
                                        "libb/1.1": "Downloaded (default)"}],
-                             # But not version ones
-                             # ["liba/*", {"liba/1.1": "Downloaded (default)",
-                             #             "libb/1.0": "Cache"}],
-                             # But not consumer
-                             ["&", {"liba/1.0": "Cache",
-                                    "libb/1.0": "Cache"}],
+                             ["liba/*", {"liba/1.0": "Cache",
+                                         "libb/1.0": "Cache"}],
                              # None only passes legacy --update without args,
                              # to ensure it works, it should be the same as passing *
                              [None, {"liba/1.1": "Downloaded (default)",


### PR DESCRIPTION
Changelog: Feature: Allow patterns for recipe names in `--update` flag
Docs: Omit