### PR TITLE
Forward underlying system package manager error messages

### DIFF
--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -115,13 +115,8 @@ class _SystemPackageManagerTool:
         ret = self._conanfile.run(command, ignore_errors=True, quiet=quiet, stdout=stdout_buf, stderr=stderr_buf)
         if ret not in accepted_returns:
             msg = f"Command '{command}' failed with exit code {ret}"
-            if quiet:
-                err = stderr_buf.getvalue().strip()
-                out = stdout_buf.getvalue().strip()
-                if err:
-                    msg += f"\nstderr:\n{err}"
-                if out:
-                    msg += f"\nstdout:\n{out}"
+            msg += f"\nstderr:\n{stderr_buf.getvalue().strip()}" if stderr_buf is not None else ""
+            msg += f"\nstdout:\n{stdout_buf.getvalue().strip()}" if stdout_buf is not None else ""
             raise ConanException(msg)
         return ret
 

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -1,5 +1,5 @@
 import platform
-import shutil
+from io import StringIO
 
 from conan.tools.build import cross_building
 from conan.internal.graph.graph import CONTEXT_BUILD
@@ -28,7 +28,6 @@ class _SystemPackageManagerTool:
         """
         self._conanfile = conanfile
         self._active_tool = self._conanfile.conf.get("tools.system.package_manager:tool") or self.get_default_tool()
-        self._check_package_manager_in_path()
         self._sudo = self._conanfile.conf.get("tools.system.package_manager:sudo", default=False, check_type=bool)
         self._sudo_askpass = self._conanfile.conf.get("tools.system.package_manager:sudo_askpass", default=False, check_type=bool)
         self._mode = self._conanfile.conf.get("tools.system.package_manager:mode", default=self.mode_check)
@@ -68,20 +67,10 @@ class _SystemPackageManagerTool:
                 if d in os_name:
                     return tool
 
-
-    def _check_package_manager_in_path(self):
-        if not self._active_tool:
-            raise ConanException(
-                "System requirements: A default system package manager couldn't be found in your system. "
-                "Verify your installation or define the package manager to use with "
-                "'tools.system.package_manager:tool' configuration."
-            )
-        if not shutil.which(self._active_tool):
-            raise ConanException(
-                f"System requirements: '{self.tool_name}' is not found in PATH, system packages cannot be installed. "
-                f"Please install '{self.tool_name}' or change the package manager tool using "
-                f"'tools.system.package_manager:tool' configuration."
-            )
+        # No default package manager was found for the system,
+        # so notify the user
+        self._conanfile.output.info("A default system package manager couldn't be found for {}, "
+                                    "system packages will not be installed.".format(os_name))
 
     def _split_package_name(self, package, host_package):
 
@@ -120,9 +109,24 @@ class _SystemPackageManagerTool:
 
     def _conanfile_run(self, command, accepted_returns, quiet=True):
         # When checking multiple packages, this is too noisy
-        ret = self._conanfile.run(command, ignore_errors=True, quiet=quiet)
+        # Capture output and show it only on failure.
+        if quiet:
+            stdout_buf = StringIO()
+            stderr_buf = StringIO()
+            ret = self._conanfile.run(command, ignore_errors=True, quiet=quiet,
+                                      stdout=stdout_buf, stderr=stderr_buf)
+        else:
+            ret = self._conanfile.run(command, ignore_errors=True, quiet=quiet)
         if ret not in accepted_returns:
-            raise ConanException("Command '%s' failed" % command)
+            msg = f"Command '{command}' failed with exit code {ret}"
+            if quiet:
+                err = stderr_buf.getvalue().strip()
+                out = stdout_buf.getvalue().strip()
+                if err:
+                    msg += f"\nstderr:\n{err}"
+                if out:
+                    msg += f"\nstdout:\n{out}"
+            raise ConanException(msg)
         return ret
 
     def install_substitutes(self, *args, **kwargs):

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -115,8 +115,10 @@ class _SystemPackageManagerTool:
         ret = self._conanfile.run(command, ignore_errors=True, quiet=quiet, stdout=stdout_buf, stderr=stderr_buf)
         if ret not in accepted_returns:
             msg = f"Command '{command}' failed with exit code {ret}"
-            msg += f"\nstderr:\n{stderr_buf.getvalue().strip()}" if stderr_buf is not None else ""
-            msg += f"\nstdout:\n{stdout_buf.getvalue().strip()}" if stdout_buf is not None else ""
+            if stderr_buf is not None and stderr_buf.getvalue():
+                msg += f"\nstderr: {stderr_buf.getvalue().strip()}"
+            if stdout_buf is not None and stdout_buf.getvalue():
+                msg += f"\nstdout: {stdout_buf.getvalue().strip()}"
             raise ConanException(msg)
         return ret
 

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -1,4 +1,5 @@
 import platform
+import shutil
 
 from conan.tools.build import cross_building
 from conan.internal.graph.graph import CONTEXT_BUILD
@@ -27,6 +28,7 @@ class _SystemPackageManagerTool:
         """
         self._conanfile = conanfile
         self._active_tool = self._conanfile.conf.get("tools.system.package_manager:tool") or self.get_default_tool()
+        self._check_package_manager_in_path()
         self._sudo = self._conanfile.conf.get("tools.system.package_manager:sudo", default=False, check_type=bool)
         self._sudo_askpass = self._conanfile.conf.get("tools.system.package_manager:sudo_askpass", default=False, check_type=bool)
         self._mode = self._conanfile.conf.get("tools.system.package_manager:mode", default=self.mode_check)
@@ -66,10 +68,20 @@ class _SystemPackageManagerTool:
                 if d in os_name:
                     return tool
 
-        # No default package manager was found for the system,
-        # so notify the user
-        self._conanfile.output.info("A default system package manager couldn't be found for {}, "
-                                    "system packages will not be installed.".format(os_name))
+
+    def _check_package_manager_in_path(self):
+        if not self._active_tool:
+            raise ConanException(
+                "System requirements: A default system package manager couldn't be found in your system. "
+                "Verify your installation or define the package manager to use with "
+                "'tools.system.package_manager:tool' configuration."
+            )
+        if not shutil.which(self._active_tool):
+            raise ConanException(
+                f"System requirements: '{self.tool_name}' is not found in PATH, system packages cannot be installed. "
+                f"Please install '{self.tool_name}' or change the package manager tool using "
+                f"'tools.system.package_manager:tool' configuration."
+            )
 
     def _split_package_name(self, package, host_package):
 

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -110,13 +110,9 @@ class _SystemPackageManagerTool:
     def _conanfile_run(self, command, accepted_returns, quiet=True):
         # When checking multiple packages, this is too noisy
         # Capture output and show it only on failure.
-        if quiet:
-            stdout_buf = StringIO()
-            stderr_buf = StringIO()
-            ret = self._conanfile.run(command, ignore_errors=True, quiet=quiet,
-                                      stdout=stdout_buf, stderr=stderr_buf)
-        else:
-            ret = self._conanfile.run(command, ignore_errors=True, quiet=quiet)
+        stdout_buf = StringIO() if quiet else None
+        stderr_buf = StringIO() if quiet else None
+        ret = self._conanfile.run(command, ignore_errors=True, quiet=quiet, stdout=stdout_buf, stderr=stderr_buf)
         if ret not in accepted_returns:
             msg = f"Command '{command}' failed with exit code {ret}"
             if quiet:

--- a/test/functional/tools/system/package_manager_test.py
+++ b/test/functional/tools/system/package_manager_test.py
@@ -146,9 +146,6 @@ def test_brew_install_install_mode():
     assert "Error: No formulae found in taps." in client.out
 
 
-@pytest.mark.tool("brew")
-@pytest.mark.skipif(platform.system() != "Darwin", reason="Requires brew")
-@pytest.mark.skip(reason="brew update takes a lot of time")
 def test_collect_system_requirements():
     """ we can know the system_requires for every package because they are part of the graph,
     this naturally execute at ``install``, but we can also prove that with ``graph info`` we can

--- a/test/functional/tools/system/package_manager_test.py
+++ b/test/functional/tools/system/package_manager_test.py
@@ -146,6 +146,9 @@ def test_brew_install_install_mode():
     assert "Error: No formulae found in taps." in client.out
 
 
+@pytest.mark.tool("brew")
+@pytest.mark.skipif(platform.system() != "Darwin", reason="Requires brew")
+@pytest.mark.skip(reason="brew update takes a lot of time")
 def test_collect_system_requirements():
     """ we can know the system_requires for every package because they are part of the graph,
     this naturally execute at ``install``, but we can also prove that with ``graph info`` we can

--- a/test/integration/tools/system/package_manager_test.py
+++ b/test/integration/tools/system/package_manager_test.py
@@ -96,6 +96,37 @@ def test_conf_tool_skips_default_detection_message_on_unknown_distro():
         get_default_mock.assert_not_called()
 
 
+def test_no_default_package_manager_raises():
+    """When no tool is configured and default detection yields nothing, fail early."""
+    with mock.patch('conan.ConanFile.context', new_callable=PropertyMock) as context_mock:
+        context_mock.return_value = "host"
+        conanfile = ConanFileMock()
+        conanfile.settings = Settings()
+        with mock.patch.object(_SystemPackageManagerTool, "get_default_tool", return_value=None):
+            with pytest.raises(ConanException) as exc_info:
+                Apt(conanfile)
+    msg = str(exc_info.value)
+    assert "default system package manager couldn't be found" in msg
+    assert "tools.system.package_manager:tool" in msg
+
+
+@pytest.mark.parametrize("tool_class", [Apt, Apk, Brew])
+def test_package_manager_binary_not_in_path_raises(tool_class):
+    """When the resolved tool is absent from PATH, construction must raise ConanException."""
+    conanfile = ConanFileMock()
+    conanfile.settings = Settings()
+    conanfile.conf.define("tools.system.package_manager:tool", tool_class.tool_name)
+    with mock.patch('conan.ConanFile.context', new_callable=PropertyMock) as context_mock:
+        context_mock.return_value = "host"
+        with mock.patch("conan.tools.system.package_manager.shutil.which", return_value=None):
+            with pytest.raises(ConanException) as exc_info:
+                tool_class(conanfile)
+    msg = str(exc_info.value)
+    assert "not found in PATH" in msg
+    assert "tools.system.package_manager:tool" in msg
+    assert tool_class.tool_name in msg
+
+
 @pytest.mark.parametrize("sudo, sudo_askpass, expected_str", [
     (True, True, "sudo -A "),
     (True, False, "sudo "),

--- a/test/integration/tools/system/package_manager_test.py
+++ b/test/integration/tools/system/package_manager_test.py
@@ -95,36 +95,34 @@ def test_conf_tool_skips_default_detection_message_on_unknown_distro():
             Apt(conanfile)
         get_default_mock.assert_not_called()
 
-
-def test_no_default_package_manager_raises():
-    """When no tool is configured and default detection yields nothing, fail early."""
-    with mock.patch('conan.ConanFile.context', new_callable=PropertyMock) as context_mock:
-        context_mock.return_value = "host"
-        conanfile = ConanFileMock()
-        conanfile.settings = Settings()
-        with mock.patch.object(_SystemPackageManagerTool, "get_default_tool", return_value=None):
-            with pytest.raises(ConanException) as exc_info:
-                Apt(conanfile)
-    msg = str(exc_info.value)
-    assert "default system package manager couldn't be found" in msg
-    assert "tools.system.package_manager:tool" in msg
-
-
-@pytest.mark.parametrize("tool_class", [Apt, Apk, Brew])
-def test_package_manager_binary_not_in_path_raises(tool_class):
-    """When the resolved tool is absent from PATH, construction must raise ConanException."""
+@pytest.mark.parametrize("use_quiet_check", [True, False])
+def test_package_manager_not_found(use_quiet_check):
+    """Failed runs surface the shell's error (e.g. command not found) when output is captured."""
     conanfile = ConanFileMock()
     conanfile.settings = Settings()
-    conanfile.conf.define("tools.system.package_manager:tool", tool_class.tool_name)
+    conanfile.conf.define("tools.system.package_manager:tool", "apt-get")
+    conanfile.conf.define("tools.system.package_manager:mode", "install")
+
+    def fake_run(command, stdout=None, stderr=None, ignore_errors=False, env="", quiet=False, **kwargs):
+        if quiet and stderr is not None:
+            stderr.write("sh: apt-get: command not found\n")
+        return 127
+
+    conanfile.run = fake_run
     with mock.patch('conan.ConanFile.context', new_callable=PropertyMock) as context_mock:
         context_mock.return_value = "host"
-        with mock.patch("conan.tools.system.package_manager.shutil.which", return_value=None):
-            with pytest.raises(ConanException) as exc_info:
-                tool_class(conanfile)
+        tool = Apt(conanfile)
+        with pytest.raises(ConanException) as exc_info:
+            if use_quiet_check:
+                tool.check(["pkg"])
+            else:
+                tool.install(["pkg"], check=False)
+
     msg = str(exc_info.value)
-    assert "not found in PATH" in msg
-    assert "tools.system.package_manager:tool" in msg
-    assert tool_class.tool_name in msg
+    assert "failed with exit code 127" in msg
+    if use_quiet_check:
+        assert "stderr:" in msg
+        assert "sh: apt-get: command not found" in msg
 
 
 @pytest.mark.parametrize("sudo, sudo_askpass, expected_str", [
@@ -228,7 +226,7 @@ def test_dnf_yum_return_code_100(tool_class, result):
         tool = tool_class(conanfile)
 
         def fake_run(command, win_bash=False, subsystem=None, env=None, ignore_errors=False,  # noqa
-                     quiet=False):  # noqa
+                     quiet=False, **kwargs):  # noqa
             assert command == result
             return 100 if "check-update" in command else 0
 
@@ -241,13 +239,13 @@ def test_dnf_yum_return_code_100(tool_class, result):
         tool = tool_class(conanfile)
 
         def fake_run(command, win_bash=False, subsystem=None, env=None, ignore_errors=False,
-                     quiet=False):
+                     quiet=False, **kwargs):
             return 55 if "check-update" in command else 0
 
         conanfile.run = fake_run
         with pytest.raises(ConanException) as exc_info:
             tool.update()
-        assert f"Command '{result}' failed" == str(exc_info.value)
+        assert f"Command '{result}' failed with exit code 55" == str(exc_info.value)
 
 
 @pytest.mark.parametrize("tool_class, arch_host, result", [


### PR DESCRIPTION
Changelog: Fix: Forward underlying system package manager error messages
Docs: omit
 
Mind that Conan behavior changes a little bit with this PR, by throwing an early exception if the system package manager is not detected by default (and not configured by config) and also, if the package manager is not found in path @memsharded 

Close https://github.com/conan-io/conan/issues/19854

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
