### PR TITLE
Revert quote changes for nmake defines

### DIFF
--- a/conan/__init__.py
+++ b/conan/__init__.py
@@ -2,5 +2,5 @@ from conan.internal.model.conan_file import ConanFile
 from conan.internal.model.workspace import Workspace
 from conan.internal.model.version import Version
 
-__version__ = '2.27.0'
+__version__ = '2.27.1'
 conan_version = Version(__version__)

--- a/conan/tools/microsoft/nmakedeps.py
+++ b/conan/tools/microsoft/nmakedeps.py
@@ -5,7 +5,7 @@ from conan.tools import CppInfo
 from conan.tools.env import Environment
 
 
-def format_defines(defines):
+def format_defines(defines, toolchain=False):
     def is_hex_or_numeric(s):
         try:
             # Check for Hexadecimal (base 16)
@@ -22,9 +22,9 @@ def format_defines(defines):
             macro, value = define.split("=", 1)
             if value and not is_hex_or_numeric(value):
                 # value quotes are escaped
-                value = f'\\"{value}\\"'
+                value = f'\\"{value}\\"' if toolchain else f'\"{value}\"'
             define = f"{macro}#{value}"
-        formated_defines.append(f'/D"{define}"')
+        formated_defines.append(f'/D\"{define}\"')
     return formated_defines
 
 

--- a/conan/tools/microsoft/nmakedeps.py
+++ b/conan/tools/microsoft/nmakedeps.py
@@ -24,7 +24,7 @@ def format_defines(defines, toolchain=False):
                 # value quotes are escaped
                 value = f'\\"{value}\\"' if toolchain else f'\"{value}\"'
             define = f"{macro}#{value}"
-        formated_defines.append(f'/D\"{define}\"')
+        formated_defines.append(f'/D"{define}"')
     return formated_defines
 
 

--- a/conan/tools/microsoft/nmaketoolchain.py
+++ b/conan/tools/microsoft/nmaketoolchain.py
@@ -58,7 +58,7 @@ class NMakeToolchain:
         defines.extend(self.extra_defines)
 
         return (["/nologo"] + self._format_options(bt_flags + rt_flags + cflags + cxxflags) +
-                format_defines(defines))
+                format_defines(defines, toolchain=True))
 
     @property
     def _link(self):

--- a/test/integration/toolchains/microsoft/test_nmakedeps.py
+++ b/test/integration/toolchains/microsoft/test_nmakedeps.py
@@ -44,7 +44,7 @@ def test_nmakedeps():
     for flag in (
         r'/D"TEST_DEFINITION1"', '/D"TEST_DEFINITION2#0"',
         r'/D"TEST_DEFINITION3#"', '/D"TEST_DEFINITION4#"foo""',
-        r'/D"TEST_DEFINITION5#"__declspec\(dllexport\)""',
+        r'/D"TEST_DEFINITION5#"__declspec(dllexport)""',
         r'/D"TEST_DEFINITION6#"foo bar""',
         r'/D"TEST_DEFINITION7#7"',
         r'/D"TEST_WINVER#0x0601"'

--- a/test/integration/toolchains/microsoft/test_nmakedeps.py
+++ b/test/integration/toolchains/microsoft/test_nmakedeps.py
@@ -43,9 +43,9 @@ def test_nmakedeps():
     # Checking that defines are added to CL
     for flag in (
         r'/D"TEST_DEFINITION1"', '/D"TEST_DEFINITION2#0"',
-        r'/D"TEST_DEFINITION3#"', r'/D"TEST_DEFINITION4#\"foo\""',
-        r'/D"TEST_DEFINITION5#\"__declspec(dllexport)\""',
-        r'/D"TEST_DEFINITION6#\"foo bar\""',
+        r'/D"TEST_DEFINITION3#"', '/D"TEST_DEFINITION4#"foo""',
+        r'/D"TEST_DEFINITION5#"__declspec\(dllexport\)""',
+        r'/D"TEST_DEFINITION6#"foo bar""',
         r'/D"TEST_DEFINITION7#7"',
         r'/D"TEST_WINVER#0x0601"'
     ):


### PR DESCRIPTION
Changelog: Bugfix: Revert quote escaping changes in defines for `NMake` integrations.
Docs: Omit

This reverts the quoting changes made in https://github.com/conan-io/conan/pull/19779/ but keeps the int changes.
Closes https://github.com/conan-io/conan/issues/19857

Note that the old behaviour is still buggy. Defines coming from the toolchain (ie, profile) will still break