### PR TITLE
Build mode now understands ref names

### DIFF
--- a/conan/internal/graph/build_mode.py
+++ b/conan/internal/graph/build_mode.py
@@ -63,6 +63,10 @@ class BuildMode:
             if self._never and (self._missing or self._patterns or self.cascade):
                 raise ConanException("--build=never not compatible with other options")
 
+    @staticmethod
+    def ref_matches(ref, pattern, is_consumer=None):
+        return ref.name == pattern or ref_matches(ref, pattern, is_consumer)
+
     @property
     def editable(self):
         # we can make this conditional on the context in the future
@@ -72,7 +76,7 @@ class BuildMode:
         # TODO: ref can be obtained from conan_file
 
         for pattern in self._excluded_patterns:
-            if ref_matches(ref, pattern, is_consumer=conan_file._conan_is_consumer):  # noqa
+            if self.ref_matches(ref, pattern, is_consumer=conan_file._conan_is_consumer):  # noqa
                 conan_file.output.info("Excluded build from source")
                 return False
 
@@ -91,7 +95,7 @@ class BuildMode:
 
         # Patterns to match, if package matches pattern, build is forced
         for pattern in self._patterns:
-            if ref_matches(ref, pattern, is_consumer=conan_file._conan_is_consumer):  # noqa
+            if self.ref_matches(ref, pattern, is_consumer=conan_file._conan_is_consumer):  # noqa
                 return True
         return False
 
@@ -113,21 +117,21 @@ class BuildMode:
     def allowed_compatible(self, conanfile):
         if self._build_compatible_excluded:
             for pattern in self._build_compatible_excluded:
-                if ref_matches(conanfile.ref, pattern, is_consumer=False):
+                if self.ref_matches(conanfile.ref, pattern, is_consumer=False):
                     return False
             return True  # If it has not been excluded by the negated patterns, it is included
 
         for pattern in self._build_compatible_patterns:
-            if ref_matches(conanfile.ref, pattern, is_consumer=conanfile._conan_is_consumer):  # noqa
+            if self.ref_matches(conanfile.ref, pattern, is_consumer=conanfile._conan_is_consumer):  # noqa
                 return True
 
     def should_build_missing(self, conanfile):
         if self._build_missing_excluded:
             for pattern in self._build_missing_excluded:
-                if ref_matches(conanfile.ref, pattern, is_consumer=False):
+                if self.ref_matches(conanfile.ref, pattern, is_consumer=False):
                     return False
             return True  # If it has not been excluded by the negated patterns, it is included
 
         for pattern in self._build_missing_patterns:
-            if ref_matches(conanfile.ref, pattern, is_consumer=conanfile._conan_is_consumer):  # noqa
+            if self.ref_matches(conanfile.ref, pattern, is_consumer=conanfile._conan_is_consumer):  # noqa
                 return True

--- a/test/integration/command/install/test_graph_build_mode.py
+++ b/test/integration/command/install/test_graph_build_mode.py
@@ -40,10 +40,11 @@ def check_if_build_from_sources(refs_modes, output):
             assert "{}/1.0@user/testing: Forced build from source".format(ref) not in output
 
 
-def test_install_build_single(build_all):
+@pytest.mark.parametrize("ref", ["foo/*", "foo"])
+def test_install_build_single(build_all, ref):
     """ When only --build=<ref> is passed, only <ref> must be built
     """
-    build_all.run("install --requires=foobar/1.0@user/testing --build=foo/*")
+    build_all.run(f"install --requires=foobar/1.0@user/testing --build={ref}")
     build_all.assert_listed_binary({"bar/1.0@user/testing": (bar_id, "Cache"),
                                     "foo/1.0@user/testing": (foo_id, "Build"),
                                     "foobar/1.0@user/testing": (foobar_id, "Cache"),

--- a/test/unittests/client/graph/build_mode_test.py
+++ b/test/unittests/client/graph/build_mode_test.py
@@ -172,3 +172,47 @@ def test_pattern_matching(conanfile):
         assert build_mode.forced(conanfile, reference) is True
         reference = RecipeReference.loads("pythontool/0.1@lasote/stable")
         assert build_mode.forced(conanfile, reference) is False
+
+
+def test_name_matching(conanfile):
+    output = RedirectedTestOutput()
+    with redirect_output(output):
+        build_mode = BuildMode(["boost"])
+        reference = RecipeReference.loads("boost/1.69.0@user/stable")
+        assert (build_mode.forced(conanfile, reference)) is True
+        reference = RecipeReference.loads("boost_addons/1.0.0@user/stable")
+        assert (build_mode.forced(conanfile, reference)) is False
+        reference = RecipeReference.loads("myboost/1.0@user/stable")
+        assert (build_mode.forced(conanfile, reference)) is False
+        reference = RecipeReference.loads("foo/boost@user/stable")
+        assert (build_mode.forced(conanfile, reference)) is False
+        reference = RecipeReference.loads("foo/1.0@boost/stable")
+        assert (build_mode.forced(conanfile, reference)) is False
+        reference = RecipeReference.loads("foo/1.0@user/boost")
+        assert build_mode.forced(conanfile, reference) is False
+
+        build_mode = BuildMode(["foo"])
+        reference = RecipeReference.loads("foo/1.0.0@user/stable")
+        assert build_mode.forced(conanfile, reference) is True
+        reference = RecipeReference.loads("foo/1.0@user/stable")
+        assert build_mode.forced(conanfile, reference) is True
+        reference = RecipeReference.loads("foo/1.0.0-abcdefg@user/stable")
+        assert build_mode.forced(conanfile, reference) is True
+
+        build_mode = BuildMode(["bar"])
+        reference = RecipeReference.loads("foo/1.0.0@user/stable")
+        assert build_mode.forced(conanfile, reference) is False
+        reference = RecipeReference.loads("bar/1.0@user/stable")
+        assert build_mode.forced(conanfile, reference) is True
+        reference = RecipeReference.loads("foo/1.0.0-abcdefg@user/stable")
+        assert build_mode.forced(conanfile, reference) is False
+        reference = RecipeReference.loads("foo/1.0.0@NewUser/stable")
+        assert build_mode.forced(conanfile, reference) is False
+
+        build_mode = BuildMode(["tool"])
+        reference = RecipeReference.loads("tool/0.1@lasote/stable")
+        assert build_mode.forced(conanfile, reference) is True
+        reference = RecipeReference.loads("pythontool/0.1@lasote/stable")
+        assert build_mode.forced(conanfile, reference) is False
+        reference = RecipeReference.loads("sometool/1.2@user/channel")
+        assert build_mode.forced(conanfile, reference) is False


### PR DESCRIPTION
Changelog: Feature: Build mode now understands ref names
Docs: TODO

So that we have some homogeniety between this and the `--update` flag. This is s asketch to discuss witht he team if we want to move this forward