### PR TITLE
fix error option output

### DIFF
--- a/conan/cli/commands/list.py
+++ b/conan/cli/commands/list.py
@@ -34,7 +34,7 @@ def print_serial(item, indent=None, color_index=None):
     if isinstance(item, dict):
         for k, v in item.items():
             if isinstance(v, (str, int)):
-                if k.lower() in ["error", "pkgsign_error"]:
+                if k.lower() in ("error", "pkgsign_error"):
                     color = Color.BRIGHT_RED
                     k = "ERROR"
                 elif k.lower() == "warning":

--- a/conan/cli/commands/list.py
+++ b/conan/cli/commands/list.py
@@ -34,7 +34,7 @@ def print_serial(item, indent=None, color_index=None):
     if isinstance(item, dict):
         for k, v in item.items():
             if isinstance(v, (str, int)):
-                if "error" in k.lower():
+                if k.lower() in ["error", "pkgsign_error"]:
                     color = Color.BRIGHT_RED
                     k = "ERROR"
                 elif k.lower() == "warning":

--- a/test/integration/command/list/list_test.py
+++ b/test/integration/command/list/list_test.py
@@ -995,3 +995,10 @@ def test_list_local_recipe_index():
     assert "ERROR: Recipe 'pkg/0.1@a' not found" in c.out
     c.run("list 'pkg%0.1#a@b/c' -r=local")
     assert "ERROR: Recipe 'pkg%0.1' not found" in c.out
+
+def test_list_error_option():
+    c = TestClient(default_server_user=False)
+    c.save({"conanfile.py": GenConanfile("pkg", "1.0").with_option("my_error_option", [1, 2])})
+    c.run("create . -o my_error_option=1")
+    c.run("list pkg/1.0#*:*")
+    assert "my_error_option: 1" in c.out


### PR DESCRIPTION
Changelog: Fix: Fix output of options with "error" in its name in `conan list` command.
Docs: omit

Related to https://github.com/conan-io/conan/pull/19345
