### PR TITLE
Test for absolute core.sources:download_cache

### DIFF
--- a/conan/internal/rest/caching_file_downloader.py
+++ b/conan/internal/rest/caching_file_downloader.py
@@ -54,7 +54,7 @@ class SourcesCachingDownloader:
         # regular local shared download cache, not using Conan backup sources servers
         backups_urls = backups_urls or ["origin"]
         if download_cache_folder and not os.path.isabs(download_cache_folder):
-            raise ConanException("core.download:download_cache must be an absolute path")
+            raise ConanException("core.sources:download_cache must be an absolute path")
 
         download_cache = DownloadCache(download_cache_folder)
         cached_path = download_cache.source_path(sha256)

--- a/test/integration/cache/backup_sources_test.py
+++ b/test/integration/cache/backup_sources_test.py
@@ -899,3 +899,19 @@ class TestDownloadCacheBackupSources:
         self.client.run("upload * -c -r=default")
         assert "No backup sources files to upload" in self.client.out
         assert sha256 + ".dirty" not in os.listdir(os.path.join(self.download_cache_folder, "s"))
+
+    def test_absolute_core_sources_conf(self):
+        client = TestClient(light=True)
+        client.save_home(
+            {"global.conf": f"core.sources:download_cache=relative\n"
+                            "core.sources:download_urls=['origin']"})
+        conanfile = textwrap.dedent(f"""
+                        from conan import ConanFile
+                        from conan.tools.files import download
+                        class Pkg(ConanFile):
+                           def source(self):
+                               download(self, "badbad", "myfile.txt", sha256="sha256")
+                        """)
+        client.save({"conanfile.py": conanfile})
+        client.run("source .", assert_error=True)
+        assert "core.sources:download_cache must be an absolute path" in client.out


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Realized the message directed to the wrong conf, ensured with a test