### PR TITLE
Warn when credentials env vars are ignored due to anonymous server access

### DIFF
--- a/conan/api/subapi/remotes.py
+++ b/conan/api/subapi/remotes.py
@@ -278,6 +278,16 @@ class RemotesAPI:
                 return
         self._api_helpers.remote_manager.check_credentials(remote, force)
         user, token, _ = localdb.get_login(remote.url)
+        if not force and user is None:
+            remote_upper = remote.name.replace("-", "_").upper()
+            candidate_vars = [f"CONAN_LOGIN_USERNAME_{remote_upper}", "CONAN_LOGIN_USERNAME",
+                              f"CONAN_PASSWORD_{remote_upper}", "CONAN_PASSWORD"]
+            found_vars = [v for v in candidate_vars if os.getenv(v)]
+            if found_vars:
+                ConanOutput().warning(
+                    f"Remote '{remote.name}' accepted anonymous access. {', '.join(found_vars)} "
+                    f"environment variables were not used. Use '--force' to force authentication."
+                )
         return user
 
 

--- a/test/integration/command/remote/test_remote_users.py
+++ b/test/integration/command/remote/test_remote_users.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 from unittest.mock import patch
 
 from conan.internal.api.remotes.localdb import LocalDB
+from conan.internal.rest.rest_client_v2 import RestV2Methods
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient, TestServer
 from conan.test.utils.env import environment_update
@@ -492,3 +493,31 @@ class TestRemoteAuth:
         c.run("remote auth *")
         assert "Remote 'default' needs authentication, obtaining credentials" in c.out
         assert "user: myuser" in c.out
+
+    def test_remote_auth_env_vars_anonymous_warning(self):
+        """https://github.com/conan-io/conan/issues/19807
+        Warn when env vars are set but server accepts anonymous access"""
+        server = TestServer(users={"admin": "password"})
+        c = TestClient(light=True, servers={"default": server})
+
+        # env vars set + anonymous server → warning with var names
+        with patch.object(RestV2Methods, "check_credentials", return_value=None):
+            with environment_update({"CONAN_LOGIN_USERNAME": "admin", "CONAN_PASSWORD": "password"}):
+                c.run("remote auth default")
+
+        assert "CONAN_LOGIN_USERNAME" in c.out
+        assert "environment variables were not used. Use '--force'" in c.out
+
+        # env vars set + --force → authenticated, no warning
+        with environment_update({"CONAN_LOGIN_USERNAME": "admin", "CONAN_PASSWORD": "password"}):
+            c.run("remote auth default --force")
+
+        assert "user: admin" in c.out
+        assert "environment variables were not used" not in c.out
+
+        # no env vars + anonymous server → no warning
+        c.run("remote logout default")
+        with patch.object(RestV2Methods, "check_credentials", return_value=None):
+            c.run("remote auth default")
+
+        assert "environment variables were not used" not in c.out


### PR DESCRIPTION
Changelog: Fix: Warn when credentials environment variables are set but not used because the server accepted anonymous access and point users to add `--force` to force authentication.
Docs: Omit

Closes #19807

When a server accepts anonymous access (e.g. Artifactory with anonymous access enabled), `conan remote auth` silently ignored `CONAN_LOGIN_USERNAME`/`CONAN_PASSWORD` environment variables without informing the user. A warning is now shown listing the ignored variables and pointing to the `--force` flag.

