### PR TITLE
tools.build:install_strip now accepts a list of possible build systems

### DIFF
--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -156,7 +156,8 @@ BUILT_IN_CONFS = {
     "tools.build:rcflags": "List of extra RC (resource compiler) flags used by different toolchains like CMakeToolchain, MSBuildToolchain and MesonToolchain",
     "tools.build:linker_scripts": "List of linker script files to pass to the linker used by different toolchains like CMakeToolchain, AutotoolsToolchain, and MesonToolchain",
     # Toolchain installation
-    "tools.build:install_strip": "(boolean) Strip the binaries when installing them with CMake, Meson and Autotools",
+    "tools.build:install_strip": "(boolean or list) True/False to strip on install for every CMake, Meson and Autotools "
+                                 "integration, or a list of 'cmake', 'meson', 'autotools' to strip only for those.",
     # Package ID composition
     "tools.info.package_id:confs": "List of existing configuration to be part of the package ID",
 }

--- a/conan/tools/cmake/cmake.py
+++ b/conan/tools/cmake/cmake.py
@@ -249,7 +249,10 @@ class CMake:
                                            "deprecated, use 'tools.build:install_strip' instead.",
                                            warn_tag="deprecated")
 
-        do_strip = self._conanfile.conf.get("tools.build:install_strip", check_type=bool)
+        try:
+            do_strip = self._conanfile.conf.get("tools.build:install_strip", check_type=bool)
+        except ConanException:
+            do_strip = "cmake" in self._conanfile.conf.get("tools.build:install_strip", check_type=list)
         if do_strip or deprecated_install_strip:
             arg_list.append("--strip")
 

--- a/conan/tools/gnu/autotools.py
+++ b/conan/tools/gnu/autotools.py
@@ -1,6 +1,7 @@
 import os
 import re
 
+from conan.errors import ConanException
 from conan.tools.build import build_jobs, cmd_args_to_string, load_toolchain_args
 from conan.internal.subsystems import subsystem_path, deduce_subsystem
 from conan.tools.files import chdir
@@ -99,7 +100,10 @@ class Autotools:
         """
         if target is None:
             target = "install"
-            do_strip = self._conanfile.conf.get("tools.build:install_strip", check_type=bool)
+            try:
+                do_strip = self._conanfile.conf.get("tools.build:install_strip", check_type=bool)
+            except ConanException:
+                do_strip = "autotools" in self._conanfile.conf.get("tools.build:install_strip", check_type=list)
             if do_strip:
                 target += "-strip"
         args = args if args else []

--- a/conan/tools/meson/meson.py
+++ b/conan/tools/meson/meson.py
@@ -1,5 +1,6 @@
 import os
 
+from conan.errors import ConanException
 from conan.tools.build import build_jobs
 from conan.tools.meson.toolchain import MesonToolchain
 
@@ -85,7 +86,11 @@ class Meson:
         verbosity = self._install_verbosity
         if verbosity:
             cmd += " " + verbosity
-        if self._conanfile.conf.get("tools.build:install_strip", check_type=bool):
+        try:
+            do_strip = self._conanfile.conf.get("tools.build:install_strip", check_type=bool)
+        except ConanException:
+            do_strip = "meson" in self._conanfile.conf.get("tools.build:install_strip", check_type=list)
+        if do_strip:
             cmd += " --strip"
         if cli_args:
             cmd += " " + " ".join(cli_args)

--- a/test/unittests/tools/cmake/test_cmake_install.py
+++ b/test/unittests/tools/cmake/test_cmake_install.py
@@ -1,5 +1,6 @@
 import pytest
 
+from conan.errors import ConanException
 from conan.internal.default_settings import default_settings_yml
 from conan.tools.cmake import CMake
 from conan.tools.cmake.presets import write_cmake_presets
@@ -39,12 +40,10 @@ def test_run_install_component():
     assert "--component foo" in conanfile.command
 
 
-@pytest.mark.parametrize("config, value, deprecated, strip",
-                         [("tools.cmake:install_strip", True, True, True),
-                          ("tools.build:install_strip", True, False, True),
-                          ("tools.build:install_strip", ['cmake', 'meson'], False, True),
-                          ("tools.build:install_strip", ['autotools'], False, False)])
-def test_run_install_strip(config, value, deprecated, strip):
+@pytest.mark.parametrize("config, deprecated",
+                         [("tools.cmake:install_strip", True),
+                          ("tools.build:install_strip", False),])
+def test_run_install_strip(config, deprecated):
     """
     Testing that the install/strip rule is called
     Issue related: https://github.com/conan-io/conan/issues/14166
@@ -60,7 +59,7 @@ def test_run_install_strip(config, value, deprecated, strip):
     conanfile = ConanFileMock()
 
     conanfile.conf = Conf()
-    conanfile.conf.define(config, value)
+    conanfile.conf.define(config, True)
 
     conanfile.folders.generators = "."
     conanfile.folders.set_base_generators(temp_folder())
@@ -79,7 +78,43 @@ def test_run_install_strip(config, value, deprecated, strip):
                " 'tools.build:install_strip' instead" in stderr
     else:
         assert "tools.cmake:install_strip" not in stderr
-    assert "--strip" in conanfile.command if strip else "--strip" not in conanfile.command
+    assert "--strip" in conanfile.command
+
+
+@pytest.mark.parametrize("value, do_raise, do_strip",
+                         [("cmake", True, False),
+                          ("{'cmake': True', 'meson': False}", True, False),
+                          (None, False, False),
+                          ("['cmake']", True, True),
+                          ("['autotools', 'meson']", True, False)])
+def test_run_install_strip_check_conf_values(value, do_raise, do_strip):
+    """
+    Testing that ``tools.build:install_strip`` only accepts bool or list,
+    and that the install/strip rule is called when the value is correct.
+    """
+    settings = Settings.loads(default_settings_yml)
+    settings.os = "Linux"
+    settings.arch = "x86_64"
+    settings.build_type = "Release"
+    settings.compiler = "gcc"
+    settings.compiler.version = "11"
+
+    conanfile = ConanFileMock()
+    conanfile.conf = Conf()
+    conanfile.conf.define("tools.build:install_strip", value)
+    conanfile.folders.generators = "."
+    conanfile.folders.set_base_generators(temp_folder())
+    conanfile.settings = settings
+    conanfile.folders.set_base_package(temp_folder())
+    write_cmake_presets(conanfile, "toolchain", "Unix Makefiles", {})
+    cmake = CMake(conanfile)
+    if do_raise:
+        with pytest.raises(ConanException) as exc_info:
+            cmake.install()
+        assert "tools.build:install_strip must be a list-like object" in str(exc_info.value)
+    else:
+        cmake.install()
+        assert "--strip" not in conanfile.command if not do_strip else "--strip" in conanfile.command
 
 
 def test_run_install_cli_args():

--- a/test/unittests/tools/cmake/test_cmake_install.py
+++ b/test/unittests/tools/cmake/test_cmake_install.py
@@ -39,10 +39,12 @@ def test_run_install_component():
     assert "--component foo" in conanfile.command
 
 
-@pytest.mark.parametrize("config, deprecated",
-                         [("tools.cmake:install_strip", True),
-                          ("tools.build:install_strip", False),])
-def test_run_install_strip(config, deprecated):
+@pytest.mark.parametrize("config, value, deprecated, strip",
+                         [("tools.cmake:install_strip", True, True, True),
+                          ("tools.build:install_strip", True, False, True),
+                          ("tools.build:install_strip", ['cmake', 'meson'], False, True),
+                          ("tools.build:install_strip", ['autotools'], False, False)])
+def test_run_install_strip(config, value, deprecated, strip):
     """
     Testing that the install/strip rule is called
     Issue related: https://github.com/conan-io/conan/issues/14166
@@ -58,7 +60,7 @@ def test_run_install_strip(config, deprecated):
     conanfile = ConanFileMock()
 
     conanfile.conf = Conf()
-    conanfile.conf.define(config, True)
+    conanfile.conf.define(config, value)
 
     conanfile.folders.generators = "."
     conanfile.folders.set_base_generators(temp_folder())
@@ -77,7 +79,7 @@ def test_run_install_strip(config, deprecated):
                " 'tools.build:install_strip' instead" in stderr
     else:
         assert "tools.cmake:install_strip" not in stderr
-    assert "--strip" in conanfile.command
+    assert "--strip" in conanfile.command if strip else "--strip" not in conanfile.command
 
 
 def test_run_install_cli_args():

--- a/test/unittests/tools/gnu/autotools_test.py
+++ b/test/unittests/tools/gnu/autotools_test.py
@@ -37,11 +37,18 @@ def test_source_folder_works(chdir_mock):
     assert conanfile.command == 'autoreconf -bar foo'
 
 
-@pytest.mark.parametrize("install_strip", [False, True])
-def test_install_strip(install_strip):
+@pytest.mark.parametrize("install_strip, expect_strip", [
+    (False, False),
+    (True, True),
+    (["autotools"], True),
+    (["cmake"], False),
+    (["meson"], False),
+    (["cmake", "meson", "autotools"], True),
+])
+def test_install_strip(install_strip, expect_strip):
     """
-    When the configuration `tools.build:install_strip` is set to True,
-    the Autotools install command should invoke the `install-strip` target.
+    When `tools.build:install_strip` is True or lists ``autotools``, the install command
+    should use the ``install-strip`` target; list values only strip for named backends.
     """
     folder = temp_folder()
     os.chdir(folder)
@@ -59,7 +66,7 @@ def test_install_strip(install_strip):
     autotools = Autotools(conanfile)
     autotools.install()
 
-    assert ('install-strip' in str(conanfile.command)) == install_strip
+    assert ('install-strip' in str(conanfile.command)) == expect_strip
 
 
 def test_configure_arguments():

--- a/test/unittests/tools/meson/test_meson.py
+++ b/test/unittests/tools/meson/test_meson.py
@@ -68,16 +68,14 @@ def test_meson_to_cppstd_flag(compiler, compiler_version, cppstd, expected):
 
 
 @pytest.mark.parametrize("conf_line, expect_strip", [
-    ("tools.build:install_strip=True", True),
-    ("tools.build:install_strip=False", False),
-    ("tools.build:install_strip=['meson', 'cmake']", True),
-    ("tools.build:install_strip=['autotools', 'autotools']", False),
+    (True, True),
+    (False, False),
+    (['meson'], True),
+    (['meson', 'cmake'], True),
+    (['autotools', 'cmake'], False),
 ])
 def test_meson_install_strip(conf_line, expect_strip):
     """``tools.build:install_strip`` as True or a list containing ``meson`` adds ``--strip``."""
-    c = ConfDefinition()
-    c.loads(conf_line)
-
     settings = MockSettings({"build_type": "Release",
                              "compiler": "gcc",
                              "compiler.version": "7",
@@ -85,7 +83,7 @@ def test_meson_install_strip(conf_line, expect_strip):
                              "arch": "x86_64"})
     conanfile = ConanFileMock()
     conanfile.settings = settings
-    conanfile.conf = c.get_conanfile_conf(None)
+    conanfile.conf.define("tools.build:install_strip", conf_line)
     conanfile.folders.generators = "."
     conanfile.folders.set_base_generators(temp_folder())
     conanfile.folders.set_base_package(temp_folder())

--- a/test/unittests/tools/meson/test_meson.py
+++ b/test/unittests/tools/meson/test_meson.py
@@ -67,12 +67,16 @@ def test_meson_to_cppstd_flag(compiler, compiler_version, cppstd, expected):
     assert to_cppstd_flag(ConanFileMock(), compiler, compiler_version, cppstd) == expected
 
 
-def test_meson_install_strip():
-    """When the configuration `tools.build:install_strip` is set to True,
-        the Meson install command should include the `--strip` option.
-    """
+@pytest.mark.parametrize("conf_line, expect_strip", [
+    ("tools.build:install_strip=True", True),
+    ("tools.build:install_strip=False", False),
+    ("tools.build:install_strip=['meson', 'cmake']", True),
+    ("tools.build:install_strip=['autotools', 'autotools']", False),
+])
+def test_meson_install_strip(conf_line, expect_strip):
+    """``tools.build:install_strip`` as True or a list containing ``meson`` adds ``--strip``."""
     c = ConfDefinition()
-    c.loads("tools.build:install_strip=True")
+    c.loads(conf_line)
 
     settings = MockSettings({"build_type": "Release",
                              "compiler": "gcc",
@@ -89,7 +93,7 @@ def test_meson_install_strip():
     meson = Meson(conanfile)
     meson.install()
 
-    assert '--strip' in str(conanfile.command)
+    assert ('--strip' in str(conanfile.command)) == expect_strip
 
 def test_meson_install_cli_args():
     """When the `cli_args` are provided, the Meson install command should include them.


### PR DESCRIPTION
Changelog: Feature: `tools.build:install_strip` now accepts a list of possible build systems
Docs: https://github.com/conan-io/docs/pull/4424

Mentioned in https://github.com/conan-io/conan-center-index/issues/29989#issuecomment-4251195087
After Conan v2.20 and the creation of the `tools.build:install_strip` config, this configuration started affecting not only CMake but Autotools and Meson. Some projects do not support stripping...

This PR aims to address the inconvenience of having to explicitly disable the rule for some recipes, 
e.g. `!my_recipe/*:tools.build:install_strip` by enabling stripping in the desired build system backends, `tools.build:install_strip=["cmake"]`
  

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
