### PR TITLE
Remove some deprecated features

### DIFF
--- a/conan/api/model/list.py
+++ b/conan/api/model/list.py
@@ -246,13 +246,6 @@ class PackagesList:
             for rrev_dict in ref_dict.get("revisions", {}).values():
                 rrev_dict.pop("packages", None)
 
-    def add_refs(self, refs):
-        ConanOutput().warning("PackagesLists.add_refs() non-public, non-documented method will be "
-                              "removed, use .add_ref() instead", warn_tag="deprecated")
-        # RREVS alreday come in ASCENDING order, so upload does older revisions first
-        for ref in refs:
-            self.add_ref(ref)
-
     def add_ref(self, ref: RecipeReference) -> None:
         """
         Adds a new RecipeReference to a package list
@@ -263,13 +256,6 @@ class PackagesList:
             rev_dict = revs_dict.setdefault(ref.revision, {})
             if ref.timestamp:
                 rev_dict["timestamp"] = ref.timestamp
-
-    def add_prefs(self, rrev, prefs):
-        ConanOutput().warning("PackageLists.add_prefs() non-public, non-documented method will be "
-                              "removed, use .add_pref() instead", warn_tag="deprecated")
-        # Prevs already come in ASCENDING order, so upload does older revisions first
-        for p in prefs:
-            self.add_pref(p)
 
     def add_pref(self, pref: PkgReference, pkg_info: dict = None) -> None:
         """
@@ -286,30 +272,6 @@ class PackagesList:
                 prev_dict["timestamp"] = pref.timestamp
         if pkg_info is not None:
             package_dict["info"] = pkg_info
-
-    def add_configurations(self, confs):
-        ConanOutput().warning("PackageLists.add_configurations() non-public, non-documented method "
-                              "will be removed, use .add_pref() instead",
-                              warn_tag="deprecated")
-        for pref, conf in confs.items():
-            rev_dict = self.recipe_dict(pref.ref)
-            try:
-                rev_dict["packages"][pref.package_id]["info"] = conf
-            except KeyError:  # If package_id does not exist, do nothing, only add to existing prefs
-                pass
-
-    def refs(self):
-        ConanOutput().warning("PackageLists.refs() non-public, non-documented method will be "
-                              "removed, use .items() instead", warn_tag="deprecated")
-        result = {}
-        for ref, ref_dict in self._data.items():
-            for rrev, rrev_dict in ref_dict.get("revisions", {}).items():
-                t = rrev_dict.get("timestamp")
-                recipe = RecipeReference.loads(f"{ref}#{rrev}")  # TODO: optimize this
-                if t is not None:
-                    recipe.timestamp = t
-                result[recipe] = rrev_dict
-        return result
 
     def items(self) -> Iterable[Tuple[RecipeReference, Dict[PkgReference, Dict]]]:
         """Iterate over the contents of the package list.
@@ -370,19 +332,6 @@ class PackagesList:
         """
         ref_dict = self.recipe_dict(pref.ref)
         return ref_dict["packages"][pref.package_id]["revisions"][pref.revision]
-
-    @staticmethod
-    def prefs(ref, recipe_bundle):
-        ConanOutput().warning("PackageLists.prefs() non-public, non-documented method will be "
-                              "removed, use .items() instead", warn_tag="deprecated")
-        result = {}
-        for package_id, pkg_bundle in recipe_bundle.get("packages", {}).items():
-            prevs = pkg_bundle.get("revisions", {})
-            for prev, prev_bundle in prevs.items():
-                t = prev_bundle.get("timestamp")
-                pref = PkgReference(ref, package_id, prev, t)
-                result[pref] = prev_bundle
-        return result
 
     def serialize(self):
         """ Serialize the instance to a dictionary."""

--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -67,14 +67,13 @@ def graph_build_order(conan_api, parser, subparser, *args):
     """
     common_graph_args(subparser)
     subparser.add_argument("--order-by", choices=['recipe', 'configuration'],
+                           default="recipe",
                            help='Select how to order the output, "recipe" by default if not set.')
     subparser.add_argument("--reduce", action='store_true', default=False,
                            help='Reduce the build order, output only those to build. Use this '
                                 'only if the result will not be merged later with other build-order')
     args = parser.parse_args(*args)
     validate_common_graph_args(args)
-    if args.order_by is None:
-        ConanOutput().warning("Please specify --order-by argument", warn_tag="deprecated")
 
     cwd = os.getcwd()
     path = conan_api.local.get_conanfile_path(args.path, cwd, py=None) if args.path else None
@@ -109,8 +108,6 @@ def graph_build_order(conan_api, parser, subparser, *args):
     install_graph = conan_api.graph.build_order(deps_graph, args.order_by, args.reduce,
                                                 profile_args=args)
     install_order_serialized = install_graph.install_build_order()
-    if args.order_by is None:  # legacy
-        install_order_serialized = install_order_serialized["order"]
 
     lockfile = conan_api.lockfile.update_lockfile(lockfile, deps_graph, args.lockfile_packages,
                                                   clean=args.lockfile_clean)

--- a/conan/cli/commands/graph.py
+++ b/conan/cli/commands/graph.py
@@ -67,13 +67,14 @@ def graph_build_order(conan_api, parser, subparser, *args):
     """
     common_graph_args(subparser)
     subparser.add_argument("--order-by", choices=['recipe', 'configuration'],
-                           default="recipe",
                            help='Select how to order the output, "recipe" by default if not set.')
     subparser.add_argument("--reduce", action='store_true', default=False,
                            help='Reduce the build order, output only those to build. Use this '
                                 'only if the result will not be merged later with other build-order')
     args = parser.parse_args(*args)
     validate_common_graph_args(args)
+    if args.order_by is None:
+        ConanOutput().warning("Please specify --order-by argument", warn_tag="deprecated")
 
     cwd = os.getcwd()
     path = conan_api.local.get_conanfile_path(args.path, cwd, py=None) if args.path else None
@@ -108,6 +109,8 @@ def graph_build_order(conan_api, parser, subparser, *args):
     install_graph = conan_api.graph.build_order(deps_graph, args.order_by, args.reduce,
                                                 profile_args=args)
     install_order_serialized = install_graph.install_build_order()
+    if args.order_by is None:  # legacy
+        install_order_serialized = install_order_serialized["order"]
 
     lockfile = conan_api.lockfile.update_lockfile(lockfile, deps_graph, args.lockfile_packages,
                                                   clean=args.lockfile_clean)

--- a/conan/internal/api/detect/detect_api.py
+++ b/conan/internal/api/detect/detect_api.py
@@ -522,13 +522,6 @@ def detect_gcc_compiler(compiler_exe="gcc"):
         return None, None, None
 
 
-def detect_compiler():
-    ConanOutput(scope="detect_api").warning("detect_compiler() is deprecated, "
-                                            "use detect_default_compiler()", warn_tag="deprecated")
-    compiler, version, _ = detect_default_compiler()
-    return compiler, version
-
-
 def detect_intel_compiler(compiler_exe="icx"):
     try:
         ret, out = detect_runner(f'"{compiler_exe}" --version')

--- a/conan/internal/api/profile/profile_loader.py
+++ b/conan/internal/api/profile/profile_loader.py
@@ -229,7 +229,6 @@ class _ProfileValueParser:
     def get_profile(profile_text, base_profile=None):
         # Trying to strip comments might be problematic if things contain #
         doc = TextINIParse(profile_text, allowed_fields=["tool_requires",
-                                                         "system_tools",  # DEPRECATED: platform_tool_requires
                                                          "platform_requires",
                                                          "platform_tool_requires", "settings",
                                                          "options", "conf", "buildenv", "runenv",
@@ -241,10 +240,7 @@ class _ProfileValueParser:
         tool_requires = _ProfileValueParser._parse_tool_requires(doc)
 
         doc_platform_requires = doc.platform_requires or ""
-        doc_platform_tool_requires = doc.platform_tool_requires or doc.system_tools or ""
-        if doc.system_tools:
-            ConanOutput().warning("Profile [system_tools] is deprecated,"
-                                  " please use [platform_tool_requires]", warn_tag="deprecated")
+        doc_platform_tool_requires = doc.platform_tool_requires or ""
 
         def parse_replaces(replaces):
             result = [RecipeReference.loads(r) for r in replaces.splitlines()]

--- a/conan/internal/cache/home_paths.py
+++ b/conan/internal/cache/home_paths.py
@@ -22,11 +22,6 @@ class HomePaths:
 
     @property
     def deployers_path(self):
-        deploy = os.path.join(self._home, _EXTENSIONS_FOLDER, "deploy")
-        if os.path.exists(deploy):
-            ConanOutput().warning("Use 'deployers' cache folder for deployers instead of 'deploy'",
-                                  warn_tag="deprecated")
-            return deploy
         return os.path.join(self._home, _EXTENSIONS_FOLDER, "deployers")
 
     @property

--- a/conan/internal/graph/graph.py
+++ b/conan/internal/graph/graph.py
@@ -73,13 +73,6 @@ class Node:
         self.skipped_build_requires = False
         self.editable_output_folder = None  # In case this node is editable
 
-    @property
-    def dependencies(self):
-        ConanOutput().warning("Node.dependencies is private and shouldn't be used. It is now "
-                              "node.edges. Please fix your code, Node.dependencies will be removed "
-                              "in future versions", warn_tag="deprecated")
-        return self.edges
-
     def subgraph(self):
         nodes = [self]
         opened = [self]

--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -143,7 +143,7 @@ BUILT_IN_CONFS = {
     "tools.apple:enable_bitcode": "(boolean) Enable/Disable Bitcode Apple Clang flags",
     "tools.apple:enable_arc": "(boolean) Enable/Disable ARC Apple Clang flags",
     "tools.apple:enable_visibility": "(boolean) Enable/Disable Visibility Apple Clang flags",
-    "tools.env.virtualenv:powershell": "If specified, it generates PowerShell launchers (.ps1). Use this configuration setting the PowerShell executable you want to use (e.g., 'powershell.exe' or 'pwsh'). Setting it to True or False is deprecated as of Conan 2.11.0.",
+    "tools.env.virtualenv:powershell": "If specified, it generates PowerShell launchers (.ps1). Use this configuration setting the PowerShell executable you want to use (e.g., 'powershell.exe' or 'pwsh')",
     "tools.env:dotenv": "(Experimental) Generate dotenv environment files",
     "tools.env:deactivation_mode": "(Experimental) If 'function', generate a deactivate function instead of a script to unset the environment variables",
     # Compilers/Flags configurations

--- a/conan/tools/cmake/cmakeconfigdeps/target_configuration.py
+++ b/conan/tools/cmake/cmakeconfigdeps/target_configuration.py
@@ -22,13 +22,6 @@ class TargetConfigurationTemplate2:
         self._full_cpp_info = full_cpp_info
 
     def content(self):
-        auto_link = self._cmakedeps.get_property("cmake_set_interface_link_directories",
-                                                 self._conanfile, check_type=bool)
-        if auto_link:
-            out = self._cmakedeps._conanfile.output  # noqa
-            out.warning("CMakeConfigDeps: cmake_set_interface_link_directories deprecated and "
-                        "invalid. The package 'package_info()' must correctly define the (CPS) "
-                        "information", warn_tag="deprecated")
         t = Template(self._template, trim_blocks=True, lstrip_blocks=True,
                      undefined=jinja2.StrictUndefined)
         return t.render(self._context)

--- a/conan/tools/cmake/cmakedeps/templates/target_configuration.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_configuration.py
@@ -26,22 +26,13 @@ class TargetConfigurationTemplate(CMakeDepsFileTemplate):
         components_names = [(components_target_name.replace("::", "_"), components_target_name)
                             for components_target_name in components_targets_names]
 
-        is_win = self.conanfile.settings.get_safe("os") == "Windows"
-        auto_link = self.cmakedeps.get_property("cmake_set_interface_link_directories",
-                                                self.conanfile, check_type=bool)
-        if auto_link:
-            out = self.cmakedeps._conanfile.output # noqa
-            out.warning("CMakeDeps: cmake_set_interface_link_directories is legacy, not necessary",
-                        warn_tag="deprecated")
-
         return {"pkg_name": self.pkg_name,
                 "root_target_name": self.root_target_name,
                 "config_suffix": self.config_suffix,
                 "config": self.configuration.upper(),
                 "deps_targets_names": ";".join(deps_targets_names),
                 "components_names": components_names,
-                "configuration": self.cmakedeps.configuration,
-                "set_interface_link_directories": auto_link and is_win}
+                "configuration": self.cmakedeps.configuration}
 
     @property
     def template(self):

--- a/conan/tools/env/environment.py
+++ b/conan/tools/env/environment.py
@@ -52,8 +52,7 @@ def environment_wrap_command(conanfile, env_filenames, env_folder, cmd, subsyste
         raise ConanException("Cannot wrap command with different envs,"
                              "{} - {}".format(bats+ps1s, shs))
 
-    powershell = conanfile.conf.get("tools.env.virtualenv:powershell") or "powershell.exe"
-    powershell = "powershell.exe" if powershell is True else powershell
+    powershell = conanfile.conf.get("tools.env.virtualenv:powershell", default="powershell.exe")
 
     if bats:
         launchers = " && ".join('"{}"'.format(b) for b in bats)
@@ -586,19 +585,7 @@ class EnvVars:
             is_ps1 = ext == ".ps1"
         else:  # Need to deduce it automatically
             is_bat = self._subsystem == WINDOWS
-            try:
-                is_ps1 = self._conanfile.conf.get("tools.env.virtualenv:powershell", check_type=bool)
-                if is_ps1 is not None:
-                    ConanOutput().warning(
-                        "Boolean values for 'tools.env.virtualenv:powershell' are deprecated. "
-                        "Please specify 'powershell.exe' or 'pwsh' instead, appending arguments if needed "
-                        "(for example: 'powershell.exe -argument'). "
-                        "To unset this configuration, use `tools.env.virtualenv:powershell=!`, which matches "
-                        "the previous 'False' behavior.",
-                        warn_tag="deprecated"
-                    )
-            except ConanException:
-                is_ps1 = self._conanfile.conf.get("tools.env.virtualenv:powershell", check_type=str)
+            is_ps1 = self._conanfile.conf.get("tools.env.virtualenv:powershell", check_type=str)
             if is_ps1:
                 filename = filename + ".ps1"
                 is_bat = False

--- a/conan/tools/microsoft/visual.py
+++ b/conan/tools/microsoft/visual.py
@@ -166,19 +166,7 @@ class VCVars:
         create_env_script(conanfile, content, conan_vcvars_bat, scope)
         _create_deactivate_vcvars_file(conanfile, conan_vcvars_bat)
 
-        try:
-            is_ps1 = self._conanfile.conf.get("tools.env.virtualenv:powershell", check_type=bool)
-            if is_ps1 is not None:
-                ConanOutput().warning(
-                    "Boolean values for 'tools.env.virtualenv:powershell' are deprecated. "
-                    "Please specify 'powershell.exe' or 'pwsh' instead, appending arguments "
-                    "if needed (for example: 'powershell.exe -argument'). "
-                    "To unset this configuration, use `tools.env.virtualenv:powershell=!`, "
-                    "which matches the previous 'False' behavior.",
-                    warn_tag="deprecated"
-                )
-        except ConanException:
-            is_ps1 = self._conanfile.conf.get("tools.env.virtualenv:powershell", check_type=str)
+        is_ps1 = self._conanfile.conf.get("tools.env.virtualenv:powershell", check_type=str)
         if is_ps1:
             content_ps1 = textwrap.dedent(rf"""
             if (-not $env:VSCMD_ARG_VCVARS_VER){{

--- a/test/functional/command/test_install_deploy.py
+++ b/test/functional/command/test_install_deploy.py
@@ -184,9 +184,9 @@ def test_multi_deploy():
             conanfile = graph.root.conanfile
             conanfile.output.info("deploy cache!!")
         """)
-    save(os.path.join(c.cache_folder, "extensions", "deploy", "deploy_cache.py"), deploy_cache)
+    save(os.path.join(c.cache_folder, "extensions", "deployers", "deploy_cache.py"), deploy_cache)
     # This should never be called in this test, always the local is found first
-    save(os.path.join(c.cache_folder, "extensions", "deploy", "mydeploy.py"), "CRASH!!!!")
+    save(os.path.join(c.cache_folder, "extensions", "deployers", "mydeploy.py"), "CRASH!!!!")
     c.save({"conanfile.txt": "",
             "mydeploy.py": deploy1,
             "sub/mydeploy2.py": deploy2})

--- a/test/functional/command/test_install_deploy.py
+++ b/test/functional/command/test_install_deploy.py
@@ -62,7 +62,7 @@ def test_install_deploy(client, powershell):
             "CMakeLists.txt": cmake,
             "main.cpp": gen_function_cpp(name="main", includes=["matrix"], calls=["matrix"])},
            clean_first=True)
-    pwsh = "-c tools.env.virtualenv:powershell=True" if powershell else ""
+    pwsh = "-c tools.env.virtualenv:powershell=powershell.exe" if powershell else ""
     c.run("install . -o *:shared=True "
           f"--deployer=deploy.py -of=mydeploy -g CMakeToolchain -g CMakeDeps {pwsh}")
     c.run("remove * -c")  # Make sure the cache is clean, no deps there

--- a/test/functional/toolchains/env/test_virtualenv_powershell.py
+++ b/test/functional/toolchains/env/test_virtualenv_powershell.py
@@ -73,7 +73,7 @@ def test_virtualenv(client):
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows powershell")
-@pytest.mark.parametrize("powershell", [True, "powershell.exe", "pwsh"])
+@pytest.mark.parametrize("powershell", ["powershell.exe", "pwsh"])
 def test_virtualenv_test_package(powershell):
     """ The test_package could crash if not cleaning correctly the test_package
     output folder. This will still crassh if the layout is not creating different build folders

--- a/test/functional/toolchains/env/test_virtualenv_powershell.py
+++ b/test/functional/toolchains/env/test_virtualenv_powershell.py
@@ -164,7 +164,7 @@ def test_vcvars(powershell):
 
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Test for powershell")
-@pytest.mark.parametrize("powershell", [True, "powershell.exe", "pwsh", "powershell.exe -NoProfile", "pwsh -NoProfile"])
+@pytest.mark.parametrize("powershell", ["powershell.exe", "pwsh", "powershell.exe -NoProfile", "pwsh -NoProfile"])
 def test_concatenate_build_and_run_env(powershell):
     # this tests that if we have both build and run env, they are concatenated correctly when using
     # powershell

--- a/test/functional/toolchains/env/test_virtualenv_powershell.py
+++ b/test/functional/toolchains/env/test_virtualenv_powershell.py
@@ -119,7 +119,7 @@ def test_virtualenv_test_package(powershell):
     assert "MYVC_CUSTOMVAR2=PATATA2" in client.out
 
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows powershell")
-@pytest.mark.parametrize("powershell", [True, "powershell.exe", "pwsh"])
+@pytest.mark.parametrize("powershell", ["powershell.exe", "pwsh"])
 def test_vcvars(powershell):
     client = TestClient()
     conanfile = textwrap.dedent(r"""
@@ -211,29 +211,8 @@ def test_concatenate_build_and_run_env(powershell):
     assert "MYTOOL 1!!" in client.out
 
 
-@pytest.mark.parametrize("powershell", [None, True, False])
-def test_powershell_deprecated_message(powershell):
-    client = TestClient(light=True)
-    conanfile = textwrap.dedent("""\
-        from conan import ConanFile
-        class Pkg(ConanFile):
-            settings = "os"
-            name = "pkg"
-            version = "0.1"
-        """)
-
-    client.save({"conanfile.py": conanfile})
-    powershell_arg = f'-c tools.env.virtualenv:powershell={powershell}' if powershell is not None else ""
-    client.run(f'install . {powershell_arg}')
-    # only show message if the value is set to False or True if not set do not show message
-    if powershell is not None:
-        assert "Boolean values for 'tools.env.virtualenv:powershell' are deprecated" in client.out
-    else:
-        assert "Boolean values for 'tools.env.virtualenv:powershell' are deprecated" not in client.out
-
-
 @pytest.mark.skipif(platform.system() != "Windows", reason="Test for powershell")
-@pytest.mark.parametrize("powershell", [True, "pwsh", "powershell.exe"])
+@pytest.mark.parametrize("powershell", ["pwsh", "powershell.exe"])
 def test_powershell_quoting(powershell):
     client = TestClient(path_with_spaces=False)
     conanfile = textwrap.dedent("""\

--- a/test/integration/cache/test_home_special_char.py
+++ b/test/integration/cache/test_home_special_char.py
@@ -66,6 +66,6 @@ def test_reuse_buildenv(client_with_special_chars):
 @pytest.mark.skipif(platform.system() != "Windows", reason="powershell only win")
 def test_reuse_buildenv_powershell(client_with_special_chars):
     c = client_with_special_chars
-    c.run("create . -c tools.env.virtualenv:powershell=True")
+    c.run("create . -c tools.env.virtualenv:powershell=powershell.exe")
     assert _path_chars in c.out
     assert "MYTOOL WORKS!!" in c.out

--- a/test/integration/graph/test_system_tools.py
+++ b/test/integration/graph/test_system_tools.py
@@ -18,16 +18,15 @@ class TestToolRequires:
         assert f"tool/1.0{revision or '#platform'} - Platform" in client.out
 
     def test_system_tool_require_non_matching(self):
-        """ if what is specified in [system_tool_require] doesn't match what the recipe requires, then
-        the system_tool_require will not be used, and the recipe will use its declared version
+        """ if what is specified in [platform_tool_requires] doesn't match what the recipe requires, then
+        the platform_tool_requires will not be used, and the recipe will use its declared version
         """
         client = TestClient(light=True)
         client.save({"tool/conanfile.py": GenConanfile("tool", "1.0"),
                      "conanfile.py": GenConanfile("pkg", "1.0").with_tool_requires("tool/1.0"),
-                     "profile": "[system_tools]\ntool/1.1"})
+                     "profile": "[platform_tool_requires]\ntool/1.1"})
         client.run("create tool")
         client.run("create . -pr=profile")
-        assert "WARN: deprecated: Profile [system_tools] is deprecated" in client.out
         assert "tool/1.0#60ed6e65eae112df86da7f6d790887fd - Cache" in client.out
 
     @pytest.mark.parametrize("revision", ["", "#myrev"])

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -219,26 +219,6 @@ def test_system_wrappers():
            '             $<$<CONFIG:RELEASE>:my_system_cool_lib>)' in cmake
 
 
-def test_autolink_pragma():
-    """https://github.com/conan-io/conan/issues/10837"""
-    c = TestClient()
-    conanfile = textwrap.dedent("""
-        from conan import ConanFile
-        class Pkg(ConanFile):
-            def package_info(self):
-                self.cpp_info.set_property("cmake_set_interface_link_directories", True)
-        """)
-    c.save({"conanfile.py": conanfile,
-            "test_package/conanfile.py": GenConanfile().with_test("pass")
-                                                       .with_settings("build_type")
-                                                       .with_generator("CMakeConfigDeps")})
-    c.run("create . --name=pkg --version=0.1")
-    assert "CMakeConfigDeps: cmake_set_interface_link_directories deprecated" in c.out
-    c.run(f"create . --name=pkg --version=0.1")
-    assert "CMakeConfigDeps: cmake_set_interface_link_directories deprecated and invalid. " \
-           "The package 'package_info()' must correctly define the (CPS) information" in c.out
-
-
 def test_consuming_cpp_info_with_components_dependency_from_same_package():
     c = TestClient()
     conanfile = textwrap.dedent("""


### PR DESCRIPTION
Changelog: Fix: Remove deprecated ``system_tools`` profile section
Changelog: Fix: Remove deprecated ``detect_compiler`` method in detect api
Changelog: Fix: Remove deprecated ``deploy`` folder in conan home
Changelog: Fix: Remove deprecated methods from ``PackagesList``
Changelog: Fix: Remove deprecated ``cmake_set_interface_link_directories`` property
Changelog: Fix: Remove deprecated ``Node::dependencies`` method
Docs: Omit


Split from https://github.com/conan-io/conan/pull/19863. Each as its own commit in case the whole diff is too noisy