### PR TITLE
HTML updates for `conan report diff` and `conan graph info`

### DIFF
--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -70,14 +70,18 @@ graph_info_html = r"""
                     <input type="checkbox" onchange="collapsePackages()" id="collapse_packages"/>
                     <label for="collapse_packages">Group packages</label>
                 </div>
-                 <div>
+                <div>
                     <input type="checkbox" onchange="showPackageType()" id="show_package_type"/>
                     <label for="show_package_type">Show package type</label>
                 </div>
-                 <div>
+                <div>
+                    <input type="checkbox" onchange="showSubgraph()" id="show_subgraph"/>
+                    <label for="show_package_type">Show subgraph</label>
+                </div>
+                <div>
                     <input type="search" placeholder="Search packages..." oninput="searchPackages(this)" onkeydown="onSearchKeyDown(event)">
                 </div>
-                 <div>
+                <div>
                     <input type="search" placeholder="Exclude packages..." title="Add a comma to exclude an additional package" oninput="excludePackages(this)">
                 </div>
                 <div>
@@ -107,6 +111,7 @@ graph_info_html = r"""
             let excluded_pkgs = null;
             let collapse_packages = false;
             let show_package_type = false;
+            let show_subgraph = false;
             let color_map = {Cache: "SkyBlue",
                              Download: "LightGreen",
                              Build: "Yellow",
@@ -402,6 +407,22 @@ graph_info_html = r"""
                     let div2 = document.createElement('div');
                     div2.innerHTML = "<pre>" + div.innerHTML + "</pre>";
                     control.appendChild(div2);
+                    if (show_subgraph && graph_data["nodes"][ids[0]]) {
+                        let node_id_list = [ids[0]];
+                        let seen = [];
+                        while (node_id_list.length > 0) {
+                            const edge = node_id_list.pop();
+                            if (edge !== undefined && !seen.includes(edge)) {
+                                seen.push(edge);
+                                const deps = graph_data["nodes"][edge]["dependencies"];
+                                for (let dep in deps) {
+                                    node_id_list.push(dep);
+                                }
+                            }
+                        }
+                        network.selectNodes(seen);
+                    }
+
                 }
                 else {
                     control.innerHTML = "Click on one package or edge to show information";
@@ -460,6 +481,10 @@ graph_info_html = r"""
             }
             function showPackageType(e) {
                 show_package_type = !show_package_type;
+                draw();
+            }
+            function showSubgraph(e) {
+                show_subgraph = !show_subgraph;
                 draw();
             }
             function showhideclass(id) {

--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -45,6 +45,10 @@ graph_info_html = r"""
                 overflow-y: auto;
                 padding: 5px 10px;
             }
+            #details {
+                background-color: #f3f3f3;
+                overflow-y: auto;
+            }
         </style>
 
         <div id="container">
@@ -403,34 +407,7 @@ graph_info_html = r"""
                     div2.innerHTML = "<pre>" + div.innerHTML + "</pre>";
                     control.appendChild(div2);
                     if (show_subgraph && graph_data["nodes"][ids[0]]) {
-                        let node_id_list = [ids[0]];
-                        let seen_nodes = [];
-                        let seen_edges = [];
-                        while (node_id_list.length > 0) {
-                            const node_id = node_id_list.pop();
-                            if (node_id !== undefined && !seen_nodes.includes(node_id)) {
-                                seen_nodes.push(node_id);
-                                const node = graph_data["nodes"][node_id];
-                                for (let dep_id in node["dependencies"]) {
-                                    if (collapse_packages) {
-                                        const dep_node = graph_data["nodes"][dep_id];
-                                        const context = dep_node["context"];
-                                        const label = getNodeLabel(dep_node);
-                                        dep_id = collapsed_packages[context][label];
-                                    }
-                                    node_id_list.push(dep_id);
-                                }
-                                const edges = network.getConnectedEdges(node_id);
-                                for (let edge_id of edges) {
-                                    const connectedNodes = network.getConnectedNodes(edge_id);
-                                    if (!seen_edges.includes(edge_id) && connectedNodes[0] === node_id) {
-                                        seen_edges.push(edge_id);
-                                    }
-                                }
-                            }
-                        }
-                        network.setSelection({nodes: seen_nodes, edges: seen_edges},
-                                            {unselectAll: true, highlightEdges: false});
+                        setSubgraphSelectionFromNode(ids[0]);
                     }
 
                 }
@@ -512,6 +489,40 @@ graph_info_html = r"""
                 else
                     label = node.recipe == "Consumer"? "conanfile": "CLI";
                 return label;
+            }
+            function setSubgraphSelectionFromNode(starting_node_id) {
+                let node_id_list = [starting_node_id];
+                let seen_nodes = [];
+                let seen_edges = [];
+                while (node_id_list.length > 0) {
+                    const node_id = node_id_list.pop();
+                    // The node might be hidden
+                    if (network.findNode(node_id).length == 0) continue;
+                    if (node_id !== undefined && !seen_nodes.includes(node_id)) {
+                        const node = graph_data["nodes"][node_id];
+                        seen_nodes.push(node_id);
+                        for (let dep_id in node["dependencies"]) {
+                            // Collapsed dependencies dont have an edge to the matching id, find which
+                            if (collapse_packages) {
+                                const dep_node = graph_data["nodes"][dep_id];
+                                const context = dep_node["context"];
+                                const label = getNodeLabel(dep_node);
+                                dep_id = collapsed_packages[context][label];
+                            }
+                            node_id_list.push(dep_id);
+                        }
+                        const edges = network.getConnectedEdges(node_id);
+                        for (let edge_id of edges) {
+                            const connectedNodes = network.getConnectedNodes(edge_id);
+                            // Only select edges that have a fromId (0th index) equal to current node
+                            if (!seen_edges.includes(edge_id) && connectedNodes[0] === node_id) {
+                                seen_edges.push(edge_id);
+                            }
+                        }
+                    }
+                }
+                network.setSelection({nodes: seen_nodes, edges: seen_edges},
+                                     {unselectAll: true, highlightEdges: false});
             }
             window.addEventListener("load", () => {
                draw();

--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -48,6 +48,9 @@ graph_info_html = r"""
             #details {
                 background-color: #f3f3f3;
                 overflow-y: auto;
+                border: 1px solid #e4e4e4;
+                border-radius: 5px;
+                padding: 3px 5px;
             }
         </style>
 

--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -123,13 +123,14 @@ graph_info_html = r"""
                              Invalid: "Red",
                              Platform: "Violet"};
             let global_edges = {};
+            let collapsed_packages = null;
             function define_data(){
                 let nodes = [];
                 let edges = [];
-                let collapsed_packages = {"build": {}, "host": {}};
+                collapsed_packages = {"build": {}, "host": {}};
                 let targets = {};
                 global_edges = {};
-                let edge_counter = 0;
+                let edge_counter = Math.max(...Object.keys(graph_data["nodes"])) + 1;
                 let conflict=null;
                 let provide_conflict=null;
                 let missing_error=null;
@@ -146,13 +147,7 @@ graph_info_html = r"""
                     if (node.context == "build" && hide_build) continue;
                     if (node.test && hide_test) continue;
                     let shape = node.context == "build" || node.test ? "ellipse" : "box";
-                    let label = null;
-                    if (node["name"])
-                        label =  node["name"] + "/" + node["version"];
-                    else if (node["ref"])
-                        label = node["ref"];
-                    else
-                        label = node.recipe == "Consumer"? "conanfile": "CLI";
+                    const label = getNodeLabel(node);
                     if (collapse_packages) {
                         let existing = collapsed_packages[node.context][label];
                         targets[node_id] = existing;
@@ -409,18 +404,33 @@ graph_info_html = r"""
                     control.appendChild(div2);
                     if (show_subgraph && graph_data["nodes"][ids[0]]) {
                         let node_id_list = [ids[0]];
-                        let seen = [];
+                        let seen_nodes = [];
+                        let seen_edges = [];
                         while (node_id_list.length > 0) {
-                            const edge = node_id_list.pop();
-                            if (edge !== undefined && !seen.includes(edge)) {
-                                seen.push(edge);
-                                const deps = graph_data["nodes"][edge]["dependencies"];
-                                for (let dep in deps) {
-                                    node_id_list.push(dep);
+                            const node_id = node_id_list.pop();
+                            if (node_id !== undefined && !seen_nodes.includes(node_id)) {
+                                seen_nodes.push(node_id);
+                                const node = graph_data["nodes"][node_id];
+                                for (let dep_id in node["dependencies"]) {
+                                    if (collapse_packages) {
+                                        const dep_node = graph_data["nodes"][dep_id];
+                                        const context = dep_node["context"];
+                                        const label = getNodeLabel(dep_node);
+                                        dep_id = collapsed_packages[context][label];
+                                    }
+                                    node_id_list.push(dep_id);
+                                }
+                                const edges = network.getConnectedEdges(node_id);
+                                for (let edge_id of edges) {
+                                    const connectedNodes = network.getConnectedNodes(edge_id);
+                                    if (!seen_edges.includes(edge_id) && connectedNodes[0] === node_id) {
+                                        seen_edges.push(edge_id);
+                                    }
                                 }
                             }
                         }
-                        network.selectNodes(seen);
+                        network.setSelection({nodes: seen_nodes, edges: seen_edges},
+                                            {unselectAll: true, highlightEdges: false});
                     }
 
                 }
@@ -492,6 +502,16 @@ graph_info_html = r"""
                 for (let i = 0; i < elements.length; i++) {
                     elements[i].style.display = (elements[i].style.display != 'none') ? 'none' : 'block';
                 }
+            }
+            function getNodeLabel(node) {
+                let label = null;
+                if (node["name"])
+                    label =  node["name"] + "/" + node["version"];
+                else if (node["ref"])
+                    label = node["ref"];
+                else
+                    label = node.recipe == "Consumer"? "conanfile": "CLI";
+                return label;
             }
             window.addEventListener("load", () => {
                draw();

--- a/conan/cli/formatters/graph/info_graph_html.py
+++ b/conan/cli/formatters/graph/info_graph_html.py
@@ -21,12 +21,39 @@ graph_info_html = r"""
                 display: inline-block;
                 font-size: 18px;
             }
+            label {
+                user-select: none
+            }
+
+            #container {
+                display: grid;
+                grid-template-columns: 75% 25%;
+                grid-template-rows: 50px auto;
+                height: 100vh;
+            }
+            #mylegend {
+                border-bottom: 2px solid #f2f2f2;
+                grid-column-end: span 1;
+                font-size: 14px;
+                height: 100%;
+            }
+            #empty-sidebar, #sidebar {
+                background-color: #f9f9fe;
+                border: none;
+                min-height:100%;
+                height:0;
+                overflow-y: auto;
+                padding: 5px 10px;
+            }
         </style>
 
-        <div style="display: grid; grid-template-columns: 75% 25%; grid-template-rows: 30px auto; height: 100vh;">
-            <div id="mylegend" style="background-color: lightgrey; grid-column-end: span 2;height: 100%"></div>
+        <div id="container">
+            <div id="mylegend"></div>
+            <div id="empty-sidebar">
+                <h3>Controls</h3>
+            </div>
             <div id="mynetwork"></div>
-            <div style="background-color: lightgrey;min-height:100%;height:0;overflow-y: auto;">
+            <div id="sidebar">
                 <div>
                     <input type="checkbox" onchange="switchBuild()" id="show_build_requires" checked />
                     <label for="show_build_requires">Show build-requires</label>
@@ -54,11 +81,18 @@ graph_info_html = r"""
                     <input type="search" placeholder="Exclude packages..." title="Add a comma to exclude an additional package" oninput="excludePackages(this)">
                 </div>
                 <div>
-                    <input type="checkbox" onchange="showhideclass('controls')" id="show_controls"/>
-                    <label for="show_controls">Show graph controls</label>
+                    <details>
+                    <summary>Extra graph controls</summary>
+                    <div id="controls" class="controls" style="padding: 5;"></div>
+                    </details>
                 </div>
-                <div id="controls" class="controls" style="padding:5; display:none"></div>
-                <div id="details"  style="padding:10;" class="noPrint">Package info: Click on one package to show information</div>
+
+                <div id="details-container" style="padding:10;" class="noPrint">
+                    <h3>Information</h3>
+                    <div id="details">
+                    Click on one package or edge to show information
+                    </div>
+                </div>
                 <div id="error" style="padding:10;" class="noPrint"></div>
             </div>
         </div>
@@ -370,7 +404,7 @@ graph_info_html = r"""
                     control.appendChild(div2);
                 }
                 else {
-                    control.innerHTML = "<b>Info</b>: Click on a package or edge for more info";
+                    control.innerHTML = "Click on one package or edge to show information";
                 }
             });
             function draw() {

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -770,8 +770,6 @@ diff_html = r"""
                     "new": document.getElementById("show-new-files").checked,
                     "old": document.getElementById("show-old-files").checked,
                 };
-                console.log("Include", includeSearchQuery);
-                console.log("Exclude", excludeSearchQuery);
                 sidebar.forEach(async function(item) {
                     if (item.dataset.path === undefined) {
                         // A folder, those are handled later
@@ -793,8 +791,6 @@ diff_html = r"""
                     const isTypeVisible = typeVisibility[fileType] !== false;
 
                     shouldExclude = shouldExclude || !isTypeVisible;
-
-                    console.log(text, shouldInclude, includeSearchQuery === "", text.includes(includeSearchQuery), extensions[extension] === true, extension);
 
                     if (shouldInclude) {
                         if (shouldExclude) {

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -96,9 +96,9 @@ diff_html = r"""
                 --context-chunk-header-bgColor: #e7f6ff;
                 --context-chunk-header-color: var(--context-line-color);
                 --added-line-bgColor: #dafbe1;
-                --added-line-color: #1a7f37;
+                --added-line-color: black;
                 --deleted-line-bgColor: #ffebe9;
-                --deleted-line-color: #d1242f;
+                --deleted-line-color: black;
                 --line-number-added-bgColor: #b6f4bb;
                 --line-number-deleted-bgColor: #ffd6d5;
                 --shadow: 0 2px 8px 0 #0001;

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -517,7 +517,7 @@ diff_html = r"""
                         const ext = file.split('.').pop();
                         if (extensions[ext] === undefined) {
                             exts.push(ext);
-                            extensions[ext] = false;
+                            extensions[ext] = true;
                         }
                     } else {
                         addNoExtension = true;
@@ -526,7 +526,7 @@ diff_html = r"""
                 exts.sort();
                 if (addNoExtension) {
                     exts.unshift(null);
-                    extensions[null] = false;
+                    extensions[null] = true;
                 }
 
                 /* example: <div class="file-tree-more-option">
@@ -750,8 +750,8 @@ diff_html = r"""
                     }, delay);
                 };
             }
-            let includeSearchQuery = new RegExp(".*", "i")
-            let excludeSearchQuery = new RegExp("", "i");
+            let includeSearchQuery = "";
+            let excludeSearchQuery = "";
 
             async function onSearchInput() {
                 const sidebar = document.querySelectorAll(".sidebar li");
@@ -770,6 +770,8 @@ diff_html = r"""
                     "new": document.getElementById("show-new-files").checked,
                     "old": document.getElementById("show-old-files").checked,
                 };
+                console.log("Include", includeSearchQuery);
+                console.log("Exclude", excludeSearchQuery);
                 sidebar.forEach(async function(item) {
                     if (item.dataset.path === undefined) {
                         // A folder, those are handled later
@@ -782,8 +784,8 @@ diff_html = r"""
                     if (filenameParts.length > 1) {
                         extension = filenameParts.pop();
                     }
-                    const shouldInclude = includeSearchQuery.test(text) && extensions[extension] === true;
-                    let shouldExclude = excludeSearchQuery.test(text) && extensions[extension] === false;
+                    const shouldInclude = (includeSearchQuery === "" || text.includes(includeSearchQuery)) && extensions[extension] === true;
+                    let shouldExclude = (excludeSearchQuery !== "" && text.includes(excludeSearchQuery)) && extensions[extension] === false;
                     const associatedId = item.querySelector("a").getAttribute("href").substring(1)
                     const contentItem = document.getElementById(associatedId);
 
@@ -791,6 +793,8 @@ diff_html = r"""
                     const isTypeVisible = typeVisibility[fileType] !== false;
 
                     shouldExclude = shouldExclude || !isTypeVisible;
+
+                    console.log(text, shouldInclude, includeSearchQuery === "", text.includes(includeSearchQuery), extensions[extension] === true, extension);
 
                     if (shouldInclude) {
                         if (shouldExclude) {
@@ -841,17 +845,12 @@ diff_html = r"""
             const debouncedOnSearchInput = debounce(onSearchInput, 300);
 
             async function onExcludeSearchInput(event) {
-                let expr = event.currentTarget.value.toLowerCase();
-                excludeSearchQuery = new RegExp(expr, "i")
+                excludeSearchQuery = event.currentTarget.value.toLowerCase();
                 debouncedOnSearchInput();
             }
 
             async function onIncludeSearchInput(event) {
-                let expr = event.currentTarget.value.toLowerCase();
-                if (expr === "") {
-                    expr = ".*";
-                }
-                includeSearchQuery = new RegExp(expr, "i")
+                includeSearchQuery = event.currentTarget.value.toLowerCase();
                 debouncedOnSearchInput();
             }
 

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -185,7 +185,8 @@ diff_html = r"""
 
             .file-tree-controls button,
             .sidebar-reveal button,
-            .search-header button {
+            .search-header button,
+            .file-tree-more button {
                 cursor: pointer;
                 border: 0px solid var(--search-field-borderColor);
                 border-radius: 5px;
@@ -196,7 +197,8 @@ diff_html = r"""
 
             .file-tree-controls button:hover,
             .sidebar-reveal button:hover,
-            .search-header button:hover {
+            .search-header button:hover,
+            .file-tree-more button:hover {
                 background-color: var(--sidebar-li-a-hover-bgColor);
             }
 
@@ -208,6 +210,13 @@ diff_html = r"""
 
             .file-tree-more-option {
                 display: block;
+            }
+
+            #file-tree-more-extensions {
+                max-height: 200px;
+                overflow-y: scroll;
+                border: 1px solid var(--file-list-borderColor);
+                border-radius: 5px;
             }
 
             .file-list {
@@ -496,6 +505,56 @@ diff_html = r"""
                 return [parseInt(match[1]), parseInt(match[2])];
             }
 
+            let extensions = {}
+
+            function initializeExtensionsFilter() {
+                const exts = [];
+                for (let path in data) {
+                    const bits = path.split("/");
+                    const file = bits.pop();
+                    if (file.includes(".")) {
+                        const ext = file.split('.').pop();
+                        if (extensions[ext] === undefined) {
+                            exts.push(ext);
+                            extensions[ext] = false;
+                        }
+                    }
+                }
+                exts.sort();
+
+                /* example: <div class="file-tree-more-option">
+                                <input type="checkbox" id="show-moved-files" checked
+                                    onclick="debouncedOnSearchInput(event)"/>
+                                <label for="show-moved-files">Moved files</label>
+                            </div> */
+                const container = document.getElementById("file-tree-more-extensions");
+                for (let ext of exts) {
+                    const optionDiv = document.createElement("div");
+                    const checkbox = document.createElement("input")
+                    const label = document.createElement("label")
+
+                    const id = "show-ext-" + ext;
+
+                    optionDiv.classList.add("file-tree-more-option");
+
+                    checkbox.id = id;
+                    checkbox.type = "checkbox"
+                    checkbox.checked = true;
+                    checkbox.dataset.extension = ext;
+                    checkbox.onclick = (event) => {
+                        onExtensionsChange(event);
+                    }
+
+                    label.for = id;
+                    label.innerText = "." + ext;
+
+                    optionDiv.appendChild(checkbox);
+                    optionDiv.appendChild(label);
+
+                    container.appendChild(optionDiv);
+                }
+
+            }
 
             function makeDiffLines(lines) {
                 const element = document.createElement("div");
@@ -667,6 +726,7 @@ diff_html = r"""
                 document.querySelectorAll('.diff-container').forEach((section) => {
                     observer.observe(section);
                 });
+                initializeExtensionsFilter();
             });
 
             function debounce(func, delay) {
@@ -679,8 +739,8 @@ diff_html = r"""
                     }, delay);
                 };
             }
-            let includeSearchQuery = "";
-            let excludeSearchQuery = "";
+            let includeSearchQuery = new RegExp(".*", "i")
+            let excludeSearchQuery = new RegExp("", "i");
 
             async function onSearchInput(event) {
                 const sidebar = document.querySelectorAll(".sidebar li");
@@ -706,8 +766,10 @@ diff_html = r"""
                         return;
                     }
                     const text = item.dataset.path.toLowerCase();
-                    const shouldInclude = includeSearchQuery === "" || text.includes(includeSearchQuery);
-                    let shouldExclude = excludeSearchQuery !== "" && text.includes(excludeSearchQuery);
+                    const bits = text.split("/");
+                    const extension = bits.pop().split(".").pop();
+                    const shouldInclude = includeSearchQuery.test(text) && extensions[extension] === true;
+                    let shouldExclude = excludeSearchQuery.test(text) && extensions[extension] === false;
                     const associatedId = item.querySelector("a").getAttribute("href").substring(1)
                     const contentItem = document.getElementById(associatedId);
 
@@ -765,13 +827,33 @@ diff_html = r"""
             const debouncedOnSearchInput = debounce(onSearchInput, 300);
 
             async function onExcludeSearchInput(event) {
-                excludeSearchQuery = event.currentTarget.value.toLowerCase();
+                let expr = event.currentTarget.value.toLowerCase();
+                excludeSearchQuery = new RegExp(expr, "i")
                 debouncedOnSearchInput(event);
             }
 
             async function onIncludeSearchInput(event) {
-                includeSearchQuery = event.currentTarget.value.toLowerCase();
+                let expr = event.currentTarget.value.toLowerCase();
+                if (expr === "") {
+                    expr = ".*";
+                }
+                includeSearchQuery = new RegExp(expr, "i")
                 debouncedOnSearchInput(event);
+            }
+
+            function onExtensionsChange(event) {
+                const ext = event.currentTarget.dataset.extension;
+                const value = event.currentTarget.checked;
+                extensions[ext] = value;
+                debouncedOnSearchInput(event);
+            }
+
+            function onExtensionsToggle(value) {
+                const container = document.getElementById("file-tree-more-extensions");
+                const checkboxes = container.getElementsByTagName("input");
+                for (let checkbox of checkboxes) {
+                    checkbox.checked = value;
+                }
             }
 
             function setDataIsLinked(event) {
@@ -820,7 +902,6 @@ diff_html = r"""
 
             function toggleMoreFileTree() {
                 const moreOptions = document.querySelector('.file-tree-more');
-                console.log(moreOptions.style.display);
                 const show = moreOptions.style.display !== 'block';
                 if (show) {
                     moreOptions.style.display = 'block';
@@ -892,6 +973,10 @@ diff_html = r"""
                                     onclick="debouncedOnSearchInput(event)"/>
                                 <label for="show-moved-files">Moved files</label>
                             </div>
+                            <h4>Extensions</h4>
+                            <button onclick="onExtensionsToggle(true);">Check all</button>
+                            <button onclick="onExtensionsToggle(false);">Uncheck all</button>
+                            <div id="file-tree-more-extensions"></div>
                         </div>
                         <ul class="file-list">
                             {{ render_sidebar_folder("", per_folder) }}

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -66,41 +66,41 @@ diff_html = r"""
         <style>
             /* --- Colors --- */
             :root {
-                --body-bgColor: #f8f8f8;
-                --sidebar-bgColor: #f4f4f466;
-                --sidebar-borderColor: #ccc;
-                --sidebar-contents-bgColor: #f4f4f4;
-                --content-bgColor: #f8f8f8;
-                --search-area-borderColor: #ccc;
-                --search-field-borderColor: #ccc;
-                --file-list-borderColor: #ddd;
-                --folder-summary-hover-bgColor: #e0e0e033;
-                --folder-ul-hover-borderColor: #00000066;
-                --sidebar-li-a-hover-bgColor: #e0e0e0;
+                --body-bgColor: #ffffff;
+                --sidebar-bgColor: #f4f6fbcc;
+                --sidebar-borderColor: #d0d7de;
+                --sidebar-contents-bgColor: #f4f6fb;
+                --content-bgColor: #ffffff;
+                --search-area-borderColor: #d0d7de;
+                --search-field-borderColor: #d0d7de;
+                --file-list-borderColor: #eaecef;
+                --folder-summary-hover-bgColor: #e5eaf3cc;
+                --folder-ul-hover-borderColor: #b6b6b6cc;
+                --sidebar-li-a-hover-bgColor: #e5eaf3;
                 --sidebar-button-hover-bgColor: var(--sidebar-li-a-hover-bgColor);
-                --sidebar-link-color: black;
+                --sidebar-link-color: #22272e;
                 --sidebar-link-hover-color: var(--sidebar-link-color);
                 --sidebar-link-visited-color: var(--sidebar-link-color);
-                --sidebar-file-new-color: green;
-                --sidebar-file-old-color: gray;
-                --sidebar-file-deleted-color: red;
-                --diff-content-borderColor: black;
-                --diff-content-bgColor: white;
-                --diff-container-linked-borderColor: #0078d7;
-                --diff-summary-borderColor: #ccc;
-                --diff-summary-bgColor: #f8f8f8;
-                --diff-summary-hover-bgColor: #f0f0f0;
-                --new-lines-count-color: green;
-                --old-lines-count-color: black;
-                --context-line-color: #888;
-                --context-chunk-header-bgColor: #cef8ff;
+                --sidebar-file-new-color: #1a7f37;
+                --sidebar-file-old-color: #6e7781;
+                --sidebar-file-deleted-color: #d1242f;
+                --diff-content-borderColor: #d0d7de;
+                --diff-content-bgColor: #fff;
+                --diff-container-linked-borderColor: #0969da;
+                --diff-summary-borderColor: #d0d7de;
+                --diff-summary-bgColor: #f6f8fa;
+                --diff-summary-hover-bgColor: #eaeef2;
+                --new-lines-count-color: #1a7f37;
+                --old-lines-count-color: #6e7781;
+                --context-line-color: #6e7781;
+                --context-chunk-header-bgColor: #e7f6ff;
                 --context-chunk-header-color: var(--context-line-color);
-                --added-line-bgColor: #cbfcd9;
-                --added-line-color: black;
+                --added-line-bgColor: #dafbe1;
+                --added-line-color: #1a7f37;
                 --deleted-line-bgColor: #ffebe9;
-                --deleted-line-color: black;
-                --line-number-added-bgColor: #76ffbb;
-                --line-number-deleted-bgColor: #fdb9c1;
+                --deleted-line-color: #d1242f;
+                --line-number-added-bgColor: #b6f4bb;
+                --line-number-deleted-bgColor: #ffd6d5;
                 --shadow: 0 2px 8px 0 #0001;
                 --radius: 10px;
                 --transition: 0.15s cubic-bezier(.4,0,.2,1);
@@ -144,8 +144,6 @@ diff_html = r"""
                 background: var(--content-bgColor);
                 width: 100%;
                 border-radius: var(--radius);
-                box-shadow: var(--shadow);
-                transition: box-shadow var(--transition);
             }
 
             /* --- Sidebar & File Tree --- */
@@ -669,7 +667,9 @@ diff_html = r"""
                         } else {
                             const spanSymbol = document.createElement("span");
                             spanSymbol.className = "diff-symbol";
-                            spanLine.textContent = line;
+                            // Removes the empty space from the beginning of the line,
+                            // to match layout of removed char for diff lines
+                            spanLine.textContent = line.substring(1);
                             spanLine.prepend(spanSymbol);
                         }
 

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -101,6 +101,9 @@ diff_html = r"""
                 --deleted-line-color: black;
                 --line-number-added-bgColor: #76ffbb;
                 --line-number-deleted-bgColor: #fdb9c1;
+                --shadow: 0 2px 8px 0 #0001;
+                --radius: 10px;
+                --transition: 0.15s cubic-bezier(.4,0,.2,1);
             }
 
             /* --- Global Styles --- */
@@ -117,6 +120,7 @@ diff_html = r"""
                 display: flex;
                 height: 100%;
                 overflow: scroll;
+                background: var(--body-bgColor);
             }
 
             .sidebar {
@@ -130,19 +134,25 @@ diff_html = r"""
                 resize: horizontal;
                 position: sticky;
                 top: 0;
+                box-shadow: var(--shadow);
+                border-radius: 0 var(--radius) var(--radius) 0;
+                transition: box-shadow var(--transition);
             }
 
             .content {
                 padding: 20px;
                 background: var(--content-bgColor);
                 width: 100%;
+                border-radius: var(--radius);
+                box-shadow: var(--shadow);
+                transition: box-shadow var(--transition);
             }
 
             /* --- Sidebar & File Tree --- */
 
             #sidebar-contents {
                 background: var(--sidebar-contents-bgColor);
-                border-radius: 7px;
+                border-radius: var(--radius);
                 overflow-y: hidden;
                 padding-top: 5px;
             }
@@ -164,7 +174,7 @@ diff_html = r"""
 
             .search-field {
                 border: 1px solid var(--search-field-borderColor);
-                border-radius: 5px;
+                border-radius: var(--radius);
                 padding: 5px;
                 margin: 5px;
                 width: 80%;
@@ -189,7 +199,7 @@ diff_html = r"""
             .file-tree-more button {
                 cursor: pointer;
                 border: 0px solid var(--search-field-borderColor);
-                border-radius: 5px;
+                border-radius: var(--radius);
                 background: none;
                 padding: 5px;
                 min-width: 3ch;
@@ -216,7 +226,7 @@ diff_html = r"""
                 max-height: 200px;
                 overflow-y: scroll;
                 border: 1px solid var(--file-list-borderColor);
-                border-radius: 5px;
+                border-radius: var(--radius);
             }
 
             .file-list {
@@ -278,14 +288,17 @@ diff_html = r"""
                 text-decoration: none;
                 padding: 5px;
                 color: var(--sidebar-link-color);
+                border-radius: var(--radius);
+                transition: background-color var(--transition), color var(--transition);
             }
 
             .sidebar li a:hover {
                 text-decoration: none;
-                border-radius: 5px;
+                border-radius: var(--radius);
                 background-color: var(--sidebar-li-a-hover-bgColor);
                 padding: 5px;
                 color: var(--sidebar-link-hover-color);
+                box-shadow: 0 1px 4px 0 #0001;
             }
 
             .sidebar li a:visited {
@@ -337,9 +350,11 @@ diff_html = r"""
             .diff-content {
                 padding-bottom: 7px;
                 border: 1px solid var(--diff-content-borderColor);
-                border-radius: 7px;
+                border-radius: var(--radius);
                 margin-bottom: 10px;
                 background-color: var(--diff-content-bgColor);
+                box-shadow: var(--shadow);
+                transition: box-shadow var(--transition);
             }
 
             .diff-container[data-is-linked="true"] .diff-content {
@@ -356,7 +371,7 @@ diff_html = r"""
                 position: sticky;
                 top: 0;
                 background-color: var(--diff-summary-bgColor);
-                border-radius: 7px 7px 0px 0px;
+                border-radius: var(--radius) var(--radius) 0px 0px;
             }
 
             details.diff-details summary.diff-summary:hover {

--- a/conan/cli/formatters/report/diff_html.py
+++ b/conan/cli/formatters/report/diff_html.py
@@ -509,6 +509,7 @@ diff_html = r"""
 
             function initializeExtensionsFilter() {
                 const exts = [];
+                let addNoExtension = false;
                 for (let path in data) {
                     const bits = path.split("/");
                     const file = bits.pop();
@@ -518,9 +519,15 @@ diff_html = r"""
                             exts.push(ext);
                             extensions[ext] = false;
                         }
+                    } else {
+                        addNoExtension = true;
                     }
                 }
                 exts.sort();
+                if (addNoExtension) {
+                    exts.unshift(null);
+                    extensions[null] = false;
+                }
 
                 /* example: <div class="file-tree-more-option">
                                 <input type="checkbox" id="show-moved-files" checked
@@ -541,12 +548,16 @@ diff_html = r"""
                     checkbox.type = "checkbox"
                     checkbox.checked = true;
                     checkbox.dataset.extension = ext;
-                    checkbox.onclick = (event) => {
+                    checkbox.onchange = (event) => {
                         onExtensionsChange(event);
                     }
 
                     label.for = id;
-                    label.innerText = "." + ext;
+                    if (ext != null) {
+                        label.innerText = "." + ext;
+                    } else {
+                        label.innerText = "No extension";
+                    }
 
                     optionDiv.appendChild(checkbox);
                     optionDiv.appendChild(label);
@@ -742,7 +753,7 @@ diff_html = r"""
             let includeSearchQuery = new RegExp(".*", "i")
             let excludeSearchQuery = new RegExp("", "i");
 
-            async function onSearchInput(event) {
+            async function onSearchInput() {
                 const sidebar = document.querySelectorAll(".sidebar li");
                 const fileList = document.querySelector(".file-list");
                 const content = document.querySelectorAll(".content .diff-container .diff-content");
@@ -759,7 +770,6 @@ diff_html = r"""
                     "new": document.getElementById("show-new-files").checked,
                     "old": document.getElementById("show-old-files").checked,
                 };
-
                 sidebar.forEach(async function(item) {
                     if (item.dataset.path === undefined) {
                         // A folder, those are handled later
@@ -767,7 +777,11 @@ diff_html = r"""
                     }
                     const text = item.dataset.path.toLowerCase();
                     const bits = text.split("/");
-                    const extension = bits.pop().split(".").pop();
+                    const filenameParts = bits.pop().split(".")
+                    let extension = null;
+                    if (filenameParts.length > 1) {
+                        extension = filenameParts.pop();
+                    }
                     const shouldInclude = includeSearchQuery.test(text) && extensions[extension] === true;
                     let shouldExclude = excludeSearchQuery.test(text) && extensions[extension] === false;
                     const associatedId = item.querySelector("a").getAttribute("href").substring(1)
@@ -829,7 +843,7 @@ diff_html = r"""
             async function onExcludeSearchInput(event) {
                 let expr = event.currentTarget.value.toLowerCase();
                 excludeSearchQuery = new RegExp(expr, "i")
-                debouncedOnSearchInput(event);
+                debouncedOnSearchInput();
             }
 
             async function onIncludeSearchInput(event) {
@@ -838,14 +852,14 @@ diff_html = r"""
                     expr = ".*";
                 }
                 includeSearchQuery = new RegExp(expr, "i")
-                debouncedOnSearchInput(event);
+                debouncedOnSearchInput();
             }
 
             function onExtensionsChange(event) {
                 const ext = event.currentTarget.dataset.extension;
                 const value = event.currentTarget.checked;
                 extensions[ext] = value;
-                debouncedOnSearchInput(event);
+                debouncedOnSearchInput();
             }
 
             function onExtensionsToggle(value) {
@@ -853,6 +867,19 @@ diff_html = r"""
                 const checkboxes = container.getElementsByTagName("input");
                 for (let checkbox of checkboxes) {
                     checkbox.checked = value;
+                    extensions[checkbox.dataset.extension] = value;
+                }
+                debouncedOnSearchInput();
+            }
+
+            function onExtensionsSearch(event) {
+                const filter = event.currentTarget.value.toLowerCase();
+                const container = document.getElementById("file-tree-more-extensions");
+                const checkboxes = container.getElementsByTagName("input");
+                for (let checkbox of checkboxes) {
+                    const ext = checkbox.dataset.extension;
+                    const display = filter == "" || ext.includes(filter) ? "block" : "none";
+                    checkbox.parentElement.style.display = display;
                 }
             }
 
@@ -974,6 +1001,7 @@ diff_html = r"""
                                 <label for="show-moved-files">Moved files</label>
                             </div>
                             <h4>Extensions</h4>
+                            <input type="search" class="search-field" oninput="onExtensionsSearch(event);" placeholder="Search extension"></input>
                             <button onclick="onExtensionsToggle(true);">Check all</button>
                             <button onclick="onExtensionsToggle(false);">Uncheck all</button>
                             <div id="file-tree-more-extensions"></div>

--- a/test/integration/command/info/test_graph_info_graphical.py
+++ b/test/integration/command/info/test_graph_info_graphical.py
@@ -95,10 +95,10 @@ class TestInfo:
         create_export(test_deps, "hello0")
 
         # arbitrary case - file will be named according to argument
-        self.client.run("graph info . --format=html")
-        html = self.client.stdout
+        self.client.run("graph info . --format=html", redirect_stdout="graph.html")
         # Just make sure it doesn't crash
-        assert "<body>" in html
+        assert "<body>" in self.client.load("graph.html")
+        self.client.open("graph.html")
 
 
 def test_user_templates():

--- a/test/integration/command/info/test_graph_info_graphical.py
+++ b/test/integration/command/info/test_graph_info_graphical.py
@@ -98,7 +98,6 @@ class TestInfo:
         self.client.run("graph info . --format=html", redirect_stdout="graph.html")
         # Just make sure it doesn't crash
         assert "<body>" in self.client.load("graph.html")
-        self.client.open("graph.html")
 
 
 def test_user_templates():


### PR DESCRIPTION
Changelog: Feature: Add ability to show transitive requires in `conan graph info ... -f=html` output
Changelog: Feature: Add ability to show node subgraph in `conan graph info ... -f=html` output
Changelog: Feature: Add ability to filter by file extensions in `conan report diff ... -f=html` output
Docs: Omit

PR done while I had some connectivity issues to internet so couldn't progress much more elsewhere

Some changes for the html formats of `conan graph info` (As part of the team feedback from the last conference) and `conan report diff` (as part of team feedback after usage for CCI pr reviews).


`conan report diff`
* Fixed a bug where the context lines were overindented by 1 character compared to diff lines

| Old | New |
|-----|-----|
|<img width="1913" height="926" alt="image" src="https://github.com/user-attachments/assets/3b5db8d0-2d49-472f-bfa1-2e5d715473a8" />|<img width="1919" height="926" alt="image" src="https://github.com/user-attachments/assets/550c0684-002e-44b7-9396-8503bba42618" />|

`conan graph info`
* No changes to the graph itself, that's left for follow-up PRs
* Changes to the styling mostly

| Old | New |
|-----|-----|
| <img width="1920" height="928" alt="image" src="https://github.com/user-attachments/assets/5a98e5e4-1903-4616-abb4-52ab05aad715" />|<img width="1914" height="927" alt="image" src="https://github.com/user-attachments/assets/9f5a96f7-326b-4dfd-9bb4-f6e66f270122" /> |
