### PR TITLE
fix workspace install with lockfile

### DIFF
--- a/conan/cli/commands/workspace.py
+++ b/conan/cli/commands/workspace.py
@@ -193,7 +193,10 @@ def _install_build(conan_api: ConanAPI, parser, subparser, build, *args):
     order = install_order.install_build_order()
 
     profile_args = ProfileArgs.from_args(args)
-    lockfile_args = [f"--lockfile={args.lockfile}"] if args.lockfile else ["--lockfile="]
+    # Use explicit user lockfile argument, the one in the current folder or explicitly
+    # avoid using any lockfile that could be inside workspace packages folders
+    lock = args.lockfile if args.lockfile else ("conan.lock" if lockfile else "")
+    lockfile_args = [f"--lockfile={lock}"]
     if args.lockfile_partial:
         lockfile_args.append("--lockfile-partial")
     lockfile_args = " ".join(lockfile_args)

--- a/conan/cli/commands/workspace.py
+++ b/conan/cli/commands/workspace.py
@@ -193,7 +193,7 @@ def _install_build(conan_api: ConanAPI, parser, subparser, build, *args):
     order = install_order.install_build_order()
 
     profile_args = ProfileArgs.from_args(args)
-    lockfile_args = [f"--lockfile={args.lockfile}"] if args.lockfile else []
+    lockfile_args = [f"--lockfile={args.lockfile}"] if args.lockfile else ["--lockfile="]
     if args.lockfile_partial:
         lockfile_args.append("--lockfile-partial")
     lockfile_args = " ".join(lockfile_args)

--- a/conan/cli/commands/workspace.py
+++ b/conan/cli/commands/workspace.py
@@ -193,7 +193,7 @@ def _install_build(conan_api: ConanAPI, parser, subparser, build, *args):
     order = install_order.install_build_order()
 
     profile_args = ProfileArgs.from_args(args)
-    lockfile_args = [f"--lockfile={a}" for a in args.lockfile or []]
+    lockfile_args = [f"--lockfile={args.lockfile}"] if args.lockfile else []
     if args.lockfile_partial:
         lockfile_args.append("--lockfile-partial")
     lockfile_args = " ".join(lockfile_args)

--- a/conan/cli/commands/workspace.py
+++ b/conan/cli/commands/workspace.py
@@ -170,8 +170,8 @@ def _install_build(conan_api: ConanAPI, parser, subparser, build, *args):
     remotes = conan_api.remotes.list(args.remote) if not args.no_remote else []
     # The lockfile by default if not defined will be read from the root workspace folder
     ws_folder = conan_api.workspace.folder()
-    lockfile = conan_api.lockfile.get_lockfile(lockfile=args.lockfile, conanfile_path=ws_folder,
-                                               cwd=None, partial=args.lockfile_partial)
+    lockfile = conan_api.lockfile.get_lockfile(lockfile=args.lockfile, cwd=ws_folder,
+                                               partial=args.lockfile_partial)
     conan_api.lockfile.check_lockfile_config(lockfile)
     profile_host, profile_build = conan_api.profiles.get_profiles_from_args(args)
     print_profiles(profile_host, profile_build)

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -1362,6 +1362,16 @@ class TestInstall:
         c.run("workspace create --lockfile-out=conan.lock", assert_error=True)
         assert "error: unrecognized arguments: --lockfile-out=conan.lock" in c.out
 
+    def test_install_with_lockfile(self):
+        # https://github.com/conan-io/conan/issues/19891
+        c = TestClient()
+        c.run("workspace init .")
+        c.run("new cmake_exe -d name=app -d version=1.0 -o app")
+        c.run("workspace add app")
+        c.run("lock create app")
+        c.run("workspace build --lockfile=app/conan.lock --lockfile-partial")
+        # it doesn't fail
+
 
 def test_keep_core_conf():
     c = TestClient()

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -1366,7 +1366,7 @@ class TestInstall:
         # https://github.com/conan-io/conan/issues/19891
         c = TestClient()
         c.run("workspace init .")
-        c.run("new cmake_exe -d name=app -d version=1.0 -o app")
+        c.save({"app/conanfile.py": GenConanfile("app", "1.0")})
         c.run("workspace add app")
         c.run("lock create app")
         c.run("workspace build --lockfile=app/conan.lock --lockfile-partial")

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -1372,6 +1372,23 @@ class TestInstall:
         c.run("workspace build --lockfile=app/conan.lock --lockfile-partial")
         # it doesn't fail
 
+    def test_install_error(self):
+        c = TestClient()
+        c.save({"hello/conanfile.py": GenConanfile("hello", "0.1"),
+                "app/conanfile.py": GenConanfile("app", "0.1").with_requires("hello/0.1")})
+        c.run("export hello")
+        c.run("lock create app")
+
+        # make some kind of change in hello/conanfile.py
+        c.save({"hello/conanfile.py": GenConanfile("hello", "0.1").with_class_attribute("v=1")})
+        c.run("export hello")  # (new revision)
+ 
+        # rm -rf hello/ (no longer needed)
+        shutil.rmtree(os.path.join(c.current_folder, "hello"))
+        c.run("workspace init .")
+        c.run("workspace add app")
+        c.run("workspace build --build=missing")
+
 
 def test_keep_core_conf():
     c = TestClient()

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -1389,7 +1389,7 @@ class TestInstall:
         c.run("workspace add app")
         c.run("workspace build --build=missing")
 
-    def test_build_ignore_use_auto_lockfile(self):
+    def test_build_use_auto_lockfile(self):
         c = TestClient()
         c.save({"hello/conanfile.py": GenConanfile("hello", "0.1"),
                 "app/conanfile.py": GenConanfile("app", "0.1").with_requires("hello/0.1")})
@@ -1411,6 +1411,7 @@ class TestInstall:
         c.run("workspace build --build=missing --lockfile-partial")
         assert "Using lockfile" in c.out
         assert f"hello/0.1#{rev1}" in c.out
+        assert rev2 not in c.out
 
 
 def test_keep_core_conf():

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -1372,7 +1372,7 @@ class TestInstall:
         c.run("workspace build --lockfile=app/conan.lock --lockfile-partial")
         # it doesn't fail
 
-    def test_install_error(self):
+    def test_build_ignore_local_lockfiles(self):
         c = TestClient()
         c.save({"hello/conanfile.py": GenConanfile("hello", "0.1"),
                 "app/conanfile.py": GenConanfile("app", "0.1").with_requires("hello/0.1")})
@@ -1382,12 +1382,35 @@ class TestInstall:
         # make some kind of change in hello/conanfile.py
         c.save({"hello/conanfile.py": GenConanfile("hello", "0.1").with_class_attribute("v=1")})
         c.run("export hello")  # (new revision)
- 
+
         # rm -rf hello/ (no longer needed)
         shutil.rmtree(os.path.join(c.current_folder, "hello"))
         c.run("workspace init .")
         c.run("workspace add app")
         c.run("workspace build --build=missing")
+
+    def test_build_ignore_use_auto_lockfile(self):
+        c = TestClient()
+        c.save({"hello/conanfile.py": GenConanfile("hello", "0.1"),
+                "app/conanfile.py": GenConanfile("app", "0.1").with_requires("hello/0.1")})
+        c.run("export hello")
+        rev1 = c.exported_recipe_revision()
+        # This is in the root workspace folder, so it is found automatically
+        c.run("lock create app --lockfile-out=conan.lock")
+
+        # make some kind of change in hello/conanfile.py
+        c.save({"hello/conanfile.py": GenConanfile("hello", "0.1").with_class_attribute("v=1")})
+        c.run("export hello")  # (new revision)
+        rev2 = c.exported_recipe_revision()
+        assert rev2 != rev1
+
+        # rm -rf hello/ (no longer needed)
+        shutil.rmtree(os.path.join(c.current_folder, "hello"))
+        c.run("workspace init .")
+        c.run("workspace add app")
+        c.run("workspace build --build=missing --lockfile-partial")
+        assert "Using lockfile" in c.out
+        assert f"hello/0.1#{rev1}" in c.out
 
 
 def test_keep_core_conf():

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -1388,6 +1388,14 @@ class TestInstall:
         c.run("workspace init .")
         c.run("workspace add app")
         c.run("workspace build --build=missing")
+        assert "Using lockfile" not in c.out
+
+        c.run("lock create --requires=app/0.1 --lockfile-out=conan.lock")
+        c.run("workspace build --build=missing")
+        assert "Using lockfile" in c.out
+
+        c.run("workspace build --build=missing --lockfile=")
+        assert "Using lockfile" not in c.out
 
     def test_build_use_auto_lockfile(self):
         c = TestClient()


### PR DESCRIPTION
Changelog: Bugfix: Solve crash of ``conan workspace install/build --lockfile=mylock --lockfile-partial``
Changelog: Fix: Ignore local package lockfiles in ``conan workspace install/build`` and use consistently a global lockfile if provided or found by default. 
Docs: Omit

Close https://github.com/conan-io/conan/issues/19891
Close https://github.com/conan-io/conan/issues/19894