### PR TITLE
Allow using patch-ng 1.19 as a dependency

### DIFF
--- a/conans/requirements.txt
+++ b/conans/requirements.txt
@@ -2,7 +2,7 @@ requests>=2.25, <3.0.0
 urllib3>=1.26.6, <3.0
 colorama>=0.4.3, <0.5.0
 PyYAML>=6.0, <7.0
-patch-ng>=1.18.0, <1.19
+patch-ng>=1.18.0, <1.20
 fasteners>=0.15
 distro>=1.4.0, <2.0.0; platform_system == 'Linux' or platform_system == 'FreeBSD'
 Jinja2>=3.0, <4.0.0


### PR DESCRIPTION
Changelog: Feature: Allow using patch-ng 1.19 to incorporate fixes
Docs: Omit

The Patch-NG 1.19.0 was released 6 months ago, and has a few fixes, including one reported in the Conan client. Version 1.19.1 was recently released, only to include wheel support; no code changes were made: https://github.com/conan-io/python-patch-ng/releases/tag/1.19.0

In order to validate that version 1.19 will not break patches that were working with 1.18.0, a script was created to run over all recipes of Conan Center Index, where each project is downloaded and patched. The process is executed using patch-ng 1.18 and 1.19; later, the script compares both trees to check for any differences. 

No differences were found. See the script and the full log available here: https://gist.github.com/uilianries/4ac2fcfdeae10726004eb38bd9f5c2b9

Regards! 

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
