### PR TITLE
allow upload to disabled remotes

### DIFF
--- a/conan/cli/commands/upload.py
+++ b/conan/cli/commands/upload.py
@@ -70,6 +70,8 @@ def upload(conan_api: ConanAPI, parser, *args):
                         help='Upload all matching recipes without confirmation')
     parser.add_argument('--dry-run', default=False, action='store_true',
                         help='Do not execute the real upload (experimental)')
+    parser.add_argument('--allow-disabled', default=False, action='store_true',
+                        help='Allow uploading to disabled remote')
     parser.add_argument("-l", "--list", help="Package list file")
     parser.add_argument("-m", "--metadata", action='append',
                         help='Upload the metadata, even if the package is already in the server and '
@@ -86,6 +88,8 @@ def upload(conan_api: ConanAPI, parser, *args):
         raise ConanException("Cannot define both the pattern and the package list file")
     if args.package_query and args.list:
         raise ConanException("Cannot define package-query and the package list file")
+    if args.allow_disabled:
+        remote.disabled = False
 
     if args.list:
         listfile = make_abs_path(args.list)

--- a/test/integration/command/upload/upload_test.py
+++ b/test/integration/command/upload/upload_test.py
@@ -562,3 +562,14 @@ def test_upload_json_output(dry_run):
         assert "upload-urls" not in c.out
         assert "url:" not in c.out
         assert "checksum:" not in c.out
+
+
+def test_upload_to_disabled():
+    c = TestClient(default_server_user=True, light=True)
+    c.run("remote disable *")
+    c.save({"conanfile.py": GenConanfile("tool", "0.1")})
+    c.run("create")
+    c.run("upload * -c -r=default", assert_error=True)
+    assert "ERROR: Remote 'default' is disabled" in c.out
+    c.run("upload * -c -r=default --allow-disabled")
+    assert "tool/0.1: Uploading recipe" in c.out


### PR DESCRIPTION
Changelog: Feature: ``conan upload --allow-disabled`` to allow uploading to a disabled remote.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19914
