### PR TITLE
Add gcc 16 support

### DIFF
--- a/conan/internal/api/detect/detect_api.py
+++ b/conan/internal/api/detect/detect_api.py
@@ -307,6 +307,8 @@ def default_cppstd(compiler, compiler_version):
         return "gnu98" if version < "6" else "gnu14"
 
     def _gcc_cppstd_default(version):
+        if version >= "16":
+            return "gnu20"
         if version >= "11":
             return "gnu17"
         return "gnu98" if version < "6" else "gnu14"

--- a/conan/internal/default_settings.py
+++ b/conan/internal/default_settings.py
@@ -123,7 +123,8 @@ compiler:
                     "12", "12.1", "12.2", "12.3", "12.4", "12.5",
                     "13", "13.1", "13.2", "13.3", "13.4",
                     "14", "14.1", "14.2", "14.3",
-                    "15", "15.1", "15.2"]
+                    "15", "15.1", "15.2",
+                    "16", "16.1"]
         libcxx: [libstdc++, libstdc++11]
         threads: [null, posix, win32, mcf]  # Windows MinGW
         exception: [null, dwarf2, sjlj, seh]  # Windows MinGW

--- a/test/unittests/client/build/cpp_std_flags_test.py
+++ b/test/unittests/client/build/cpp_std_flags_test.py
@@ -83,6 +83,15 @@ class TestCompilerFlags:
         assert _make_cppstd_flag("gcc", "15", "20") == '-std=c++20'
         assert _make_cppstd_flag("gcc", "15", "23") == '-std=c++23'
         assert _make_cppstd_flag("gcc", "15", "26") == '-std=c++26'
+        assert _make_cppstd_flag("gcc", "15", "26") == '-std=c++26'
+
+        assert _make_cppstd_flag("gcc", "16", "11") == '-std=c++11'
+        assert _make_cppstd_flag("gcc", "16", "14") == '-std=c++14'
+        assert _make_cppstd_flag("gcc", "16", "17") == '-std=c++17'
+        assert _make_cppstd_flag("gcc", "16", "20") == '-std=c++20'
+        assert _make_cppstd_flag("gcc", "16", "23") == '-std=c++23'
+        assert _make_cppstd_flag("gcc", "16", "26") == '-std=c++26'
+        assert _make_cppstd_flag("gcc", "16", "26") == '-std=c++26'
 
     def test_gcc_cppstd_defaults(self):
         assert _make_cppstd_default("gcc", "4") == "gnu98"
@@ -94,6 +103,8 @@ class TestCompilerFlags:
         assert _make_cppstd_default("gcc", "11") == "gnu17"
         assert _make_cppstd_default("gcc", "11.1") == "gnu17"
         assert _make_cppstd_default("gcc", "15.1") == "gnu17"
+        assert _make_cppstd_default("gcc", "16") == "gnu20"
+        assert _make_cppstd_default("gcc", "16.1") == "gnu20"
 
     def test_clang_cppstd_flags(self):
         assert _make_cppstd_flag("clang", "2.0", "98") is None


### PR DESCRIPTION
Changelog: Feature: Add support for GCC 16.
Docs: Omit

GCC 16 is soon (generic April-May date is given at the moment which should be tagged as 16.1, see for example [here](https://www.phoronix.com/news/GCC-16.1-Coming-Soon))  to be released and we already have 16.0 in latest Fedora.

Tested the changes (all related tests run successfully) on latest Fedora.
