### PR TITLE
fix workspace pattern conf

### DIFF
--- a/conan/api/subapi/workspace.py
+++ b/conan/api/subapi/workspace.py
@@ -332,8 +332,10 @@ class WorkspaceAPI:
         if root_class is not None:
             conanfile = root_class(f"{WORKSPACE_PY} base project Conanfile")
             conanfile._conan_is_consumer = True
+            # We extract the ref, so pattern-based conf works too
+            ref = RecipeReference(conanfile.name, conanfile.version) if conanfile.name else None
             initialize_conanfile_profile(conanfile, profile_build, profile_host, CONTEXT_HOST,
-                                         is_build_require=False)
+                                         is_build_require=False, ref=ref)
             # consumer_definer(conanfile, profile_host, profile_build)
             self._init_options(conanfile, profile_host.options)
             for field in ("requires", "build_requires", "test_requires", "requirements", "build",

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -832,6 +832,32 @@ class TestMeta:
         c.run("workspace super-install -of=build -o *:myoption=1")
         assert "project Conanfile: Generating with opt dep/0.1:myoption=1!!!!" in c.out
 
+    def test_apply_conf_pattern(self):
+        c = TestClient()
+        conanfilews = textwrap.dedent("""
+            from conan import ConanFile
+            from conan import Workspace
+
+            class MyWs(ConanFile):
+                name = "mywspkg"
+                def generate(self):
+                    self.output.info(f"Generating with conf {self.conf.get("user:myconf")}!!")
+
+            class Ws(Workspace):
+                def root_conanfile(self):
+                    return MyWs
+            """)
+
+        c.save({"dep/conanfile.py": GenConanfile("dep", "0.1"),
+                "conanws.py": conanfilews})
+        c.run("workspace add dep")
+        c.run("workspace super-install -c user:myconf=myvalue123")
+        assert "conanws.py base project Conanfile: Generating with conf myvalue123!!" in c.out
+        c.run("workspace super-install -c &:user:myconf=myvalue123")
+        assert "conanws.py base project Conanfile: Generating with conf myvalue123!!" in c.out
+        c.run("workspace super-install -c mywspkg*:user:myconf=myvalue123")
+        assert "conanws.py base project Conanfile: Generating with conf myvalue123!!" in c.out
+
     def test_workspace_pkg_definitions(self):
         c = TestClient()
         conanfilews = textwrap.dedent("""

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -841,7 +841,7 @@ class TestMeta:
             class MyWs(ConanFile):
                 name = "mywspkg"
                 def generate(self):
-                    self.output.info(f"Generating with conf {self.conf.get("user:myconf")}!!")
+                    self.output.info(f'Generating with conf {self.conf.get("user:myconf")}!!')
 
             class Ws(Workspace):
                 def root_conanfile(self):


### PR DESCRIPTION
Changelog: Fix: Allow workspaces root Conanfile to have a name to apply ``conf`` with patterns that would match that name.
Docs: Omit

Close https://github.com/conan-io/conan/issues/19925