### PR TITLE
Fix regression for downloads without sha256

### DIFF
--- a/conan/internal/rest/caching_file_downloader.py
+++ b/conan/internal/rest/caching_file_downloader.py
@@ -35,10 +35,11 @@ class SourcesCachingDownloader:
             download_cache_folder = HomePaths(self._home_folder).default_sources_backup_folder
         if download_cache_folder and not os.path.isabs(download_cache_folder):
             raise ConanException("core.sources:download_cache must be an absolute path")
+        source_origins = source_origins or ["origin"]
         if download_cache_folder and not sha256:
             self._output.warning("Cannot cache download() without sha256 checksum")
             download_cache_folder = None  # Cannot cache
-        source_origins = source_origins or ["origin"] if sha256 else ["origin"]
+            source_origins = ["origin"]
         if None in source_origins:
             raise ConanException(f"Incorrect 'core.sources:download_urls' contains invalid 'None'"
                                  f"url: {source_origins}")

--- a/conan/internal/rest/caching_file_downloader.py
+++ b/conan/internal/rest/caching_file_downloader.py
@@ -38,14 +38,10 @@ class SourcesCachingDownloader:
         if download_cache_folder and not sha256:
             self._output.warning("Cannot cache download() without sha256 checksum")
             download_cache_folder = None  # Cannot cache
-        source_origins = source_origins or ["origin"]
+        source_origins = source_origins or ["origin"] if sha256 else ["origin"]
         if None in source_origins:
             raise ConanException(f"Incorrect 'core.sources:download_urls' contains invalid 'None'"
                                  f"url: {source_origins}")
-        if not sha256:
-            # Don't try to use backup feature if no sha256 is defined
-            download_cache_folder = None
-            source_origins = ["origin"]
 
         # First, see if it is already in the download cache
         if download_cache_folder:

--- a/conan/internal/rest/caching_file_downloader.py
+++ b/conan/internal/rest/caching_file_downloader.py
@@ -47,8 +47,8 @@ class SourcesCachingDownloader:
             download_cache_folder = None
             source_origins = ["origin"]
 
+        # First, see if it is already in the download cache
         if download_cache_folder:
-            # First, see if it is already in the download cache
             download_cache = DownloadCache(download_cache_folder)
             download_path = download_cache.source_path(sha256)
             with download_cache.lock(sha256):

--- a/conan/internal/rest/caching_file_downloader.py
+++ b/conan/internal/rest/caching_file_downloader.py
@@ -43,8 +43,13 @@ class SourcesCachingDownloader:
             raise ConanException(f"Incorrect 'core.sources:download_urls' contains invalid 'None'"
                                  f"url: {source_origins}")
 
-        # First, see if it is already in the download cache
-        if download_cache_folder:
+        if not sha256:
+            # Don't try to use backup feature if no sha256 is defined
+            # This doesn't need to be dirty-protected, as the full "source" folder is protected
+            self._download_from_urls(urls, file_path, retry, retry_wait, verify_ssl,
+                                     auth, headers, md5, sha1, sha256)
+        elif download_cache_folder:
+            # First, see if it is already in the download cache
             download_cache = DownloadCache(download_cache_folder)
             download_path = download_cache.source_path(sha256)
             with download_cache.lock(sha256):
@@ -63,6 +68,7 @@ class SourcesCachingDownloader:
                 shutil.copy2(download_path, file_path)
                 download_cache.update_backup_sources_json(download_path, self._conanfile, urls)
         else:
+            # Not in local cache, check origins from core.sources:download_urls
             # This doesn't need to be dirty-protected, as the full "source" folder is protected
             self._do_download(source_origins, urls, file_path, retry, retry_wait, verify_ssl, auth,
                               headers, md5, sha1, sha256)

--- a/conan/internal/rest/caching_file_downloader.py
+++ b/conan/internal/rest/caching_file_downloader.py
@@ -42,13 +42,12 @@ class SourcesCachingDownloader:
         if None in source_origins:
             raise ConanException(f"Incorrect 'core.sources:download_urls' contains invalid 'None'"
                                  f"url: {source_origins}")
-
         if not sha256:
             # Don't try to use backup feature if no sha256 is defined
-            # This doesn't need to be dirty-protected, as the full "source" folder is protected
-            self._download_from_urls(urls, file_path, retry, retry_wait, verify_ssl,
-                                     auth, headers, md5, sha1, sha256)
-        elif download_cache_folder:
+            download_cache_folder = None
+            source_origins = ["origin"]
+
+        if download_cache_folder:
             # First, see if it is already in the download cache
             download_cache = DownloadCache(download_cache_folder)
             download_path = download_cache.source_path(sha256)

--- a/test/integration/cache/backup_sources_test.py
+++ b/test/integration/cache/backup_sources_test.py
@@ -918,3 +918,27 @@ class TestDownloadCacheBackupSources:
         client.save({"conanfile.py": conanfile})
         client.run("source .", assert_error=True)
         assert "core.sources:download_cache must be an absolute path" in client.out
+
+    def test_download_no_sha_no_backup(self):
+        http_server_base_folder_internet = os.path.join(self.file_server.store, "internet")
+
+        save(os.path.join(http_server_base_folder_internet, "myfile.txt"), "Hello, world!")
+        save(os.path.join(self.file_server.store, "mycompanystorage", "mycompanyfile.txt"),
+             "Business stuff")
+        self.client.save_home(
+            {"global.conf": f"core.sources:download_cache={self.download_cache_folder}\n"
+                            f"core.sources:download_urls=['{self.file_server.fake_url}', 'origin']\n"})
+        conanfile = textwrap.dedent(f"""
+        from conan import ConanFile
+        from conan.tools.files import download
+        class Pkg(ConanFile):
+            def source(self):
+                download(self, "{self.file_server.fake_url}/mycompanystorage/mycompanyfile.txt", "myfile.txt")
+        """)
+        self.client.save({"conanfile.py": conanfile})
+        self.client.run("source")
+        print(self.client.out)
+        assert "Cannot cache download() without sha256 checksum" in self.client.out
+        assert f"Sources correctly downloaded from {self.file_server.fake_url}" in self.client.out
+        assert "myfile.txt" in os.listdir(self.client.current_folder)
+        assert len(os.listdir(self.download_cache_folder)) == 0

--- a/test/integration/cache/backup_sources_test.py
+++ b/test/integration/cache/backup_sources_test.py
@@ -937,7 +937,6 @@ class TestDownloadCacheBackupSources:
         """)
         self.client.save({"conanfile.py": conanfile})
         self.client.run("source")
-        print(self.client.out)
         assert "Cannot cache download() without sha256 checksum" in self.client.out
         assert f"Sources correctly downloaded from {self.file_server.fake_url}" in self.client.out
         assert "myfile.txt" in os.listdir(self.client.current_folder)

--- a/test/integration/cache/backup_sources_test.py
+++ b/test/integration/cache/backup_sources_test.py
@@ -919,15 +919,17 @@ class TestDownloadCacheBackupSources:
         client.run("source .", assert_error=True)
         assert "core.sources:download_cache must be an absolute path" in client.out
 
-    def test_download_no_sha_no_backup(self):
+    @pytest.mark.parametrize("download_cache", [True, False])
+    @pytest.mark.parametrize("download_urls", [True, False])
+    def test_download_no_sha_no_backup(self, download_cache, download_urls):
         http_server_base_folder_internet = os.path.join(self.file_server.store, "internet")
 
         save(os.path.join(http_server_base_folder_internet, "myfile.txt"), "Hello, world!")
         save(os.path.join(self.file_server.store, "mycompanystorage", "mycompanyfile.txt"),
              "Business stuff")
-        self.client.save_home(
-            {"global.conf": f"core.sources:download_cache={self.download_cache_folder}\n"
-                            f"core.sources:download_urls=['{self.file_server.fake_url}', 'origin']\n"})
+        download_cache_line = f"core.sources:download_cache={self.download_cache_folder}\n" if download_cache else ""
+        download_urls_line = f"core.sources:download_urls=['{self.file_server.fake_url}', 'origin']\n" if download_urls else ""
+        self.client.save_home({"global.conf": download_cache_line + download_urls_line})
         conanfile = textwrap.dedent(f"""
         from conan import ConanFile
         from conan.tools.files import download
@@ -937,7 +939,8 @@ class TestDownloadCacheBackupSources:
         """)
         self.client.save({"conanfile.py": conanfile})
         self.client.run("source")
-        assert "Cannot cache download() without sha256 checksum" in self.client.out
+        if download_cache or download_urls:
+            assert "Cannot cache download() without sha256 checksum" in self.client.out
         assert f"Sources correctly downloaded from {self.file_server.fake_url}" in self.client.out
         assert "myfile.txt" in os.listdir(self.client.current_folder)
         assert len(os.listdir(self.download_cache_folder)) == 0


### PR DESCRIPTION
Changelog: Bugfix: Fix regression for downloads without sha256.
Docs: Omit

Closes https://github.com/conan-io/conan/issues/19932