### PR TITLE
compiler_executables emulator key

### DIFF
--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -159,7 +159,7 @@ BUILT_IN_CONFS = {
     "tools.env:dotenv": "(Experimental) Generate dotenv environment files",
     "tools.env:deactivation_mode": "(Experimental) If 'function', generate a deactivate function instead of a script to unset the environment variables",
     # Compilers/Flags configurations
-    "tools.build:compiler_executables": "Defines a Python dict-like with the compilers path to be used. Allowed keys {'c', 'cpp', 'cuda', 'objc', 'objcxx', 'rc', 'fortran', 'asm', 'hip', 'ispc'}",
+    "tools.build:compiler_executables": "Defines a Python dict-like with the compilers path to be used. Allowed keys {'c', 'cpp', 'cuda', 'objc', 'objcxx', 'rc', 'fortran', 'asm', 'hip', 'ispc', 'emulator'}",
     "tools.build:cxxflags": "List of extra CXX flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:cflags": "List of extra C flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:defines": "List of extra definition flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -1,5 +1,6 @@
 import os
 import re
+import shlex
 import textwrap
 
 from jinja2 import Template
@@ -994,6 +995,9 @@ class GenericSystemBlock(Block):
         set(CMAKE_SYSTEM_PROCESSOR {{ cmake_system_processor }})
         endif()
         {% endif %}
+        {% if cmake_crosscompiling_emulator %}
+        set(CMAKE_CROSSCOMPILING_EMULATOR "{{ cmake_crosscompiling_emulator }}")
+        {% endif %}
 
         {% if generator_platform and not winsdk_version %}
         set(CMAKE_GENERATOR_PLATFORM "{{ generator_platform }}" CACHE STRING "" FORCE)
@@ -1213,11 +1217,17 @@ class GenericSystemBlock(Block):
         result = self._get_winsdk_version(system_version, generator_platform)
         system_version, winsdk_version, gen_platform_sdk_version = result
 
+        compilers_by_conf = self._conanfile.conf.get("tools.build:compiler_executables", default={},
+                                                     check_type=dict)
+        emulator = compilers_by_conf.get("emulator")
+        cmake_crosscompiling_emulator = ";".join(shlex.split(emulator)) if emulator else None
+
         return {"toolset": toolset,
                 "generator_platform": generator_platform,
                 "cmake_system_name": system_name,
                 "cmake_system_version": system_version,
                 "cmake_system_processor": system_processor,
+                "cmake_crosscompiling_emulator": cmake_crosscompiling_emulator,
                 "cmake_sysroot": cmake_sysroot,
                 "winsdk_version": winsdk_version,
                 "gen_platform_sdk_version": gen_platform_sdk_version}

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -91,6 +91,9 @@ class MesonToolchain:
     {% if pkgconfig %}
     pkg-config = '{{pkgconfig}}'
     {% endif %}
+    {% if emulator %}
+    exe_wrapper = '{{emulator}}'
+    {% endif %}
 
     [built-in options]
     {% if buildtype %}
@@ -248,6 +251,11 @@ class MesonToolchain:
         self.libcxx, self.gcc_cxx11_abi = libcxx_flags(self._conanfile)
         #: Dict-like object with the build, host, and target as the Meson machine context
         self.cross_build = {}
+
+        # Read configuration for compilers
+        compilers_by_conf = self._conanfile_conf.get("tools.build:compiler_executables", default={},
+                                                     check_type=dict)
+        self.emulator = compilers_by_conf.get("emulator")
         default_comp = ""
         default_comp_cpp = ""
         if native is False and is_cross_building:
@@ -267,7 +275,7 @@ class MesonToolchain:
                 self.cross_build["host"]["subsystem"] = get_apple_subsystem(sdk_host)
                 self.cross_build["build"]["subsystem"] = get_apple_subsystem(sdk_build)
             # Issue: https://github.com/conan-io/conan/issues/19217
-            self.properties["needs_exe_wrapper"] = not can_run(self._conanfile)
+            self.properties["needs_exe_wrapper"] = self.emulator is not None or not can_run(self._conanfile)
             if hasattr(conanfile, 'settings_target') and conanfile.settings_target:
                 settings_target = conanfile.settings_target
                 os_target = settings_target.get_safe("os")
@@ -291,9 +299,6 @@ class MesonToolchain:
         # Read configuration for sys_root property (honoring existing conf)
         self._sys_root = self._conanfile_conf.get("tools.build:sysroot", check_type=str)
 
-        # Read configuration for compilers
-        compilers_by_conf = self._conanfile_conf.get("tools.build:compiler_executables", default={},
-                                                     check_type=dict)
         # Read the VirtualBuildEnv to update the variables
         build_env = self._conanfile.buildenv_build.vars(self._conanfile) if native else (
             VirtualBuildEnv(self._conanfile, auto_generate=True).vars())
@@ -450,7 +455,7 @@ class MesonToolchain:
         self.c = os.path.join(ndk_bin, f"{android_target}{android_api_level}-clang{compile_ext}")
         self.cpp = os.path.join(ndk_bin, f"{android_target}{android_api_level}-clang++{compile_ext}")
         self.ar = os.path.join(ndk_bin, "llvm-ar")
-    
+
     @property
     def _rpath_link_flag(self):
         add_rpath_link = self._conanfile.conf.get("tools.build:add_rpath_link", check_type=bool)
@@ -462,7 +467,7 @@ class MesonToolchain:
             cppinfo = req.cpp_info.aggregated_components()
             runtime_dirs.extend(cppinfo.libdirs)
         return ["-Wl,-rpath-link=" + ":".join(runtime_dirs)] if runtime_dirs else []
-    
+
     def _get_extra_flags(self):
         # Now, it's time to get all the flags defined by the user
         cxxflags = self._conanfile_conf.get("tools.build:cxxflags", default=[], check_type=list)
@@ -564,6 +569,7 @@ class MesonToolchain:
             "as": self.as_,
             "windres": self.windres,
             "pkgconfig": self.pkgconfig,
+            "emulator": self.emulator,
             # https://mesonbuild.com/Builtin-options.html#core-options
             "buildtype": self.buildtype,
             "default_library": self.default_library,

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -91,8 +91,8 @@ class MesonToolchain:
     {% if pkgconfig %}
     pkg-config = '{{pkgconfig}}'
     {% endif %}
-    {% if emulator %}
-    exe_wrapper = '{{emulator}}'
+    {% if exe_wrapper %}
+    exe_wrapper = '{{exe_wrapper}}'
     {% endif %}
 
     [built-in options]
@@ -200,6 +200,9 @@ class MesonToolchain:
         compiler_version = self._conanfile.settings.get_safe("compiler.version")
         if compiler_version is None:
             raise ConanException("MesonToolchain needs 'settings.compiler.version', but it is not defined")
+        # Read configuration for compilers
+        compilers_by_conf = self._conanfile_conf.get("tools.build:compiler_executables", default={},
+                                                     check_type=dict)
 
         cppstd = self._conanfile.settings.get_safe("compiler.cppstd")
         cstd = self._conanfile.settings.get_safe("compiler.cstd")
@@ -251,11 +254,6 @@ class MesonToolchain:
         self.libcxx, self.gcc_cxx11_abi = libcxx_flags(self._conanfile)
         #: Dict-like object with the build, host, and target as the Meson machine context
         self.cross_build = {}
-
-        # Read configuration for compilers
-        compilers_by_conf = self._conanfile_conf.get("tools.build:compiler_executables", default={},
-                                                     check_type=dict)
-        self.emulator = compilers_by_conf.get("emulator")
         default_comp = ""
         default_comp_cpp = ""
         if native is False and is_cross_building:
@@ -274,8 +272,10 @@ class MesonToolchain:
                 sdk_host = conanfile.settings.get_safe("os.sdk")
                 self.cross_build["host"]["subsystem"] = get_apple_subsystem(sdk_host)
                 self.cross_build["build"]["subsystem"] = get_apple_subsystem(sdk_build)
+            # Let's check if any emulator was defined
+            self._exe_wrapper = compilers_by_conf.get("emulator")
             # Issue: https://github.com/conan-io/conan/issues/19217
-            self.properties["needs_exe_wrapper"] = self.emulator is not None or not can_run(self._conanfile)
+            self.properties["needs_exe_wrapper"] = self._exe_wrapper is not None or not can_run(self._conanfile)
             if hasattr(conanfile, 'settings_target') and conanfile.settings_target:
                 settings_target = conanfile.settings_target
                 os_target = settings_target.get_safe("os")
@@ -569,7 +569,7 @@ class MesonToolchain:
             "as": self.as_,
             "windres": self.windres,
             "pkgconfig": self.pkgconfig,
-            "emulator": self.emulator,
+            "exe_wrapper": self._exe_wrapper,
             # https://mesonbuild.com/Builtin-options.html#core-options
             "buildtype": self.buildtype,
             "default_library": self.default_library,

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -254,6 +254,7 @@ class MesonToolchain:
         self.libcxx, self.gcc_cxx11_abi = libcxx_flags(self._conanfile)
         #: Dict-like object with the build, host, and target as the Meson machine context
         self.cross_build = {}
+        self._exe_wrapper = None
         default_comp = ""
         default_comp_cpp = ""
         if native is False and is_cross_building:

--- a/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1516,3 +1516,56 @@ def test_cmake_toolchain_verbosity_propagation():
     toolchain = t.load("conan_toolchain.cmake")
     # assert 'set(CMAKE_VERBOSE_MAKEFILE "OFF"' in toolchain
     assert 'set(CMAKE_MESSAGE_LOG_LEVEL "WARNING"' in toolchain
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="Bash wrapper not available on Windows")
+def test_cmake_toolchain_crosscompiling_emulator():
+    client = TestClient(path_with_spaces=False)
+    wrapper_script = textwrap.dedent("""\
+        #!/bin/bash
+        SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+        echo "EMULATOR_INVOKED: $@" >> "$SCRIPT_DIR/emulator.log"
+        exec "$@"
+        """)
+    conanfile = textwrap.dedent("""\
+        from conan import ConanFile
+        from conan.tools.cmake import CMake, CMakeToolchain
+        class Pkg(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+            exports_sources = "CMakeLists.txt"
+            def generate(self):
+                tc = CMakeToolchain(self)
+                tc.generate()
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+        """)
+    cmakelists = textwrap.dedent("""\
+        cmake_minimum_required(VERSION 3.15)
+        project(test_emulator CXX)
+        file(WRITE ${CMAKE_BINARY_DIR}/test_try_run.cpp [[
+            #include <iostream>
+            int main() { std::cout << "TRY_RUN_OUTPUT" << std::endl; return 42; }
+        ]])
+        try_run(RUN_RESULT COMPILE_RESULT
+                ${CMAKE_BINARY_DIR} ${CMAKE_BINARY_DIR}/test_try_run.cpp
+                RUN_OUTPUT_VARIABLE RUN_OUTPUT)
+        message(STATUS "TRY_RUN RUN_RESULT: ${RUN_RESULT}")
+        """)
+    profile = textwrap.dedent("""\
+        include(default)
+        [conf]
+        tools.build:compiler_executables={'emulator': '{{profile_dir}}/emulator_wrapper.sh'}
+        tools.cmake.cmaketoolchain:system_name=Linux
+        """)
+    client.save({"conanfile.py": conanfile, "CMakeLists.txt": cmakelists,
+                 "emulator_wrapper.sh": wrapper_script, "profile": profile})
+    os.chmod(os.path.join(client.current_folder, "emulator_wrapper.sh"), 0o755)
+
+    client.run("build . -pr=profile")
+
+    wrapper_path = os.path.join(client.current_folder, "emulator_wrapper.sh")
+    assert f'set(CMAKE_CROSSCOMPILING_EMULATOR "{wrapper_path}")' in client.load("conan_toolchain.cmake")
+    assert "TRY_RUN RUN_RESULT: 42" in client.out
+    assert "EMULATOR_INVOKED" in client.load("emulator.log")
+    print(client.load("emulator.log"))

--- a/test/functional/toolchains/cmake/test_cmake_toolchain.py
+++ b/test/functional/toolchains/cmake/test_cmake_toolchain.py
@@ -1568,4 +1568,3 @@ def test_cmake_toolchain_crosscompiling_emulator():
     assert f'set(CMAKE_CROSSCOMPILING_EMULATOR "{wrapper_path}")' in client.load("conan_toolchain.cmake")
     assert "TRY_RUN RUN_RESULT: 42" in client.out
     assert "EMULATOR_INVOKED" in client.load("emulator.log")
-    print(client.load("emulator.log"))

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -947,3 +947,45 @@ def test_needs_exe_wrapper():
     client.run("install . -pr:h host -pr:b build")
     content = client.load(MesonToolchain.cross_filename)
     assert "needs_exe_wrapper = false" in content
+
+
+def test_compiler_executables_emulator_exe_wrapper():
+    """
+    ``tools.build:compiler_executables['emulator']`` maps to Meson's ``exe_wrapper`` and forces
+    ``needs_exe_wrapper`` even when ``tools.build.cross_building:can_run=True``.
+    """
+    qemu = "/opt/sysroots/usr/bin/qemu-aarch64-static"
+    host = textwrap.dedent(f"""
+    [settings]
+    arch=x86_64
+    build_type=Release
+    compiler=apple-clang
+    compiler.cppstd=gnu17
+    compiler.libcxx=libc++
+    compiler.version=16
+    os=Macos
+    [conf]
+    tools.build:compiler_executables={{"emulator": "{qemu}"}}
+    """)
+    build = textwrap.dedent("""
+    [settings]
+    arch=armv8
+    build_type=Release
+    compiler=apple-clang
+    compiler.cppstd=gnu17
+    compiler.libcxx=libc++
+    compiler.version=16
+    os=Macos
+    """)
+    client = TestClient()
+    client.save({
+        "host": host,
+        "build": build,
+        "conanfile.py": GenConanfile("pkg", "1.0")
+                        .with_settings("os", "arch", "compiler", "build_type")
+                        .with_generator("MesonToolchain")
+    })
+    client.run("install . -pr:h host -pr:b build")
+    content = client.load(MesonToolchain.cross_filename)
+    assert "needs_exe_wrapper = true" in content
+    assert f"exe_wrapper = '{qemu}'" in content

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -965,6 +965,7 @@ def test_compiler_executables_emulator_exe_wrapper():
     compiler.version=16
     os=Macos
     [conf]
+    tools.apple:sdk_path=/my/sdk/path
     tools.build:compiler_executables={{"emulator": "{qemu}"}}
     """)
     build = textwrap.dedent("""

--- a/test/unittests/tools/cmake/test_cmaketoolchain.py
+++ b/test/unittests/tools/cmake/test_cmaketoolchain.py
@@ -552,3 +552,14 @@ class TestCrossBuild:
         toolchain = CMakeToolchain(conanfile_cross)
         content = toolchain.content
         assert 'set(CMAKE_SYSTEM_NAME Generic)' in content
+
+    @pytest.mark.parametrize("emulator,expected", [
+        ("qemu-arm", "qemu-arm"),
+        ("qemu-arm -L /usr/arm-linux-gnueabi", "qemu-arm;-L;/usr/arm-linux-gnueabi"),
+        ('"/path/with spaces/emulator" --arg', "/path/with spaces/emulator;--arg"),
+    ])
+    def test_crosscompiling_emulator(self, conanfile_cross, emulator, expected):
+        conanfile_cross.conf.define("tools.build:compiler_executables", {"emulator": emulator})
+        toolchain = CMakeToolchain(conanfile_cross)
+        content = toolchain.content
+        assert f'set(CMAKE_CROSSCOMPILING_EMULATOR "{expected}")' in content


### PR DESCRIPTION
Changelog: Feature: `compiler_executables` admit new `emulator` key which can control Meson `exe_wrapper` and CMake `CMAKE_CROSSCOMPILING_EMULATOR`
Docs: TODO

Close https://github.com/conan-io/conan/issues/18718
Close https://github.com/conan-io/conan/issues/19912

Related PR: #19983 

----

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
