### PR TITLE
Legacy include variables in ``CMakeConfigDeps`` are now only set based on requirement traits

### DIFF
--- a/conan/tools/cmake/cmakeconfigdeps/config.py
+++ b/conan/tools/cmake/cmakeconfigdeps/config.py
@@ -93,24 +93,27 @@ class ConfigTemplate2:
         include_dirs = definitions = libraries = None
         if not self._require.build:  # To add global variables for try_compile and legacy
             aggregated_cppinfo = self._full_cpp_info.aggregated_components()
-            # FIXME: Proper escaping of paths for CMake
-            incdirs = [i.replace("\\", "/") for i in aggregated_cppinfo.includedirs]
-            incdirs = [relativize_path(i, self._cmakedeps._conanfile, "${CMAKE_CURRENT_LIST_DIR}")
-                       for i in incdirs]
-            include_dirs = ";".join(incdirs)
+            include_dirs = None
+            if self._require.headers:
+                # FIXME: Proper escaping of paths for CMake
+                incdirs = [i.replace("\\", "/") for i in aggregated_cppinfo.includedirs]
+                incdirs = [relativize_path(i, self._cmakedeps._conanfile, "${CMAKE_CURRENT_LIST_DIR}")
+                           for i in incdirs]
+                include_dirs = ";".join(incdirs)
             definitions = ";".join("-D" + cmake_escape_value(d) for d in aggregated_cppinfo.defines)
 
             libraries = []
-            if self._full_cpp_info.has_components:
-                for component in self._full_cpp_info.components.keys():
-                    root_target_name = self._cmakedeps.get_property("cmake_target_name",
-                                                                    self._conanfile,
-                                                                    comp_name=component)
-                    libraries.append(root_target_name or f"{pkg_name}::{component}")
-            else:
-                root_target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile)
-                libraries.append(root_target_name or f"{pkg_name}::{pkg_name}")
-            libraries = " ".join(libraries) if libraries else ""
+            if self._require.libs:
+                if self._full_cpp_info.has_components:
+                    for component in self._full_cpp_info.components.keys():
+                        root_target_name = self._cmakedeps.get_property("cmake_target_name",
+                                                                        self._conanfile,
+                                                                        comp_name=component)
+                        libraries.append(root_target_name or f"{pkg_name}::{component}")
+                else:
+                    root_target_name = self._cmakedeps.get_property("cmake_target_name", self._conanfile)
+                    libraries.append(root_target_name or f"{pkg_name}::{pkg_name}")
+            libraries = " ".join(libraries) if libraries else None
         return {"additional_variables_prefixes": prefixes,
                 "version": self._conanfile.ref.version,
                 "include_dirs": include_dirs,

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -1,6 +1,8 @@
 import re
 import textwrap
 
+import pytest
+
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
 
@@ -796,6 +798,40 @@ class TestLegacyVariables:
         # If there's no interface global target
         # mypkg::lib2 is not added to the list of libraries
         assert "set(mypkg_LIBRARIES mypkg::mypkg mypkg::lib2 )" in mypkg_config
+
+    @pytest.mark.parametrize("headers", [True, False])
+    def test_legacy_include_dirs_trait(self, headers):
+        tc = TestClient()
+        tc.save({"dep/conanfile.py": GenConanfile("dep", "1.0")
+                    .with_package_file("include/mylib1.h", "header"),
+                 "conanfile.py": GenConanfile("mypkg", "1.0")
+                    .with_requirement("dep/1.0", headers=headers)
+                    .with_settings("build_type", "os", "arch", "compiler")
+                })
+        tc.run("create dep")
+        tc.run("install -g CMakeConfigDeps")
+        mypkg_config = tc.load("dep-config.cmake")
+        if headers:
+            assert "set(dep_INCLUDE_DIRS" in mypkg_config
+        else:
+            assert "set(dep_INCLUDE_DIRS" not in mypkg_config
+
+    @pytest.mark.parametrize("libs", [True, False])
+    def test_legacy_libs_dirs_trait(self, libs):
+        tc = TestClient()
+        tc.save({"dep/conanfile.py": GenConanfile("dep", "1.0")
+                .with_package_file("include/mylib1.h", "header"),
+                 "conanfile.py": GenConanfile("mypkg", "1.0")
+                .with_requirement("dep/1.0", libs=libs)
+                .with_settings("build_type", "os", "arch", "compiler")
+                 })
+        tc.run("create dep")
+        tc.run("install -g CMakeConfigDeps")
+        mypkg_config = tc.load("dep-config.cmake")
+        if libs:
+            assert "set(dep_LIBRARIES" in mypkg_config
+        else:
+            assert "set(dep_LIBRARIES" not in mypkg_config
 
 
 class TestPropertiesBuildContext:


### PR DESCRIPTION
Changelog: Bugfix: Legacy include variables in ``CMakeConfigDeps`` are now only set based on requirement traits
Docs: Omit

Completely speculative