### PR TITLE
Fix copy-paste docstring in `conan workspace init`

### DIFF
--- a/conan/cli/commands/workspace.py
+++ b/conan/cli/commands/workspace.py
@@ -312,7 +312,7 @@ def workspace_clean(conan_api: ConanAPI, parser, subparser, *args):  # noqa
 @conan_subcommand()
 def workspace_init(conan_api: ConanAPI, parser, subparser, *args):
     """
-    Clean the temporary build folders when possible
+    Initialize a workspace in the given folder
     """
     subparser.add_argument("path", nargs="?", default=os.getcwd(),
                            help="Path to a folder where the workspace will be initialized. "


### PR DESCRIPTION
## Summary

The `workspace_init` subcommand had the same docstring as `workspace_clean`
(`Clean the temporary build folders when possible`), which surfaces as the
wrong description in `conan workspace init -h`. This is clearly a copy-paste
error — `init` and `clean` are sibling subcommands defined adjacently in
`conan/cli/commands/workspace.py`.

Replaced with a description that matches the existing argparse help text
("Path to a folder where the workspace will be initialized").

## Before

```
$ conan workspace init -h
usage: conan workspace init [-h] [path]

Clean the temporary build folders when possible
```

## After

```
$ conan workspace init -h
usage: conan workspace init [-h] [path]

Initialize a workspace in the given folder
```

fixes #19958

## Test plan
- [x] Verified bug exists on `develop2` (line 315)
- [x] Manual: `conan workspace init -h` now shows correct description
- [ ] No new tests required — docstring-only change