### PR TITLE
Add `conan.tools.gnu.is_mingw()` helper

### DIFF
--- a/conan/tools/gnu/__init__.py
+++ b/conan/tools/gnu/__init__.py
@@ -5,3 +5,4 @@ from conan.tools.gnu.autotoolsdeps import AutotoolsDeps
 from conan.tools.gnu.pkgconfig import PkgConfig
 from conan.tools.gnu.pkgconfigdeps import PkgConfigDeps
 from conan.tools.gnu.makedeps import MakeDeps
+from conan.tools.gnu.mingw import is_mingw

--- a/conan/tools/gnu/mingw.py
+++ b/conan/tools/gnu/mingw.py
@@ -1,0 +1,30 @@
+def is_mingw(conanfile, build_context=False):
+    """
+    Validate if the current compiler is a MinGW toolchain (host context by default).
+
+    A MinGW toolchain is detected by the following Conan settings:
+
+    - ``os == "Windows"`` (a non-Windows host is never MinGW)
+    - ``os.subsystem != "cygwin"`` (Cygwin uses a POSIX layer, not MinGW)
+    - ``compiler == "gcc"``, OR
+      ``compiler == "clang"`` with ``compiler.runtime`` unset (MinGW Clang).
+      ``clang-cl`` is detected via ``compiler.runtime`` and is not considered MinGW.
+
+    Reference:
+    https://blog.conan.io/2022/10/13/Different-flavors-Clang-compiler-Windows.html
+
+    :param conanfile: ``< ConanFile object >`` The current recipe object. Always use ``self``.
+    :param build_context: If True, will use the settings from the build context, not host ones.
+    :return: ``bool`` True if the selected context targets a MinGW toolchain, otherwise False.
+    """
+    settings = conanfile.settings_build if build_context else conanfile.settings
+    if settings.get_safe("os") != "Windows":
+        return False
+    if settings.get_safe("os.subsystem") == "cygwin":
+        return False
+    compiler = settings.get_safe("compiler")
+    if compiler == "gcc":
+        return True
+    if compiler == "clang" and settings.get_safe("compiler.runtime") is None:
+        return True
+    return False

--- a/test/unittests/tools/gnu/test_mingw.py
+++ b/test/unittests/tools/gnu/test_mingw.py
@@ -1,0 +1,83 @@
+import pytest
+
+from conan import ConanFile
+from conan.tools.gnu import is_mingw
+from conan.internal.model.settings import Settings
+
+
+def _make_conanfile(os_, compiler, version, *, libcxx=None, runtime=None,
+                    runtime_type=None, subsystem=None):
+    compiler_def = {compiler: {"version": [version]}}
+    if libcxx is not None:
+        compiler_def[compiler]["libcxx"] = [libcxx]
+    if runtime is not None:
+        compiler_def[compiler]["runtime"] = [runtime]
+    if runtime_type is not None:
+        compiler_def[compiler]["runtime_type"] = [runtime_type]
+    os_def = {os_: {"subsystem": [subsystem]}} if subsystem else [os_]
+    settings = Settings({
+        "os": os_def,
+        "arch": ["x86_64"],
+        "compiler": compiler_def,
+        "build_type": ["Release"],
+    })
+    conanfile = ConanFile()
+    conanfile.settings = settings
+    conanfile.settings.os = os_
+    if subsystem is not None:
+        conanfile.settings.os.subsystem = subsystem
+    conanfile.settings.compiler = compiler
+    conanfile.settings.compiler.version = version
+    if libcxx is not None:
+        conanfile.settings.compiler.libcxx = libcxx
+    if runtime is not None:
+        conanfile.settings.compiler.runtime = runtime
+    if runtime_type is not None:
+        conanfile.settings.compiler.runtime_type = runtime_type
+    return conanfile
+
+
+@pytest.mark.parametrize("os_,compiler,version,kwargs,expected", [
+    # MinGW with gcc — the canonical case
+    ("Windows", "gcc", "13", {"libcxx": "libstdc++11"}, True),
+    # MinGW with Clang — `compiler.runtime` is unset
+    ("Windows", "clang", "17", {"libcxx": "libstdc++11"}, True),
+    # clang-cl on Windows — `compiler.runtime` is set, not MinGW
+    ("Windows", "clang", "17", {"runtime": "dynamic", "runtime_type": "Release"}, False),
+    # MSVC — never MinGW
+    ("Windows", "msvc", "193", {"runtime": "dynamic", "runtime_type": "Release"}, False),
+    # Cygwin uses a POSIX layer, not MinGW
+    ("Windows", "gcc", "13", {"subsystem": "cygwin", "libcxx": "libstdc++11"}, False),
+    # Non-Windows hosts are never MinGW
+    ("Linux", "gcc", "13", {"libcxx": "libstdc++11"}, False),
+    ("Linux", "clang", "17", {"libcxx": "libc++"}, False),
+    ("Macos", "apple-clang", "15", {"libcxx": "libc++"}, False),
+])
+def test_is_mingw(os_, compiler, version, kwargs, expected):
+    conanfile = _make_conanfile(os_, compiler, version, **kwargs)
+    assert is_mingw(conanfile) is expected
+
+
+def test_is_mingw_build_context():
+    """`build_context=True` must consult settings_build, not the host settings."""
+    host = _make_conanfile("Linux", "gcc", "13", libcxx="libstdc++11")
+    build = _make_conanfile("Windows", "gcc", "13", libcxx="libstdc++11")
+    host.settings_build = build.settings
+    assert is_mingw(host) is False
+    assert is_mingw(host, build_context=True) is True
+
+
+def test_is_mingw_libcxx_not_required():
+    """`compiler.libcxx` is removed in pure-C recipes; detection must still work without it."""
+    settings = Settings({
+        "os": ["Windows"],
+        "arch": ["x86_64"],
+        "compiler": {"gcc": {"version": ["13"]}},
+        "build_type": ["Release"],
+    })
+    conanfile = ConanFile()
+    conanfile.settings = settings
+    conanfile.settings.os = "Windows"
+    conanfile.settings.compiler = "gcc"
+    conanfile.settings.compiler.version = "13"
+    assert is_mingw(conanfile) is True


### PR DESCRIPTION
## Summary

Adds a `conan.tools.gnu.is_mingw(conanfile, build_context=False)` helper.
Recipes commonly need to branch on a MinGW toolchain (Autotools instead
of NMake/MSBuild, MinGW-specific `package_info`, import-library naming
in `package()`); today they reimplement this check inline, often missing
edge cases.

This is a fresh take on the prior 1.x attempt (#12678), rewritten for
2.x with the review feedback applied:

- **Early-return body** for readability — the original review (@memsharded,
  @CJCombrink) flagged the dense boolean expression as the main blocker.
- **No reliance on `compiler.libcxx`** — it is removed in `configure()` of
  pure-C recipes, so it can't be used to disambiguate clang-mingw vs.
  clang-cl (@SpaceIm).
- **`compiler.runtime` for clang disambiguation** — clang-cl sets it,
  MinGW-Clang doesn't. Aligns with the official guidance in
  https://blog.conan.io/2022/10/13/Different-flavors-Clang-compiler-Windows.html
  (@mhthies).

## Detection rules

A toolchain is identified as MinGW when:

| Setting               | Required value                                |
|-----------------------|-----------------------------------------------|
| `os`                  | `"Windows"`                                   |
| `os.subsystem`        | not `"cygwin"`                                |
| `compiler`            | `"gcc"`, **or** `"clang"` with `compiler.runtime` unset |

Anything else (incl. `msvc`, `clang-cl`, Cygwin gcc, Linux/macOS gcc/clang)
returns `False`.

## API

```python
from conan.tools.gnu import is_mingw

class Recipe(ConanFile):
    def generate(self):
        if is_mingw(self):
            ...                    # MinGW-specific branch
```

`build_context=True` mirrors `is_msvc()` and consults `settings_build`
instead of host settings.

closes #15648

## Test plan

### Unit tests

New parametrized suite at `test/unittests/tools/gnu/test_mingw.py` covers:
gcc-mingw, MinGW-Clang, clang-cl, msvc, Cygwin gcc, Linux gcc/clang,
macOS apple-clang, `build_context=True`, and a C-only recipe with no
`compiler.libcxx` set.

| Suite | Result |
|---|---|
| `pytest test/unittests/tools/gnu/test_mingw.py` | 10 passed (Linux/macOS) + 10 passed (Windows Server 2022) |
| `pytest test/unittests/tools/gnu/` | 164 passed |
| `pytest test/unittests/tools/` | 710 passed, 8 skipped (pre-existing) |

### End-to-end on real Windows host

Verified via `conan install` on Windows Server 2022 Standard Evaluation
with four profiles, each driving a tiny recipe whose `generate()` calls
`is_mingw(self)`:

| Profile | Expected | Got |
|---|---|---|
| Windows + gcc-mingw + libstdc++11 | `True` | ✅ `True` |
| Windows + clang + `compiler.runtime=dynamic` (clang-cl) | `False` | ✅ `False` |
| Windows + msvc 193 | `False` | ✅ `False` |
| Windows host → cross to Linux gcc | `False` | ✅ `False` |

### Follow-up

Docs PR to follow at conan-io/docs once this lands.