### PR TITLE
Fix sha256 cache bypass when URL differs from cached entry

### DIFF
--- a/conan/internal/rest/caching_file_downloader.py
+++ b/conan/internal/rest/caching_file_downloader.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 
@@ -10,7 +11,27 @@ from conan.internal.rest.file_downloader import FileDownloader
 from conan.internal.rest.download_cache import DownloadCache
 from conan.internal.errors import AuthenticationException, ForbiddenException, NotFoundException
 from conan.errors import ConanException
-from conan.internal.util.files import mkdir, set_dirty_context_manager, remove_if_dirty, human_size
+from conan.internal.util.files import load, mkdir, set_dirty_context_manager, remove_if_dirty, \
+    human_size
+
+
+def _cached_known_urls(cache_path):
+    """Return the set of URLs previously associated with a backup-source cache
+    entry, by reading its sidecar `<cache_path>.json`. Empty set if the file
+    is missing or malformed (legacy caches predate the metadata file)."""
+    metadata_path = cache_path + ".json"
+    if not os.path.exists(metadata_path):
+        return set()
+    try:
+        metadata = json.loads(load(metadata_path))
+    except Exception:
+        return set()
+    refs = metadata.get("references", {}) if isinstance(metadata, dict) else {}
+    known = set()
+    for ref_urls in refs.values():
+        if isinstance(ref_urls, list):
+            known.update(ref_urls)
+    return known
 
 
 class SourcesCachingDownloader:
@@ -51,10 +72,30 @@ class SourcesCachingDownloader:
             with download_cache.lock(sha256):
                 remove_if_dirty(download_path)
 
-                if os.path.exists(download_path):
+                requested_urls = urls if isinstance(urls, (list, tuple)) else [urls]
+                cache_hit = os.path.exists(download_path)
+                # A cache entry is reusable as-is only when at least one of the
+                # requested URLs has been seen with this sha256 before.
+                # Otherwise the recipe may have declared a sha256 that
+                # accidentally collides with an unrelated package's hash
+                # (see conan-io/conan#19956). Re-download in that case so
+                # FileDownloader.check_checksum can flag the mismatch.
+                cache_url_match = False
+                if cache_hit:
+                    known_urls = _cached_known_urls(download_path)
+                    cache_url_match = (not known_urls
+                                       or any(u in known_urls for u in requested_urls))
+
+                if cache_hit and cache_url_match:
                     self._output.info(f"Source {urls} retrieved from local download cache")
                 else:
-                    # not in cache, we need to actually download from internet or backup servers
+                    if cache_hit:
+                        self._output.warning(
+                            f"Source {urls} not previously associated with the cached "
+                            f"sha256 {sha256[:16]}…; re-downloading to verify the URL "
+                            f"matches that hash"
+                        )
+                    # not in cache (or URL mismatch), download from internet / backup servers
                     with set_dirty_context_manager(download_path):
                         self._do_download(source_origins, urls, download_path, retry, retry_wait,
                                           verify_ssl, auth, headers, md5, sha1, sha256)

--- a/test/integration/cache/backup_sources_test.py
+++ b/test/integration/cache/backup_sources_test.py
@@ -694,6 +694,93 @@ class TestDownloadCacheBackupSources:
                 f"backup {self.file_server.fake_url}/backup2/") in self.client.out
         assert "sha256 hash failed for" in self.client.out
 
+    def test_url_mismatch_redownloads_on_sha256_collision(self):
+        # Repro for conan-io/conan#19956: a recipe that declares a sha256 already
+        # present in the source cache (under an unrelated URL) must NOT silently
+        # reuse the cached payload. The cache lookup must verify the URL was seen
+        # before with that sha256; otherwise re-download so check_checksum runs.
+        http_server_base_folder_internet = os.path.join(self.file_server.store, "internet")
+
+        # sha256 of "Hello, world!"
+        sha256 = "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3"
+        save(os.path.join(http_server_base_folder_internet, "good.txt"), "Hello, world!")
+        # Different content under a different URL — the second recipe declares the
+        # same sha256 by mistake (e.g. copy/paste from a sibling recipe).
+        save(os.path.join(http_server_base_folder_internet, "evil.txt"), "Bye, world!")
+
+        good_recipe = textwrap.dedent(f"""
+           from conan import ConanFile
+           from conan.tools.files import download
+           class PkgA(ConanFile):
+               name = "pkga"
+               version = "1.0"
+               def source(self):
+                   download(self, "{self.file_server.fake_url}/internet/good.txt", "good.txt",
+                            sha256="{sha256}")
+           """)
+        bad_recipe = textwrap.dedent(f"""
+           from conan import ConanFile
+           from conan.tools.files import download
+           class PkgB(ConanFile):
+               name = "pkgb"
+               version = "1.0"
+               def source(self):
+                   download(self, "{self.file_server.fake_url}/internet/evil.txt", "evil.txt",
+                            sha256="{sha256}")
+           """)
+
+        self.client.save_home(
+            {"global.conf": f"core.sources:download_cache={self.download_cache_folder}\n"
+                            f"core.sources:download_urls=['origin']\n"})
+
+        # First recipe: legitimately downloads and registers good.txt against the sha256
+        self.client.save({"conanfile.py": good_recipe})
+        self.client.run("create .")
+        sidecar_path = os.path.join(self.download_cache_folder, "s", sha256 + ".json")
+        sidecar = json.loads(load(sidecar_path))
+        known_urls = sum(sidecar["references"].values(), [])
+        assert f"{self.file_server.fake_url}/internet/good.txt" in known_urls
+        assert f"{self.file_server.fake_url}/internet/evil.txt" not in known_urls
+
+        # Second recipe declares the same sha256 but a different URL — the cache
+        # entry is reused only after re-download, which then fails check_checksum.
+        self.client.save({"conanfile.py": bad_recipe})
+        self.client.run("create .", assert_error=True)
+        assert "not previously associated with the cached" in self.client.out
+        assert "sha256 hash failed for" in self.client.out
+
+    def test_url_match_reuses_cache_without_redownload(self):
+        # Companion to test_url_mismatch_redownloads_on_sha256_collision: a recipe
+        # that uses a URL already registered for the cached sha256 must hit the
+        # cache as before, with no warning and no re-download.
+        http_server_base_folder_internet = os.path.join(self.file_server.store, "internet")
+
+        sha256 = "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3"
+        save(os.path.join(http_server_base_folder_internet, "good.txt"), "Hello, world!")
+
+        def _recipe(name):
+            return textwrap.dedent(f"""
+                from conan import ConanFile
+                from conan.tools.files import download
+                class Pkg(ConanFile):
+                    name = "{name}"
+                    version = "1.0"
+                    def source(self):
+                        download(self, "{self.file_server.fake_url}/internet/good.txt",
+                                 "good.txt", sha256="{sha256}")
+                """)
+
+        self.client.save_home(
+            {"global.conf": f"core.sources:download_cache={self.download_cache_folder}\n"
+                            f"core.sources:download_urls=['origin']\n"})
+
+        self.client.save({"conanfile.py": _recipe("pkga")})
+        self.client.run("create .")
+        self.client.save({"conanfile.py": _recipe("pkgb")})
+        self.client.run("create .")
+        assert "not previously associated with the cached" not in self.client.out
+        assert "retrieved from local download cache" in self.client.out
+
     def test_export_then_upload_workflow(self):
         mkdir(os.path.join(self.download_cache_folder, "s"))
 


### PR DESCRIPTION
## Changelog: Bugfix: detect sha256 collisions across unrelated URLs in the local source cache

Fixes #19956.

The source cache was indexed by sha256 alone: a recipe that declared the same sha256 as an existing cache entry would silently inherit that cached payload, even when its `download()` URL pointed at unrelated content. `check_checksum` never ran against the recipe's actual URL, so a hash collision (typically a copy-paste mistake from a sibling recipe) went undetected and produced a wrong-but-correctly-hashed `source` folder.

### Change
On cache hit, `SourcesCachingDownloader` now consults the sidecar `<sha256>.json` and only reuses the cached file when one of the requested URLs has been registered for that sha256 before. Otherwise it re-downloads from the recipe URL so `FileDownloader.check_checksum` runs and surfaces the mismatch.

Caches predating the sidecar (missing/malformed metadata file) keep the previous behavior — backwards-compatible with existing `core.sources:download_cache` directories.

### Tests
`test/integration/cache/backup_sources_test.py`:
- `test_url_mismatch_redownloads_on_sha256_collision` — repro: PkgA caches `good.txt` under sha256 H, PkgB declares H for `evil.txt`; without the fix PkgB silently inherits PkgA's bytes; with the fix re-download triggers and `check_checksum` raises.
- `test_url_match_reuses_cache_without_redownload` — confirms legit cache hits (same URL, same sha256, different recipe) still skip the network.