### PR TITLE
Redownload files when URL mismatch across SHA

### DIFF
--- a/conan/internal/rest/caching_file_downloader.py
+++ b/conan/internal/rest/caching_file_downloader.py
@@ -55,12 +55,10 @@ class SourcesCachingDownloader:
                 in_cache = os.path.exists(download_path)
                 need_download = not in_cache
                 if in_cache:
-                    recorded_urls = download_cache.read_backup_sources_metadata_urls(download_path)
-                    url_mismatch = False
-                    if recorded_urls:
-                        urls_set = set(urls if isinstance(urls, (list, tuple)) else [urls])
-                        url_mismatch = not (recorded_urls & urls_set)
-                    if url_mismatch:
+                    recorded_urls = download_cache.get_urls_from_backup_sources(download_path)
+                    urls_set = set(urls if isinstance(urls, (list, tuple)) else [urls])
+                    # URLs mismatch
+                    if not recorded_urls.intersection(urls_set):
                         self._output.warning(
                             "The requested URL(s) are not listed in backup-sources metadata for this "
                             "SHA256 cache entry. This may be a conandata mistake, or the same checksum "

--- a/conan/internal/rest/caching_file_downloader.py
+++ b/conan/internal/rest/caching_file_downloader.py
@@ -48,13 +48,29 @@ class SourcesCachingDownloader:
         if download_cache_folder:
             download_cache = DownloadCache(download_cache_folder)
             download_path = download_cache.source_path(sha256)
+
             with download_cache.lock(sha256):
                 remove_if_dirty(download_path)
 
-                if os.path.exists(download_path):
-                    self._output.info(f"Source {urls} retrieved from local download cache")
-                else:
-                    # not in cache, we need to actually download from internet or backup servers
+                in_cache = os.path.exists(download_path)
+                need_download = not in_cache
+                if in_cache:
+                    recorded_urls = download_cache.read_backup_sources_metadata_urls(download_path)
+                    url_mismatch = False
+                    if recorded_urls:
+                        urls_set = set(urls if isinstance(urls, (list, tuple)) else [urls])
+                        url_mismatch = not (recorded_urls & urls_set)
+                    if url_mismatch:
+                        self._output.warning(
+                            "The requested URL(s) are not listed in backup-sources metadata for this "
+                            "SHA256 cache entry. This may be a conandata mistake, or the same checksum "
+                            "reused for a different upstream version. Re-downloading to verify."
+                        )
+                        need_download = True
+                    else:
+                        self._output.info(f"Source {urls} retrieved from local download cache")
+
+                if need_download:
                     with set_dirty_context_manager(download_path):
                         self._do_download(source_origins, urls, download_path, retry, retry_wait,
                                           verify_ssl, auth, headers, md5, sha1, sha256)

--- a/conan/internal/rest/caching_file_downloader.py
+++ b/conan/internal/rest/caching_file_downloader.py
@@ -63,7 +63,7 @@ class SourcesCachingDownloader:
                     if recorded_urls and not recorded_urls.intersection(urls_set):
                         self._output.warning(
                             "The requested URL(s) are not listed in backup-sources metadata for this "
-                            "SHA256 cache entry. This may be a conandata mistake, or the same checksum "
+                            "SHA256 cache entry. This may be a mistake, or the same checksum "
                             "reused for a different upstream version. Re-downloading to verify."
                         )
                         need_download = True

--- a/conan/internal/rest/caching_file_downloader.py
+++ b/conan/internal/rest/caching_file_downloader.py
@@ -57,8 +57,10 @@ class SourcesCachingDownloader:
                 if in_cache:
                     recorded_urls = download_cache.get_urls_from_backup_sources(download_path)
                     urls_set = set(urls if isinstance(urls, (list, tuple)) else [urls])
-                    # URLs mismatch
-                    if not recorded_urls.intersection(urls_set):
+                    # URLs mismatch: only re-download if there are recorded URLs and they don't match the requested ones.
+                    # Some users could not have available the metadata files (json) while using
+                    # backup-sources. We do not want to force re-downloading
+                    if recorded_urls and not recorded_urls.intersection(urls_set):
                         self._output.warning(
                             "The requested URL(s) are not listed in backup-sources metadata for this "
                             "SHA256 cache entry. This may be a conandata mistake, or the same checksum "

--- a/conan/internal/rest/download_cache.py
+++ b/conan/internal/rest/download_cache.py
@@ -111,7 +111,7 @@ class DownloadCache:
         return files_to_upload
 
     @staticmethod
-    def read_backup_sources_metadata_urls(cached_path):
+    def get_urls_from_backup_sources(cached_path):
         """All download URLs stored in the backup-sources summary file ``<cached_path>.json``.
         """
         summary_path = cached_path + ".json"

--- a/conan/internal/rest/download_cache.py
+++ b/conan/internal/rest/download_cache.py
@@ -111,6 +111,25 @@ class DownloadCache:
         return files_to_upload
 
     @staticmethod
+    def read_backup_sources_metadata_urls(cached_path):
+        """All download URLs stored in the backup-sources summary file ``<cached_path>.json``.
+        """
+        summary_path = cached_path + ".json"
+        if not os.path.exists(summary_path):
+            return set()
+        data = json.loads(load(summary_path))
+        refs = data.get("references") or {}
+        result = set()
+        for mirror in refs.values():
+            if not mirror:
+                continue
+            if isinstance(mirror, (list, tuple)):
+                result.update(mirror)
+            else:
+                result.add(mirror)
+        return result
+
+    @staticmethod
     def update_backup_sources_json(cached_path, conanfile, urls):
         """ create or update the sha256.json file with the references and new urls used
         """

--- a/conan/internal/rest/download_cache.py
+++ b/conan/internal/rest/download_cache.py
@@ -117,17 +117,8 @@ class DownloadCache:
         summary_path = cached_path + ".json"
         if not os.path.exists(summary_path):
             return set()
-        data = json.loads(load(summary_path))
-        refs = data.get("references") or {}
-        result = set()
-        for mirror in refs.values():
-            if not mirror:
-                continue
-            if isinstance(mirror, (list, tuple)):
-                result.update(mirror)
-            else:
-                result.add(mirror)
-        return result
+        refs = json.loads(load(summary_path)).get("references") or {}
+        return {url for urls in refs.values() for url in urls}
 
     @staticmethod
     def update_backup_sources_json(cached_path, conanfile, urls):

--- a/conan/test/assets/genconanfile.py
+++ b/conan/test/assets/genconanfile.py
@@ -28,6 +28,7 @@ class GenConanfile:
         self._deprecated = None
         self._package_lines = None
         self._finalize_lines = None
+        self._source_lines = None
         self._package_files = None
         self._package_files_env = None
         self._build_messages = None
@@ -224,6 +225,11 @@ class GenConanfile:
             self._finalize_lines.append(line)
         return self
 
+    def with_source(self, *lines):
+        self._source_lines = self._source_lines or []
+        self._source_lines.extend(lines)
+        return self
+
     def with_build_msg(self, msg):
         self._build_messages = self._build_messages or []
         self._build_messages.append(msg)
@@ -406,6 +412,20 @@ class GenConanfile:
         """.format("\n".join(lines))
 
     @property
+    def _source(self):
+        return self._source_lines or None
+
+    @property
+    def _source_render(self):
+        if not self._source_lines:
+            return None
+        lines = ["        {}".format(line) for line in self._source_lines]
+        return """
+    def source(self):
+{}
+    """.format("\n".join(lines))
+
+    @property
     def _build_render(self):
         if not self._build_messages and not self._cmake_build:
             return None
@@ -488,7 +508,7 @@ class GenConanfile:
         for member in ("name", "version", "package_type", "provides", "deprecated",
                        "exports_sources", "exports", "generators", "requires", "build_requires",
                        "tool_requires", "test_requires", "requirements", "python_requires",
-                       "revision_mode", "settings", "options", "default_options", "build",
+                       "revision_mode", "settings", "options", "default_options", "source", "build",
                        "package_method", "package_info", "package_id_lines", "test_lines",
                        "finalize_method"
                        ):

--- a/test/integration/cache/backup_sources_test.py
+++ b/test/integration/cache/backup_sources_test.py
@@ -989,9 +989,12 @@ class TestDownloadCacheBackupSources:
         self.client.save({"conanfile.py": GenConanfile("pkg", "1.0").with_import(dl_import).with_source(
             f'download(self, "{url_a}", "src.tgz", sha256="{sha}")')})
         self.client.run("source")
+        summary_json = os.path.join(self.download_cache_folder, "s", sha + ".json")
+        meta_after_first = json.loads(load(summary_json))
 
         self.client.save({"conanfile.py": GenConanfile("pkg", "1.1").with_import(dl_import).with_source(
             f'download(self, "{url_bad}", "src.tgz", sha256="{sha}")')})
         self.client.run("source", assert_error=True)
         assert warn in self.client.out
         assert "sha256 hash failed" in self.client.out
+        assert json.loads(load(summary_json)) == meta_after_first

--- a/test/integration/cache/backup_sources_test.py
+++ b/test/integration/cache/backup_sources_test.py
@@ -974,7 +974,7 @@ class TestDownloadCacheBackupSources:
         assert url_a in meta["references"]["pkg/1.0"]
         assert url_b in meta["references"]["pkg/1.1"]
 
-    def test_download_urls_origin_only_missing_summary_json_uses_cached_blob(self):
+    def test_backup_sources_empty_missing_summary_json_uses_cached_blob(self):
         """Not having a backup-sources ``.json`` must not prevent reusing the cached blob on a second ``source``"""
         d = os.path.join(self.file_server.store, "internet")
         sha = "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3"
@@ -988,8 +988,15 @@ class TestDownloadCacheBackupSources:
         self.client.run("source")
 
         summary_json = os.path.join(self.client.cache_folder, "sources", "s", sha + ".json")
-        os.remove(summary_json)
 
+        # Empty the references in the summary JSON to simulate a missing or corrupted summary, but keep the cached blob
+        with open(summary_json, "w") as f:
+            json.dump({"references": {}}, f)
+        self.client.run("source")
+        assert "retrieved from local download cache" in self.client.out
+
+        # Remove the summary JSON entirely, it should still reuse the cached blob because the URL and SHA256 are the same
+        os.remove(summary_json)
         self.client.run("source")
         assert "retrieved from local download cache" in self.client.out
 

--- a/test/integration/cache/backup_sources_test.py
+++ b/test/integration/cache/backup_sources_test.py
@@ -974,6 +974,25 @@ class TestDownloadCacheBackupSources:
         assert url_a in meta["references"]["pkg/1.0"]
         assert url_b in meta["references"]["pkg/1.1"]
 
+    def test_download_urls_origin_only_missing_summary_json_uses_cached_blob(self):
+        """Not having a backup-sources ``.json`` must not prevent reusing the cached blob on a second ``source``"""
+        d = os.path.join(self.file_server.store, "internet")
+        sha = "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3"
+        save(os.path.join(d, "myfile.txt"), "Hello, world!")
+        url = f"{self.file_server.fake_url}/internet/myfile.txt"
+
+        self.client.save_home({"global.conf": "core.sources:download_urls=['origin']\n"})
+        dl_import = "from conan.tools.files import download"
+        self.client.save({"conanfile.py": GenConanfile("pkg", "1.0").with_import(dl_import).with_source(
+            f'download(self, "{url}", "src.tgz", sha256="{sha}")')})
+        self.client.run("source")
+
+        summary_json = os.path.join(self.client.cache_folder, "sources", "s", sha + ".json")
+        os.remove(summary_json)
+
+        self.client.run("source")
+        assert "retrieved from local download cache" in self.client.out
+
     def test_backup_sources_unlisted_url_wrong_content_checksum_error(self):
         """New URL vs summary triggers re-download; wrong bytes vs declared SHA256 fail checksum."""
         warn = "not listed in backup-sources metadata"

--- a/test/integration/cache/backup_sources_test.py
+++ b/test/integration/cache/backup_sources_test.py
@@ -11,6 +11,7 @@ from webtest import TestApp
 
 from conan.internal.errors import NotFoundException
 from conan.errors import ConanException
+from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.file_server import TestFileServer
 from conan.test.utils.test_files import temp_folder
 from conan.test.utils.tools import TestClient
@@ -944,3 +945,53 @@ class TestDownloadCacheBackupSources:
         assert f"Sources correctly downloaded from {self.file_server.fake_url}" in self.client.out
         assert "myfile.txt" in os.listdir(self.client.current_folder)
         assert len(os.listdir(self.download_cache_folder)) == 0
+
+    def test_backup_sources_unlisted_url_same_sha_warns(self):
+        """New URL(s) with no overlap vs summary JSON for the same cached SHA256 emit a warning once."""
+        warn = "not listed in backup-sources metadata"
+        d = os.path.join(self.file_server.store, "internet")
+        sha = "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3"
+        save(os.path.join(d, "upstream_a.txt"), "Hello, world!")
+        save(os.path.join(d, "upstream_b.txt"), "Hello, world!")
+        url_a = f"{self.file_server.fake_url}/internet/upstream_a.txt"
+        url_b = f"{self.file_server.fake_url}/internet/upstream_b.txt"
+
+        self.client.save_home({"global.conf": f"core.sources:download_cache={self.download_cache_folder}\n"})
+        dl_import = "from conan.tools.files import download"
+        self.client.save({"conanfile.py": GenConanfile("pkg", "1.0").with_import(dl_import).with_source(
+            f'download(self, "{url_a}", "src.tgz", sha256="{sha}")')})
+        self.client.run("source")
+        assert warn not in self.client.out
+
+        self.client.save({"conanfile.py": GenConanfile("pkg", "1.1").with_import(dl_import).with_source(
+            f'download(self, "{url_b}", "src.tgz", sha256="{sha}")')})
+        self.client.run("source")
+        assert warn in self.client.out
+        self.client.run("source")
+        assert warn not in self.client.out
+
+        meta = json.loads(load(os.path.join(self.download_cache_folder, "s", sha + ".json")))
+        assert url_a in meta["references"]["pkg/1.0"]
+        assert url_b in meta["references"]["pkg/1.1"]
+
+    def test_backup_sources_unlisted_url_wrong_content_checksum_error(self):
+        """New URL vs summary triggers re-download; wrong bytes vs declared SHA256 fail checksum."""
+        warn = "not listed in backup-sources metadata"
+        d = os.path.join(self.file_server.store, "internet")
+        sha = "315f5bdb76d078c43b8ac0064e4a0164612b1fce77c869345bfc94c75894edd3"
+        save(os.path.join(d, "upstream_a.txt"), "Hello, world!")
+        save(os.path.join(d, "upstream_bad.txt"), "Wrong tarball contents")
+        url_a = f"{self.file_server.fake_url}/internet/upstream_a.txt"
+        url_bad = f"{self.file_server.fake_url}/internet/upstream_bad.txt"
+
+        self.client.save_home({"global.conf": f"core.sources:download_cache={self.download_cache_folder}\n"})
+        dl_import = "from conan.tools.files import download"
+        self.client.save({"conanfile.py": GenConanfile("pkg", "1.0").with_import(dl_import).with_source(
+            f'download(self, "{url_a}", "src.tgz", sha256="{sha}")')})
+        self.client.run("source")
+
+        self.client.save({"conanfile.py": GenConanfile("pkg", "1.1").with_import(dl_import).with_source(
+            f'download(self, "{url_bad}", "src.tgz", sha256="{sha}")')})
+        self.client.run("source", assert_error=True)
+        assert warn in self.client.out
+        assert "sha256 hash failed" in self.client.out


### PR DESCRIPTION
Changelog: Fix: Warn and re-fetch when requested URLs conflict with existing ones with the same SHA256.
Docs: Omit

Close https://github.com/conan-io/conan/pull/19966
Fix https://github.com/conan-io/conan/issues/19956 

#### Problem
Adding a new version in Conan Center with a new URL but the old SHA256 is an easy mistake. Without a source download cache, you usually still hit the new URL. With core.sources:download_cache, Conan may reuse the cached tarball for that SHA256 and never download the new URL, so you can build the wrong sources without noticing.

#### Solution
If the requested URL(s) are not listed in the existing <sha256>.json backup summary for that blob, Conan warns, re-downloads from the requested URL(s), and checks the checksum again—so bad conandata shows up as a failed or corrected download instead of a silent cache hit.

#### Extras

A new `with_source` method has been added to `GenConanfile` in order to be able to use this useful test class, reducing this way the code test size.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
