### PR TITLE
AutotoolsDeps: -rpath on shared dependencies

### DIFF
--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -29,7 +29,7 @@ class AutotoolsDeps:
     def _rpaths_flags(self):
         flags = []
         for dep in self.ordered_deps:
-            flags.extend(["-Wl,-rpath -Wl,{}".format(libdir) for libdir in dep.cpp_info.libdirs
+            flags.extend(["-Wl,-rpath -Wl,{}".format(libdir) for libdir in self._get_cpp_info().libdirs
                           if dep.package_type == "shared-library"])
         return flags
 

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -30,9 +30,9 @@ class AutotoolsDeps:
     def _rpaths_flags(self):
         flags = []
         for dep in self.ordered_deps:
-            flags.extend(["-Wl,-rpath -Wl,{}".format(libdir)
-                          for libdir in dep.cpp_info.aggregated_components().libdirs
-                          if dep.package_type is PackageType.SHARED])
+            if dep.package_type is PackageType.SHARED:
+                flags.extend(["-Wl,-rpath -Wl,{}".format(libdir) for libdir in
+                              dep.cpp_info.aggregated_components().libdirs])
         return flags
 
     @property

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -29,7 +29,8 @@ class AutotoolsDeps:
     def _rpaths_flags(self):
         flags = []
         for dep in self.ordered_deps:
-            flags.extend(["-Wl,-rpath -Wl,{}".format(libdir) for libdir in self._get_cpp_info().libdirs
+            flags.extend(["-Wl,-rpath -Wl,{}".format(libdir)
+                          for libdir in dep.cpp_info.aggregated_components().libdirs
                           if dep.package_type == "shared-library"])
         return flags
 
@@ -79,6 +80,6 @@ class AutotoolsDeps:
     def vars(self, scope="build"):
         return self.environment.vars(self._conanfile, scope=scope)
 
-    def generate(self,  scope="build"):
+    def generate(self, scope="build"):
         check_duplicated_generator(self, self._conanfile)
         self.vars(scope).save_script("conanautotoolsdeps")

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -1,4 +1,5 @@
 from conan.internal import check_duplicated_generator
+from conan.internal.model.pkg_type import PackageType
 from conan.tools import CppInfo
 from conan.tools.env import Environment
 from conan.tools.gnu.gnudeps_flags import GnuDepsFlags
@@ -31,7 +32,7 @@ class AutotoolsDeps:
         for dep in self.ordered_deps:
             flags.extend(["-Wl,-rpath -Wl,{}".format(libdir)
                           for libdir in dep.cpp_info.aggregated_components().libdirs
-                          if dep.package_type == "shared-library"])
+                          if dep.package_type is PackageType.SHARED])
         return flags
 
     @property

--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -30,7 +30,7 @@ class AutotoolsDeps:
         flags = []
         for dep in self.ordered_deps:
             flags.extend(["-Wl,-rpath -Wl,{}".format(libdir) for libdir in dep.cpp_info.libdirs
-                          if dep.options.get_safe("shared", False)])
+                          if dep.package_type == "shared-library"])
         return flags
 
     @property

--- a/test/integration/toolchains/gnu/test_autotoolsdeps.py
+++ b/test/integration/toolchains/gnu/test_autotoolsdeps.py
@@ -155,10 +155,11 @@ def test_autotoolsdeps_macos_rpath_by_package_type(package_type, use_shared_opti
             "conanfile.py": consumer,
             "macos": profile})
     t.run("create dep_pkg --profile:host=macos")
+    dp_pkg_package_path = t.created_layout().package()
     t.run("install --profile:host=macos")
     deps = t.load("conanautotoolsdeps.sh")
     if expect_rpath:
-        assert "-Wl,-rpath" in deps
+        assert f"-Wl,-rpath -Wl,{dp_pkg_package_path}" in deps
     else:
         assert "-Wl,-rpath" not in deps
 
@@ -194,7 +195,8 @@ def test_autotoolsdeps_macos_rpath_shared_dep_with_components():
             "conanfile.py": consumer,
             "macos": profile})
     t.run("create dep_pkg --profile:host=macos")
+    dp_pkg_package_path = t.created_layout().package()
     t.run("install --profile:host=macos")
     deps = t.load("conanautotoolsdeps.sh")
     assert "nested" in deps
-    assert "-Wl,-rpath" in deps
+    assert f"-Wl,-rpath -Wl,{dp_pkg_package_path}" in deps

--- a/test/integration/toolchains/gnu/test_autotoolsdeps.py
+++ b/test/integration/toolchains/gnu/test_autotoolsdeps.py
@@ -155,9 +155,46 @@ def test_autotoolsdeps_macos_rpath_by_package_type(package_type, use_shared_opti
             "conanfile.py": consumer,
             "macos": profile})
     t.run("create dep_pkg --profile:host=macos")
-    t.run("install . --profile:host=macos")
+    t.run("install --profile:host=macos")
     deps = t.load("conanautotoolsdeps.sh")
     if expect_rpath:
         assert "-Wl,-rpath" in deps
     else:
         assert "-Wl,-rpath" not in deps
+
+
+@pytest.mark.skipif(platform.system() not in ["Linux", "Darwin"], reason="Autotools")
+def test_autotoolsdeps_macos_rpath_shared_dep_with_components():
+    profile = textwrap.dedent("""
+         [settings]
+         build_type=Release
+         arch=x86
+         os=Macos
+         compiler=gcc
+         compiler.libcxx=libstdc++11
+         compiler.version=7.1
+         compiler.cppstd=17
+    """)
+    dep = (GenConanfile("pkg", "1.0")
+           .with_settings("os", "arch", "compiler", "build_type")
+           .with_package_type("shared-library")
+           .with_package_info({
+               "libdirs": [],
+               "components": {
+                   "cmp": {"libdirs": ["nested/lib"], "libs": ["pkg"]},
+               },
+           }))
+    consumer = (GenConanfile("app", "1.0")
+                .with_settings("os", "arch", "compiler", "build_type")
+                .with_require("pkg/1.0")
+                .with_generator("AutotoolsDeps"))
+
+    t = TestClient()
+    t.save({"dep_pkg/conanfile.py": dep,
+            "conanfile.py": consumer,
+            "macos": profile})
+    t.run("create dep_pkg --profile:host=macos")
+    t.run("install --profile:host=macos")
+    deps = t.load("conanautotoolsdeps.sh")
+    assert "nested" in deps
+    assert "-Wl,-rpath" in deps

--- a/test/integration/toolchains/gnu/test_autotoolsdeps.py
+++ b/test/integration/toolchains/gnu/test_autotoolsdeps.py
@@ -116,3 +116,48 @@ def test_cpp_info_aggregation():
 
     t.save({"conanfile.py": consumer})
     t.run("create . --name consumer --version 1.0 --profile:host=macos")
+
+
+@pytest.mark.skipif(platform.system() not in ["Linux", "Darwin"], reason="Autotools")
+@pytest.mark.parametrize(
+    "package_type,use_shared_option,expect_rpath",
+    [
+        ("shared-library", False, True),
+        ("static-library", False, False),
+        ("library", True, True),
+    ],
+)
+def test_autotoolsdeps_macos_rpath_by_package_type(package_type, use_shared_option, expect_rpath):
+    """On Macos, ``AutotoolsDeps`` adds ``-Wl,-rpath`` only for host deps whose type is shared."""
+    profile = textwrap.dedent("""
+         [settings]
+         build_type=Release
+         arch=x86
+         os=Macos
+         compiler=gcc
+         compiler.libcxx=libstdc++11
+         compiler.version=7.1
+         compiler.cppstd=17
+    """)
+    dep = (GenConanfile("pkg", "1.0")
+           .with_settings("os", "arch", "compiler", "build_type")
+           .with_package_type(package_type)
+           .with_package_info({"libdirs": ["lib"], "libs": ["pkg"]}))
+    if use_shared_option:
+        dep = dep.with_shared_option(True)
+    consumer = (GenConanfile("app", "1.0")
+                .with_settings("os", "arch", "compiler", "build_type")
+                .with_require("pkg/1.0")
+                .with_generator("AutotoolsDeps"))
+
+    t = TestClient()
+    t.save({"dep_pkg/conanfile.py": dep,
+            "conanfile.py": consumer,
+            "macos": profile})
+    t.run("create dep_pkg --profile:host=macos")
+    t.run("install . --profile:host=macos")
+    deps = t.load("conanautotoolsdeps.sh")
+    if expect_rpath:
+        assert "-Wl,-rpath" in deps
+    else:
+        assert "-Wl,-rpath" not in deps


### PR DESCRIPTION
Changelog: Fix: `AutotoolsDeps` will link with `-rpath` on shared package types and components correctly.
Docs: omit

Fix #19973
Diagnosed by @jcar87 

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
