### PR TITLE
runtime_deploy: avoid crashing when overriding existing symlinks

### DIFF
--- a/conan/internal/deploy.py
+++ b/conan/internal/deploy.py
@@ -175,12 +175,18 @@ def _flatten_directory(dep, src_dir, output_dir, symlinks, extension_filter=None
             if not os.path.exists(os.path.dirname(dest_filepath)):
                 os.makedirs(os.path.dirname(dest_filepath))
 
-            if os.path.exists(dest_filepath):
-                if filecmp.cmp(src_filepath, dest_filepath):  # Be efficient, do not copy
+            # lexists: detect existing symlinks; shutil.copy2(..., follow_symlinks=False) uses
+            # os.symlink() and fails with EEXIST if the destination path already exists.
+            if os.path.lexists(dest_filepath):
+                try:
+                    same = filecmp.cmp(src_filepath, dest_filepath, shallow=True)
+                except OSError:  # e.g. broken symlink at dest — replace via unlink below
+                    same = False
+                if same:  # Be efficient, do not copy
                     output.verbose(f"{dest_filepath} exists with same contents, skipping copy")
                     continue
-                else:
-                    output.warning(f"{dest_filepath} exists and will be overwritten")
+                output.warning(f"{dest_filepath} exists and will be overwritten")
+                os.unlink(dest_filepath)
 
             try:
                 file_count += 1
@@ -188,6 +194,7 @@ def _flatten_directory(dep, src_dir, output_dir, symlinks, extension_filter=None
                 # copy all metadata from the src symbolic link to the newly created dst link
                 shutil.copy2(src_filepath, dest_filepath, follow_symlinks=not symlinks)
                 output.verbose(f"Copied {src_filepath} into {output_dir}")
+
             except Exception as e:
                 if "WinError 1314" in str(e):
                     ConanOutput().error("runtime_deploy: Windows symlinks require admin privileges "

--- a/test/functional/command/test_install_deploy.py
+++ b/test/functional/command/test_install_deploy.py
@@ -567,6 +567,39 @@ class TestRuntimeDeployer:
         else:
             assert not os.path.islink(lib)
 
+    def test_runtime_deploy_symlink_overwrite(self):
+        """Two deps may ship the same symlink name pointing at different targets; overwrite must
+        not raise FileExistsError (https://github.com/conan-io/conan/issues/19968).
+        """
+        if platform.system() == "Windows":
+            pytest.skip("Requires POSIX symlinks")
+        c = TestClient()
+
+        def _shared_lib_pkg(name, versioned_so, body):
+            return (GenConanfile(name, "1.0")
+                    .with_package_type("shared-library")
+                    .with_import("import os")
+                    .with_import("from conan.tools.files import save, chdir")
+                    .with_package(
+                        f'save(self, os.path.join(self.package_folder, "lib", "{versioned_so}"), "{body}")',
+                        'with chdir(self, os.path.join(self.package_folder, "lib")):',
+                        f'    os.symlink(src="{versioned_so}", dst="libfoo.so")',
+                    ))
+
+        pkga = _shared_lib_pkg("pkga", "libfoo.so.1", "v1")
+        pkgb = _shared_lib_pkg("pkgb", "libfoo.so.2", "v2")
+        c.save({"pkga/conanfile.py": pkga,
+                "pkgb/conanfile.py": pkgb,
+                "conanfile.txt": "[requires]\npkga/1.0\npkgb/1.0\n"})
+        c.run("export-pkg pkga --name=pkga --version=1.0")
+        c.run("export-pkg pkgb --name=pkgb --version=1.0")
+        c.run("install . --deployer=runtime_deploy --deployer-folder=myruntime -vvv")
+        assert "libfoo.so exists and will be overwritten" in c.out
+        link = os.path.join(c.current_folder, "myruntime", "libfoo.so")
+        assert os.path.islink(link)
+        # Last dependency in host order wins the symlink target; both outcomes are valid.
+        assert os.readlink(link) in ("libfoo.so.1", "libfoo.so.2")
+
     def test_runtime_deploy_subfolder(self):
         """ The deployer runtime_deploy should preserve subfolder structure when deploying
         shared libraries

--- a/test/functional/command/test_install_deploy.py
+++ b/test/functional/command/test_install_deploy.py
@@ -437,6 +437,19 @@ def test_deploy_incorrect_folder():
         assert "ERROR: Deployer folder cannot be created" in c.out
 
 
+def _runtime_deploy_shared_lib_conanfile(name, versioned_so, body):
+    """Recipe with one versioned .so under lib/ and lib/libfoo.so -> that file (POSIX symlink)."""
+    return (GenConanfile(name, "1.0")
+            .with_package_type("shared-library")
+            .with_import("import os")
+            .with_import("from conan.tools.files import save, chdir")
+            .with_package(
+                f'save(self, os.path.join(self.package_folder, "lib", "{versioned_so}"), "{body}")',
+                'with chdir(self, os.path.join(self.package_folder, "lib")):',
+                f'    os.symlink(src="{versioned_so}", dst="libfoo.so")',
+            ))
+
+
 class TestRuntimeDeployer:
     def test_runtime_deploy(self):
         c = TestClient()
@@ -567,27 +580,14 @@ class TestRuntimeDeployer:
         else:
             assert not os.path.islink(lib)
 
+    @pytest.mark.skipif(platform.system() == "Windows", reason="Requires POSIX symlinks")
     def test_runtime_deploy_symlink_overwrite(self):
         """Two deps may ship the same symlink name pointing at different targets; overwrite must
         not raise FileExistsError (https://github.com/conan-io/conan/issues/19968).
         """
-        if platform.system() == "Windows":
-            pytest.skip("Requires POSIX symlinks")
         c = TestClient()
-
-        def _shared_lib_pkg(name, versioned_so, body):
-            return (GenConanfile(name, "1.0")
-                    .with_package_type("shared-library")
-                    .with_import("import os")
-                    .with_import("from conan.tools.files import save, chdir")
-                    .with_package(
-                        f'save(self, os.path.join(self.package_folder, "lib", "{versioned_so}"), "{body}")',
-                        'with chdir(self, os.path.join(self.package_folder, "lib")):',
-                        f'    os.symlink(src="{versioned_so}", dst="libfoo.so")',
-                    ))
-
-        pkga = _shared_lib_pkg("pkga", "libfoo.so.1", "v1")
-        pkgb = _shared_lib_pkg("pkgb", "libfoo.so.2", "v2")
+        pkga = _runtime_deploy_shared_lib_conanfile("pkga", "libfoo.so.1", "v1")
+        pkgb = _runtime_deploy_shared_lib_conanfile("pkgb", "libfoo.so.2", "v2")
         c.save({"pkga/conanfile.py": pkga,
                 "pkgb/conanfile.py": pkgb,
                 "conanfile.txt": "[requires]\npkga/1.0\npkgb/1.0\n"})
@@ -599,6 +599,60 @@ class TestRuntimeDeployer:
         assert os.path.islink(link)
         # Last dependency in host order wins the symlink target; both outcomes are valid.
         assert os.readlink(link) in ("libfoo.so.1", "libfoo.so.2")
+
+    @pytest.mark.skipif(platform.system() == "Windows", reason="Requires POSIX symlinks")
+    def test_runtime_deploy_recovers_broken_symlink_on_redeploy(self):
+        """Broken symlink in the deploy dir (filecmp can raise); redeploy must replace it."""
+        c = TestClient()
+        c.save({"pkga/conanfile.py": _runtime_deploy_shared_lib_conanfile("pkga", "libfoo.so.1", "v1"),
+                "conanfile.txt": "[requires]\npkga/1.0\n"})
+        c.run("export-pkg pkga --name=pkga --version=1.0")
+        out = os.path.join(c.current_folder, "out")
+        c.run("install . --deployer=runtime_deploy --deployer-folder=out -vvv")
+        deployed_soname = os.path.join(out, "libfoo.so.1")
+        os.remove(deployed_soname)
+        link = os.path.join(out, "libfoo.so")
+        assert os.path.islink(link)
+        assert not os.path.exists(deployed_soname)
+        c.run("install . --deployer=runtime_deploy --deployer-folder=out -vvv")
+        assert os.path.isfile(deployed_soname)
+        assert os.readlink(link) == "libfoo.so.1"
+
+    @pytest.mark.skipif(platform.system() == "Windows", reason="Requires POSIX symlinks")
+    def test_runtime_deploy_same_ref_reinstall_different_options(self):
+        """Same pkga/1.0 reinstalled with a different option: symlink name unchanged, target differs
+        (https://github.com/conan-io/conan/issues/19968).
+        """
+        pkga = (GenConanfile("pkga", "1.0")
+                .with_package_type("shared-library")
+                .with_settings("os", "compiler", "build_type", "arch")
+                .with_option("which", ["1", "2"])
+                .with_default_option("which", "1")
+                .with_import("import os")
+                .with_import("from conan.tools.files import save, chdir")
+                .with_package(*textwrap.dedent("""
+                    lib_dir = os.path.join(self.package_folder, "lib")
+                    os.makedirs(lib_dir, exist_ok=True)
+                    if self.options.which == "1":
+                        save(self, os.path.join(lib_dir, "libfoo.so.1"), "v1")
+                        with chdir(self, lib_dir):
+                            os.symlink("libfoo.so.1", "libfoo.so")
+                    else:
+                        save(self, os.path.join(lib_dir, "libfoo.so.2"), "v2")
+                        with chdir(self, lib_dir):
+                            os.symlink("libfoo.so.2", "libfoo.so")
+                    """).strip().splitlines()))
+        c = TestClient()
+        c.save({"pkga/conanfile.py": pkga,
+                "conanfile.txt": "[requires]\npkga/1.0\n"})
+        c.run("create pkga -o pkga/*:which=1 --build=missing")
+        c.run("create pkga -o pkga/*:which=2 --build=missing")
+        out = os.path.join(c.current_folder, "deploy_out")
+        c.run("install . -o pkga/*:which=1 --deployer=runtime_deploy --deployer-folder=deploy_out")
+        c.run("install . -o pkga/*:which=2 --deployer=runtime_deploy --deployer-folder=deploy_out")
+        link = os.path.join(out, "libfoo.so")
+        assert os.path.islink(link)
+        assert os.readlink(link) == "libfoo.so.2"
 
     def test_runtime_deploy_subfolder(self):
         """ The deployer runtime_deploy should preserve subfolder structure when deploying


### PR DESCRIPTION
Changelog: Fix: `runtime_deploy`: avoid crashing when overriding existing symlinks.
Docs: omit

Fix #19968

With symlinks enabled, `runtime_deploy` tried to create a new symlink where one already existed (another package, same filename, different target). os.symlink does not overwrite, so the deploy failed with "file exists".

If we are going to replace the destination anyway, remove it first, then copy. If `filecmp` crash (e.g. broken symlink there), treat it as "not the same" and replace.


- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
