### PR TITLE
[EXPERIMENTAL] allow test_packages run in emulated environment

### DIFF
--- a/conan/api/subapi/local.py
+++ b/conan/api/subapi/local.py
@@ -177,6 +177,7 @@ class LocalAPI:
         """
         with conanfile_exception_formatter(conanfile, "test"):
             with chdir(conanfile.build_folder):
+                setattr(conanfile, "_conan_in_test_package_test", True)
                 conanfile.test()
 
     def inspect(self, conanfile_path, remotes, lockfile, name=None, version=None, user=None,

--- a/conan/internal/conan_app.py
+++ b/conan/internal/conan_app.py
@@ -19,6 +19,13 @@ class CmdWrapper:
             self._wrapper = None
 
     def wrap(self, cmd, conanfile, **kwargs):
+        # Prepend emulator when run() is invoked from test_package test() only
+        if getattr(conanfile, "_conan_in_test_package_test", False):
+            compilers = conanfile.conf.get("tools.build:compiler_executables", default={}, check_type=dict)
+            emulator = compilers.get("emulator")
+            if emulator:
+                cmd = f"{emulator} {cmd}"
+
         if self._wrapper is None:
             return cmd
         return self._wrapper(cmd, conanfile=conanfile, **kwargs)

--- a/conan/internal/model/conan_file.py
+++ b/conan/internal/model/conan_file.py
@@ -387,6 +387,7 @@ class ConanFile:
         """
         # NOTE: "self.win_bash" is the new parameter "win_bash" for Conan 2.0
         command = self._conan_helpers.cmd_wrapper.wrap(command, conanfile=self)
+        command = self._emulator_prefix_for_test_package(command)
         if env == "":  # This default allows not breaking for users with ``env=None`` indicating
             # they don't want any env-file applied
             env = "conanbuild" if scope == "build" else "conanrun"
@@ -411,6 +412,18 @@ class ConanFile:
             raise ConanException("Error %d while executing" % retcode)
 
         return retcode
+
+    def _emulator_prefix_for_test_package(self, command):
+        """Prepend ``tools.build:compiler_executables['emulator']`` when ``run()`` is invoked from
+        ``test_package`` ``test()`` only.
+        """
+        if not getattr(self, "_conan_in_test_package_test", False):
+            return command
+        compilers = self.conf.get("tools.build:compiler_executables", default={}, check_type=dict)
+        emulator = compilers.get("emulator")
+        if not emulator:
+            return command
+        return f"{emulator} {command}"
 
     def __repr__(self):
         return self.display_name

--- a/conan/internal/model/conan_file.py
+++ b/conan/internal/model/conan_file.py
@@ -387,7 +387,6 @@ class ConanFile:
         """
         # NOTE: "self.win_bash" is the new parameter "win_bash" for Conan 2.0
         command = self._conan_helpers.cmd_wrapper.wrap(command, conanfile=self)
-        command = self._emulator_prefix_for_test_package(command)
         if env == "":  # This default allows not breaking for users with ``env=None`` indicating
             # they don't want any env-file applied
             env = "conanbuild" if scope == "build" else "conanrun"
@@ -412,18 +411,6 @@ class ConanFile:
             raise ConanException("Error %d while executing" % retcode)
 
         return retcode
-
-    def _emulator_prefix_for_test_package(self, command):
-        """Prepend ``tools.build:compiler_executables['emulator']`` when ``run()`` is invoked from
-        ``test_package`` ``test()`` only.
-        """
-        if not getattr(self, "_conan_in_test_package_test", False):
-            return command
-        compilers = self.conf.get("tools.build:compiler_executables", default={}, check_type=dict)
-        emulator = compilers.get("emulator")
-        if not emulator:
-            return command
-        return f"{emulator} {command}"
 
     def __repr__(self):
         return self.display_name

--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -159,7 +159,7 @@ BUILT_IN_CONFS = {
     "tools.env:dotenv": "(Experimental) Generate dotenv environment files",
     "tools.env:deactivation_mode": "(Experimental) If 'function', generate a deactivate function instead of a script to unset the environment variables",
     # Compilers/Flags configurations
-    "tools.build:compiler_executables": "Defines a Python dict-like with the compilers path to be used. Allowed keys {'c', 'cpp', 'cuda', 'objc', 'objcxx', 'rc', 'fortran', 'asm', 'hip', 'ispc'}",
+    "tools.build:compiler_executables": "Defines a Python dict-like with the compilers path to be used. Allowed keys {'c', 'cpp', 'cuda', 'objc', 'objcxx', 'rc', 'fortran', 'asm', 'hip', 'ispc', 'emulator'}",
     "tools.build:cxxflags": "List of extra CXX flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:cflags": "List of extra C flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:defines": "List of extra definition flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",

--- a/conan/tools/build/cross_building.py
+++ b/conan/tools/build/cross_building.py
@@ -45,6 +45,17 @@ def can_run(conanfile):
     """
     # Issue related: https://github.com/conan-io/conan/issues/11035
     allowed = conanfile.conf.get("tools.build.cross_building:can_run", check_type=bool)
+    compiler_executables = conanfile.conf.get("tools.build:compiler_executables", default={},
+                                               check_type=dict)
+    if not isinstance(compiler_executables, dict):
+        compiler_executables = {}
+    # ``tools.build:compiler_executables['emulator']`` (e.g. qemu-user) means host binaries can be
+    # executed via the emulator (see ``ConanFile.run`` during ``test_package`` ``test()``).
+    if compiler_executables.get("emulator"):
+        if allowed is None:
+            return True
+        return allowed
+
     if allowed is None:
         return not cross_building(conanfile)
     return allowed


### PR DESCRIPTION
Changelog: Feature: Allow running test_package in an emulated environment
Docs: https://github.com/conan-io/docs/pull/XXXX

Directly related to #19940 

This PR makes use of the "incubating" `emulator` key in order to allow running the test package in a cross compilation.
This could be used in Conan Center Index in order to compile and **test** new configurations (e.g. emscripten, android). 

## Examples

Create a basic CMake library:
```sh
$ conan new cmake_lib -d name="cmake_lib" -d version=1.0 -o cmake_lib
```

### Android NDK

```ini
[settings]
arch=armv8
build_type=Release
compiler=clang
compiler.cppstd=17
compiler.libcxx=c++_static
compiler.version=19
os=Android
os.api_level=28
[tool_requires]
*: android-ndk/[*]

[conf]
tools.build:compiler_executables={'emulator': '{{profile_dir}}/android_emulator.sh'}
```

`android_emulator.sh` -> wrapper to call Android Studio emulator (this could be far simpler if we use `qemu-user` emulator from a Linux environment (Macos only supports `qemu-system` which does not allow direct invokation)

For this, we create a wrapper:
```sh
#!/bin/bash
set -e

BINARY="$1"
shift

BINARY_NAME="$(basename "$BINARY")"
REMOTE_PATH="/data/local/tmp/$BINARY_NAME"

echo "Pushing $BINARY to emulator at $REMOTE_PATH"
adb push "$BINARY" "$REMOTE_PATH" >/dev/null 2>&1
adb shell chmod +x "$REMOTE_PATH"

echo "Executing $REMOTE_PATH with arguments: $@"
OUTPUT=$(adb shell "$REMOTE_PATH" "$@" 2>&1; echo "EXIT_CODE:$?")
EXIT_CODE=$(echo "$OUTPUT" | grep -o 'EXIT_CODE:[0-9]*' | cut -d: -f2)
echo "$OUTPUT" | grep -v 'EXIT_CODE:'

adb shell rm -f "$REMOTE_PATH" >/dev/null 2>&1
exit ${EXIT_CODE:-1}
```

```sh
$ conan create -pr android
...

======== Testing the package: Executing test ========
cmake_lib/1.0 (test package): Running test()
cmake_lib/1.0 (test package): RUN: /Users/perseo/sources/test/meson/cmake_emulator/android_emulator.sh ./example
Pushing ./example to emulator at /data/local/tmp/example
Executing /data/local/tmp/example with arguments: 
cmake_lib/1.0: Hello World Release!
  cmake_lib/1.0: __aarch64__ defined
  cmake_lib/1.0: __cplusplus201703
  cmake_lib/1.0: __GNUC__4
  cmake_lib/1.0: __GNUC_MINOR__2
  cmake_lib/1.0: __clang_major__21
cmake_lib/1.0 test_package
```

The test_package will be passed to the `emulator` wrapper, which will push the binary to the emulator and run from it!

### Emscripten/Node

An easier example will be to use emscripten toolchain to cross-compile to WASM and then, invoke `node` directly.

```ini
[settings]
arch=wasm
build_type=Release
compiler=emcc
compiler.cppstd=17
compiler.libcxx=libc++
compiler.version=5.0.3
os=Emscripten

[conf]
tools.build:compiler_executables={'c':'emcc', 'cpp':'em++', 'emulator': '/tmp/node_wrapper.sh --trace-exit'}
```

```sh
$ conan create -pr wasm
...
======== Testing the package: Executing test ========
cmake_lib/1.0 (test package): Running test()
cmake_lib/1.0 (test package): RUN: node ./example
[EMULATOR] node --trace-exit ./example
cmake_lib/1.0: Hello World Release!
  cmake_lib/1.0: __cplusplus201703
  cmake_lib/1.0: __GNUC__4
  cmake_lib/1.0: __GNUC_MINOR__2
  cmake_lib/1.0: __clang_major__23
cmake_lib/1.0 test_package
```
