### PR TITLE
Fix conan list command output showing references even when package ID does not match

### DIFF
--- a/conan/api/subapi/list.py
+++ b/conan/api/subapi/list.py
@@ -216,14 +216,18 @@ class ListAPI:
             if lru and pattern.package_id is None:  # Filter LRUs
                 rrevs = [r for r in rrevs if cache.get_recipe_lru(r) < limit_time]
 
-            for rr in rrevs:
-                if pattern.package_id is None:
-                    select_bundle.add_ref(rr)
-
             if pattern.package_id is None:  # Stop if not displaying binaries
+                for rr in rrevs:
+                    select_bundle.add_ref(rr)
                 continue
 
             trrevs = TimedOutput(5, msg_format=msg_format)
+            # Include the recipe revision in the result if no filter was applied
+            # ("*" package_id, no profile/query/lru), so empty recipes still appear (conan upload)
+            unfiltered_wildcard = (pattern.package_id == "*"
+                                   and package_query is None
+                                   and profile is None
+                                   and not lru)
             for rrev in rrevs:
                 trrevs.info(f"Listing binaries of {rrev.repr_notime()} in {remote_name}", rrev, rrevs)
                 prefs = []
@@ -259,14 +263,7 @@ class ListAPI:
                 if lru:  # Filter LRUs
                     prefs = [r for r in prefs if cache.get_package_lru(r) < limit_time]
 
-                # Include this recipe revision in the result if either:
-                # - it has at least one matching package, OR
-                # - no filter was applied (bare "*" package_id, no profile/query/lru),
-                #   so naturally-empty recipes still appear (e.g. for `conan upload`)
-                unfiltered_wildcard = (pattern.package_id == "*"
-                                       and package_query is None
-                                       and profile is None
-                                       and not lru)
+                # Include this recipe revision if it has a matching package or if no filter was applied
                 if prefs or unfiltered_wildcard:
                     select_bundle.add_ref(rrev)
                     select_bundle.recipe_dict(rrev)["packages"] = {}

--- a/conan/api/subapi/list.py
+++ b/conan/api/subapi/list.py
@@ -153,7 +153,7 @@ class ListAPI:
         return result
 
     def select(self, pattern: ListPattern, package_query=None, remote: Remote = None, lru=None,
-               profile=None) -> PackagesList:
+               profile=None, include_empty_revisions=False) -> PackagesList:
         """For a given pattern, return a list of recipes and packages matching the provided filters.
 
         :parameter ListPattern pattern: Search criteria
@@ -166,6 +166,10 @@ class ListAPI:
             packages/binaries that have been used in the last 'lru' time.
             It can be a string like ``"2d"`` (2 days) or ``"3h"`` (3 hours).
         :parameter Profile profile: Profile to filter the packages by settings and options.
+        :parameter bool include_empty_revisions: When ``True`` and ``package_id`` is the bare
+            ``"*"`` wildcard with no other filters applied, recipe revisions that have no
+            matching binaries are included in the result. Only ``conan upload`` should set
+            this to ``True`` so that exported-but-not-built recipes are still uploaded.
         """
         # TODO: Implement better error forwarding for "list" command that captures Exceptions
         if package_query and pattern.package_id and "*" not in pattern.package_id:
@@ -222,9 +226,13 @@ class ListAPI:
                 continue
 
             trrevs = TimedOutput(5, msg_format=msg_format)
-            # Include the recipe revision in the result if no filter was applied
-            # ("*" package_id, no profile/query/lru), so empty recipes still appear (conan upload)
-            unfiltered_wildcard = (pattern.package_id == "*"
+            # Only include recipe revisions with no matching binaries when the caller explicitly
+            # opts in via include_empty_revisions=True (used by "conan upload") AND the
+            # package_id is the bare "*" wildcard with no other filters applied.
+            # Any more specific pattern — including patterns containing "*" like "abc123*" —
+            # must only emit revisions that have at least one matching binary.
+            unfiltered_wildcard = (include_empty_revisions
+                                   and pattern.package_id == "*"
                                    and package_query is None
                                    and profile is None
                                    and not lru)
@@ -263,7 +271,6 @@ class ListAPI:
                 if lru:  # Filter LRUs
                     prefs = [r for r in prefs if cache.get_package_lru(r) < limit_time]
 
-                # Include this recipe revision if it has a matching package or if no filter was applied
                 if prefs or unfiltered_wildcard:
                     select_bundle.add_ref(rrev)
                     select_bundle.recipe_dict(rrev)["packages"] = {}

--- a/conan/api/subapi/list.py
+++ b/conan/api/subapi/list.py
@@ -217,7 +217,8 @@ class ListAPI:
                 rrevs = [r for r in rrevs if cache.get_recipe_lru(r) < limit_time]
 
             for rr in rrevs:
-                select_bundle.add_ref(rr)
+                if pattern.package_id is None:
+                    select_bundle.add_ref(rr)
 
             if pattern.package_id is None:  # Stop if not displaying binaries
                 continue
@@ -258,12 +259,20 @@ class ListAPI:
                 if lru:  # Filter LRUs
                     prefs = [r for r in prefs if cache.get_package_lru(r) < limit_time]
 
-                # Packages dict has been listed, even if empty
-                select_bundle.recipe_dict(rrev)["packages"] = {}
-                for p in prefs:
-                    # the "packages" dict is not using the package-revision
-                    pkg_info = packages.get(PkgReference(p.ref, p.package_id))
-                    select_bundle.add_pref(p, pkg_info)
+                # Only omit the recipe revision when an explicit filter reduced packages to zero.
+                # A naturally-empty recipe (no binaries ever built) must still appear so that
+                # commands like `upload` can process the conanfile.
+                # The only "unfiltered" case is package_id="*" with no profile/query/lru.
+                explicit_filter = (package_query is not None or profile is not None
+                                   or lru is not None
+                                   or pattern.package_id != "*")
+                if prefs or not explicit_filter:
+                    select_bundle.add_ref(rrev)
+                    select_bundle.recipe_dict(rrev)["packages"] = {}
+                    for p in prefs:
+                        # the "packages" dict is not using the package-revision
+                        pkg_info = packages.get(PkgReference(p.ref, p.package_id))
+                        select_bundle.add_pref(p, pkg_info)
         return select_bundle
 
     def explain_missing_binaries(self, ref, conaninfo, remotes):

--- a/conan/api/subapi/list.py
+++ b/conan/api/subapi/list.py
@@ -259,14 +259,15 @@ class ListAPI:
                 if lru:  # Filter LRUs
                     prefs = [r for r in prefs if cache.get_package_lru(r) < limit_time]
 
-                # Only omit the recipe revision when an explicit filter reduced packages to zero.
-                # A naturally-empty recipe (no binaries ever built) must still appear so that
-                # commands like `upload` can process the conanfile.
-                # The only "unfiltered" case is package_id="*" with no profile/query/lru.
-                explicit_filter = (package_query is not None or profile is not None
-                                   or lru is not None
-                                   or pattern.package_id != "*")
-                if prefs or not explicit_filter:
+                # Include this recipe revision in the result if either:
+                # - it has at least one matching package, OR
+                # - no filter was applied (bare "*" package_id, no profile/query/lru),
+                #   so naturally-empty recipes still appear (e.g. for `conan upload`)
+                unfiltered_wildcard = (pattern.package_id == "*"
+                                       and package_query is None
+                                       and profile is None
+                                       and not lru)
+                if prefs or unfiltered_wildcard:
                     select_bundle.add_ref(rrev)
                     select_bundle.recipe_dict(rrev)["packages"] = {}
                     for p in prefs:

--- a/conan/cli/commands/upload.py
+++ b/conan/cli/commands/upload.py
@@ -99,7 +99,8 @@ def upload(conan_api: ConanAPI, parser, *args):
             package_list.only_recipes()
     else:
         ref_pattern = ListPattern(args.pattern, package_id="*", only_recipe=args.only_recipe)
-        package_list = conan_api.list.select(ref_pattern, package_query=args.package_query)
+        package_list = conan_api.list.select(ref_pattern, package_query=args.package_query,
+                                             include_empty_revisions=True)
 
     if package_list:
         # If only if search with "*" we ask for confirmation

--- a/test/integration/command/list/list_test.py
+++ b/test/integration/command/list/list_test.py
@@ -1029,6 +1029,19 @@ def test_list_wildcard_recipe_specific_package_id_omits_nonmatching_revisions():
         assert "pkg2/1.0" not in local
 
 
+def test_list_star_package_id_no_binaries_empty_output():
+    """pkg/version:* must produce empty output when no binaries exist.
+    The colon syntax means 'show recipes that have at least one matching binary';
+    an exported-but-never-built recipe must not appear."""
+    c = TestClient()
+    c.save({"conanfile.py": GenConanfile("hello", "0.1")})
+    c.run("export conanfile.py")
+
+    c.run("list hello/0.1:* --format=json", redirect_stdout="result.json")
+    result = json.loads(c.load("result.json"))
+    assert result["Local Cache"] == {}
+
+
 def test_list_wildcard_recipe_nonexistent_package_id_empty_output():
     """pkg/*:nonexistent_id should produce completely empty output. No recipes or revisions
     should appear when no binary matches the given package ID."""

--- a/test/integration/command/list/list_test.py
+++ b/test/integration/command/list/list_test.py
@@ -1002,3 +1002,43 @@ def test_list_error_option():
     c.run("create . -o my_error_option=1")
     c.run("list pkg/1.0#*:*")
     assert "my_error_option: 1" in c.out
+
+
+def test_list_wildcard_recipe_specific_package_id_omits_nonmatching_revisions():
+    """*/*:<specific_id> must only include recipe revisions that actually have that package ID.
+    Revisions (and recipes) with no matching binary must be absent from the output entirely."""
+    c = TestClient()
+    c.save({"pkg1.py": GenConanfile("pkg1", "1.0").with_settings("os"),
+            "pkg2.py": GenConanfile("pkg2", "1.0")})
+    c.run("create pkg1.py -s os=Windows")
+    c.run("create pkg1.py -s os=Linux")
+    c.run("create pkg2.py")
+
+    windows_id = "ebec3dc6d7f6b907b3ada0c3d3cdc83613a2b715"
+    windows_id_pattern = "ebec3*"
+
+    for pkg_id in (windows_id, windows_id_pattern):
+        c.run(f"list */*:{pkg_id} --format=json", redirect_stdout="result.json")
+        result = json.loads(c.load("result.json"))
+        local = result["Local Cache"]
+
+        # pkg1/1.0 has the Windows binary
+        assert "pkg1/1.0" in local
+        rrev_data = list(local["pkg1/1.0"]["revisions"].values())[0]
+        assert windows_id in rrev_data["packages"]
+
+        # pkg2/1.0 has no binary with that ID
+        assert "pkg2/1.0" not in local
+
+
+def test_list_wildcard_recipe_nonexistent_package_id_empty_output():
+    """pkg/*:nonexistent_id should produce completely empty output. No recipes or revisions
+    should appear when no binary matches the given package ID."""
+    c = TestClient()
+    c.save({"conanfile.py": GenConanfile("pkg", "1.0").with_settings("os")})
+    c.run("create . -s os=Windows")
+    c.run("create . -s os=Linux")
+
+    c.run(f"list pkg/*:nonexistent_id --format=json", redirect_stdout="result.json")
+    result = json.loads(c.load("result.json"))
+    assert result["Local Cache"] == {}

--- a/test/integration/command/list/list_test.py
+++ b/test/integration/command/list/list_test.py
@@ -719,9 +719,8 @@ def test_list_empty_settings():
     c.run("create .")
 
     c.run("list pkg/1.0:* -p os=Windows -f=json")
-    revisions = json.loads(c.stdout)["Local Cache"]["pkg/1.0"]["revisions"]
-    pkgs = revisions["a69a86bbd19ae2ef7eedc64ae645c531"]["packages"]
-    assert pkgs == {}
+    result = json.loads(c.stdout)["Local Cache"]
+    assert result == {}
     c.run("list pkg/1.0:* -p os=None -f=json")
     revisions = json.loads(c.stdout)["Local Cache"]["pkg/1.0"]["revisions"]
     pkgs = revisions["a69a86bbd19ae2ef7eedc64ae645c531"]["packages"]
@@ -915,8 +914,7 @@ class TestListBinaryFilter:
         result = json.loads(c.stdout)
         header = result[pkg_key]["header/1.0"]["revisions"]["747cc49983b14bdd00df50a0671bd8b3"]
         assert header["packages"] == {"da39a3ee5e6b4b0d3255bfef95601890afd80709": {"info": {}}}
-        pkg = result[pkg_key]["pkg/1.0"]["revisions"]["03591c8b22497dd74214e08b3bf2a56f"]
-        assert pkg["packages"] == {}
+        assert "pkg/1.0" not in result[pkg_key]
 
         c.run(f"list *:* -fp=profile_armv8 --format=json {r}")
         result = json.loads(c.stdout)

--- a/test/integration/command/list/test_combined_pkglist_flows.py
+++ b/test/integration/command/list/test_combined_pkglist_flows.py
@@ -537,6 +537,9 @@ class TestListRemove:
         assert len(zli_uc_revs["ffd4bc45820ddb320ab224685b9ba3fb"]["packages"]) == 1
 
         client.run(f"list *:* {remote}")
+        assert "There are no matching recipe references" in client.out
+
+        client.run(f"list * {remote}")
         assert "zli/1.0.0" in client.out
         assert "zlib/1.0.0@user/channel" in client.out
 

--- a/test/integration/command/list/test_list_lru.py
+++ b/test/integration/command/list/test_list_lru.py
@@ -63,11 +63,15 @@ class TestLRU:
         # What if no revision, but package id is passed
         c.run("list pkg/0.1:* --lru=1d", assert_error=True)
         assert "'--lru' must be used with package revision pattern" in c.out
-        # Doesn't fail, but packages is empty
+        # No packages match, so the revision itself should be absent
         c.run("list pkg/0.1:*#* --lru=1d --format=json")
         pkgs = json.loads(c.stdout)
-        rev = pkgs["Local Cache"]["pkg/0.1"]["revisions"]["485dad6cb11e2fa99d9afbe44a57a164"]
-        assert rev["packages"] == {}
+        assert pkgs["Local Cache"] == {}
+        # Wait a bit and try again, now the package should be listed
+        time.sleep(2)
+        c.run("list pkg/0.1:*#* --lru=1s --format=json")
+        pkgs = json.loads(c.stdout)
+        assert pkgs["Local Cache"]["pkg/0.1"]["revisions"]["485dad6cb11e2fa99d9afbe44a57a164"]["packages"] != {}
 
     def test_update_lru_when_used_as_dependency(self):
         """Show that using a recipe as a dependency will update its LRU"""

--- a/test/integration/command/upload/test_upload_patterns.py
+++ b/test/integration/command/upload/test_upload_patterns.py
@@ -141,6 +141,29 @@ class TestUploadPatterns:
         self.assert_uploaded("pkga", result, client, query="os=Windows")
 
 
+class TestUploadExportOnly:
+    """Recipes that have been exported but never built (no binaries) must still be
+    uploadable, because upload uses package_id="*" internally which triggers the
+    packages-listing path in list.select()."""
+
+    @pytest.fixture(scope="class")
+    def client(self):
+        client = TestClient(default_server_user=True)
+        client.save({"conanfile.py": GenConanfile("pkg", "1.0")})
+        client.run(f"export .")
+        return client
+
+    def test_upload_export_only_recipe(self, client):
+        """A recipe that was exported but has no packages should still be uploaded."""
+        client.run("upload pkg/1.0 -r=default -c")
+        assert "Uploading recipe 'pkg/1.0" in client.out
+
+    def test_upload_export_only_recipe_wildcard(self, client):
+        """Wildcard pattern upload should include exported-only recipes alongside built ones."""
+        client.run("upload * -r=default -c")
+        assert "Uploading recipe 'pkg/1.0" in client.out
+
+
 class TestUploadPatternErrors:
 
     @pytest.fixture(scope="class")

--- a/test/integration/command/upload/test_upload_patterns.py
+++ b/test/integration/command/upload/test_upload_patterns.py
@@ -146,22 +146,21 @@ class TestUploadExportOnly:
     uploadable, because upload uses package_id="*" internally which triggers the
     packages-listing path in list.select()."""
 
-    @pytest.fixture(scope="class")
-    def client(self):
-        client = TestClient(default_server_user=True)
-        client.save({"conanfile.py": GenConanfile("pkg", "1.0")})
-        client.run(f"export .")
-        return client
-
-    def test_upload_export_only_recipe(self, client):
+    def test_upload_export_only_recipe(self):
         """A recipe that was exported but has no packages should still be uploaded."""
-        client.run("upload pkg/1.0 -r=default -c")
-        assert "Uploading recipe 'pkg/1.0" in client.out
+        c = TestClient(default_server_user=True)
+        c.save({"conanfile.py": GenConanfile("pkg", "1.0")})
+        c.run("export .")
+        c.run("upload pkg/1.0 -r=default -c")
+        assert "Uploading recipe 'pkg/1.0" in c.out
 
-    def test_upload_export_only_recipe_wildcard(self, client):
+    def test_upload_export_only_recipe_wildcard(self):
         """Wildcard pattern upload should include exported-only recipes alongside built ones."""
-        client.run("upload * -r=default -c")
-        assert "Uploading recipe 'pkg/1.0" in client.out
+        c = TestClient(default_server_user=True)
+        c.save({"conanfile.py": GenConanfile("pkg", "1.0")})
+        c.run("export .")
+        c.run("upload * -r=default -c")
+        assert "Uploading recipe 'pkg/1.0" in c.out
 
 
 class TestUploadPatternErrors:


### PR DESCRIPTION
Changelog: Fix: Fix `conan list */*:non-existent` output showing references even when package ID does not match.
Docs: omit

For cases like:
```
conan list "openjdk/*:churoo" -r conancenter
Connecting to remote 'conancenter' anonymously
Found 4 pkg/version recipes matching openjdk/* in conancenter
conancenter
  openjdk
    openjdk/16.0.1
      revisions
        30c5ee3472d468410afa8047f9cca313 (2024-08-29 14:06:13 UTC)
          packages
    openjdk/19.0.2
      revisions
        06e56f0ff1a749c568802e8d6868835c (2024-08-29 14:06:12 UTC)
          packages
    openjdk/21.0.1
      revisions
        d501945d7bd0389210414c627b6bbb29 (2024-08-29 14:06:12 UTC)
          packages
    openjdk/21.0.2
      revisions
        275461a6408068c79212a73d65ad984f (2024-08-29 14:06:12 UTC)
          packages
```
