### PR TITLE
fix: workspace add --output-folder updates existing package entry

### DIFF
--- a/conan/internal/model/workspace.py
+++ b/conan/internal/model/workspace.py
@@ -71,6 +71,10 @@ class Workspace:
             if p["path"] == path:
                 self.output.warning(f"Package {path} already exists, updating its reference")
                 p["ref"] = editable["ref"]
+                if output_folder:
+                    p["output_folder"] = self._conan_rel_path(output_folder)
+                else:
+                    p.pop("output_folder", None)
                 break
         else:
             packages.append(editable)

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -137,6 +137,27 @@ class TestAddRemove:
         assert "dep1/0.2" in c.out
         assert "dep1/0.1" not in c.out
 
+    def test_add_output_folder_updated(self):
+        # https://github.com/conan-io/conan/issues/19987
+        # When re-adding a package with --output-folder, the output_folder
+        # should be updated, not silently ignored.
+        c = TestClient(light=True)
+        c.save({"conanws.yml": "",
+                "dep1/conanfile.py": GenConanfile("dep1", "0.1")})
+        c.run('workspace add dep1 --output-folder myout')
+        assert "Reference 'dep1/0.1' added to workspace" in c.out
+        ws = c.load("conanws.yml")
+        assert "output_folder: myout" in ws
+        # Change version and re-add with a different output-folder
+        c.save({"dep1/conanfile.py": GenConanfile("dep1", "0.2")})
+        c.run('workspace add dep1 --output-folder newout')
+        assert "Package dep1 already exists, updating its reference" in c.out
+        assert "Reference 'dep1/0.2' added to workspace" in c.out
+        ws = c.load("conanws.yml")
+        assert "output_folder: newout" in ws
+        # output_folder for myout should no longer be there
+        assert "output_folder: myout" not in ws
+
     @pytest.mark.parametrize("api", [False, True])
     def test_dynamic_editables(self, api):
         c = TestClient(light=True)

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -158,6 +158,24 @@ class TestAddRemove:
         # output_folder for myout should no longer be there
         assert "output_folder: myout" not in ws
 
+    def test_add_output_folder_removed_when_omitted(self):
+        # When re-adding without --output-folder, the existing output_folder
+        # should be removed from the workspace entry.
+        c = TestClient(light=True)
+        c.save({"conanws.yml": "",
+                "dep1/conanfile.py": GenConanfile("dep1", "0.1")})
+        c.run("workspace add dep1 --output-folder myout")
+        assert "Reference 'dep1/0.1' added to workspace" in c.out
+        ws = c.load("conanws.yml")
+        assert "output_folder: myout" in ws
+        # Re-add without output-folder — should remove it
+        c.save({"dep1/conanfile.py": GenConanfile("dep1", "0.2")})
+        c.run("workspace add dep1")
+        assert "Package dep1 already exists, updating its reference" in c.out
+        assert "Reference 'dep1/0.2' added to workspace" in c.out
+        ws = c.load("conanws.yml")
+        assert "output_folder" not in ws
+
     @pytest.mark.parametrize("api", [False, True])
     def test_dynamic_editables(self, api):
         c = TestClient(light=True)


### PR DESCRIPTION
Changelog: Fix: `conan workspace add --output-folder` now properly updates the `output_folder` of an existing package entry in `conanws.yml` instead of ignoring it.
Docs: Omit


Fixes #19987

When re-adding a package to the workspace with `--output-folder` using
`conan workspace add <path> --output-folder <folder>`, the output_folder
was previously ignored if the package already existed in `conanws.yml`.
The code only updated the `ref` field but not the `output_folder`.

Now the `output_folder` is properly updated (or removed if not specified)
when a package already exists at the given path.

## Changes
- `conan/internal/model/workspace.py`: In `Workspace.add()`, when a package
  already exists at the same path, update both `ref` and `output_folder`
  fields instead of only `ref`.