### PR TITLE
Fix None vs null in settings for Neutrino and VxWorks variants

### DIFF
--- a/conan/internal/default_settings.py
+++ b/conan/internal/default_settings.py
@@ -95,11 +95,11 @@ os:
     Emscripten:
     Neutrino:
         version: ["6.4", "6.5", "6.6", "7.0", "7.1", "8.0"]
-        variant: [None, "safe"]
+        variant: [null, "safe"]
     baremetal:
     VxWorks:
         version: ["7"]
-        variant: [None, "certified"]
+        variant: [null, "certified"]
 arch: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64,
        armv4, armv4i, armv5el, armv5hf, armv6, armv7, armv7hf, armv7s, armv7k, armv8, armv8_32, armv8.3, arm64ec,
        sparc, sparcv9,


### PR DESCRIPTION
Fixes #19972

Changed Python string `None` to YAML `null` for the variant field
of Neutrino and VxWorks OS entries in default_settings.py.

The uppercase Python `None` would be parsed as the string "None" by
PyYAML, while lowercase `null` is correctly parsed as Python `None`
(null type), matching conventions used elsewhere in the file.