### PR TITLE
Fix CMakeConfigDeps build_modules not getting Full link: True

### DIFF
--- a/conan/tools/cmake/cmakeconfigdeps/target_configuration.py
+++ b/conan/tools/cmake/cmakeconfigdeps/target_configuration.py
@@ -103,6 +103,12 @@ class TargetConfigurationTemplate2:
                         link = not (pkg_type is PackageType.SHARED and
                                     dep_comp.type is PackageType.SHARED)
                     link = req.libs or link
+                    # If the dependency has cmake_build_modules, it needs full link
+                    # because the build_module may bring hidden dependencies (like Python libs)
+                    build_modules = self._cmakedeps.get_property("cmake_build_modules", dep, comp,
+                                                                  check_type=list) or []
+                    if build_modules:
+                        link = True
                     dep_target = self._cmakedeps.get_property("cmake_target_name", dep, comp)
                     dep_target = dep_target or default_target
                     link_feature = self._cmakedeps.get_property("cmake_link_feature", dep, comp)


### PR DESCRIPTION
Fixes #19974

When a dependency has `cmake_build_modules` property (like pybind11 which does `find_package(Python)` internally), the generated CMake target must get `Full link: True` so hidden dependencies (like Python libs pulled in by build modules) are properly propagated.

Without this fix, targets that include libraries from a build_module would lose those hidden link dependencies, causing symbol lookup failures at link time or runtime.