### PR TITLE
Fix deployer inconsistent with files and symlinks

### DIFF
--- a/conan/internal/deploy.py
+++ b/conan/internal/deploy.py
@@ -175,7 +175,13 @@ def _flatten_directory(dep, src_dir, output_dir, symlinks, extension_filter=None
             if not os.path.exists(os.path.dirname(dest_filepath)):
                 os.makedirs(os.path.dirname(dest_filepath))
 
-            if os.path.exists(dest_filepath):
+            if os.path.islink(dest_filepath):
+                if os.path.islink(src_filepath) and os.readlink(src_filepath) == os.readlink(dest_filepath):
+                    output.verbose(f"{dest_filepath} symlink already points to the same target, skipping")
+                    continue
+                output.warning(f"{dest_filepath} exists and will be overwritten")
+                os.unlink(dest_filepath)
+            elif os.path.exists(dest_filepath):
                 if filecmp.cmp(src_filepath, dest_filepath):  # Be efficient, do not copy
                     output.verbose(f"{dest_filepath} exists with same contents, skipping copy")
                     continue


### PR DESCRIPTION
Fixes #19968

When deploying packages with symlinks, `shutil.copy2()` with `follow_symlinks=False` fails with EEXIST if the destination symlink already exists. Previously, the deployer only checked `os.path.exists()` which treats symlinks as existing, but only handled regular file comparison.

This fix:
- If dest is the same symlink as src → skip (noop)
- If dest is a different symlink → warn and unlink before proceeding
- Regular files keep existing filecmp.cmp() behavior

All 23 deploy tests pass.