### PR TITLE
cppstd_flag(): fix clang-cl cppstd flag for C++23 mode

### DIFF
--- a/conan/tools/build/flags.py
+++ b/conan/tools/build/flags.py
@@ -279,7 +279,12 @@ def cppstd_flag(conanfile) -> str:
     if func:
         flag = func(Version(compiler_version), str(cppstd))
     if flag and llvm_clang_front(conanfile) == "clang-cl":
-        flag = flag.replace("=", ":")
+        # clang-cl maps -std:c++NN to wrong MSVC /std:c++latest flag for C++23+
+        # Use -clang:-std=c++NN prefix to pass the clang-style flag through
+        if flag.startswith("-std="):
+            flag = "-clang:" + flag
+        else:
+            flag = flag.replace("=", ":")
     return flag
 
 


### PR DESCRIPTION
When using clang-cl driver on Windows, the cppstd_flag() function converts the clang-style '-std=c++23' flag to '-std:c++23' by replacing '=' with ':'. However, clang-cl maps '-std:c++23' to the MSVC '/std:c++latest' flag, which is wrong for C++23.

The fix: for clang-style flags (starting with '-std='), prefix them with '-clang:' to pass the flag directly to the underlying clang compiler, bypassing clang-cl's MSVC-compatible flag remapping.

For MSVC-style flags (like '/std:c++latest'), keep the existing behavior of replacing '=' with ':'.

Fixes #19887