### PR TITLE
source_credentials.json now supports supplying only headers

### DIFF
--- a/conan/internal/rest/conan_requester.py
+++ b/conan/internal/rest/conan_requester.py
@@ -45,7 +45,8 @@ class _SourceURLCredentials:
             return
 
         def _get_auth(credentials):
-            if "token" in credentials or ("user" in credentials and "password" in credentials):
+            if ("headers" in credentials or "token" in credentials or
+               ("user" in credentials and "password" in credentials)):
                 return credentials
             raise ConanException(f"Unknown credentials method for '{credentials['url']}'")
 

--- a/test/integration/configuration/conf/test_auth_source_plugin.py
+++ b/test/integration/configuration/conf/test_auth_source_plugin.py
@@ -101,9 +101,24 @@ class TestAuthSourcePlugin:
             assert headers["myheader"] == "myvalue"
             assert f"Conan/{__version__}" in headers["User-Agent"]
 
-    def test_source_credentials_headers(self):
+    def test_source_credentials_headers_with_token(self):
         cache_folder = temp_folder()
         source_credentials = json.dumps({"credentials": [{"url": "aaa", "token": "mytok",
+                                                          "headers": {"myheader2": "myvalue2"}}]})
+        save(os.path.join(cache_folder, "source_credentials.json"), source_credentials)
+
+        mock_http_requester = MagicMock()
+        with mock.patch("conan.internal.rest.conan_requester.requests", mock_http_requester):
+            requester = ConanRequester(ConfDefinition(), cache_folder)
+            requester.get(url="aaa", source_credentials=True)
+            headers = requester._http_requester.get.call_args[1]["headers"]
+            assert headers["myheader2"] == "myvalue2"
+            assert headers["Authorization"] == "Bearer mytok"
+            assert f"Conan/{__version__}" in headers["User-Agent"]
+
+    def test_source_credentials_headers_without_token(self):
+        cache_folder = temp_folder()
+        source_credentials = json.dumps({"credentials": [{"url": "aaa",
                                                           "headers": {"myheader2": "myvalue2"}}]})
         save(os.path.join(cache_folder, "source_credentials.json"), source_credentials)
 


### PR DESCRIPTION
Changelog: Fix: ``source_credentials.json`` now supports supplying only headers
Docs: https://github.com/conan-io/docs/pull/4455

Closes https://github.com/conan-io/conan/issues/20002

