### PR TITLE
[fix] Add message when no packages found in conan list command

### DIFF
--- a/conan/cli/commands/list.py
+++ b/conan/cli/commands/list.py
@@ -89,6 +89,19 @@ def print_list_text(results):
             return result
         return item
     info = {remote: format_timestamps(values) for remote, values in info.items()}
+
+    def format_empty_packages(item):
+        if isinstance(item, dict):
+            result = {}
+            for k, v in item.items():
+                if k == "packages" and isinstance(v, dict) and not v:
+                    result[k] = ["No packages found for this revision"]
+                else:
+                    result[k] = format_empty_packages(v)
+            return result
+        return item
+    info = {remote: format_empty_packages(values) for remote, values in info.items()}
+
     print_serial(info)
 
 

--- a/test/integration/command/list/list_test.py
+++ b/test/integration/command/list/list_test.py
@@ -1040,6 +1040,26 @@ def test_list_star_package_id_no_binaries_empty_output():
     assert "No packages found for this revision" in c.out
 
 
+def test_list_revisions_output():
+    """test non-existent package ID and package revision output"""
+    c = TestClient()
+    c.save({"conanfile.py": GenConanfile("hello", "0.1")})
+    c.run("create conanfile.py")
+
+    c.run("list hello/0.1:da39a3ee5e6b4b0d3255bfef95601890afd80709#*")
+    assert """\
+          packages
+            da39a3ee5e6b4b0d3255bfef95601890afd80709
+              revisions
+                0ba8627bd47edc3a501e8f0eb9a79e5e""" in c.out
+    c.run("list hello/0.1:da39a3ee5e6b4b0d3255bfef95601890afd80709#non-existent")
+    assert "ERROR: Package revision 'hello/0.1:da39a3ee5e6b4b0d3255bfef95601890afd80709#non-existent' not found" in c.out
+    c.run("list hello/0.1:non-existent#non-existent")
+    assert "ERROR: Package revision 'hello/0.1:non-existent#non-existent' not found" in c.out
+    c.run("list hello/0.1:non-existent#*")
+    assert "No packages found for this revision" in c.out
+
+
 def test_list_wildcard_recipe_nonexistent_package_id_empty_output():
     """pkg/*:nonexistent_id shows the revision with "No packages found for this revision"
     when the package ID does not match any existing binary."""

--- a/test/integration/command/list/list_test.py
+++ b/test/integration/command/list/list_test.py
@@ -1002,3 +1002,52 @@ def test_list_error_option():
     c.run("create . -o my_error_option=1")
     c.run("list pkg/1.0#*:*")
     assert "my_error_option: 1" in c.out
+
+def test_list_wildcard_recipe_specific_package_id_omits_nonmatching_revisions():
+    """*/*:<specific_id> only shows the recipe revision that has that package ID.
+    Revisions with no matching binary show "No packages found for this revision"."""
+    c = TestClient()
+    c.save({"pkg1.py": GenConanfile("pkg1", "1.0").with_settings("os"),
+            "pkg2.py": GenConanfile("pkg2", "1.0")})
+    c.run("create pkg1.py -s os=Windows")
+    c.run("create pkg1.py -s os=Linux")
+    c.run("create pkg2.py")
+
+    windows_id = "ebec3dc6d7f6b907b3ada0c3d3cdc83613a2b715"
+    windows_id_pattern = "ebec3*"
+
+    for pkg_id in (windows_id, windows_id_pattern):
+        c.run(f"list */*:{pkg_id}")
+
+        # pkg1/1.0 has the Windows binary
+        assert "pkg1/1.0" in c.out
+        assert windows_id in c.out
+
+        # pkg2/1.0 has no binary with that ID: revision is shown but packages are empty
+        assert "pkg2/1.0" in c.out
+        assert "No packages found for this revision" in c.out
+
+
+def test_list_star_package_id_no_binaries_empty_output():
+    """pkg/version:* on an exported-but-never-built recipe shows the revision with
+    "No packages found for this revision" because no binaries exist."""
+    c = TestClient()
+    c.save({"conanfile.py": GenConanfile("hello", "0.1")})
+    c.run("export conanfile.py")
+
+    c.run("list hello/0.1:*")
+    assert "hello/0.1" in c.out
+    assert "No packages found for this revision" in c.out
+
+
+def test_list_wildcard_recipe_nonexistent_package_id_empty_output():
+    """pkg/*:nonexistent_id shows the revision with "No packages found for this revision"
+    when the package ID does not match any existing binary."""
+    c = TestClient()
+    c.save({"conanfile.py": GenConanfile("pkg", "1.0").with_settings("os")})
+    c.run("create . -s os=Windows")
+    c.run("create . -s os=Linux")
+
+    c.run("list pkg/*:nonexistent_id")
+    assert "pkg/1.0" in c.out
+    assert "No packages found for this revision" in c.out


### PR DESCRIPTION
Changelog: Fix: Add message when no packages found in conan list command.
Docs: omit

Issue described at #19984 but with different approach in this PR, just printing a message
