### PR TITLE
fix unittest test_linked_folder_copy_from_linked_folder

### DIFF
--- a/test/unittests/tools/files/test_tool_copy.py
+++ b/test/unittests/tools/files/test_tool_copy.py
@@ -142,7 +142,7 @@ class TestToolCopy:
         copied = copy(None, "dir*", src, dst)
 
         assert copied == [dst_dir_file, dst_dir_link]
-        assert os.listdir(dst) == os.listdir(src)
+        assert sorted(os.listdir(dst)) == sorted(os.listdir(src))
         assert os.path.islink(dst_dir_link)
 
     def test_excludes(self):


### PR DESCRIPTION
listdir returns the list of files in arbitrary order. Comparing two unsorted listdirs leads to flaky tests.

Changelog: Omit
Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
