### PR TITLE
Correctly handle package_type in MesonToolchain

### DIFF
--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -184,13 +184,14 @@ class MesonToolchain:
 
         # https://mesonbuild.com/Builtin-options.html#base-options
         fpic = self._conanfile.options.get_safe("fPIC")
-        shared = self._conanfile.package_type is PackageType.SHARED or self._conanfile.options.get_safe("shared")
+        shared = self._conanfile.package_type is PackageType.SHARED
+        static = self._conanfile.package_type is PackageType.STATIC
         #: Build static libraries as position independent. By default, ``self.options.get_safe("fPIC")``
-        self.b_staticpic = fpic if (shared is False and fpic is not None) else None
+        self.b_staticpic = fpic if (static and fpic is not None) else None
         # https://mesonbuild.com/Builtin-options.html#core-options
         # Do not adjust "debug" if already adjusted "buildtype"
         #: Default library type, e.g., "shared.
-        self.default_library = ("shared" if shared else "static") if shared is not None else None
+        self.default_library = ("shared" if shared else "static") if shared or static else None
 
         compiler = self._conanfile.settings.get_safe("compiler")
         if compiler is None:

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -184,7 +184,7 @@ class MesonToolchain:
 
         # https://mesonbuild.com/Builtin-options.html#base-options
         fpic = self._conanfile.options.get_safe("fPIC")
-        shared = self._conanfile.package_type == PackageType.SHARED
+        shared = self._conanfile.package_type is PackageType.SHARED or self._conanfile.options.get_safe("shared")
         #: Build static libraries as position independent. By default, ``self.options.get_safe("fPIC")``
         self.b_staticpic = fpic if (shared is False and fpic is not None) else None
         # https://mesonbuild.com/Builtin-options.html#core-options

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -6,6 +6,7 @@ from jinja2 import Template, StrictUndefined
 from conan.errors import ConanException
 from conan.internal import check_duplicated_generator
 from conan.internal.internal_tools import raise_on_universal_arch
+from conan.internal.model.pkg_type import PackageType
 from conan.tools.apple.apple import is_apple_os, apple_min_version_flag, \
     resolve_apple_flags, apple_extra_flags
 from conan.tools.build.cross_building import cross_building, can_run
@@ -183,7 +184,7 @@ class MesonToolchain:
 
         # https://mesonbuild.com/Builtin-options.html#base-options
         fpic = self._conanfile.options.get_safe("fPIC")
-        shared = self._conanfile.options.get_safe("shared")
+        shared = self._conanfile.package_type == PackageType.SHARED
         #: Build static libraries as position independent. By default, ``self.options.get_safe("fPIC")``
         self.b_staticpic = fpic if (shared is False and fpic is not None) else None
         # https://mesonbuild.com/Builtin-options.html#core-options

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -906,6 +906,39 @@ def test_new_public_attributes():
     assert expected in content
 
 
+@pytest.mark.parametrize(
+    "package_type, shared_option, default_library, has_fpic",
+    [
+        ("shared-library", None, "shared", False),
+        ("static-library", None, "static", True),
+        ("library", True, "shared", False),
+        ("library", False, "static", True),
+    ],
+)
+def test_package_type(package_type, shared_option, default_library, has_fpic):
+    client = TestClient()
+
+    conanfile = (GenConanfile("pkg", "1.0")
+                 .with_settings("os", "arch", "compiler", "build_type")
+                 .with_package_type(package_type)
+                 .with_generator("MesonToolchain"))
+
+    if shared_option is not None:
+        conanfile = conanfile.with_option("shared", [True, False], shared_option)
+    if has_fpic:
+        conanfile = conanfile.with_option("fPIC", [True, False], True)
+
+    client.save({"conanfile.py": conanfile})
+    client.run("install")
+    content = client.load(MesonToolchain.native_filename)
+    assert "buildtype = 'release'" in content
+    assert f"default_library = '{default_library}'" in content
+    if has_fpic:
+        assert "b_staticpic = True" in content
+    else:
+        assert "b_staticpic" not in content
+
+
 def test_needs_exe_wrapper():
     """
     Tests needs_exe_wrapper depends on `can_run()` function instead of

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -931,7 +931,6 @@ def test_package_type(package_type, shared_option, default_library, has_fpic):
     client.save({"conanfile.py": conanfile})
     client.run("install")
     content = client.load(MesonToolchain.native_filename)
-    print(content)
     assert "buildtype = 'release'" in content
     assert f"default_library = '{default_library}'" in content
     if has_fpic:

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -931,6 +931,7 @@ def test_package_type(package_type, shared_option, default_library, has_fpic):
     client.save({"conanfile.py": conanfile})
     client.run("install")
     content = client.load(MesonToolchain.native_filename)
+    print(content)
     assert "buildtype = 'release'" in content
     assert f"default_library = '{default_library}'" in content
     if has_fpic:


### PR DESCRIPTION
Changelog: Bugfix: Properly handle package_type on MesonToolchain used to define `default_library` and `b_staticpic`
Docs: omit


