### PR TITLE
Correctly handle package_type and shared option contradictions

### DIFF
--- a/conan/internal/model/pkg_type.py
+++ b/conan/internal/model/pkg_type.py
@@ -59,6 +59,15 @@ class PackageType(Enum):
                     raise ConanException(f"{conanfile}: Package type is 'library',"
                                          " but no 'shared' option declared")
             elif any(option in conanfile.options for option in ["shared", "header_only"]):
+                shared_value = conanfile.options.get_safe("shared")
+                if conanfile_type is PackageType.SHARED and shared_value == "False":
+                    raise ConanException(
+                        f"{conanfile}: 'shared-library' should not have 'shared' option set to False. "
+                        "Consider removing the 'shared' option.")
+                if conanfile_type is PackageType.STATIC and shared_value == "True":
+                    raise ConanException(
+                        f"{conanfile}: 'static-library' should not have 'shared' option set to True. "
+                        "Consider removing the 'shared' option")
                 conanfile.output.warning(f"{conanfile}: package_type '{conanfile_type}' is defined, "
                                          "but 'shared' and/or 'header_only' options are present. "
                                          "The package_type will have precedence over the options "

--- a/conan/internal/model/pkg_type.py
+++ b/conan/internal/model/pkg_type.py
@@ -60,11 +60,11 @@ class PackageType(Enum):
                                          " but no 'shared' option declared")
             elif any(option in conanfile.options for option in ["shared", "header_only"]):
                 shared_value = conanfile.options.get_safe("shared")
-                if conanfile_type is PackageType.SHARED and shared_value == "False":
+                if conanfile_type is PackageType.SHARED and shared_value == False:  # noqa
                     raise ConanException(
                         f"{conanfile}: 'shared-library' should not have 'shared' option set to False. "
                         "Consider removing the 'shared' option.")
-                if conanfile_type is PackageType.STATIC and shared_value == "True":
+                if conanfile_type is PackageType.STATIC and shared_value:
                     raise ConanException(
                         f"{conanfile}: 'static-library' should not have 'shared' option set to True. "
                         "Consider removing the 'shared' option")

--- a/test/integration/graph/core/test_auto_package_type.py
+++ b/test/integration/graph/core/test_auto_package_type.py
@@ -65,3 +65,50 @@ def test_package_type_and_header_library():
     tc.run("graph info . --filter package_type -o &:header_only=True")
     assert "package_type: static-library" in tc.out
     assert "The package_type will have precedence over the options" in tc.out
+
+
+@pytest.mark.parametrize("package_type, shared_value", [
+    ("shared-library", False),
+    ("static-library", True),
+])
+def test_package_type_shared_option_contradiction(package_type, shared_value):
+    """
+    Test that contradictory package_type and shared option raises an error.
+    """
+    tc = TestClient(light=True)
+    tc.save({"conanfile.py": textwrap.dedent(f"""
+    from conan import ConanFile
+
+    class Pkg(ConanFile):
+        package_type = "{package_type}"
+        options = {{"shared": [True, False]}}
+        default_options = {{"shared": {shared_value}}}
+
+    """)})
+    tc.run("graph info .", assert_error=True)
+    assert f"'{package_type}' should not have 'shared' option set to {shared_value}. " \
+           "Consider removing the 'shared' option" in tc.out
+
+
+@pytest.mark.parametrize("package_type, shared_value", [
+    ("shared-library", True),
+    ("static-library", False),
+])
+def test_package_type_shared_option_warning(package_type, shared_value):
+    """
+    Test that package_type with non-contradictory shared option emits warning.
+    The package_type takes precedence over the option value.
+    """
+    tc = TestClient(light=True)
+    tc.save({"conanfile.py": textwrap.dedent(f"""
+    from conan import ConanFile
+
+    class Pkg(ConanFile):
+        package_type = "{package_type}"
+        options = {{"shared": [True, False]}}
+        default_options = {{"shared": {shared_value}}}
+
+    """)})
+    tc.run("graph info . --filter package_type")
+    assert f"package_type: {package_type}" in tc.out and \
+           "The package_type will have precedence over the options" in tc.out


### PR DESCRIPTION
Changelog: Bugfix: Raise an error if `package_type` and `shared` option mismatch (``package-type`` is set to ``shared-library`` and ``shared=False`` or ``package_type=static-library`` and ``shared=True``)


Docs: omit