### PR TITLE
MesonToolchain: add extra_variables and exe_wrapper property

### DIFF
--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -133,6 +133,7 @@ BUILT_IN_CONFS = {
     "tools.google.bazel:bazelrc_path": "List of paths to bazelrc files to be used as 'bazel --bazelrc=rcpath1 ... build'",
     "tools.meson.mesontoolchain:backend": "Any Meson backend: ninja, vs, vs2010, vs2012, vs2013, vs2015, vs2017, vs2019, xcode",
     "tools.meson.mesontoolchain:extra_machine_files": "List of paths for any additional native/cross file references to be appended to the existing Conan ones",
+    "tools.meson.mesontoolchain:extra_variables": "Dict of dicts defining extra variables per meson file section: 'properties', 'binaries', 'project_options'",
     "tools.microsoft:winsdk_version": "Use this winsdk_version in vcvars",
     "tools.microsoft:msvc_update": "Force the specific update irrespective of compiler.update (CMakeToolchain and VCVars)",
     "tools.microsoft.msbuild:vs_version": "Defines the IDE version (15, 16, 17) when using the msvc compiler. Necessary if compiler.version specifies a toolset that is not the IDE default",

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -233,6 +233,8 @@ class MesonToolchain:
                 sdk_host = conanfile.settings.get_safe("os.sdk")
                 self.cross_build["host"]["subsystem"] = get_apple_subsystem(sdk_host)
                 self.cross_build["build"]["subsystem"] = get_apple_subsystem(sdk_build)
+            # Issue: https://github.com/conan-io/conan/issues/19217
+            self.properties["needs_exe_wrapper"] = not can_run(self._conanfile)
             if hasattr(conanfile, 'settings_target') and conanfile.settings_target:
                 settings_target = conanfile.settings_target
                 os_target = settings_target.get_safe("os")
@@ -541,12 +543,6 @@ class MesonToolchain:
         self.properties.update(extra_variables.get("properties", {}))
         self.binaries.update(extra_variables.get("binaries", {}))
         self.project_options.update(extra_variables.get("project_options", {}))
-
-        if self.cross_build:
-            has_exe_wrapper = self.binaries.get("exe_wrapper") is not None
-            # Auto evaluation of needs_exe_wrapper only if the user has not set it in the properties
-            if "needs_exe_wrapper" not in self.properties:
-                self.properties["needs_exe_wrapper"] = has_exe_wrapper or not can_run(self._conanfile)
 
         return {
             # https://mesonbuild.com/Machine-files.html#properties

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -331,8 +331,6 @@ class MesonToolchain:
         self._resolve_apple_flags_and_variables(build_env, compilers_by_conf)
         if not native:
             self._resolve_android_cross_compilation()
-        #: Defines the Meson ``exe_wrapper`` variable
-        self.exe_wrapper = None
 
     def _get_default_dirs(self):
         """
@@ -491,7 +489,6 @@ class MesonToolchain:
             "windres": self.windres,
             "pkgconfig": self.pkgconfig,
             "pkg-config": self.pkgconfig,
-            "exe_wrapper": self.exe_wrapper,
         }
         if self._is_apple_system:
             ret.update({
@@ -545,14 +542,11 @@ class MesonToolchain:
         self.binaries.update(extra_variables.get("binaries", {}))
         self.project_options.update(extra_variables.get("project_options", {}))
 
-        # Issue: https://github.com/conan-io/conan/issues/19217
-        # Issue: https://github.com/conan-io/conan/issues/18718
-        # Evaluate needs_exe_wrapper at generation time to consider user-defined exe_wrapper
-        # exe_wrapper can be set via tc.exe_wrapper attribute or via tc.binaries["exe_wrapper"]
-        # or via tools.meson.mesontoolchain:extra_variables conf
         if self.cross_build:
-            has_exe_wrapper = self.exe_wrapper is not None or self.binaries.get("exe_wrapper") is not None
-            self.properties["needs_exe_wrapper"] = has_exe_wrapper or not can_run(self._conanfile)
+            has_exe_wrapper = self.binaries.get("exe_wrapper") is not None
+            # Auto evaluation of needs_exe_wrapper only if the user has not set it in the properties
+            if "needs_exe_wrapper" not in self.properties:
+                self.properties["needs_exe_wrapper"] = has_exe_wrapper or not can_run(self._conanfile)
 
         return {
             # https://mesonbuild.com/Machine-files.html#properties

--- a/conan/tools/meson/toolchain.py
+++ b/conan/tools/meson/toolchain.py
@@ -233,8 +233,6 @@ class MesonToolchain:
                 sdk_host = conanfile.settings.get_safe("os.sdk")
                 self.cross_build["host"]["subsystem"] = get_apple_subsystem(sdk_host)
                 self.cross_build["build"]["subsystem"] = get_apple_subsystem(sdk_build)
-            # Issue: https://github.com/conan-io/conan/issues/19217
-            self.properties["needs_exe_wrapper"] = not can_run(self._conanfile)
             if hasattr(conanfile, 'settings_target') and conanfile.settings_target:
                 settings_target = conanfile.settings_target
                 os_target = settings_target.get_safe("os")
@@ -333,6 +331,8 @@ class MesonToolchain:
         self._resolve_apple_flags_and_variables(build_env, compilers_by_conf)
         if not native:
             self._resolve_android_cross_compilation()
+        #: Defines the Meson ``exe_wrapper`` variable
+        self.exe_wrapper = None
 
     def _get_default_dirs(self):
         """
@@ -490,7 +490,8 @@ class MesonToolchain:
             "as": self.as_,
             "windres": self.windres,
             "pkgconfig": self.pkgconfig,
-            "pkg-config": self.pkgconfig
+            "pkg-config": self.pkgconfig,
+            "exe_wrapper": self.exe_wrapper,
         }
         if self._is_apple_system:
             ret.update({
@@ -535,6 +536,24 @@ class MesonToolchain:
                     raise ConanException("MesonToolchain.subproject_options must be a list of dicts")
                 subproject_options[subproject] = [{k: to_meson_value(v) for k, v in keypair.items()}
                                                   for keypair in listkeypair]
+
+        # Apply extra_variables from conf at generation time so conf has priority over toolchain attributes
+        # Issue: https://github.com/conan-io/conan/issues/18718
+        extra_variables = self._conanfile_conf.get("tools.meson.mesontoolchain:extra_variables",
+                                                   default={}, check_type=dict)
+        self.properties.update(extra_variables.get("properties", {}))
+        self.binaries.update(extra_variables.get("binaries", {}))
+        self.project_options.update(extra_variables.get("project_options", {}))
+
+        # Issue: https://github.com/conan-io/conan/issues/19217
+        # Issue: https://github.com/conan-io/conan/issues/18718
+        # Evaluate needs_exe_wrapper at generation time to consider user-defined exe_wrapper
+        # exe_wrapper can be set via tc.exe_wrapper attribute or via tc.binaries["exe_wrapper"]
+        # or via tools.meson.mesontoolchain:extra_variables conf
+        if self.cross_build:
+            has_exe_wrapper = self.exe_wrapper is not None or self.binaries.get("exe_wrapper") is not None
+            self.properties["needs_exe_wrapper"] = has_exe_wrapper or not can_run(self._conanfile)
+
         return {
             # https://mesonbuild.com/Machine-files.html#properties
             "properties": {k: to_meson_value(v) for k, v in self.properties.items()},

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -1005,3 +1005,105 @@ def test_binaries_attribute():
     content = client.load(MesonToolchain.native_filename)
     assert "wayland-scanner = '/path/to/wayland-scanner'" in content
     assert "c = '/path/to/c'" in content
+
+
+@pytest.mark.parametrize("wrapper_value", [
+    "'/usr/bin/qemu-aarch64'",
+    "['/usr/bin/qemu-aarch64', '-L', '/usr/aarch64-linux-gnu']",
+])
+def test_exe_wrapper(wrapper_value):
+    """Issue: https://github.com/conan-io/conan/issues/18718"""
+    client = TestClient()
+    conanfile = textwrap.dedent(f"""
+        from conan import ConanFile
+        from conan.tools.meson import MesonToolchain
+        class Pkg(ConanFile):
+            settings = "os", "compiler", "arch", "build_type"
+            def generate(self):
+                tc = MesonToolchain(self)
+                tc.exe_wrapper = {wrapper_value}
+                tc.generate()
+        """)
+    client.save({"conanfile.py": conanfile})
+    client.run("install . -s arch=armv8 -s:b arch=x86_64")
+    content = client.load(MesonToolchain.cross_filename)
+    assert "needs_exe_wrapper = true" in content
+    assert f"exe_wrapper = {wrapper_value}" in content
+
+
+@pytest.mark.parametrize("attribute, extra_args", [
+    ("exe_wrapper", ""),
+    ("exe_wrapper", " -c tools.build.cross_building:can_run=True"),
+    ("binaries", ""),
+])
+def test_exe_wrapper_needs_wrapper(attribute, extra_args):
+    """Issue: https://github.com/conan-io/conan/issues/18718"""
+    client = TestClient()
+    attr_line = 'tc.exe_wrapper = "/usr/bin/qemu"' if attribute == "exe_wrapper" else 'tc.binaries["exe_wrapper"] = "/usr/bin/qemu"'
+    conanfile = textwrap.dedent(f"""
+        from conan import ConanFile
+        from conan.tools.meson import MesonToolchain
+        class Pkg(ConanFile):
+            settings = "os", "compiler", "arch", "build_type"
+            def generate(self):
+                tc = MesonToolchain(self)
+                {attr_line}
+                tc.generate()
+        """)
+    client.save({"conanfile.py": conanfile})
+    client.run(f"install . -s arch=armv8 -s:b arch=x86_64{extra_args}")
+    content = client.load(MesonToolchain.cross_filename)
+    assert "needs_exe_wrapper = true" in content
+    assert "exe_wrapper = '/usr/bin/qemu'" in content
+
+
+@pytest.mark.parametrize("section, key, value", [
+    ("properties", "custom_prop", "value"),
+    ("project_options", "my_option", "enabled"),
+])
+def test_extra_variables_conf(section, key, value):
+    """Issue: https://github.com/conan-io/conan/issues/18718"""
+    client = TestClient()
+    client.save({"conanfile.py": GenConanfile("pkg", "1.0")
+                .with_settings("os", "arch", "compiler", "build_type")
+                .with_generator("MesonToolchain")})
+    conf = f'{{"\\"{section}\\"": {{\\"{key}\\": \\"{value}\\"}}}}'
+    client.run(f'install . -c tools.meson.mesontoolchain:extra_variables="{conf}"')
+    content = client.load(MesonToolchain.native_filename)
+    assert f"{key} = '{value}'" in content
+
+
+def test_extra_variables_conf_binaries():
+    """Issue: https://github.com/conan-io/conan/issues/18718"""
+    client = TestClient()
+    client.save({"conanfile.py": GenConanfile("pkg", "1.0")
+                .with_settings("os", "arch", "compiler", "build_type")
+                .with_generator("MesonToolchain")})
+    client.run('install . -s arch=armv8 -s:b arch=x86_64 '
+               '-c:h tools.meson.mesontoolchain:extra_variables="{\\"binaries\\": {\\"exe_wrapper\\": \\"/usr/bin/qemu\\"}}"')
+    content = client.load(MesonToolchain.cross_filename)
+    assert "exe_wrapper = '/usr/bin/qemu'" in content
+    assert "needs_exe_wrapper = true" in content
+
+
+def test_extra_variables_conf_has_priority_over_toolchain():
+    """Issue: https://github.com/conan-io/conan/issues/18718"""
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.meson import MesonToolchain
+        class Pkg(ConanFile):
+            settings = "os", "compiler", "arch", "build_type"
+            def generate(self):
+                tc = MesonToolchain(self)
+                tc.binaries["custom_tool"] = "/conanfile/path"
+                tc.properties["my_prop"] = "conanfile_value"
+                tc.generate()
+        """)
+    client.save({"conanfile.py": conanfile})
+    client.run('install . -c tools.meson.mesontoolchain:extra_variables="{\\"binaries\\": {\\"custom_tool\\": \\"/conf/path\\"}, \\"properties\\": {\\"my_prop\\": \\"conf_value\\"}}"')
+    content = client.load(MesonToolchain.native_filename)
+    assert "custom_tool = '/conf/path'" in content
+    assert "my_prop = 'conf_value'" in content
+    assert "/conanfile/path" not in content
+    assert "conanfile_value" not in content

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -1007,51 +1007,21 @@ def test_binaries_attribute():
     assert "c = '/path/to/c'" in content
 
 
-@pytest.mark.parametrize("wrapper_value", [
-    "'/usr/bin/qemu-aarch64'",
-    "['/usr/bin/qemu-aarch64', '-L', '/usr/aarch64-linux-gnu']",
-])
-def test_exe_wrapper(wrapper_value):
+def test_exe_wrapper_needs_wrapper():
     """Issue: https://github.com/conan-io/conan/issues/18718"""
     client = TestClient()
-    conanfile = textwrap.dedent(f"""
+    conanfile = textwrap.dedent("""
         from conan import ConanFile
         from conan.tools.meson import MesonToolchain
         class Pkg(ConanFile):
             settings = "os", "compiler", "arch", "build_type"
             def generate(self):
                 tc = MesonToolchain(self)
-                tc.exe_wrapper = {wrapper_value}
+                tc.binaries["exe_wrapper"] = "/usr/bin/qemu"
                 tc.generate()
         """)
     client.save({"conanfile.py": conanfile})
     client.run("install . -s arch=armv8 -s:b arch=x86_64")
-    content = client.load(MesonToolchain.cross_filename)
-    assert "needs_exe_wrapper = true" in content
-    assert f"exe_wrapper = {wrapper_value}" in content
-
-
-@pytest.mark.parametrize("attribute, extra_args", [
-    ("exe_wrapper", ""),
-    ("exe_wrapper", " -c tools.build.cross_building:can_run=True"),
-    ("binaries", ""),
-])
-def test_exe_wrapper_needs_wrapper(attribute, extra_args):
-    """Issue: https://github.com/conan-io/conan/issues/18718"""
-    client = TestClient()
-    attr_line = 'tc.exe_wrapper = "/usr/bin/qemu"' if attribute == "exe_wrapper" else 'tc.binaries["exe_wrapper"] = "/usr/bin/qemu"'
-    conanfile = textwrap.dedent(f"""
-        from conan import ConanFile
-        from conan.tools.meson import MesonToolchain
-        class Pkg(ConanFile):
-            settings = "os", "compiler", "arch", "build_type"
-            def generate(self):
-                tc = MesonToolchain(self)
-                {attr_line}
-                tc.generate()
-        """)
-    client.save({"conanfile.py": conanfile})
-    client.run(f"install . -s arch=armv8 -s:b arch=x86_64{extra_args}")
     content = client.load(MesonToolchain.cross_filename)
     assert "needs_exe_wrapper = true" in content
     assert "exe_wrapper = '/usr/bin/qemu'" in content

--- a/test/integration/toolchains/meson/test_mesontoolchain.py
+++ b/test/integration/toolchains/meson/test_mesontoolchain.py
@@ -1056,6 +1056,24 @@ def test_extra_variables_conf_binaries():
     assert "needs_exe_wrapper = true" in content
 
 
+def test_extra_variables_needs_exe_wrapper():
+    """
+    Test that needs_exe_wrapper can be overridden via extra_variables conf.
+    """
+    client = TestClient()
+    client.save({"conanfile.py": GenConanfile("pkg", "1.0")
+                .with_settings("os", "arch", "compiler", "build_type")
+                .with_generator("MesonToolchain")})
+    # Cross-compilation with exe_wrapper defined would normally set needs_exe_wrapper=true
+    # But we override it to false via conf to demonstrate conf has priority
+    client.run('install . -s arch=armv8 -s:b arch=x86_64 '
+               '-c:h tools.meson.mesontoolchain:extra_variables="{\\"binaries\\": {\\"exe_wrapper\\": \\"/usr/bin/qemu\\"}, \\"properties\\": {\\"needs_exe_wrapper\\": \\"false\\"}}"')
+    content = client.load(MesonToolchain.cross_filename)
+    assert "exe_wrapper = '/usr/bin/qemu'" in content
+    print(content)
+    assert "needs_exe_wrapper = 'false'" in content
+
+
 def test_extra_variables_conf_has_priority_over_toolchain():
     """Issue: https://github.com/conan-io/conan/issues/18718"""
     client = TestClient()


### PR DESCRIPTION
Changelog: Feature: Add ``tools.meson.mesontoolchain:extra_variables`` configuration to ``MesonToolchain``.

Second attempt for https://github.com/conan-io/conan/pull/19940
Close https://github.com/conan-io/conan/issues/18718
Close https://github.com/conan-io/conan/issues/19912

Docs: https://github.com/conan-io/docs/pull/4483

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
