### PR TITLE
[CMakeConfigDeps] Fix context check

### DIFF
--- a/conan/tools/cmake/cmakeconfigdeps/target_configuration.py
+++ b/conan/tools/cmake/cmakeconfigdeps/target_configuration.py
@@ -7,7 +7,6 @@ from jinja2 import Template
 from conan.errors import ConanException
 from conan.internal.api.install.generators import relativize_path
 from conan.internal.model.pkg_type import PackageType
-from conan.internal.graph.graph import CONTEXT_BUILD
 from conan.tools.cmake.utils import cmake_escape_value
 
 
@@ -32,7 +31,7 @@ class TargetConfigurationTemplate2:
         # Fallback to consumer configuration if it doesn't have build_type
         config = self._conanfile.settings.get_safe("build_type", self._cmakedeps.configuration)
         config = (config or "none").lower()
-        build = "Build" if self._conanfile.context == CONTEXT_BUILD else ""
+        build = "Build" if self._require.build else ""
         return f"{f}-Targets{build}-{config}.cmake"
 
     def _requires(self, info, components):
@@ -123,7 +122,7 @@ class TargetConfigurationTemplate2:
         config = config.upper() if config else None
         pkg_folder = self._conanfile.package_folder.replace("\\", "/")
         config_folder = f"_{config}" if config else ""
-        build = "_BUILD" if self._conanfile.context == CONTEXT_BUILD else ""
+        build = "_BUILD" if self._require.build else ""
         pkg_folder_var = f"{pkg_name}_PACKAGE_FOLDER{config_folder}{build}"
 
         libs = {}

--- a/test/functional/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps_new.py
+++ b/test/functional/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps_new.py
@@ -1108,7 +1108,8 @@ class TestToolRequires:
         # Ninja for same layout in all platforms
         c.run(f"install bye --build-require -c:a tools.cmake.cmakedeps:new={new_value} "
               f"-c:a tools.cmake.cmaketoolchain:generator=Ninja")
-        cmake = c.load("bye/build/Release/generators/hello-TargetsBuild-release.cmake")
+        # Despite installing "bye" in the build context, "hello" should be in the host one
+        cmake = c.load("bye/build/Release/generators/hello-Targets-release.cmake")
         assert "add_library(hello::hello INTERFACE IMPORTED)" in cmake
 
 


### PR DESCRIPTION
Changelog: Fix: Remove ``build`` context suffix from host requirements in CMakeConfigDeps.
Docs: omit
