### PR TITLE
[CMakeConfigDeps] Added IMPORTED_CONFIGURATIONS to package_frameworks

### DIFF
--- a/conan/tools/cmake/cmakeconfigdeps/target_configuration.py
+++ b/conan/tools/cmake/cmakeconfigdeps/target_configuration.py
@@ -469,6 +469,7 @@ class TargetConfigurationTemplate2:
                      "{{config_wrapper(config, lib_info["frameworks"])}}")
         {% endif %}
         {% if lib_info.get("package_framework") %}
+        set_property(TARGET {{lib}} APPEND PROPERTY IMPORTED_CONFIGURATIONS {{config}})
         set_target_properties({{lib}} PROPERTIES
             IMPORTED_LOCATION_{{config}} "{{lib_info["package_framework"]["location"]}}"
             FRAMEWORK TRUE)

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps_frameworks.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps_frameworks.py
@@ -83,7 +83,7 @@ def test_framework_add_imported_configurations():
         def package_info(self):
             self.cpp_info.set_property("cmake_target_name", "frame::frame")
             self.cpp_info.type = "static-library"
-            self.cpp_info.package_framework = True
+            self.cpp_info.package_framework = "Frame"
             self.cpp_info.location = os.path.join(self.package_folder, "Frame.framework")
     """)
     tc = TestClient()

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps_frameworks.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps_frameworks.py
@@ -65,3 +65,30 @@ def test_framework_only_component_generates_target():
     tc.run(f"install --requires=frame/1.0 -g CMakeConfigDeps")
     targets = tc.load("frame-Targets-release.cmake")
     assert "add_library(frame::frame INTERFACE IMPORTED)" in targets
+
+
+def test_framework_add_imported_configurations():
+    """
+    Issue: https://github.com/conan-io/conan/issues/20034
+    """
+    conanfile = textwrap.dedent(f"""
+    import os
+    from conan import ConanFile
+
+    class MyFramework(ConanFile):
+        name = "frame"
+        version = "1.0"
+        settings = "os", "arch", "compiler", "build_type"
+
+        def package_info(self):
+            self.cpp_info.set_property("cmake_target_name", "frame::frame")
+            self.cpp_info.type = "static-library"
+            self.cpp_info.package_framework = True
+            self.cpp_info.location = os.path.join(self.package_folder, "Frame.framework")
+    """)
+    tc = TestClient()
+    tc.save({"conanfile.py": conanfile})
+    tc.run("create -s build_type=Debug")
+    tc.run(f"install --requires=frame/1.0 -g CMakeConfigDeps -s build_type=Debug")
+    targets = tc.load("frame-Targets-debug.cmake")
+    assert "set_property(TARGET frame::frame APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)" in targets


### PR DESCRIPTION
Changelog: Fix: Set `IMPORTED_CONFIGURATIONS` property to package frameworks in CMakeConfigDeps.
Docs: omit
Closes: https://github.com/conan-io/conan/issues/20034