### PR TITLE
[CMakeConfigDeps] Asserts for package_frameworks

### DIFF
--- a/conan/tools/cmake/cmakeconfigdeps/target_configuration.py
+++ b/conan/tools/cmake/cmakeconfigdeps/target_configuration.py
@@ -218,6 +218,9 @@ class TargetConfigurationTemplate2:
         # FIXME: We're ignoring this value at this moment. It relies on cmake_target_name or lib name
         #        Revisit when cpp.exe value is used too.
         if info.package_framework:
+            assert isinstance(info.package_framework, str), f"package_framework should be a str"
+            if info.libs:
+                raise ConanException("Can't define .libs and .package_framework for the same component")
             target["package_framework"] = {}
             lib_type = "SHARED" if info.type is PackageType.SHARED else \
                 "STATIC" if info.type is PackageType.STATIC else "STATIC"

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps_frameworks.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps_frameworks.py
@@ -92,3 +92,31 @@ def test_framework_add_imported_configurations():
     tc.run(f"install --requires=frame/1.0 -g CMakeConfigDeps -s build_type=Debug")
     targets = tc.load("frame-Targets-debug.cmake")
     assert "set_property(TARGET frame::frame APPEND PROPERTY IMPORTED_CONFIGURATIONS DEBUG)" in targets
+
+
+def test_framework_raises_error_if_libs():
+    """
+    Tests it's raised an exception when libs and package_framework
+    are used together
+    """
+    conanfile = textwrap.dedent(f"""
+    import os
+    from conan import ConanFile
+
+    class MyFramework(ConanFile):
+        name = "frame"
+        version = "1.0"
+        settings = "os", "arch", "compiler", "build_type"
+
+        def package_info(self):
+            self.cpp_info.libs = ["myframe"]
+            self.cpp_info.set_property("cmake_target_name", "frame::frame")
+            self.cpp_info.type = "static-library"
+            self.cpp_info.package_framework = "Frame"
+            self.cpp_info.location = os.path.join(self.package_folder, "Frame.framework")
+    """)
+    tc = TestClient()
+    tc.save({"conanfile.py": conanfile})
+    tc.run("create")
+    tc.run(f"install --requires=frame/1.0 -g CMakeConfigDeps", assert_error=True)
+    assert "Can't define .libs and .package_framework for the same component" in tc.out


### PR DESCRIPTION
Changelog: Feature: Prevent multiple ``.libs`` or ``.package_framework`` entries in CMakeConfigDeps.
Docs: omit
