### PR TITLE
improve message broken global.conf jinja

### DIFF
--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -786,19 +786,26 @@ def load_global_conf(home_folder):
     home_paths = HomePaths(home_folder)
     global_conf_path = home_paths.global_conf_path
     new_config = ConfDefinition()
-    if os.path.exists(global_conf_path):
-        text = load(global_conf_path)
+
+    def render(tmp_text):
         distro = None
         if platform.system() in ["Linux", "FreeBSD"]:
             import distro
-        template = Environment(loader=FileSystemLoader(home_folder)).from_string(text)
-        home_folder = home_folder.replace("\\", "/")
+        template = Environment(loader=FileSystemLoader(home_folder)).from_string(tmp_text)
         from conan import conan_version
-        content = template.render({"platform": platform, "os": os, "distro": distro,
-                                   "conan_version": conan_version,
-                                   "conan_home_folder": home_folder,
-                                   "detect_api": detect_api,
-                                   "hashlib": hashlib})
+        home_folder_fwd = home_folder.replace("\\", "/")
+        try:
+            c = template.render({"platform": platform, "os": os, "distro": distro,
+                                 "conan_version": conan_version,
+                                 "conan_home_folder": home_folder_fwd, "detect_api": detect_api,
+                                 "hashlib": hashlib})
+        except Exception as e:
+            raise ConanException(f"Error loading 'global.conf' in home folder: {e}")
+        return c
+
+    if os.path.exists(global_conf_path):
+        text = load(global_conf_path)
+        content = render(text)
         new_config.loads(content)
     else:  # creation of a blank global.conf file for user convenience
         default_global_conf = textwrap.dedent("""\
@@ -810,21 +817,10 @@ def load_global_conf(home_folder):
             """)
         save(global_conf_path, default_global_conf)
 
-    # TODO: This is a bit repeated, to be refactored later, to keep PR clear
     global_conf_path_user = home_paths.global_conf_path_user
     if os.path.exists(global_conf_path_user):
         text = load(global_conf_path_user)
-        distro = None
-        if platform.system() in ["Linux", "FreeBSD"]:
-            import distro
-        template = Environment(loader=FileSystemLoader(home_folder)).from_string(text)
-        from conan import conan_version
-        home_folder_fwd = home_folder.replace("\\", "/")
-        content = template.render({"platform": platform, "os": os, "distro": distro,
-                                   "conan_version": conan_version,
-                                   "conan_home_folder": home_folder_fwd,
-                                   "detect_api": detect_api,
-                                   "hashlib": hashlib})
+        content = render(text)
         user_conf = ConfDefinition()
         user_conf.loads(content)
         new_config.update_conf_definition(user_conf)

--- a/test/integration/configuration/conf/test_conf.py
+++ b/test/integration/configuration/conf/test_conf.py
@@ -462,3 +462,10 @@ def test_conf_test_package():
     c.run("create . -c &:user.myteam:myconf=myvalue")
     assert "dep/0.1: user.myteam:myconf: myvalue" in c.out
     assert "dep/0.1 (test package): user.myteam:myconf: myvalue" in c.out
+
+
+def test_global_conf_jinja_broken_msg():
+    c = TestClient(light=True)
+    c.save_home({"global.conf": "{{some + error}}"})
+    c.run("config list", assert_error=True)
+    assert "ERROR: Error loading 'global.conf' in home folder: 'some' is undefined" in c.out


### PR DESCRIPTION
Changelog: Fix: Improve error message for broken Jinja2 syntax in ``global.conf``.
Docs: Omit

Close https://github.com/conan-io/conan/issues/20055
