### PR TITLE
Fix importlib find for case where extension is defined in libs and yo…

### DIFF
--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -577,36 +577,25 @@ class _Component:
         libdirs = self.libdirs
         bindirs = self.bindirs
         libname = self.libs[0]
-        static_location = None
-        shared_location = None
         dll_location = None
         deduced_type = None
-        # libname is exactly the pattern, e.g., ["mylib.a"] instead of ["mylib"]
-        _, ext = os.path.splitext(libname)
-        if ext in (".lib", ".a", ".dll", ".so", ".dylib"):
-            if ext in (".lib", ".a"):
-                static_location = _find_matching(libdirs, libname)
-            elif ext in (".so", ".dylib"):
-                shared_location = _find_matching(libdirs, libname)
-            elif ext == ".dll":
-                dll_location = _find_matching(bindirs, libname)
-        else:
-            lib_sanitized = re.escape(libname)
-            component_sanitized = re.escape(library_name)
-            # At first, exact match
-            regex_static = re.compile(rf"(?:lib)?{lib_sanitized}\.(?:a|lib)")
-            regex_shared = re.compile(rf"(?:lib)?{lib_sanitized}\.(?:so|dylib)")
-            regex_dll = re.compile(rf".*(?:{lib_sanitized}|{component_sanitized}).*\.dll")
-            static_location = _find_matching(libdirs, regex_static)
-            shared_location = _find_matching(libdirs, regex_shared)
-            if not any([static_location, shared_location]):
-                # Let's extend a little bit the pattern search
-                regex_wider_static = re.compile(rf"(?:lib)?{lib_sanitized}(?:[._-].+)?\.(?:a|lib)")
-                regex_wider_shared = re.compile(rf"(?:lib)?{lib_sanitized}(?:[._-].+)?\.(?:so|dylib)")
-                static_location = _find_matching(libdirs, regex_wider_static)
-                shared_location = _find_matching(libdirs, regex_wider_shared)
-            if static_location or not shared_location:
-                dll_location = _find_matching(bindirs, regex_dll)
+        libname, ext = os.path.splitext(libname)
+        lib_sanitized = re.escape(libname)
+        component_sanitized = re.escape(library_name)
+        # At first, exact match
+        regex_static = re.compile(rf"(?:lib)?{lib_sanitized}\.(?:a|lib)")
+        regex_shared = re.compile(rf"(?:lib)?{lib_sanitized}\.(?:so|dylib)")
+        regex_dll = re.compile(rf".*(?:{lib_sanitized}|{component_sanitized}).*\.dll")
+        static_location = _find_matching(libdirs, regex_static)
+        shared_location = _find_matching(libdirs, regex_shared)
+        if not any([static_location, shared_location]):
+            # Let's extend a little bit the pattern search
+            regex_wider_static = re.compile(rf"(?:lib)?{lib_sanitized}(?:[._-].+)?\.(?:a|lib)")
+            regex_wider_shared = re.compile(rf"(?:lib)?{lib_sanitized}(?:[._-].+)?\.(?:so|dylib)")
+            static_location = _find_matching(libdirs, regex_wider_static)
+            shared_location = _find_matching(libdirs, regex_wider_shared)
+        if static_location or not shared_location:
+            dll_location = _find_matching(bindirs, regex_dll)
 
         if static_location:
             if shared_location:

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -1031,3 +1031,26 @@ def test_libs_no_components_multilib_component(requires):
     tc.run("install --requires=matrix/1.0 -g CMakeConfigDeps")
     matrix_targets = tc.load("matrix-Targets-release.cmake")
     assert "# Requirement matrix::_common -> base::base (Full link: True)" in matrix_targets
+
+
+def test_implib_location_explicit_extension():
+    """
+    https://github.com/conan-io/conan/issues/20054
+    If the extension was explicitly added, we would not find the importlib if it was named
+    .dll.lib
+    """
+    tc = TestClient()
+    conanfile = (GenConanfile("allocator", "1.0")
+                 .with_package_file("lib/allocator.dll.lib", "importlib")
+                 .with_package_file("bin/allocator.dll", "dll")
+                 .with_package_type("shared-library")
+                 .with_package_info({"libs": ["allocator.dll"]}))
+
+    tc.save({"conanfile.py": conanfile})
+    tc.run("create")
+    tc.run("install --requires=allocator/1.0 -g=CMakeConfigDeps")
+    targets = tc.load("allocator-Targets-release.cmake")
+    # We find the importlib
+    assert "PROPERTIES IMPORTED_IMPLIB_RELEASE" in targets
+    # And we find the dll
+    assert "PROPERTIES IMPORTED_LOCATION_RELEASE" in targets

--- a/test/unittests/model/build_info/test_deduce_locations.py
+++ b/test/unittests/model/build_info/test_deduce_locations.py
@@ -97,7 +97,9 @@ def test_complex_deduce_locations_shared(lib_name, libs, conanfile):
     ("libcurl_imp.lib", "libcurl.dll", ["libcurl_imp"], "libcurl"),
     ("libcrypto.lib", "libcrypto-3-x64.dll", ["libcrypto"], "crypto"),
     ("libssl.lib", "libssl-3-x64.dll", ["libssl"], "ssl"),
-    ("zdll.lib", "zlib1.dll", ["zdll"], "zlib")
+    ("zdll.lib", "zlib1.dll", ["zdll"], "zlib"),
+    ("mimalloc.dll.lib", "mimalloc.dll", ["mimalloc"], "mimalloc"),
+    ("mimalloc.dll.lib", "mimalloc.dll", ["mimalloc.dll"], "mimalloc"),
 ])
 def test_windows_shared_link_locations(lib_name, dll_name, libs, pkg_name, conanfile):
     """


### PR DESCRIPTION
Changelog: Bugfix: Fix some cases where ``IMPORTED_IMPLIB`` was not being declared when extension was set in ``cpp_info.libs``.
Docs: Omit

Closes https://github.com/conan-io/conan/issues/20054