### PR TITLE
[feature] Add support for cmake_extra_interface_libs and cmake_extra_dependencies properties to the CMakeDeps generator

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -55,6 +55,11 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
         dependency_filenames = self._get_dependency_filenames()
         # Get the nodes that have the property cmake_find_mode=None (no files to generate)
         dependency_find_modes = self._get_dependencies_find_modes()
+        # ``cmake_extra_dependencies`` lets a recipe declare extra ``find_dependency()`` calls
+        extra_dependencies = self.cmakedeps.get_property("cmake_extra_dependencies",
+                                                         self.conanfile, check_type=list) or []
+        dependency_filenames.extend(extra_dependencies)
+        dependency_find_modes.update({extra: "" for extra in extra_dependencies})
 
         # Make the root_folder relative to the generated xxx-data.cmake file
         root_folder = self._root_folder
@@ -311,7 +316,9 @@ class _TargetDataContext:
         self.build_paths = join_paths(cpp_info.builddirs)
         self.framework_paths = join_paths(cpp_info.frameworkdirs)
         self.libs = join_flags(" ", cpp_info.libs)
-        self.system_libs = join_flags(" ", cpp_info.system_libs)
+        extra_interface_libs = cmakedeps.get_property("cmake_extra_interface_libs", conanfile,
+                                                      comp_name, check_type=list) or []
+        self.system_libs = join_flags(" ", list(cpp_info.system_libs) + list(extra_interface_libs))
         self.frameworks = join_flags(" ", cpp_info.frameworks)
         self.defines = join_defines(cpp_info.defines, "-D")
         self.compile_definitions = join_defines(cpp_info.defines)

--- a/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
+++ b/test/integration/toolchains/cmake/cmakedeps/test_cmakedeps.py
@@ -953,3 +953,77 @@ def test_package_info_extra_variables():
     assert 'set(CMAKE_GENERATOR_INSTANCE "${GENERATOR_INSTANCE}/buildTools/")' in target
     assert 'set(FOO 42)' in target
     assert 'set(CACHE_VAR_DEFAULT_DOC "hello world" CACHE PATH "CACHE_VAR_DEFAULT_DOC")' in target
+
+
+def test_cmake_extra_interface_libs():
+    """ The cmake_extra_interface_libs property should add extra link items to the
+    generated target's INTERFACE_LINK_LIBRARIES. In CMakeDeps this is done by appending
+    them to the package (or component) SYSTEM_LIBS variable that ends up linked through
+    the <pkg>_DEPS_TARGET interface library.
+    """
+    tc = TestClient()
+    dep = textwrap.dedent("""
+        from conan import ConanFile
+        class Pkg(ConanFile):
+            name = "dep"
+            version = "0.1"
+            def package_info(self):
+                self.cpp_info.set_property("cmake_extra_interface_libs", ["MyOpenMPILib"])
+        """)
+    tc.save({"conanfile.py": dep})
+    tc.run("create .")
+    tc.run("install --requires=dep/0.1 -g CMakeDeps")
+    host_arch = tc.get_default_host_profile().settings["arch"]
+    data = tc.load(f"dep-release-{host_arch}-data.cmake")
+    assert "set(dep_SYSTEM_LIBS_RELEASE MyOpenMPILib)" in data
+
+
+def test_cmake_extra_interface_libs_components():
+    """ Same as ``test_cmake_extra_interface_libs`` but the property is set on a
+    component. The extra libs must end up in the component SYSTEM_LIBS variable.
+    """
+    tc = TestClient()
+    dep = textwrap.dedent("""
+        from conan import ConanFile
+        class Pkg(ConanFile):
+            name = "dep"
+            version = "0.1"
+            def package_info(self):
+                self.cpp_info.components["mycomp"].set_property("cmake_extra_interface_libs",
+                                                                ["MyOpenMPILib"])
+                self.cpp_info.components["mycomp"].libs = ["mycomplib"]
+        """)
+    tc.save({"conanfile.py": dep})
+    tc.run("create .")
+    tc.run("install --requires=dep/0.1 -g CMakeDeps")
+    host_arch = tc.get_default_host_profile().settings["arch"]
+    data = tc.load(f"dep-release-{host_arch}-data.cmake")
+    # Component CMake variables are prefixed with both the package name and the component
+    # target name (``dep::mycomp`` -> ``dep_mycomp``), hence the double ``dep_dep_mycomp``.
+    assert "set(dep_dep_mycomp_SYSTEM_LIBS_RELEASE MyOpenMPILib)" in data
+
+
+def test_cmake_extra_dependencies():
+    """ The cmake_extra_dependencies property adds extra ``find_dependency()`` calls
+    emitted by the generated ``<pkg>-config.cmake``. In CMakeDeps this is achieved by
+    appending them to the ``<pkg>_FIND_DEPENDENCY_NAMES`` list (driven from the
+    ``<pkg>-<config>-<arch>-data.cmake`` file) with an empty ``_FIND_MODE`` so that the
+    template iteration emits ``find_dependency(<extra> REQUIRED)``.
+    """
+    tc = TestClient()
+    dep = textwrap.dedent("""
+        from conan import ConanFile
+        class Pkg(ConanFile):
+            name = "dep"
+            version = "0.1"
+            def package_info(self):
+                self.cpp_info.set_property("cmake_extra_dependencies", ["MyOpenMPI"])
+        """)
+    tc.save({"conanfile.py": dep})
+    tc.run("create .")
+    tc.run("install --requires=dep/0.1 -g CMakeDeps")
+    host_arch = tc.get_default_host_profile().settings["arch"]
+    data = tc.load(f"dep-release-{host_arch}-data.cmake")
+    # The extra dep is appended to the package FIND_DEPENDENCY_NAMES list, with no mode.
+    assert "list(APPEND dep_FIND_DEPENDENCY_NAMES MyOpenMPI)" in data
+    assert 'set(MyOpenMPI_FIND_MODE "")' in data


### PR DESCRIPTION
Changelog: Feature: Add support for ``cmake_extra_interface_libs`` and ``cmake_extra_dependencies`` properties to the ``CMakeDeps`` generator.
Docs: https://github.com/conan-io/docs/pull/4472

Tried to add the minimal code changes to CMakeDeps
