### PR TITLE
improvements to tools defs in tests

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -249,7 +249,7 @@ def _get_individual_tool(name, version):
 
     tool_platform = platform.system()
     if tool.get("platform", tool_platform) != tool_platform:
-        return None, None
+        return None
 
     version = version or tool.get("default")
     tool_version = tool.get(version)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -226,14 +226,6 @@ except ImportError as e:
     user_tool_locations = None
 
 
-tools_environments = {
-    'mingw32': {'Windows': {'MSYSTEM': 'MINGW32'}},
-    'mingw64': {'Windows': {'MSYSTEM': 'MINGW64'}},
-    'ucrt64': {'Windows': {'MSYSTEM': 'UCRT64'}},
-    'msys2_clang64': {"Windows": {"MSYSTEM": "CLANG64"}}
-}
-
-
 _cached_tools = {}
 
 
@@ -267,7 +259,7 @@ def _get_individual_tool(name, version):
             return False
         if name == "visual_studio":
             if vs_installation_path(version):
-                return None, None
+                return None
 
         tool_path = tool_version.get("path", {}).get(tool_platform)
         tool_path = tool_path.replace("/", "\\") if tool_platform == "Windows" and tool_path is not None else tool_path
@@ -286,12 +278,7 @@ def _get_individual_tool(name, version):
             return True
         tool_path = None
 
-    try:
-        tool_env = tools_environments[name][tool_platform]
-    except KeyError:
-        tool_env = None
-
-    cached = tool_path, tool_env
+    cached = tool_path
 
     # Check this particular tool is installed
     old_environ = None
@@ -310,7 +297,7 @@ def _get_individual_tool(name, version):
         # finds the exe in a path that is not the one set in the conf -> fail
         cached = True
     elif tool_path is None:
-        cached = exe_path, tool_env
+        cached = exe_path
 
     if old_environ is not None:
         os.environ.clear()
@@ -362,11 +349,9 @@ def pytest_runtest_setup(item):
             pytest.skip("Required '{}' tool version '{}' is not available".format(tool_name,
                                                                                   version_msg))
 
-        tool_path, tool_env = result
+        tool_path = result
         if tool_path:
             tools_paths.append(tool_path)
-        if tool_env:
-            tools_env_vars.update(tool_env)
         # Fix random failures CI because of this: https://issues.jenkins.io/browse/JENKINS-9104
         if tool_name == "visual_studio":
             tools_env_vars['_MSPDBSRV_ENDPOINT_'] = str(uuid.uuid4())

--- a/test/functional/command/test_install_deploy.py
+++ b/test/functional/command/test_install_deploy.py
@@ -538,6 +538,7 @@ class TestRuntimeDeployer:
         assert (sorted(os.listdir(os.path.join(c.current_folder, "myruntime", "bin")))
                 == sorted(['pkga.dll']))
 
+    @pytest.mark.skipif(platform.system() == "Windows", reason="Requires POSIX symlinks")
     @pytest.mark.parametrize("symlink, expected",
                              [(True, ["libfoo.so.0.1.0", "libfoo.so.0", "libfoo.so"]),
                               (False, ["libfoo.so.0.1.0"])])
@@ -569,16 +570,13 @@ class TestRuntimeDeployer:
         link_so = os.path.join(c.current_folder, "output", "libfoo.so")
         lib = os.path.join(c.current_folder, "output", "libfoo.so.0.1.0")
         # INFO: This test requires in Windows to have symlinks enabled, otherwise it will fail
-        if symlink and platform.system() != "Windows":
-            assert os.path.islink(link_so_0)
-            assert os.path.islink(link_so)
-            assert not os.path.isabs(os.readlink(link_so_0))
-            assert not os.path.isabs(os.readlink(os.path.join(link_so)))
-            assert os.path.realpath(link_so) == os.path.realpath(link_so_0)
-            assert os.path.realpath(link_so_0) == os.path.realpath(lib)
-            assert not os.path.islink(lib)
-        else:
-            assert not os.path.islink(lib)
+        assert os.path.islink(link_so_0)
+        assert os.path.islink(link_so)
+        assert not os.path.isabs(os.readlink(link_so_0))
+        assert not os.path.isabs(os.readlink(os.path.join(link_so)))
+        assert os.path.realpath(link_so) == os.path.realpath(link_so_0)
+        assert os.path.realpath(link_so_0) == os.path.realpath(lib)
+        assert not os.path.islink(lib)
 
     @pytest.mark.skipif(platform.system() == "Windows", reason="Requires POSIX symlinks")
     def test_runtime_deploy_symlink_overwrite(self):
@@ -683,6 +681,7 @@ class TestRuntimeDeployer:
         assert sorted(os.listdir(os.path.join(c.current_folder, "output", "subfolder",
                                               "subsubfolder"))) == ["libqux.so"]
 
+    @pytest.mark.skipif(platform.system() == "Windows", reason="Requires POSIX symlinks")
     def test_runtime_deploy_subfolder_symlink(self):
         """ The deployer runtime_deploy should preserve subfolder structure when deploying shared
             libraries with symlinks

--- a/test/functional/command/test_install_deploy.py
+++ b/test/functional/command/test_install_deploy.py
@@ -570,12 +570,13 @@ class TestRuntimeDeployer:
         link_so = os.path.join(c.current_folder, "output", "libfoo.so")
         lib = os.path.join(c.current_folder, "output", "libfoo.so.0.1.0")
         # INFO: This test requires in Windows to have symlinks enabled, otherwise it will fail
-        assert os.path.islink(link_so_0)
-        assert os.path.islink(link_so)
-        assert not os.path.isabs(os.readlink(link_so_0))
-        assert not os.path.isabs(os.readlink(os.path.join(link_so)))
-        assert os.path.realpath(link_so) == os.path.realpath(link_so_0)
-        assert os.path.realpath(link_so_0) == os.path.realpath(lib)
+        if symlink:
+            assert os.path.islink(link_so_0)
+            assert os.path.islink(link_so)
+            assert not os.path.isabs(os.readlink(link_so_0))
+            assert not os.path.isabs(os.readlink(os.path.join(link_so)))
+            assert os.path.realpath(link_so) == os.path.realpath(link_so_0)
+            assert os.path.realpath(link_so_0) == os.path.realpath(lib)
         assert not os.path.islink(lib)
 
     @pytest.mark.skipif(platform.system() == "Windows", reason="Requires POSIX symlinks")

--- a/test/functional/subsystems_build_test.py
+++ b/test/functional/subsystems_build_test.py
@@ -45,7 +45,8 @@ class TestSubsystems:
         - Inside msys2, install pacman -S mingw-w64-i686-toolchain (all pkgs)
         """
         client = TestClient()
-        client.run_command('uname')
+        with environment_update({"MSYSTEM": "MINGW32"}):
+            client.run_command('uname')
         assert "MINGW32_NT" in client.out
 
     @pytest.mark.tool("msys2")
@@ -55,14 +56,16 @@ class TestSubsystems:
         - Inside msys2, install pacman -S mingw-w64-ucrt-x86_64-toolchain (all pkgs)
         """
         client = TestClient()
-        client.run_command('uname')
+        with environment_update({"MSYSTEM": "UCRT64"}):
+            client.run_command('uname')
         assert "MINGW64_NT" in client.out
 
     @pytest.mark.tool("msys2")
     @pytest.mark.tool("msys2_clang64")
     def test_clang64_available(self):
         client = TestClient()
-        client.run_command('uname')
+        with environment_update({"MSYSTEM": "CLANG64"}):
+            client.run_command('uname')
         assert "MINGW64_NT" in client.out
 
     @pytest.mark.tool("msys2")
@@ -72,7 +75,8 @@ class TestSubsystems:
         - Inside msys2, install pacman -S mingw-w64-x86_64-toolchain (all pkgs)
         """
         client = TestClient()
-        client.run_command('uname')
+        with environment_update({"MSYSTEM": "MINGW64"}):
+            client.run_command('uname')
         assert "MINGW64_NT" in client.out
 
     # It's important not to have uname in Path, that could

--- a/test/functional/test_profile_detect_api.py
+++ b/test/functional/test_profile_detect_api.py
@@ -4,14 +4,13 @@ import textwrap
 import pytest
 
 from conan.internal.api.detect import detect_api
-from conan.test.utils.tools import TestClient
+from conan.test.utils.tools import TestClient, default_vs_ide_version, default_msvc_version
 
 
 class TestProfileDetectAPI:
     @pytest.mark.skipif(platform.system() != "Windows", reason="Only for windows")
-    @pytest.mark.tool("visual_studio", "17")
+    @pytest.mark.tool("visual_studio")
     def test_profile_detect_compiler(self):
-
         client = TestClient()
         tpl1 = textwrap.dedent("""
             {% set compiler, version, compiler_exe = detect_api.detect_default_compiler() %}
@@ -31,8 +30,7 @@ class TestProfileDetectAPI:
 
         client.save({"profile1": tpl1})
         client.run("profile show -pr=profile1 --context=host")
-        # FIXME: check update setting
-        update = str(int(detect_api.detect_msvc_update("194")) % 10)
+        update = str(int(detect_api.detect_msvc_update(default_msvc_version)) % 10)
         expected = textwrap.dedent(f"""\
             [settings]
             compiler=msvc
@@ -40,9 +38,9 @@ class TestProfileDetectAPI:
             compiler.runtime=dynamic
             compiler.runtime_type=Release
             compiler.update={update}
-            compiler.version=194
+            compiler.version={default_msvc_version}
             [conf]
-            tools.microsoft.msbuild:vs_version=17
+            tools.microsoft.msbuild:vs_version={default_vs_ide_version}
             """)
         assert expected in client.out
 

--- a/test/functional/toolchains/cmake/test_cmake.py
+++ b/test/functional/toolchains/cmake/test_cmake.py
@@ -11,6 +11,7 @@ from test.functional.utils import check_vs_runtime, check_exe_run
 from conan.test.utils.tools import TestClient
 
 
+@pytest.mark.slow
 @pytest.mark.tool("cmake", "3.15")
 @pytest.mark.tool("mingw64")
 @pytest.mark.skipif(platform.system() != "Windows", reason="Needs windows")
@@ -30,6 +31,7 @@ def test_simple_cmake_mingw():
         compiler.cppstd=17
         """})
     client.run("create . --profile=mingw")
+    print(client.out)
     build_folder = client.created_test_build_folder("hello/1.0")
     # FIXME: Note that CI contains 10.X, so it uses another version rather than the profile one
     #  and no one notices. It would be good to have some details in confuser.py to be consistent
@@ -37,6 +39,37 @@ def test_simple_cmake_mingw():
                   subsystem="mingw64", extra_msg="Hello World", cxx11_abi="1")
     check_vs_runtime(f"test_package/{build_folder}/example.exe", client, "15",
                      build_type="Release", static_runtime=False, subsystem="mingw64")
+
+
+@pytest.mark.slow
+@pytest.mark.tool("cmake", "3.15")
+@pytest.mark.tool("ucrt64")
+@pytest.mark.skipif(platform.system() != "Windows", reason="Needs windows")
+def test_simple_cmake_ucrt64():
+    # It is enough to have the @pytest.mark.tool("ucrt64") that defines the compiler in the path
+    # to get the right one
+    client = TestClient()
+    client.run("new cmake_lib -d name=hello -d version=1.0")
+    client.save({"mingw": """
+        [settings]
+        os=Windows
+        arch=x86_64
+        build_type=Release
+        compiler=gcc
+        compiler.exception=seh
+        compiler.libcxx=libstdc++11
+        compiler.threads=win32
+        compiler.version=11.2
+        compiler.cppstd=17
+        """})
+    client.run("create . --profile=mingw")
+    build_folder = client.created_test_build_folder("hello/1.0")
+    # FIXME: Note that CI contains 10.X, so it uses another version rather than the profile one
+    #  and no one notices. It would be good to have some details in confuser.py to be consistent
+    check_exe_run(client.out, "hello/1.0:", "gcc", None, "Release", "x86_64", "17",
+                  subsystem="ucrt64", extra_msg="Hello World", cxx11_abi="1")
+    check_vs_runtime(f"test_package/{build_folder}/example.exe", client, "15",
+                     build_type="Release", static_runtime=False, subsystem="ucrt64")
 
 # TODO: How to link with mingw statically?
 

--- a/test/functional/toolchains/gnu/test_pkgconfigdeps.py
+++ b/test/functional/toolchains/gnu/test_pkgconfigdeps.py
@@ -58,6 +58,7 @@ def test_pkgconfigdeps_with_test_requires():
 @pytest.mark.skipif(platform.system() != "Windows", reason="It makes sense only for Windows")
 @pytest.mark.tool("meson")  # https://github.com/mesonbuild/meson/pull/11649 is part of Meson 1.1.0
 @pytest.mark.tool("pkg_config")
+@pytest.mark.tool("ninja")
 def test_pkgconfigdeps_bindir_and_meson():
     """
     This test checks that the field bindir introduced by PkgConfigDeps is useful for Windows

--- a/test/functional/utils.py
+++ b/test/functional/utils.py
@@ -161,6 +161,11 @@ def check_exe_run(output, names, compiler, version, build_type, arch, cppstd, de
                 assert "__MINGW32__" not in output
                 assert "__MINGW64__" not in output
                 assert "__MSYS__" not in output
+            elif subsystem == "ucrt64":
+                assert "__CYGWIN__" not in output
+                assert "__MINGW32__" in output
+                assert "__MINGW64__" in output
+                assert "__MSYS__" not in output
             else:
                 raise Exception("unknown subsystem {}".format(subsystem))
         else:


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Some improvements in tests:

- Removing automatic definition of env-vars like MSYSTEM for subsystems, so it becomes explicit in tests or fails
- New ``test_simple_cmake_ucrt64`` test
- generalizing some tests so they run in different setups (visual studio)
