### PR TITLE
new modeling of msys2 environments

### DIFF
--- a/conan/internal/subsystems.py
+++ b/conan/internal/subsystems.py
@@ -31,6 +31,7 @@ MSYS2 = 'msys2'
 MSYS = 'msys'
 CYGWIN = 'cygwin'
 WSL = 'wsl'  # Windows Subsystem for Linux
+MSYS2_ENVS = "ucrt64", "clang64", "clangarm64", "mingw32", "mingw64", "clang32"
 
 
 def command_env_wrapper(conanfile, command, envfiles, envfiles_folder, scope="build"):
@@ -58,14 +59,21 @@ def command_env_wrapper(conanfile, command, envfiles, envfiles_folder, scope="bu
     return wrapped_cmd
 
 
+def _extract_subsystem(conanfile):
+    subsystem = conanfile.conf.get("tools.microsoft.bash:subsystem")
+    if subsystem is None:
+        return None, None
+    sub_part = subsystem.split("-", 1)
+    sub, env = (sub_part[0], sub_part[1]) if len(sub_part) == 2 else (subsystem, None)
+    if env and env not in MSYS2_ENVS:
+        raise ConanException(f"Defined msys2 environment '{env}' not in {MSYS2_ENVS}")
+    return sub, env
+
+
 def _windows_bash_wrapper(conanfile, command, env, envfiles_folder):
     from conan.tools.env import Environment
     from conan.tools.env.environment import environment_wrap_command
     """ Will wrap a unix command inside a bash terminal It requires to have MSYS2, CYGWIN, or WSL"""
-
-    subsystem = conanfile.conf.get("tools.microsoft.bash:subsystem")
-    if not platform.system() == "Windows":
-        raise ConanException("Command only for Windows operating system")
 
     shell_path = conanfile.conf.get("tools.microsoft.bash:path")
     if not shell_path:
@@ -73,10 +81,14 @@ def _windows_bash_wrapper(conanfile, command, env, envfiles_folder):
                              "needed to run commands in a Windows subsystem")
     shell_path = shell_path.replace("\\", "/")  # Should work in all terminals
     env = env or []
+    subsystem, subsystem_env = _extract_subsystem(conanfile)
     if subsystem == MSYS2:
         # Configure MSYS2 to inherith the PATH
         msys2_mode_env = Environment()
-        _msystem = {"x86": "MINGW32"}.get(conanfile.settings.get_safe("arch"), "MINGW64")
+        if subsystem_env:
+            _msystem = subsystem_env.upper()
+        else:  # Previously existing default to not break
+            _msystem = {"x86": "MINGW32"}.get(conanfile.settings.get_safe("arch"), "MINGW64")
         # https://www.msys2.org/wiki/Launchers/ dictates that the shell should be launched with
         # - MSYSTEM defined
         # - CHERE_INVOKING is necessary to keep the CWD and not change automatically to the user home
@@ -138,7 +150,7 @@ def deduce_subsystem(conanfile, scope):
     if not str(the_os).startswith("Windows"):
         return None
 
-    subsystem = conanfile.conf.get("tools.microsoft.bash:subsystem")
+    subsystem, _ = _extract_subsystem(conanfile)
     if not subsystem:
         if conanfile.win_bash:
             raise ConanException("win_bash=True but tools.microsoft.bash:subsystem "
@@ -147,6 +159,7 @@ def deduce_subsystem(conanfile, scope):
             raise ConanException("win_bash_run=True but tools.microsoft.bash:subsystem "
                                  "configuration not defined")
         return WINDOWS
+
     active = conanfile.conf.get("tools.microsoft.bash:active", check_type=bool)
     if active:
         return subsystem

--- a/test/functional/toolchains/gnu/autotools/test_win_bash.py
+++ b/test/functional/toolchains/gnu/autotools/test_win_bash.py
@@ -64,6 +64,66 @@ def test_autotools_bash_complete():
     assert "conanvcvars.bat" in bat_contents
 
 
+@pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows")
+def test_autotools_bash_complete_ucrt64():
+    try:
+        msys2_path = tools_locations["msys2"]["system"]["path"]["Windows"]
+    except KeyError:
+        pytest.skip("msys2 path not defined")
+    try:
+        ucrt64_path = tools_locations["ucrt64"]["system"]["path"]["Windows"]
+    except KeyError:
+        pytest.skip("ucrt64 path not defined")
+
+    client = TestClient(path_with_spaces=False)
+    profile_win = textwrap.dedent(f"""
+        [settings]
+        os=Windows
+        compiler=gcc
+        compiler.version=16
+        compiler.libcxx=libstdc++
+        compiler.cppstd=17
+        arch=x86_64
+        build_type=Release
+
+        [conf]
+        tools.microsoft.bash:subsystem=msys2-ucrt64
+        tools.microsoft.bash:path={msys2_path}/bash.exe
+
+        [runenv]
+        PATH+=(path){ucrt64_path}
+        """)
+
+    main = gen_function_cpp(name="main")
+    makefile = gen_makefile(apps=["app"])
+
+    conanfile = textwrap.dedent(r"""
+        from conan import ConanFile
+        from conan.tools.gnu import Autotools
+
+        class TestConan(ConanFile):
+            settings = "os", "compiler", "arch", "build_type"
+            generators = "AutotoolsToolchain"
+
+            win_bash = True
+
+            def build(self):
+                autotools = Autotools(self)
+                autotools.make()
+        """)
+
+    client.save({"conanfile.py": conanfile,
+                 "Makefile": makefile,
+                 "app.cpp": main,
+                 "profile_win": profile_win})
+    client.run("build . -pr=profile_win")
+
+    client.run_command("conanrun.bat && app.exe")
+    check_exe_run(client.out, "main", "gcc", "16", "Release", "x86_64", cppstd="17",
+                  cxx11_abi=0, subsystem="ucrt64")
+    check_vs_runtime("app.exe", client, "15", "Debug", subsystem="ucrt64")
+
+
 @pytest.mark.slow
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows")
 @pytest.mark.tool("msys2")

--- a/test/functional/toolchains/gnu/autotools/test_win_bash.py
+++ b/test/functional/toolchains/gnu/autotools/test_win_bash.py
@@ -90,9 +90,6 @@ def test_autotools_bash_complete_ucrt64():
         [conf]
         tools.microsoft.bash:subsystem=msys2-ucrt64
         tools.microsoft.bash:path={msys2_path}/bash.exe
-
-        [runenv]
-        PATH+=(path){ucrt64_path}
         """)
 
     main = gen_function_cpp(name="main")
@@ -111,6 +108,9 @@ def test_autotools_bash_complete_ucrt64():
             def build(self):
                 autotools = Autotools(self)
                 autotools.make()
+                import os
+                path = os.path.abspath(".").replace("\\", "/")
+                self.run(f"{path}/app.exe")
         """)
 
     client.save({"conanfile.py": conanfile,
@@ -118,8 +118,6 @@ def test_autotools_bash_complete_ucrt64():
                  "app.cpp": main,
                  "profile_win": profile_win})
     client.run("build . -pr=profile_win")
-
-    client.run_command("conanrun.bat && app.exe")
     check_exe_run(client.out, "main", "gcc", "16", "Release", "x86_64", cppstd="17",
                   cxx11_abi=0, subsystem="ucrt64")
     check_vs_runtime("app.exe", client, "15", "Debug", subsystem="ucrt64")

--- a/test/functional/toolchains/gnu/autotools/test_win_bash.py
+++ b/test/functional/toolchains/gnu/autotools/test_win_bash.py
@@ -72,6 +72,7 @@ def test_autotools_bash_complete_ucrt64():
         pytest.skip("msys2 path not defined")
     try:
         ucrt64_path = tools_locations["ucrt64"]["system"]["path"]["Windows"]
+        ucrt64_path = ucrt64_path.replace("\\", "/")
     except KeyError:
         pytest.skip("ucrt64 path not defined")
 

--- a/test/functional/utils.py
+++ b/test/functional/utils.py
@@ -105,9 +105,10 @@ def check_exe_run(output, names, compiler, version, build_type, arch, cppstd, de
                 assert "{} __GNUC__".format(name) in output
                 assert "clang" not in output
                 if version:  # FIXME: At the moment, the GCC version is not controlled, will change
-                    major, minor = version.split(".")[0:2]
-                    assert "{} __GNUC__{}".format(name, major) in output
-                    assert "{} __GNUC_MINOR__{}".format(name, minor) in output
+                    digits = version.split(".")
+                    assert "{} __GNUC__{}".format(name, digits[0]) in output
+                    if len(digits) > 1:
+                        assert "{} __GNUC_MINOR__{}".format(name, digits[1]) in output
             elif compiler == "clang":
                 assert "{} __clang_".format(name) in output
                 if version:

--- a/test/unittests/tools/microsoft/test_subsystem.py
+++ b/test/unittests/tools/microsoft/test_subsystem.py
@@ -2,15 +2,18 @@ import textwrap
 
 import pytest
 
+from conan.errors import ConanException
 from conan.tools.microsoft import unix_path, unix_path_package_info_legacy
 from conan.internal.model.conf import ConfDefinition
 from conan.test.utils.mocks import MockSettings, ConanFileMock
 
 expected_results = [
     ("msys2", '/c/path/to/stuff'),
+    ("msys2-clang64", '/c/path/to/stuff'),
     ("msys", '/c/path/to/stuff'),
     ("cygwin", '/cygdrive/c/path/to/stuff'),
     ("wsl", '/mnt/c/path/to/stuff'),
+
 ]
 
 
@@ -32,5 +35,21 @@ def test_unix_path(subsystem, expected_path):
     path = unix_path(conanfile, test_path)
     assert expected_path == path
 
-    package_info_legacy_path = unix_path_package_info_legacy(conanfile, test_path, path_flavor=subsystem)
+    package_info_legacy_path = unix_path_package_info_legacy(conanfile, test_path,
+                                                             path_flavor=subsystem)
     assert package_info_legacy_path == test_path
+
+
+def test_unix_path_wrong_env():
+    c = ConfDefinition()
+    c.loads("tools.microsoft.bash:subsystem=msys2-xxx")
+
+    settings = MockSettings({"os": "Windows"})
+    conanfile = ConanFileMock()
+    conanfile.conf = c.get_conanfile_conf(None)
+    conanfile.settings = settings
+    conanfile.settings_build = settings
+
+    with pytest.raises(ConanException) as e:
+        unix_path(conanfile, "")
+    assert "Defined msys2 environment 'xxx' not in ('ucrt64', 'clang64'" in str(e.value)


### PR DESCRIPTION
Changelog: Feature: Model explicitly the msys2 environments (clang64, ucrt64, etc) in ``tools.microsoft.bash:subsystem``.
Docs: https://github.com/conan-io/docs/pull/4478

Close https://github.com/conan-io/conan/issues/20052

I am leaving the modeling of binaries to the user, as it is trivial to extend with ``settings_user.yml`` to model different subsystems environments