### PR TITLE
Handle special case where only one possible option is defined for shared

### DIFF
--- a/conan/__init__.py
+++ b/conan/__init__.py
@@ -2,5 +2,5 @@ from conan.internal.model.conan_file import ConanFile
 from conan.internal.model.workspace import Workspace
 from conan.internal.model.version import Version
 
-__version__ = '2.29.0'
+__version__ = '2.29.1'
 conan_version = Version(__version__)

--- a/conan/internal/model/pkg_type.py
+++ b/conan/internal/model/pkg_type.py
@@ -60,14 +60,15 @@ class PackageType(Enum):
                                          " but no 'shared' option declared")
             elif any(option in conanfile.options for option in ["shared", "header_only"]):
                 shared_value = conanfile.options.get_safe("shared")
-                if conanfile_type is PackageType.SHARED and shared_value == False:  # noqa
-                    raise ConanException(
-                        f"{conanfile}: 'shared-library' should not have 'shared' option set to False. "
-                        "Consider removing the 'shared' option.")
-                if conanfile_type is PackageType.STATIC and shared_value:
-                    raise ConanException(
-                        f"{conanfile}: 'static-library' should not have 'shared' option set to True. "
-                        "Consider removing the 'shared' option")
+                if shared_value is not None:
+                    if conanfile_type == PackageType.SHARED and not shared_value:
+                        raise ConanException(
+                            f"{conanfile}: 'shared-library' should not have 'shared' option set to False. "
+                            "Consider removing the 'shared' option.")
+                    if conanfile_type is PackageType.STATIC and shared_value:
+                        raise ConanException(
+                            f"{conanfile}: 'static-library' should not have 'shared' option set to True. "
+                            "Consider removing the 'shared' option")
                 conanfile.output.warning(f"{conanfile}: package_type '{conanfile_type}' is defined, "
                                          "but 'shared' and/or 'header_only' options are present. "
                                          "The package_type will have precedence over the options "

--- a/test/integration/graph/core/test_auto_package_type.py
+++ b/test/integration/graph/core/test_auto_package_type.py
@@ -112,3 +112,42 @@ def test_package_type_shared_option_warning(package_type, shared_value):
     tc.run("graph info . --filter package_type")
     assert f"package_type: {package_type}" in tc.out and \
            "The package_type will have precedence over the options" in tc.out
+
+@pytest.mark.parametrize("package_type, shared_value", [
+    ("shared-library", False),
+    ("static-library", True),
+])
+def test_package_type_shared_option_unique_possible_option(package_type, shared_value):
+    """
+    Test that contradictory package_type and shared option raises an error.
+    """
+    tc = TestClient(light=True)
+    tc.save({"conanfile.py": textwrap.dedent(f"""
+    from conan import ConanFile
+
+    class Pkg(ConanFile):
+        package_type = "{package_type}"
+        options = {{"shared": [{shared_value}]}}
+        default_options = {{"shared": {shared_value}}}
+
+    """)})
+    tc.run("graph info", assert_error=True)
+    assert f"'{package_type}' should not have 'shared' option set to {shared_value}. " \
+           "Consider removing the 'shared' option" in tc.out
+
+@pytest.mark.parametrize("package_type", [("shared-library"), ("static-library")])
+def test_package_type_header_only(package_type):
+    """
+    Test that no error is raised when only header_only option is defined
+    """
+    tc = TestClient(light=True)
+    tc.save({"conanfile.py": textwrap.dedent(f"""
+    from conan import ConanFile
+
+    class Pkg(ConanFile):
+        package_type = "{package_type}"
+        options = {{"header_only": [True, False]}}
+        default_options = {{"header_only": False}}
+
+    """)})
+    tc.run("graph info")


### PR DESCRIPTION
Changelog: Bugfix: Handle special case where only one possible option is defined for shared.
Docs: omit

This PR aims to fix a rarely situation where a recipe does only define only one option for `shared` recipe option:

```py
from conan import ConanFile
class helloRecipe(ConanFile):
    name = "hello"
    version = "1.0"
    package_type = "shared-library"
    options = {"shared": [True]}
    default_options = {"shared": True}
```
```
ERROR: 'False' is not a valid 'options.shared' value.
Possible values are ['True']
```

This bug happens because the equality comparator of the `_PackageOption` class internally validates that the right-hand value is in the possible value list. See [code](https://github.com/conan-io/conan/blob/a42629e0b40f1c82d205056d52dc6da92be97674/conan/internal/model/options.py?plain=1#L72).


Fix https://github.com/conan-io/conan/issues/20079

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
