### PR TITLE
conf unset tilde

### DIFF
--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -600,7 +600,7 @@ class Conf:
 class ConfDefinition:
     # Order is important, "define" must be latest
     actions = (("+=", "append"), ("=+", "prepend"),
-               ("=!", "unset"), ("*=", "update"), ("=", "define"))
+               ("=!", "unset"), ("=~", "unset"), ("*=", "update"), ("=", "define"))
 
     def __init__(self):
         self._pattern_confs = {}

--- a/test/unittests/model/test_conf.py
+++ b/test/unittests/model/test_conf.py
@@ -419,3 +419,23 @@ def test_unset_basic_same_behaviour(choices):
     c3.update_conf_definition(c4)
 
     assert c3.get("user.company.cpu:jobs", choices=choices) is None
+
+
+@pytest.mark.parametrize("choices", [None, ["Foo", "Bar"]])
+def test_unset_tilde_alias_same_behaviour(choices):
+    """=~ is an alias for =! (unset)"""
+    c = ConfDefinition()
+    assert c.get("user.company.cpu:jobs", choices=choices) is None
+
+    c2 = ConfDefinition()
+    c2.loads("user.company.cpu:jobs=~")
+    assert c2.get("user.company.cpu:jobs", choices=choices) is None
+
+    c3 = ConfDefinition()
+    c3.loads("user.company.cpu:jobs=4")
+
+    c4 = ConfDefinition()
+    c4.loads("user.company.cpu:jobs=~")
+    c3.update_conf_definition(c4)
+
+    assert c3.get("user.company.cpu:jobs", choices=choices) is None


### PR DESCRIPTION
Changelog: Feature: Implement the ``conf=~`` for the "unset" operation (alias for ``conf=!``).
Docs: https://github.com/conan-io/docs/pull/4479

Close https://github.com/conan-io/conan/issues/20083