### PR TITLE
relativize cpp_info.location for editable layouts

### DIFF
--- a/conan/internal/graph/installer.py
+++ b/conan/internal/graph/installer.py
@@ -438,11 +438,13 @@ class BinaryInstaller:
                     # convert directory entries to be relative to the declared folders.build
                     build_cppinfo = conanfile.cpp.build
                     build_cppinfo.set_relative_base_folder(conanfile.build_folder)
+                    build_cppinfo.set_relative_base_relative_folder(conanfile.folders.build)
                     conanfile.layouts.build.set_relative_base_folder(conanfile.build_folder)
 
                     # convert directory entries to be relative to the declared folders.source
                     source_cppinfo = conanfile.cpp.source
                     source_cppinfo.set_relative_base_folder(conanfile.source_folder)
+                    source_cppinfo.set_relative_base_relative_folder(conanfile.folders.source)
                     conanfile.layouts.source.set_relative_base_folder(conanfile.source_folder)
 
                     full_editable_cppinfo = CppInfo()

--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -506,6 +506,12 @@ class _Component:
             origin = getattr(self, varname)
             if origin is not None:
                 origin[:] = [os.path.join(folder, el) for el in origin]
+
+        for prop in ["_location", "_link_location"]:
+            origin = getattr(self, prop)
+            if origin is not None:
+                setattr(self, prop, os.path.join(folder, origin))
+
         properties = self._properties
         if properties is not None:
             modules = properties.get("cmake_build_modules")  # Only this prop at this moment
@@ -525,6 +531,12 @@ class _Component:
             origin = getattr(self, varname)
             if origin is not None:
                 origin[:] = [relocate(f) for f in origin]
+
+        for prop in ["_location", "_link_location"]:
+            origin = getattr(self, prop)
+            if origin is not None:
+                setattr(self, prop, relocate(origin))
+
         properties = self._properties
         if properties is not None:
             modules = properties.get("cmake_build_modules")  # Only this prop at this moment

--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -533,6 +533,12 @@ class _Component:
             origin = getattr(self, varname)
             if origin is not None:
                 origin[:] = [relocate(f) for f in origin]
+
+        for prop in ["_location", "_link_location"]:
+            origin = getattr(self, prop)
+            if origin is not None:
+                setattr(self, prop, relocate(origin))
+
         properties = self._properties
         if properties is not None:
             modules = properties.get("cmake_build_modules")  # Only this prop at this moment

--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -501,18 +501,19 @@ class _Component:
                 else:
                     current_values[k] = copy.copy(v)
 
-    def set_relative_base_relative_folder(self, folder):
+    def set_relative_base_relative_folder(self, relative_folder):
+        # This is using the relative folder location for the package root or build tree
+        # only
         for prop in ["_location", "_link_location"]:
             origin = getattr(self, prop)
             if origin is not None:
-                setattr(self, prop, os.path.join(folder, origin))
+                setattr(self, prop, os.path.join(relative_folder, origin))
 
     def set_relative_base_folder(self, folder):
         for varname in _DIRS_VAR_NAMES:
             origin = getattr(self, varname)
             if origin is not None:
                 origin[:] = [os.path.join(folder, el) for el in origin]
-
         properties = self._properties
         if properties is not None:
             modules = properties.get("cmake_build_modules")  # Only this prop at this moment
@@ -532,7 +533,6 @@ class _Component:
             origin = getattr(self, varname)
             if origin is not None:
                 origin[:] = [relocate(f) for f in origin]
-
         properties = self._properties
         if properties is not None:
             modules = properties.get("cmake_build_modules")  # Only this prop at this moment

--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -501,16 +501,17 @@ class _Component:
                 else:
                     current_values[k] = copy.copy(v)
 
+    def set_relative_base_relative_folder(self, folder):
+        for prop in ["_location", "_link_location"]:
+            origin = getattr(self, prop)
+            if origin is not None:
+                setattr(self, prop, os.path.join(folder, origin))
+
     def set_relative_base_folder(self, folder):
         for varname in _DIRS_VAR_NAMES:
             origin = getattr(self, varname)
             if origin is not None:
                 origin[:] = [os.path.join(folder, el) for el in origin]
-
-        for prop in ["_location", "_link_location"]:
-            origin = getattr(self, prop)
-            if origin is not None:
-                setattr(self, prop, os.path.join(folder, origin))
 
         properties = self._properties
         if properties is not None:
@@ -531,11 +532,6 @@ class _Component:
             origin = getattr(self, varname)
             if origin is not None:
                 origin[:] = [relocate(f) for f in origin]
-
-        for prop in ["_location", "_link_location"]:
-            origin = getattr(self, prop)
-            if origin is not None:
-                setattr(self, prop, relocate(origin))
 
         properties = self._properties
         if properties is not None:
@@ -756,6 +752,12 @@ class CppInfo:
         self._package.set_relative_base_folder(folder)
         for component in self.components.values():
             component.set_relative_base_folder(folder)
+
+    def set_relative_base_relative_folder(self, folder):
+        """Prepend the folder to all the directories definitions, that are relative"""
+        self._package.set_relative_base_relative_folder(folder)
+        for component in self.components.values():
+            component.set_relative_base_relative_folder(folder)
 
     def deploy_base_folder(self, package_folder, deploy_folder):
         """Prepend the folder to all the directories"""

--- a/test/functional/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps_new.py
+++ b/test/functional/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps_new.py
@@ -33,9 +33,9 @@ class TestExes:
                 def layout(self):
                     cmake_layout(self)
                     self.cpp.build.exe = "mytool"
-                    name = "mytool.exe" if platform.system() == "Windows" else "mytool"
-                    app_loc = os.path.join(str(self.settings.build_type), name)
-                    self.cpp.build.location = app_loc
+                    self.cpp.build.set_property("cmake_target_name", "MyTool::myexe")
+                    name = f"{self.settings.build_type}/mytool.exe" if platform.system() == "Windows" else "mytool"
+                    self.cpp.build.location = name
 
                 def build(self):
                     cmake = CMake(self)

--- a/test/functional/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps_new.py
+++ b/test/functional/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps_new.py
@@ -34,7 +34,7 @@ class TestExes:
                     cmake_layout(self)
                     self.cpp.build.exe = "mytool"
                     name = "mytool.exe" if platform.system() == "Windows" else "mytool"
-                    app_loc = os.path.join("build", str(self.settings.build_type), name)
+                    app_loc = os.path.join(str(self.settings.build_type), name)
                     self.cpp.build.location = app_loc
 
                 def build(self):

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -1135,5 +1135,4 @@ class TestEditableExeLocation:
         c.run("install --requires=app/0.1 -g CMakeConfigDeps")
 
         content = c.load("app-Targets-release.cmake")
-        print(content)
         assert "${app_PACKAGE_FOLDER_RELEASE}/mybuild/myexe.exe" in content

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -1054,3 +1054,86 @@ def test_implib_location_explicit_extension():
     assert "PROPERTIES IMPORTED_IMPLIB_RELEASE" in targets
     # And we find the dll
     assert "PROPERTIES IMPORTED_LOCATION_RELEASE" in targets
+
+
+def test_editable_exe_location_relative_to_build_folder():
+    # https://github.com/conan-io/conan/issues/20081
+    conanfile = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+
+        class AppConan(ConanFile):
+            name = "app"
+            version = "0.1"
+            package_type = "application"
+
+            def layout(self):
+                self.folders.build = "mybuild"
+                self.cpp.build.exe = "myexe"
+                self.cpp.build.location = "myexe.exe"
+
+            def package_info(self):
+                self.cpp_info.exe = "myexe"
+                self.cpp_info.location = os.path.join("bin", "myexe.exe")
+        """)
+
+    c = TestClient()
+    c.save({"app/conanfile.py": conanfile})
+
+    c.run("create app")
+    c.run("install --requires=app/0.1 -g CMakeConfigDeps")
+    content = c.load("app-Targets-release.cmake")
+    assert "${app_PACKAGE_FOLDER_RELEASE}/bin/myexe.exe" in content
+
+    # Deployers are not really affected, CMakeConfigDeps already use relative paths
+    c.run("install --requires=app/0.1 -g CMakeConfigDeps --deployer=full_deploy")
+    content = c.load("app-Targets-release.cmake")
+    assert "${app_PACKAGE_FOLDER_RELEASE}/bin/myexe.exe" in content
+
+    c.run("editable add app")
+    c.run("install --requires=app/0.1 -g CMakeConfigDeps")
+    content = c.load("app-Targets-release.cmake")
+    assert "${app_PACKAGE_FOLDER_RELEASE}/mybuild/myexe.exe" in content
+
+
+def test_editable_component_exe_location_relative_to_build_folder():
+    # https://github.com/conan-io/conan/issues/20081 (component variant)
+    # Same issue for cpp.build.components[...].location
+    conanfile = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+        from conan.tools.cmake import cmake_layout
+
+        class AppConan(ConanFile):
+            name = "app"
+            version = "0.1"
+            package_type = "application"
+
+            def layout(self):
+                self.folders.build = "mybuild"
+                self.cpp.build.components["mycomp"].exe = "myexe"
+                self.cpp.build.components["mycomp"].location = "myexe.exe"
+
+            def package_info(self):
+                self.cpp_info.components["mycomp"].exe = "myexe"
+                self.cpp_info.components["mycomp"].location = os.path.join("bin", "myexe.exe")
+        """)
+
+    c = TestClient()
+    c.save({"app/conanfile.py": conanfile})
+
+    c.run("create app")
+    c.run("install --requires=app/0.1 -g CMakeConfigDeps")
+    content = c.load("app-Targets-release.cmake")
+    assert "${app_PACKAGE_FOLDER_RELEASE}/bin/myexe.exe" in content
+
+    # Deployers are not really affected, CMakeConfigDeps already use relative paths
+    c.run("install --requires=app/0.1 -g CMakeConfigDeps --deployer=full_deploy")
+    content = c.load("app-Targets-release.cmake")
+    assert "${app_PACKAGE_FOLDER_RELEASE}/bin/myexe.exe" in content
+
+    c.run("editable add app")
+    c.run("install --requires=app/0.1 -g CMakeConfigDeps")
+
+    content = c.load("app-Targets-release.cmake")
+    assert "${app_PACKAGE_FOLDER_RELEASE}/mybuild/myexe.exe" in content

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -1056,84 +1056,84 @@ def test_implib_location_explicit_extension():
     assert "PROPERTIES IMPORTED_LOCATION_RELEASE" in targets
 
 
-def test_editable_exe_location_relative_to_build_folder():
-    # https://github.com/conan-io/conan/issues/20081
-    conanfile = textwrap.dedent("""
-        import os
-        from conan import ConanFile
+class TestEditableExeLocation:
+    def test_editable_exe(self):
+        # https://github.com/conan-io/conan/issues/20081
+        conanfile = textwrap.dedent("""
+            import os
+            from conan import ConanFile
 
-        class AppConan(ConanFile):
-            name = "app"
-            version = "0.1"
-            package_type = "application"
+            class AppConan(ConanFile):
+                name = "app"
+                version = "0.1"
+                package_type = "application"
 
-            def layout(self):
-                self.folders.build = "mybuild"
-                self.cpp.build.exe = "myexe"
-                self.cpp.build.location = "myexe.exe"
+                def layout(self):
+                    self.folders.build = "mybuild"
+                    self.cpp.build.exe = "myexe"
+                    self.cpp.build.location = "myexe.exe"
 
-            def package_info(self):
-                self.cpp_info.exe = "myexe"
-                self.cpp_info.location = os.path.join("bin", "myexe.exe")
-        """)
+                def package_info(self):
+                    self.cpp_info.exe = "myexe"
+                    self.cpp_info.location = os.path.join("bin", "myexe.exe")
+            """)
 
-    c = TestClient()
-    c.save({"app/conanfile.py": conanfile})
+        c = TestClient()
+        c.save({"app/conanfile.py": conanfile})
 
-    c.run("create app")
-    c.run("install --requires=app/0.1 -g CMakeConfigDeps")
-    content = c.load("app-Targets-release.cmake")
-    assert "${app_PACKAGE_FOLDER_RELEASE}/bin/myexe.exe" in content
+        c.run("create app")
+        c.run("install --requires=app/0.1 -g CMakeConfigDeps")
+        content = c.load("app-Targets-release.cmake")
+        assert "${app_PACKAGE_FOLDER_RELEASE}/bin/myexe.exe" in content
 
-    # Deployers are not really affected, CMakeConfigDeps already use relative paths
-    c.run("install --requires=app/0.1 -g CMakeConfigDeps --deployer=full_deploy")
-    content = c.load("app-Targets-release.cmake")
-    assert "${app_PACKAGE_FOLDER_RELEASE}/bin/myexe.exe" in content
+        # Deployers are not really affected, CMakeConfigDeps already use relative paths
+        c.run("install --requires=app/0.1 -g CMakeConfigDeps --deployer=full_deploy")
+        content = c.load("app-Targets-release.cmake")
+        assert "${app_PACKAGE_FOLDER_RELEASE}/bin/myexe.exe" in content
 
-    c.run("editable add app")
-    c.run("install --requires=app/0.1 -g CMakeConfigDeps")
-    content = c.load("app-Targets-release.cmake")
-    assert "${app_PACKAGE_FOLDER_RELEASE}/mybuild/myexe.exe" in content
+        c.run("editable add app")
+        c.run("install --requires=app/0.1 -g CMakeConfigDeps")
+        content = c.load("app-Targets-release.cmake")
+        assert "${app_PACKAGE_FOLDER_RELEASE}/mybuild/myexe.exe" in content
 
+    def test_editable_component(self):
+        # https://github.com/conan-io/conan/issues/20081 (component variant)
+        # Same issue for cpp.build.components[...].location
+        conanfile = textwrap.dedent("""
+            import os
+            from conan import ConanFile
 
-def test_editable_component_exe_location_relative_to_build_folder():
-    # https://github.com/conan-io/conan/issues/20081 (component variant)
-    # Same issue for cpp.build.components[...].location
-    conanfile = textwrap.dedent("""
-        import os
-        from conan import ConanFile
-        from conan.tools.cmake import cmake_layout
+            class AppConan(ConanFile):
+                name = "app"
+                version = "0.1"
+                package_type = "application"
 
-        class AppConan(ConanFile):
-            name = "app"
-            version = "0.1"
-            package_type = "application"
+                def layout(self):
+                    self.folders.build = "mybuild"
+                    self.cpp.build.components["mycomp"].exe = "myexe"
+                    self.cpp.build.components["mycomp"].location = "myexe.exe"
 
-            def layout(self):
-                self.folders.build = "mybuild"
-                self.cpp.build.components["mycomp"].exe = "myexe"
-                self.cpp.build.components["mycomp"].location = "myexe.exe"
+                def package_info(self):
+                    self.cpp_info.components["mycomp"].exe = "myexe"
+                    self.cpp_info.components["mycomp"].location = os.path.join("bin", "myexe.exe")
+            """)
 
-            def package_info(self):
-                self.cpp_info.components["mycomp"].exe = "myexe"
-                self.cpp_info.components["mycomp"].location = os.path.join("bin", "myexe.exe")
-        """)
+        c = TestClient()
+        c.save({"app/conanfile.py": conanfile})
 
-    c = TestClient()
-    c.save({"app/conanfile.py": conanfile})
+        c.run("create app")
+        c.run("install --requires=app/0.1 -g CMakeConfigDeps")
+        content = c.load("app-Targets-release.cmake")
+        assert "${app_PACKAGE_FOLDER_RELEASE}/bin/myexe.exe" in content
 
-    c.run("create app")
-    c.run("install --requires=app/0.1 -g CMakeConfigDeps")
-    content = c.load("app-Targets-release.cmake")
-    assert "${app_PACKAGE_FOLDER_RELEASE}/bin/myexe.exe" in content
+        # Deployers are not really affected, CMakeConfigDeps already use relative paths
+        c.run("install --requires=app/0.1 -g CMakeConfigDeps --deployer=full_deploy")
+        content = c.load("app-Targets-release.cmake")
+        assert "${app_PACKAGE_FOLDER_RELEASE}/bin/myexe.exe" in content
 
-    # Deployers are not really affected, CMakeConfigDeps already use relative paths
-    c.run("install --requires=app/0.1 -g CMakeConfigDeps --deployer=full_deploy")
-    content = c.load("app-Targets-release.cmake")
-    assert "${app_PACKAGE_FOLDER_RELEASE}/bin/myexe.exe" in content
+        c.run("editable add app")
+        c.run("install --requires=app/0.1 -g CMakeConfigDeps")
 
-    c.run("editable add app")
-    c.run("install --requires=app/0.1 -g CMakeConfigDeps")
-
-    content = c.load("app-Targets-release.cmake")
-    assert "${app_PACKAGE_FOLDER_RELEASE}/mybuild/myexe.exe" in content
+        content = c.load("app-Targets-release.cmake")
+        print(content)
+        assert "${app_PACKAGE_FOLDER_RELEASE}/mybuild/myexe.exe" in content

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -1063,9 +1063,11 @@ def test_implib_location_explicit_extension():
 
 
 class TestEditableExeLocation:
-    def test_editable_exe(self):
+    @pytest.mark.parametrize("absolute", [False, True])
+    def test_editable_exe(self, absolute):
         # https://github.com/conan-io/conan/issues/20081
-        conanfile = textwrap.dedent("""
+        loc = 'self.package_folder,' if absolute else ''
+        conanfile = textwrap.dedent(f"""
             import os
             from conan import ConanFile
 
@@ -1081,7 +1083,7 @@ class TestEditableExeLocation:
 
                 def package_info(self):
                     self.cpp_info.exe = "myexe"
-                    self.cpp_info.location = os.path.join("bin", "myexe.exe")
+                    self.cpp_info.location = os.path.join({loc} "bin", "myexe.exe")
             """)
 
         c = TestClient()
@@ -1102,10 +1104,12 @@ class TestEditableExeLocation:
         content = c.load("app-Targets-release.cmake")
         assert "${app_PACKAGE_FOLDER_RELEASE}/mybuild/myexe.exe" in content
 
-    def test_editable_component(self):
+    @pytest.mark.parametrize("absolute", [False, True])
+    def test_editable_component(self, absolute):
         # https://github.com/conan-io/conan/issues/20081 (component variant)
         # Same issue for cpp.build.components[...].location
-        conanfile = textwrap.dedent("""
+        loc = 'self.package_folder,' if absolute else ''
+        conanfile = textwrap.dedent(f"""
             import os
             from conan import ConanFile
 
@@ -1121,7 +1125,8 @@ class TestEditableExeLocation:
 
                 def package_info(self):
                     self.cpp_info.components["mycomp"].exe = "myexe"
-                    self.cpp_info.components["mycomp"].location = os.path.join("bin", "myexe.exe")
+                    self.cpp_info.components["mycomp"].location = os.path.join({loc} "bin",
+                                                                               "myexe.exe")
             """)
 
         c = TestClient()


### PR DESCRIPTION
Changelog: Fix: Relativize `cpp_info.location` for editable layouts.
Docs: https://github.com/conan-io/docs/pull/4480

Close https://github.com/conan-io/conan/issues/20081