### PR TITLE
fix input absolute paths

### DIFF
--- a/conan/cli/__init__.py
+++ b/conan/cli/__init__.py
@@ -8,7 +8,7 @@ def make_abs_path(path, cwd=None):
     if path is None:
         return None
     if os.path.isabs(path):
-        return path
+        return os.path.normpath(path)  # get rid of trailing dot and other artifacts
     cwd = cwd or os.getcwd()
     abs_path = os.path.normpath(os.path.join(cwd, path))
     return abs_path

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -151,6 +151,12 @@ def test_cmakedeps_deployer_relative_paths():
     assert ('set(liba_PACKAGE_FOLDER_RELEASE "${CMAKE_CURRENT_LIST_DIR}/full_deploy/'
             'host/liba/1.0")') in liba_targets
 
+    # Extra check with full path
+    c.run(f'install "{c.current_folder}/." --deployer=full_deploy')
+    cmake = c.load("liba-config.cmake")
+    assert 'set(liba_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/full_deploy/host/liba/1.0' in cmake
+    assert 'set(liba_INCLUDE_DIR "${CMAKE_CURRENT_LIST_DIR}/full_deploy/host/liba/1.0' in cmake
+
 
 def test_cmakeconfigdeps_recipe():
     c = TestClient()


### PR DESCRIPTION
Changelog: Fix: Fix ``conan install <path>`` failing with absolute paths ending in a dot.
Docs: Omit

Close https://github.com/conan-io/conan/issues/20090
