### PR TITLE
Correct `@classmethod` + `@pytest.fixture` decorator order

### DIFF
--- a/test/integration/command/download/test_download_patterns.py
+++ b/test/integration/command/download/test_download_patterns.py
@@ -10,9 +10,8 @@ from conan.test.utils.env import environment_update
 @pytest.mark.artifactory_ready
 class TestDownloadPatterns:
     # The fixture is very similar from TestUploadPatterns, but not worth extracting
-    @classmethod
     @pytest.fixture(scope="class")
-    def client(cls):
+    def client(self):
         """ create a few packages, with several recipe revisions, several pids, several prevs
         """
         client = TestClient(default_server_user=True)
@@ -142,9 +141,8 @@ class TestDownloadPatterns:
 
 class TestDownloadPatterErrors:
 
-    @classmethod
     @pytest.fixture(scope="class")
-    def client(cls):
+    def client(self):
         client = TestClient(default_server_user=True)
         client.save({"conanfile.py": GenConanfile("pkg", "0.1")})
         client.run(f"create .")

--- a/test/integration/command/download/test_download_patterns.py
+++ b/test/integration/command/download/test_download_patterns.py
@@ -11,7 +11,8 @@ from conan.test.utils.env import environment_update
 class TestDownloadPatterns:
     # The fixture is very similar from TestUploadPatterns, but not worth extracting
     @pytest.fixture(scope="class")
-    def client(self):
+    @classmethod
+    def client(cls):
         """ create a few packages, with several recipe revisions, several pids, several prevs
         """
         client = TestClient(default_server_user=True)
@@ -142,7 +143,8 @@ class TestDownloadPatterns:
 class TestDownloadPatterErrors:
 
     @pytest.fixture(scope="class")
-    def client(self):
+    @classmethod
+    def client(cls):
         client = TestClient(default_server_user=True)
         client.save({"conanfile.py": GenConanfile("pkg", "0.1")})
         client.run(f"create .")

--- a/test/integration/graph/core/test_build_require_invalid.py
+++ b/test/integration/graph/core/test_build_require_invalid.py
@@ -24,11 +24,10 @@ class TestInvalidConfiguration:
     linux_package_id = "9a4eb3c8701508aa9458b1a73d0633783ecc2270"
     invalid = "Invalid"
 
-    @classmethod
     @pytest.fixture(scope="class")
-    def client(cls):
+    def client(self):
         client = TestClient()
-        client.save({"pkg/conanfile.py": cls.conanfile})
+        client.save({"pkg/conanfile.py": self.conanfile})
         client.run("create pkg --name=pkg --version=0.1 -s os=Linux")
         return client
 
@@ -134,11 +133,10 @@ class TestInvalidBuildPackageID:
     linux_package_id = NO_SETTINGS_PACKAGE_ID
     windows_package_id = NO_SETTINGS_PACKAGE_ID
 
-    @classmethod
     @pytest.fixture(scope="class")
-    def client(cls):
+    def client(self):
         client = TestClient()
-        client.save({"pkg/conanfile.py": cls.conanfile})
+        client.save({"pkg/conanfile.py": self.conanfile})
         client.run("create pkg --name=pkg --version=0.1 -s os=Linux")
         return client
 

--- a/test/integration/graph/core/test_build_require_invalid.py
+++ b/test/integration/graph/core/test_build_require_invalid.py
@@ -25,9 +25,10 @@ class TestInvalidConfiguration:
     invalid = "Invalid"
 
     @pytest.fixture(scope="class")
-    def client(self):
+    @classmethod
+    def client(cls):
         client = TestClient()
-        client.save({"pkg/conanfile.py": self.conanfile})
+        client.save({"pkg/conanfile.py": cls.conanfile})
         client.run("create pkg --name=pkg --version=0.1 -s os=Linux")
         return client
 
@@ -134,9 +135,10 @@ class TestInvalidBuildPackageID:
     windows_package_id = NO_SETTINGS_PACKAGE_ID
 
     @pytest.fixture(scope="class")
-    def client(self):
+    @classmethod
+    def client(cls):
         client = TestClient()
-        client.save({"pkg/conanfile.py": self.conanfile})
+        client.save({"pkg/conanfile.py": cls.conanfile})
         client.run("create pkg --name=pkg --version=0.1 -s os=Linux")
         return client
 

--- a/test/integration/remote/rest_api_test.py
+++ b/test/integration/remote/rest_api_test.py
@@ -21,28 +21,29 @@ class TestRestApi:
     """Open a real server (sockets) to test rest_api function."""
 
     @pytest.fixture(scope="class", autouse=True)
-    def setup_class(self):
+    @classmethod
+    def setup_class(cls):
         with environment_update({"CONAN_SERVER_PORT": str(get_free_port())}):
             read_perms = [("*/*@*/*", "private_user")]
             write_perms = [("*/*@*/*", "private_user")]
-            self.server = TestServerLauncher(server_capabilities=['ImCool', 'TooCool'],
-                                             read_permissions=read_perms,
-                                             write_permissions=write_perms)
-            self.server.start()
+            cls.server = TestServerLauncher(server_capabilities=['ImCool', 'TooCool'],
+                                            read_permissions=read_perms,
+                                            write_permissions=write_perms)
+            cls.server.start()
 
             config = ConfDefinition()
             requester = ConanRequester(config)
 
-            remote = Remote("myremote", f"http://127.0.0.1:{self.server.port}", True, True)
-            self.api = RestApiClient(remote, None, requester, config)
-            self.api._token = self.api.authenticate(user="private_user", password="private_pass")
+            remote = Remote("myremote", f"http://127.0.0.1:{cls.server.port}", True, True)
+            cls.api = RestApiClient(remote, None, requester, config)
+            cls.api._token = cls.api.authenticate(user="private_user", password="private_pass")
             # Necessary for setup_class approach
-            TestRestApi.api = self.api
-            TestRestApi.server = self.server
+            TestRestApi.api = cls.api
+            TestRestApi.server = cls.server
         yield
 
-        self.server.stop()
-        self.server.clean()
+        cls.server.stop()
+        cls.server.clean()
 
     def test_get_conan(self):
         # Upload a conans

--- a/test/integration/remote/rest_api_test.py
+++ b/test/integration/remote/rest_api_test.py
@@ -20,30 +20,29 @@ from conan.internal.util.files import md5, save
 class TestRestApi:
     """Open a real server (sockets) to test rest_api function."""
 
-    @classmethod
     @pytest.fixture(scope="class", autouse=True)
-    def setup_class(cls):
+    def setup_class(self):
         with environment_update({"CONAN_SERVER_PORT": str(get_free_port())}):
             read_perms = [("*/*@*/*", "private_user")]
             write_perms = [("*/*@*/*", "private_user")]
-            cls.server = TestServerLauncher(server_capabilities=['ImCool', 'TooCool'],
-                                            read_permissions=read_perms,
-                                            write_permissions=write_perms)
-            cls.server.start()
+            self.server = TestServerLauncher(server_capabilities=['ImCool', 'TooCool'],
+                                             read_permissions=read_perms,
+                                             write_permissions=write_perms)
+            self.server.start()
 
             config = ConfDefinition()
             requester = ConanRequester(config)
 
-            remote = Remote("myremote", f"http://127.0.0.1:{cls.server.port}", True, True)
-            cls.api = RestApiClient(remote, None, requester, config)
-            cls.api._token = cls.api.authenticate(user="private_user", password="private_pass")
+            remote = Remote("myremote", f"http://127.0.0.1:{self.server.port}", True, True)
+            self.api = RestApiClient(remote, None, requester, config)
+            self.api._token = self.api.authenticate(user="private_user", password="private_pass")
             # Necessary for setup_class approach
-            TestRestApi.api = cls.api
-            TestRestApi.server = cls.server
+            TestRestApi.api = self.api
+            TestRestApi.server = self.server
         yield
 
-        cls.server.stop()
-        cls.server.clean()
+        self.server.stop()
+        self.server.clean()
 
     def test_get_conan(self):
         # Upload a conans

--- a/test/integration/remote/test_local_recipes_index.py
+++ b/test/integration/remote/test_local_recipes_index.py
@@ -404,7 +404,8 @@ class TestErrorsUx:
 
 class TestPythonRequires:
     @pytest.fixture(scope="class")
-    def c3i_pyrequires_folder(self):
+    @classmethod
+    def c3i_pyrequires_folder(cls):
         folder = temp_folder()
         recipes_folder = os.path.join(folder, "recipes")
         config = textwrap.dedent("""
@@ -433,7 +434,8 @@ class TestPythonRequires:
 
 class TestUserChannel:
     @pytest.fixture(scope="class")
-    def c3i_user_channel_folder(self):
+    @classmethod
+    def c3i_user_channel_folder(cls):
         folder = temp_folder()
         recipes_folder = os.path.join(folder, "recipes")
         config = textwrap.dedent("""

--- a/test/integration/remote/test_local_recipes_index.py
+++ b/test/integration/remote/test_local_recipes_index.py
@@ -403,9 +403,8 @@ class TestErrorsUx:
 
 
 class TestPythonRequires:
-    @classmethod
     @pytest.fixture(scope="class")
-    def c3i_pyrequires_folder(cls):
+    def c3i_pyrequires_folder(self):
         folder = temp_folder()
         recipes_folder = os.path.join(folder, "recipes")
         config = textwrap.dedent("""
@@ -433,9 +432,8 @@ class TestPythonRequires:
 
 
 class TestUserChannel:
-    @classmethod
     @pytest.fixture(scope="class")
-    def c3i_user_channel_folder(cls):
+    def c3i_user_channel_folder(self):
         folder = temp_folder()
         recipes_folder = os.path.join(folder, "recipes")
         config = textwrap.dedent("""


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Commit `621a7a996` introduced `@classmethod` above `@pytest.fixture` to silence linter warnings. The correct order per pytest 8.1+ is the opposite: `@pytest.fixture` outermost, `@classmethod` innermost. With the wrong order pytest wraps the fixture in a classmethod descriptor it cannot detect, causing "fixture not found" and `AttributeError: 'FixtureFunctionDefinition' has no attribute '__code__'` errors.
