### PR TITLE
Revert classmethod fixtures: use self instead of cls for Python 3.7 compatibility

### DIFF
--- a/test/integration/command/download/test_download_patterns.py
+++ b/test/integration/command/download/test_download_patterns.py
@@ -11,8 +11,7 @@ from conan.test.utils.env import environment_update
 class TestDownloadPatterns:
     # The fixture is very similar from TestUploadPatterns, but not worth extracting
     @pytest.fixture(scope="class")
-    @classmethod
-    def client(cls):
+    def client(self):
         """ create a few packages, with several recipe revisions, several pids, several prevs
         """
         client = TestClient(default_server_user=True)
@@ -143,8 +142,7 @@ class TestDownloadPatterns:
 class TestDownloadPatterErrors:
 
     @pytest.fixture(scope="class")
-    @classmethod
-    def client(cls):
+    def client(self):
         client = TestClient(default_server_user=True)
         client.save({"conanfile.py": GenConanfile("pkg", "0.1")})
         client.run(f"create .")

--- a/test/integration/command/upload/test_upload_patterns.py
+++ b/test/integration/command/upload/test_upload_patterns.py
@@ -9,8 +9,7 @@ from conan.test.utils.env import environment_update
 
 class TestUploadPatterns:
     @pytest.fixture(scope="class")  # Takes 6 seconds, reuse it
-    @classmethod
-    def client(cls):
+    def client(self):
         """ create a few packages, with several recipe revisions, several pids, several prevs
         """
         client = TestClient(default_server_user=True)
@@ -145,8 +144,7 @@ class TestUploadPatterns:
 class TestUploadPatternErrors:
 
     @pytest.fixture(scope="class")
-    @classmethod
-    def client(cls):
+    def client(self):
         client = TestClient(default_server_user=True)
         client.save({"conanfile.py": GenConanfile("pkg", "0.1")})
         client.run(f"create .")

--- a/test/integration/graph/core/test_build_require_invalid.py
+++ b/test/integration/graph/core/test_build_require_invalid.py
@@ -25,10 +25,9 @@ class TestInvalidConfiguration:
     invalid = "Invalid"
 
     @pytest.fixture(scope="class")
-    @classmethod
-    def client(cls):
+    def client(self):
         client = TestClient()
-        client.save({"pkg/conanfile.py": cls.conanfile})
+        client.save({"pkg/conanfile.py": self.conanfile})
         client.run("create pkg --name=pkg --version=0.1 -s os=Linux")
         return client
 
@@ -135,10 +134,9 @@ class TestInvalidBuildPackageID:
     windows_package_id = NO_SETTINGS_PACKAGE_ID
 
     @pytest.fixture(scope="class")
-    @classmethod
-    def client(cls):
+    def client(self):
         client = TestClient()
-        client.save({"pkg/conanfile.py": cls.conanfile})
+        client.save({"pkg/conanfile.py": self.conanfile})
         client.run("create pkg --name=pkg --version=0.1 -s os=Linux")
         return client
 

--- a/test/integration/remote/rest_api_test.py
+++ b/test/integration/remote/rest_api_test.py
@@ -21,29 +21,28 @@ class TestRestApi:
     """Open a real server (sockets) to test rest_api function."""
 
     @pytest.fixture(scope="class", autouse=True)
-    @classmethod
-    def setup_class(cls):
+    def setup_class(self):
         with environment_update({"CONAN_SERVER_PORT": str(get_free_port())}):
             read_perms = [("*/*@*/*", "private_user")]
             write_perms = [("*/*@*/*", "private_user")]
-            cls.server = TestServerLauncher(server_capabilities=['ImCool', 'TooCool'],
-                                            read_permissions=read_perms,
-                                            write_permissions=write_perms)
-            cls.server.start()
+            self.server = TestServerLauncher(server_capabilities=['ImCool', 'TooCool'],
+                                             read_permissions=read_perms,
+                                             write_permissions=write_perms)
+            self.server.start()
 
             config = ConfDefinition()
             requester = ConanRequester(config)
 
-            remote = Remote("myremote", f"http://127.0.0.1:{cls.server.port}", True, True)
-            cls.api = RestApiClient(remote, None, requester, config)
-            cls.api._token = cls.api.authenticate(user="private_user", password="private_pass")
+            remote = Remote("myremote", f"http://127.0.0.1:{self.server.port}", True, True)
+            self.api = RestApiClient(remote, None, requester, config)
+            self.api._token = self.api.authenticate(user="private_user", password="private_pass")
             # Necessary for setup_class approach
-            TestRestApi.api = cls.api
-            TestRestApi.server = cls.server
+            TestRestApi.api = self.api
+            TestRestApi.server = self.server
         yield
 
-        cls.server.stop()
-        cls.server.clean()
+        self.server.stop()
+        self.server.clean()
 
     def test_get_conan(self):
         # Upload a conans

--- a/test/integration/remote/test_local_recipes_index.py
+++ b/test/integration/remote/test_local_recipes_index.py
@@ -404,8 +404,7 @@ class TestErrorsUx:
 
 class TestPythonRequires:
     @pytest.fixture(scope="class")
-    @classmethod
-    def c3i_pyrequires_folder(cls):
+    def c3i_pyrequires_folder(self):
         folder = temp_folder()
         recipes_folder = os.path.join(folder, "recipes")
         config = textwrap.dedent("""
@@ -434,8 +433,7 @@ class TestPythonRequires:
 
 class TestUserChannel:
     @pytest.fixture(scope="class")
-    @classmethod
-    def c3i_user_channel_folder(cls):
+    def c3i_user_channel_folder(self):
         folder = temp_folder()
         recipes_folder = os.path.join(folder, "recipes")
         config = textwrap.dedent("""


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

