### PR TITLE
Fix revision_mode=scm_folder with conanfile in subfolder

### DIFF
--- a/conan/internal/api/export.py
+++ b/conan/internal/api/export.py
@@ -109,7 +109,7 @@ def cmd_export(loader, cache, hook_manager, global_conf, conanfile_path,
 
 def _calc_revision(scoped_output, path, manifest, revision_mode, conanfile):
     if revision_mode not in ["scm", "scm_folder", "hash"]:
-        raise ConanException("Revision mode should be one of 'hash' (default) or 'scm'")
+        raise ConanException("Revision mode should be one of 'hash' (default), 'scm' or 'scm_folder'")
 
     # Use the proper approach depending on 'revision_mode'
     if revision_mode == "hash":

--- a/test/functional/tools/scm/test_git.py
+++ b/test/functional/tools/scm/test_git.py
@@ -1332,9 +1332,47 @@ def test_revision_mode_scm_dirty_whole_repo():
     t.run("export pkg")
     assert t.exported_recipe_revision() == commit
 
-    # Dirty change outside pkga/ — only detectable by checking the whole repo
+    # Dirty change outside pkg/ — only detectable by checking the whole repo
     t.save({"other/file.txt": "modified content"})
 
     # Must raise: revision_mode=scm checks the full repository for dirtiness
     t.run("export pkg", assert_error=True)
     assert "Can't have a dirty repository using revision_mode='scm'" in t.out
+
+@pytest.mark.tool("git")
+def test_revision_mode_scm_folder_conanfile_in_subfolder():
+    """Regression test for https://github.com/conan-io/conan/issues/20124
+    When using revision_mode=scm_folder together with conanfile inside a
+    subfolder (self.folders.root is not empty), the root folder must be
+    used for both retrieving the commit as well as the dirtiness check.
+    """
+    conanfile = textwrap.dedent("""\
+        from conan import ConanFile
+
+        class Pkg(ConanFile):
+            name = "pkg"
+            version = "0.1"
+            revision_mode = "scm_folder"
+
+            def layout(self):
+                self.folders.root = ".."
+        """)
+    t = TestClient()
+    t.init_git_repo({"pkg/conan/conanfile.py": conanfile})
+    t.save({"pkg/content.txt": "new content",
+            "other/file.txt": "other content"})
+
+    # Dirty change outside recipe_folder, but inside root must fail
+    t.run("export pkg/conan", assert_error=True)
+    assert "Can't have a dirty repository using revision_mode='scm'/'scm_folder'" in t.out
+
+    # The last commit changing anything inside the root must be exported,
+    # dirty change outside root is okay
+    commit = git_add_changes_commit(os.path.join(t.current_folder, "pkg"))
+    t.run("export pkg/conan")
+    assert t.exported_recipe_revision() == commit
+
+    # Commits changing only files outside the root folder must not affect the exported commit
+    git_add_changes_commit(t.current_folder)
+    t.run("export pkg/conan")
+    assert t.exported_recipe_revision() == commit

--- a/test/integration/command/export/export_test.py
+++ b/test/integration/command/export/export_test.py
@@ -327,7 +327,7 @@ class TestExportMetadata:
         t = TestClient(light=True)
         t.save({'conanfile.py': GenConanfile().with_revision_mode("auto")})
         t.run("export . --name=name --version=version", assert_error=True)
-        assert "ERROR: Revision mode should be one of 'hash' (default) or 'scm'" in t.out
+        assert "ERROR: Revision mode should be one of 'hash' (default), 'scm' or 'scm_folder'" in t.out
 
     def test_export_no_params(self):
         client = TestClient(light=True)


### PR DESCRIPTION
`revision_mode=scm_folder` needs to use the root folder
(defined via `layout()` `self.folders.root` for both
its dirtiness check as well as retrieving the commit.

Otherwise relevant files could be missed, e.g. in example:
https://docs.conan.io/2/examples/conanfile/layout/multiple_subprojects.html

Changelog: Bugfix: `revision_mode=scm_folder` ignored `self.folders.root` for dirtiness check and commit retrieval.
Docs: omit

Closes #20124.

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
