### PR TITLE
Add `tools.build:asmflags` consumed by CMakeToolchain (CMAKE_ASM_FLAGS)

### DIFF
--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -163,6 +163,7 @@ BUILT_IN_CONFS = {
     "tools.build:compiler_executables": "Defines a Python dict-like with the compilers path to be used. Allowed keys {'c', 'cpp', 'cuda', 'objc', 'objcxx', 'rc', 'fortran', 'asm', 'hip', 'ispc'}",
     "tools.build:cxxflags": "List of extra CXX flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:cflags": "List of extra C flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
+    "tools.build:asmflags": "List of extra ASM flags used by CMakeToolchain",
     "tools.build:defines": "List of extra definition flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:sharedlinkflags": "List of extra flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",
     "tools.build:exelinkflags": "List of extra flags used by different toolchains like CMakeToolchain, AutotoolsToolchain and MesonToolchain",

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -783,6 +783,9 @@ class ExtraFlagsBlock(Block):
         {% if cflags %}
         string(APPEND CONAN_C_FLAGS{{suffix}} "{% for cflag in cflags %} {{ cflag }}{% endfor %}")
         {% endif %}
+        {% if asmflags %}
+        string(APPEND CONAN_ASM_FLAGS{{suffix}} "{% for asmflag in asmflags %} {{ asmflag }}{% endfor %}")
+        {% endif %}
         {% if sharedlinkflags %}
         string(APPEND CONAN_SHARED_LINKER_FLAGS{{suffix}} "{% for sharedlinkflag in sharedlinkflags %} {{ sharedlinkflag }}{% endfor %}")
         {% endif %}
@@ -840,6 +843,7 @@ class ExtraFlagsBlock(Block):
         # Now, it's time to get all the flags defined by the user
         cxxflags = self._toolchain.extra_cxxflags + self._conanfile.conf.get("tools.build:cxxflags", default=[], check_type=list)
         cflags = self._toolchain.extra_cflags + self._conanfile.conf.get("tools.build:cflags", default=[], check_type=list)
+        asmflags = self._toolchain.extra_asmflags + self._conanfile.conf.get("tools.build:asmflags", default=[], check_type=list)
         sharedlinkflags = self._toolchain.extra_sharedlinkflags + self._conanfile.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)
         exelinkflags = self._toolchain.extra_exelinkflags + self._conanfile.conf.get("tools.build:exelinkflags", default=[], check_type=list)
         rcflags = self._conanfile.conf.get("tools.build:rcflags", default=[], check_type=list)
@@ -863,6 +867,7 @@ class ExtraFlagsBlock(Block):
             "suffix": suffix,
             "cxxflags": cxxflags,
             "cflags": cflags,
+            "asmflags": asmflags,
             "sharedlinkflags": sharedlinkflags,
             "exelinkflags": exelinkflags,
             "rcflags": rcflags,
@@ -882,6 +887,9 @@ class CMakeFlagsInitBlock(Block):
             if(DEFINED CONAN_C_FLAGS_${config})
               string(APPEND CMAKE_C_FLAGS_${config}_INIT " ${CONAN_C_FLAGS_${config}}")
             endif()
+            if(DEFINED CONAN_ASM_FLAGS_${config})
+              string(APPEND CMAKE_ASM_FLAGS_${config}_INIT " ${CONAN_ASM_FLAGS_${config}}")
+            endif()
             if(DEFINED CONAN_SHARED_LINKER_FLAGS_${config})
               string(APPEND CMAKE_SHARED_LINKER_FLAGS_${config}_INIT " ${CONAN_SHARED_LINKER_FLAGS_${config}}")
             endif()
@@ -898,6 +906,9 @@ class CMakeFlagsInitBlock(Block):
         endif()
         if(DEFINED CONAN_C_FLAGS)
           string(APPEND CMAKE_C_FLAGS_INIT " ${CONAN_C_FLAGS}")
+        endif()
+        if(DEFINED CONAN_ASM_FLAGS)
+          string(APPEND CMAKE_ASM_FLAGS_INIT " ${CONAN_ASM_FLAGS}")
         endif()
         if(DEFINED CONAN_SHARED_LINKER_FLAGS)
           string(APPEND CMAKE_SHARED_LINKER_FLAGS_INIT " ${CONAN_SHARED_LINKER_FLAGS}")

--- a/conan/tools/cmake/toolchain/toolchain.py
+++ b/conan/tools/cmake/toolchain/toolchain.py
@@ -96,6 +96,7 @@ class CMakeToolchain:
 
         self.extra_cxxflags = []
         self.extra_cflags = []
+        self.extra_asmflags = []
         self.extra_sharedlinkflags = []
         self.extra_exelinkflags = []
         self.add_rpath_link = False

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -560,6 +560,31 @@ def test_cmaketoolchain_rcflags():
     assert 'string(APPEND CMAKE_RC_FLAGS_INIT " ${CONAN_RC_FLAGS}")' in toolchain
 
 
+def test_cmaketoolchain_asmflags():
+    """Test that tools.build:asmflags is applied to CONAN_ASM_FLAGS and CMAKE_ASM_FLAGS_INIT"""
+    profile = textwrap.dedent("""
+        [settings]
+        os=Linux
+        arch=x86_64
+        compiler=gcc
+        compiler.version=6
+        compiler.libcxx=libstdc++11
+        build_type=Release
+
+        [conf]
+        tools.build:asmflags=["-mfoo", "-mbar"]
+        """)
+
+    client = TestClient()
+    conanfile = GenConanfile().with_settings("os", "arch", "compiler", "build_type")\
+        .with_generator("CMakeToolchain")
+    client.save({"conanfile.py": conanfile, "profile": profile})
+    client.run("install . --profile:host=profile")
+    toolchain = client.load("conan_toolchain.cmake")
+    assert 'string(APPEND CONAN_ASM_FLAGS " -mfoo -mbar")' in toolchain
+    assert 'string(APPEND CMAKE_ASM_FLAGS_INIT " ${CONAN_ASM_FLAGS}")' in toolchain
+
+
 def test_bitcode_enable_flag():
     profile = textwrap.dedent("""
         [settings]
@@ -1422,6 +1447,7 @@ def test_extra_flags():
                 tc = CMakeToolchain(self)
                 tc.extra_cxxflags = ["extra_cxxflags"]
                 tc.extra_cflags = ["extra_cflags"]
+                tc.extra_asmflags = ["extra_asmflags"]
                 tc.extra_sharedlinkflags = ["extra_sharedlinkflags"]
                 tc.extra_exelinkflags = ["extra_exelinkflags"]
                 tc.generate()
@@ -1431,6 +1457,7 @@ def test_extra_flags():
         [conf]
         tools.build:cxxflags+=['cxxflags']
         tools.build:cflags+=['cflags']
+        tools.build:asmflags+=['asmflags']
         tools.build:sharedlinkflags+=['sharedlinkflags']
         tools.build:exelinkflags+=['exelinkflags']
         """)
@@ -1440,6 +1467,7 @@ def test_extra_flags():
 
     assert 'string(APPEND CONAN_CXX_FLAGS " extra_cxxflags cxxflags")' in toolchain
     assert 'string(APPEND CONAN_C_FLAGS " extra_cflags cflags")' in toolchain
+    assert 'string(APPEND CONAN_ASM_FLAGS " extra_asmflags asmflags")' in toolchain
     assert 'string(APPEND CONAN_SHARED_LINKER_FLAGS " extra_sharedlinkflags sharedlinkflags")' in toolchain
     assert 'string(APPEND CONAN_EXE_LINKER_FLAGS " extra_exelinkflags exelinkflags")' in toolchain
 


### PR DESCRIPTION
Today `CMakeToolchain` sets C/CXX/shared-link/exe-link/RC flags and defines, but nothing populates `CMAKE_ASM_FLAGS`. Projects with hand-written assembly (e.g. MCU startup `.s` files) currently have to mirror `tools.build:cflags` onto `CMAKE_ASM_FLAGS` by hand in their recipe. This closes that gap by mirroring the existing `tools.build:cflags`/`cxxflags` handling for assembly:

- new `tools.build:asmflags` conf (registered in `BUILT_IN_CONFS`),
- new `CMakeToolchain.extra_asmflags` attribute, for parity with `extra_cflags`/`extra_cxxflags`,
- `ExtraFlagsBlock` emits `CONAN_ASM_FLAGS`; `CMakeFlagsInitBlock` maps it to `CMAKE_ASM_FLAGS_INIT` (both the global and the per-config variants),
- integration tests covering both the conf and the attribute path.

**Scope:** CMakeToolchain only — the conf docstring is intentionally CMake-only. Possible follow-ups: AutotoolsToolchain/GnuToolchain parity via the existing `ASFLAGS` hook (their `asflags` property is currently Apple-only and would need the `if not is_apple_os: return []` guard reworked so flags aren't dropped elsewhere). Meson is out of scope — its generated machine file has no assembly-args slot.

Changelog: Feature: Add `tools.build:asmflags` config and `CMakeToolchain.extra_asmflags` to populate `CMAKE_ASM_FLAGS`.
Docs: Omit

- [X] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
