### PR TITLE
Add tools.cmake.cmaketoolchain:preset_name for customizable CMake preset names

### DIFF
--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -106,6 +106,7 @@ BUILT_IN_CONFS = {
     "tools.cmake.cmaketoolchain:extra_variables": "Dictionary with variables to be injected in CMakeToolchain (potential override of CMakeToolchain defined variables)",
     "tools.cmake.cmaketoolchain:enabled_blocks": "Select the specific blocks to use in the conan_toolchain.cmake",
     "tools.cmake.cmaketoolchain:user_presets": "(Experimental) Select a different name instead of CMakeUserPresets.json, empty to disable",
+    "tools.cmake.cmaketoolchain:preset_name": "List of settings/options (same grammar as tools.cmake.cmake_layout:build_folder_vars, e.g. ['settings.compiler', 'settings.build_type']) joined into the generated CMake preset name (configure/build/test), overriding the default '<prefix>-<build_type>'. Values are lowercased and '-'-joined, with no 'conan-' prefix; independent from build_folder_vars. Single-config generators only.",
     "tools.cmake.cmake_layout:build_folder_vars": "Settings and Options that will produce a different build folder and different CMake presets names",
     "tools.cmake.cmake_layout:build_folder": "(Experimental) Allow configuring the base folder of the build for local builds",
     "tools.cmake.cmake_layout:test_folder": "(Experimental) Allow configuring the base folder of the build for test_package",

--- a/conan/tools/cmake/layout.py
+++ b/conan/tools/cmake/layout.py
@@ -82,8 +82,20 @@ def get_build_folder_custom_vars(conanfile):
         else:
             build_vars = conanfile_vars or []
 
+    name = format_folder_vars_name(conanfile, build_vars,
+                                   "tools.cmake.cmake_layout:build_folder_vars")
+    user_defined_build = "settings.build_type" in build_vars
+    return name, user_defined_build
+
+
+def format_folder_vars_name(conanfile, folder_vars, conf_name):
+    """Resolve a list of 'settings.x'/'options.x'/'self.x'/'const.x' specs into a single
+    '-'-joined, lowercased name, dropping empty values. This is the grammar used by
+    'tools.cmake.cmake_layout:build_folder_vars'; it is shared by the build-folder layout and the
+    CMake preset name ('tools.cmake.cmaketoolchain:preset_name'). ``conf_name`` only feeds the
+    error message for an invalid entry."""
     ret = []
-    for s in build_vars:
+    for s in folder_vars:
         group, var = s.split(".", 1)
         tmp = None
         if group == "settings":
@@ -102,10 +114,8 @@ def get_build_folder_custom_vars(conanfile):
         elif group == "const":
             tmp = var
         else:
-            raise ConanException("Invalid 'tools.cmake.cmake_layout:build_folder_vars' value, it has"
-                                 f" to start with 'settings.', 'options.', 'self.' or 'const.': {s}")
+            raise ConanException(f"Invalid '{conf_name}' value, it has to start with 'settings.', "
+                                 f"'options.', 'self.' or 'const.': {s}")
         if tmp:
             ret.append(tmp.lower())
-
-    user_defined_build = "settings.build_type" in build_vars
-    return "-".join(ret), user_defined_build
+    return "-".join(ret)

--- a/conan/tools/cmake/presets.py
+++ b/conan/tools/cmake/presets.py
@@ -4,7 +4,7 @@ import platform
 import textwrap
 
 from conan.api.output import Color
-from conan.tools.cmake.layout import get_build_folder_custom_vars, is_consumer
+from conan.tools.cmake.layout import get_build_folder_custom_vars, is_consumer, format_folder_vars_name
 from conan.tools.cmake.toolchain.blocks import GenericSystemBlock
 from conan.tools.cmake.utils import is_multi_configuration
 from conan.tools.build import build_jobs
@@ -120,9 +120,17 @@ class _CMakePresets:
     def _configure_preset(conanfile, generator, cache_variables, toolchain_file, multiconfig,
                           preset_prefix, buildenv, cmake_executable):
         build_type = conanfile.settings.get_safe("build_type")
-        name = _CMakePresets._configure_preset_name(conanfile, multiconfig)
-        if preset_prefix:
-            name = f"{preset_prefix}-{name}"
+        custom_name = _CMakePresets._custom_preset_name(conanfile)
+        if custom_name and multiconfig:
+            conanfile.output.warning("tools.cmake.cmaketoolchain:preset_name is ignored "
+                                     "for multi-config generators")
+            custom_name = None
+        if custom_name:
+            name = custom_name
+        else:
+            name = _CMakePresets._configure_preset_name(conanfile, multiconfig)
+            if preset_prefix:
+                name = f"{preset_prefix}-{name}"
         if not multiconfig and build_type:
             cache_variables["CMAKE_BUILD_TYPE"] = build_type
         ret = {
@@ -199,11 +207,17 @@ class _CMakePresets:
     @staticmethod
     def _common_preset_fields(conanfile, multiconfig, preset_prefix):
         build_type = conanfile.settings.get_safe("build_type")
-        configure_preset_name = _CMakePresets._configure_preset_name(conanfile, multiconfig)
-        build_preset_name = _CMakePresets._build_and_test_preset_name(conanfile)
-        if preset_prefix:
-            configure_preset_name = f"{preset_prefix}-{configure_preset_name}"
-            build_preset_name = f"{preset_prefix}-{build_preset_name}"
+        custom_name = None if multiconfig else _CMakePresets._custom_preset_name(conanfile)
+        if custom_name:
+            # configure and build/test presets share the rendered name so that
+            # buildPresets[].configurePreset resolves to the existing configurePreset
+            configure_preset_name = build_preset_name = custom_name
+        else:
+            configure_preset_name = _CMakePresets._configure_preset_name(conanfile, multiconfig)
+            build_preset_name = _CMakePresets._build_and_test_preset_name(conanfile)
+            if preset_prefix:
+                configure_preset_name = f"{preset_prefix}-{configure_preset_name}"
+                build_preset_name = f"{preset_prefix}-{build_preset_name}"
         ret = {"name": build_preset_name, "configurePreset": configure_preset_name}
         if multiconfig:
             ret["configuration"] = build_type
@@ -256,6 +270,21 @@ class _CMakePresets:
             return "{}-{}".format(custom_conf, str(build_type).lower())
         else:
             return str(build_type).lower()
+
+    @staticmethod
+    def _custom_preset_name(conanfile):
+        # Build the full CMake preset name (no 'conan-' prefix) from the user-provided list of vars in
+        # 'tools.cmake.cmaketoolchain:preset_name', e.g. ['settings.compiler', 'settings.build_type'].
+        # Same grammar/formatting as 'tools.cmake.cmake_layout:build_folder_vars' (settings/options/
+        # self/const, lowercased, '-'-joined), but an independent conf so the preset name can differ
+        # from the build folder. Returns None when unset/empty -> the caller falls back to the default
+        # '<prefix>-<build_type>' naming. Single-config generators only.
+        preset_vars = conanfile.conf.get("tools.cmake.cmaketoolchain:preset_name", check_type=list)
+        if not preset_vars:
+            return None
+        name = format_folder_vars_name(conanfile, preset_vars,
+                                       "tools.cmake.cmaketoolchain:preset_name")
+        return name or None
 
 
 class _IncludingPresets:

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -585,6 +585,53 @@ def test_cmaketoolchain_asmflags():
     assert 'string(APPEND CMAKE_ASM_FLAGS_INIT " ${CONAN_ASM_FLAGS}")' in toolchain
 
 
+def test_cmaketoolchain_preset_name():
+    """tools.cmake.cmaketoolchain:preset_name builds the full CMake preset name (no 'conan-' prefix)
+    from a list of vars (same grammar as build_folder_vars), shared by the configure/build/test
+    presets and independent from the build folder (build_folder_vars)."""
+    profile = textwrap.dedent("""
+        [settings]
+        os=Linux
+        arch=x86_64
+        compiler=gcc
+        compiler.version=6
+        compiler.libcxx=libstdc++11
+        build_type=Release
+        [conf]
+        tools.cmake.cmaketoolchain:preset_name=['settings.compiler', 'settings.build_type']
+        tools.cmake.cmake_layout:build_folder_vars=['settings.arch']
+        """)
+    client = TestClient()
+    conanfile = GenConanfile().with_settings("os", "arch", "compiler", "build_type")\
+        .with_generator("CMakeToolchain")
+    client.save({"conanfile.py": conanfile, "profile": profile})
+
+    # preset_name and build_folder_vars are independent: the preset name is built from preset_name
+    # (compiler-build_type), NOT from build_folder_vars (arch).
+    client.run("install . -pr:h=profile")
+    presets = json.loads(client.load("CMakePresets.json"))
+    assert presets["configurePresets"][0]["name"] == "gcc-release"
+    assert presets["buildPresets"][0]["name"] == "gcc-release"
+    assert presets["buildPresets"][0]["configurePreset"] == "gcc-release"
+    assert presets["testPresets"][0]["configurePreset"] == "gcc-release"
+
+    # Without the conf, the default '<prefix>-<build_type>' naming is preserved (backward compat).
+    profile_default = textwrap.dedent("""
+        [settings]
+        os=Linux
+        arch=x86_64
+        compiler=gcc
+        compiler.version=6
+        compiler.libcxx=libstdc++11
+        build_type=Release
+        """)
+    client.save({"profile_default": profile_default})
+    client.run("install . -pr:h=profile_default")
+    presets = json.loads(client.load("CMakePresets.json"))
+    assert presets["configurePresets"][0]["name"] == "conan-release"
+    assert presets["buildPresets"][0]["name"] == "conan-release"
+
+
 def test_bitcode_enable_flag():
     profile = textwrap.dedent("""
         [settings]


### PR DESCRIPTION
## Summary

Adds a new `tools.cmake.cmaketoolchain:preset_name` conf that overrides the name of the generated CMake presets (configure/build/test) with a **list of settings/options** — the same grammar as `tools.cmake.cmake_layout:build_folder_vars` — e.g. `['settings.arch', 'settings.compiler', 'settings.build_type']` instead of the default `conan-<build_type>`.

The listed values are lowercased and `-`-joined into the full preset name (e.g. `x86_64-gcc-release`), with no `conan-` prefix. Each entry uses the existing `build_folder_vars` grammar:
- `settings.<name>` — any recipe setting (`compiler`, `build_type`, `arch`, nested such as `compiler.version`, and custom settings declared via `settings_user.yml`);
- `options.<name>` — a recipe option (`shared` → `shared`/`static`, others → `<name>_<value>`);
- `self.<attr>` — a `conanfile` attribute;
- `const.<literal>` — a literal string.

It is an **independent** conf: the preset name is decoupled from the build folder, so it may use a different set of vars than `build_folder_vars`.

## Motivation / use case

`tools.cmake.cmake_layout:build_folder_vars` already disambiguates build folders and derives the preset name from those same vars, but it (a) always prefixes `conan-`, and (b) couples the preset name to the build-folder name. Projects that build one recipe for many target/toolchain combinations (e.g. cross-compiling firmware, one tree per board/arch/compiler/build_type) want a preset name that is readable and unambiguous — `cmake --preset <arch>-<compiler>-<build_type>` — and possibly keyed off a different var set than the build folder. There is currently no way to customize it.

Rather than introduce a separate templating mechanism, this reuses the well-understood `build_folder_vars` grammar, so there is nothing new to learn.

## Behavior

- Opt-in: when the conf is unset, preset naming is byte-for-byte unchanged.
- Independent from `build_folder_vars`: when set, it overrides only the preset name; the build folder still follows `build_folder_vars`.
- Single-config generators only; for multi-config it is ignored with a warning (multi-config keeps one config-agnostic configure preset, so a per-config name would dangle).
- configure/build/test presets share the resulting name, so `buildPresets[].configurePreset` keeps resolving.

## Implementation

The `settings.x` / `options.x` / `self.x` / `const.x` → name resolution is factored out of `get_build_folder_custom_vars` into a shared `format_folder_vars_name()` helper, used by both the build-folder layout and the new preset name — no logic is duplicated.

Changelog: Feature: Add `tools.cmake.cmaketoolchain:preset_name` to customize the generated CMake preset names from a list of settings/options (same grammar as `tools.cmake.cmake_layout:build_folder_vars`).
Docs: Omit

- [X] Refer to the issue that supports this Pull Request.
- [X] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [X] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [X] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
