### PR TITLE
fix search pattern

### DIFF
--- a/conan/api/model/list.py
+++ b/conan/api/model/list.py
@@ -396,6 +396,11 @@ class ListPattern:
         if vrange:
             return str(RecipeReference(self.name, "*", self.user, self.channel))
         if "*" in self.ref or not self.version or (self.package_id is None and self.rrev is None):
+            # Normalize: if no version specified but user/channel is present, add explicit /*
+            # so remote servers (where * doesn't cross /) work correctly, e.g. *@myuser* -> */*@myuser*
+            if not self.version and self.user is not None:
+                user_channel = f"{self.user}/{self.channel}" if self.channel else self.user
+                return f"{self.name}/*@{user_channel}"
             return self.ref
 
     @property

--- a/test/unittests/cli/test_cli_ref_matching.py
+++ b/test/unittests/cli/test_cli_ref_matching.py
@@ -18,3 +18,23 @@ def test_list_pattern():
     with pytest.raises(ConanException) as e:
         ListPattern("*:*", only_recipe=True)
     assert "Do not specify 'package_id' with 'only-recipe'" in str(e.value)
+
+
+@pytest.mark.parametrize("pattern, search_ref", [
+    # Pattern with user but no version: normalize to include /* so remote servers work correctly
+    # (remote * doesn't cross / boundaries, so *@user* would fail to match name/ver@user*)
+    ("potato",        "potato"),
+    ("*@myuser*",        "*/*@myuser*"),
+    ("*@myuser/chan*",   "*/*@myuser/chan*"),
+    ("zlib@myuser",      "zlib/*@myuser"),
+    # Patterns with explicit version are returned unchanged
+    ("*/*@myuser*",      "*/*@myuser*"),
+    ("zlib/*@myuser",    "zlib/*@myuser"),
+    # Patterns without user are not affected
+    ("*",                "*"),
+    ("zlib/*",           "zlib/*"),
+    ("*@",               "*@"),  # trailing @ means filter no-user, not a user pattern
+])
+def test_search_ref_normalization(pattern, search_ref):
+    p = ListPattern(pattern)
+    assert p.search_ref == search_ref


### PR DESCRIPTION
Changelog: Fix: Fix Artifactory search patterns not matching `*@user/channel`, now requiring explicit `*/*@user/channel`.
Docs: Omit

Close https://github.com/conan-io/conan/issues/6857
