### PR TITLE
Fix replaced requirement not being an exact match

### DIFF
--- a/conan/internal/model/dependencies.py
+++ b/conan/internal/model/dependencies.py
@@ -102,6 +102,12 @@ class ConanFileDependencies(UserRequirementsDict):
                 existing = d[new_req]
                 added_req = new_req.copy_requirement()
                 added_req.ref = RecipeReference.loads(old_req)
+                # copy_requirement() doesn't propagate these, as they shouldn't transitively
+                # propagate downstream, but here we are aliasing the same requirement, not
+                # propagating it, so the traits must exactly match the replaced one
+                added_req.test = new_req.test
+                added_req.is_test = new_req.is_test
+                added_req.direct = new_req.direct
                 d[added_req] = existing
                 if new_req.ref.name == added_req.ref.name:
                     cant_be_removed.add(new_req)

--- a/test/integration/graph/test_replace_requires.py
+++ b/test/integration/graph/test_replace_requires.py
@@ -1007,11 +1007,16 @@ class TestReplaceRequiresCLIPriority:
 
 
 @pytest.mark.parametrize("replace", [True, False])
-def test_issue_with_requires(replace):
+@pytest.mark.parametrize("requires_first", [True, False])
+def test_replace_requires_cpp_info_requires_issue(replace, requires_first):
+    """ See https://github.com/conan-io/conan/issues/20138
+    A replace_require'ed divergent diamond structure like this used to give
+    a wrong error about cpp_info requires not being valid"""
     tc = TestClient(light=True)
 
     ref = "replaced" if replace else "common"
     profile = "include(default)\n[replace_requires]\nreplaced/*: common/1.0" if replace else "include(default)"
+    requires = 'self.requires("two/1.0")'
 
     conanfile = textwrap.dedent(f"""
     from conan import ConanFile
@@ -1019,8 +1024,9 @@ def test_issue_with_requires(replace):
         name = "consumer"
         version = "1.0"
         def requirements(self):
-            self.requires("two/1.0")
+            {requires if requires_first else ''}
             self.test_requires("{ref}/1.0")
+            {'' if requires_first else requires}
         def package_info(self):
             self.cpp_info.requires = ["two::two"]
     """)
@@ -1034,3 +1040,4 @@ def test_issue_with_requires(replace):
     tc.run("export one")
     tc.run("export two")
     tc.run("create -pr=profile -b=missing")
+    assert f"The direct dependency '{ref}' is not used" not in tc.out

--- a/test/integration/graph/test_replace_requires.py
+++ b/test/integration/graph/test_replace_requires.py
@@ -1004,3 +1004,33 @@ class TestReplaceRequiresCLIPriority:
         # CLI-specified pkg/1.0 must not be replaced by pkgng/1.0
         assert "Replaced requires" not in c.out
         c.assert_listed_require({"pkg/1.0": "Cache"})
+
+
+@pytest.mark.parametrize("replace", [True, False])
+def test_issue_with_requires(replace):
+    tc = TestClient(light=True)
+
+    ref = "replaced" if replace else "common"
+    profile = "include(default)\n[replace_requires]\nreplaced/*: common/1.0" if replace else "include(default)"
+
+    conanfile = textwrap.dedent(f"""
+    from conan import ConanFile
+    class Consumer(ConanFile):
+        name = "consumer"
+        version = "1.0"
+        def requirements(self):
+            self.requires("two/1.0")
+            self.test_requires("{ref}/1.0")
+        def package_info(self):
+            self.cpp_info.requires = ["two::two"]
+    """)
+
+    tc.save({"common/conanfile.py": GenConanfile("common", "1.0"),
+             "one/conanfile.py": GenConanfile("one", "1.0").with_requires(f"{ref}/1.0"),
+             "two/conanfile.py": GenConanfile("two", "1.0").with_requires("one/1.0"),
+             "conanfile.py": conanfile,
+             "profile": profile})
+    tc.run("create common")
+    tc.run("export one")
+    tc.run("export two")
+    tc.run("create -pr=profile -b=missing")


### PR DESCRIPTION
Changelog: Fix: Avoid a corner-case in component requires when `replace_requires` creates diamond divergent requirements.
Docs: Omit

Closes https://github.com/conan-io/conan/issues/20138