### PR TITLE
Add .tar.zst support to unzip()

### DIFF
--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -4,6 +4,7 @@ import stat
 import platform
 import shutil
 import subprocess
+import sys
 from typing import Optional
 from contextlib import contextmanager
 from fnmatch import fnmatch
@@ -375,7 +376,11 @@ def unzip(conanfile, filename, destination=".", keep_permissions=False, pattern=
     output.info(f"Uncompressing {filename} to {destination}")
     if (filename.endswith(".tar.gz") or filename.endswith(".tgz") or
             filename.endswith(".tbz2") or filename.endswith(".tar.bz2") or
-            filename.endswith(".tar")):
+            filename.endswith(".tar") or filename.endswith(".tar.xz") or
+            filename.endswith(".txz") or filename.endswith(".tar.zst")):
+        if filename.endswith(".tar.zst") and sys.version_info.minor < 14:
+            raise ConanException(f"File {os.path.basename(filename)} compressed with 'zst', "
+                                 f"unsupported for Python<3.14 ")
         return untargz(filename, destination, pattern, strip_root, extract_filter,
                        excludes=excludes)
     if filename.endswith(".gz"):
@@ -387,9 +392,6 @@ def unzip(conanfile, filename, destination=".", keep_permissions=False, pattern=
             with open(target_name, "wb") as fout:
                 shutil.copyfileobj(fin, fout)
         return
-    if filename.endswith(".tar.xz") or filename.endswith(".txz"):
-        return untargz(filename, destination, pattern, strip_root, extract_filter,
-                       excludes=excludes)
 
     import zipfile
     full_path = os.path.normpath(os.path.join(os.getcwd(), destination))

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -374,11 +374,8 @@ def unzip(conanfile, filename, destination=".", keep_permissions=False, pattern=
     output = conanfile.output
     extract_filter = conanfile.conf.get("tools.files.unzip:filter") or extract_filter
     output.info(f"Uncompressing {filename} to {destination}")
-    if (filename.endswith(".tar.gz") or filename.endswith(".tgz") or
-            filename.endswith(".tbz2") or filename.endswith(".tar.bz2") or
-            filename.endswith(".tar") or filename.endswith(".tar.xz") or
-            filename.endswith(".txz") or filename.endswith(".tar.zst")):
-        if filename.endswith(".tar.zst") and sys.version_info.minor < 14:
+    if (filename.endswith((".tar.gz", ".tgz", ".tbz2", ".tar.bz2", ".tar", ".tar.xz", ".txz", ".tar.zst", ".tzst"))):
+        if filename.endswith((".tar.zst", ".tzst")) and sys.version_info.minor < 14:
             raise ConanException(f"File {os.path.basename(filename)} compressed with 'zst', "
                                  f"unsupported for Python<3.14 ")
         return untargz(filename, destination, pattern, strip_root, extract_filter,

--- a/test/unittests/tools/files/test_zipping.py
+++ b/test/unittests/tools/files/test_zipping.py
@@ -194,11 +194,11 @@ def test_untargz_zst():
 def test_untargz_zst_unsupported_python():
     # Fake a .tar.zst, the version check happens before any decompression is attempted
     archive = create_example_tar()
-    zst_archive = join(os.path.dirname(archive), "file.tar.zst")
+    zst_archive = join(os.path.dirname(archive), "file.tzst")
     os.rename(archive, zst_archive)
 
     conanfile = ConanFileMock({})
     dest_dir = temp_folder()
     with pytest.raises(ConanException) as error:
         unzip(conanfile, zst_archive, dest_dir)
-    assert "File file.tar.zst compressed with 'zst', unsupported for Python<3.14" in str(error.value)
+    assert "File file.tzst compressed with 'zst', unsupported for Python<3.14" in str(error.value)

--- a/test/unittests/tools/files/test_zipping.py
+++ b/test/unittests/tools/files/test_zipping.py
@@ -1,3 +1,5 @@
+import os
+import sys
 import zipfile
 import tarfile
 from os.path import join, exists
@@ -171,3 +173,32 @@ def test_untargz_with_strip_root_and_pattern():
     unzip(conanfile, archive, dest_dir, pattern="src/*", strip_root=True)
     assert exists(join(dest_dir, "bar.txt"))
     assert not exists(join(dest_dir, "foo.txt"))
+
+
+@pytest.mark.skipif(sys.version_info.minor < 14, reason="zstd needs Python >= 3.14")
+def test_untargz_zst():
+    tmp_dir = temp_folder()
+    tar_path = join(tmp_dir, "file.tar.zst")
+    foo_txt = join(tmp_dir, "foo.txt")
+    save(foo_txt, "foo-content")
+    with tarfile.open(tar_path, "w:zst") as tar:
+        tar.add(foo_txt, "foo.txt")
+
+    conanfile = ConanFileMock({})
+    dest_dir = temp_folder()
+    unzip(conanfile, tar_path, dest_dir)
+    assert exists(join(dest_dir, "foo.txt"))
+
+
+@pytest.mark.skipif(sys.version_info.minor >= 14, reason="validate zstd error in python<3.14")
+def test_untargz_zst_unsupported_python():
+    # Fake a .tar.zst, the version check happens before any decompression is attempted
+    archive = create_example_tar()
+    zst_archive = join(os.path.dirname(archive), "file.tar.zst")
+    os.rename(archive, zst_archive)
+
+    conanfile = ConanFileMock({})
+    dest_dir = temp_folder()
+    with pytest.raises(ConanException) as error:
+        unzip(conanfile, zst_archive, dest_dir)
+    assert "File file.tar.zst compressed with 'zst', unsupported for Python<3.14" in str(error.value)


### PR DESCRIPTION
Changelog: Feature: Add `.tar.zst` (Zstandard) archive support to the `unzip()` tool function.
Docs: omit

When creating a [recipe](https://github.com/conan-io/cuda-conan/pull/22/changes#diff-55c9a4bca15d474cc732c25c8a9a0793a4a520174e989fb702accc368acb2753) (currently private) for `tensorrt`, I found that Conan was not yet capable of unziping (from `get()` method) `.tar.zst` compressed files.

This PR simple redirects `.tar.zst` files to `untargz` Python's function, protecting it from Python <3.14 versions, same as we did in https://github.com/conan-io/conan/pull/19337.

Also, I've folded .tar.xz/.txz into the main tar-format check.
It used to live in its own if block only because it carried a Python 2 guard (#3197).
That guard was removed in #8397 when Python 2 support was dropped, but the block was never merged back.
**No behavior change, just removing dead structure while touching this code for .tar.zst support**