### PR TITLE
[Bugfix] ConanFileDependencies.from_node: fix for non-applying replace_requires

### DIFF
--- a/conan/internal/model/dependencies.py
+++ b/conan/internal/model/dependencies.py
@@ -98,6 +98,9 @@ class ConanFileDependencies(UserRequirementsDict):
         if node.replaced_requires:
             cant_be_removed = set()
             for old_req, new_req in node.replaced_requires.items():
+                # skip replace_requires that do not apply to this node
+                if new_req not in d:
+                    continue
                 # Two different replaced_requires can point to the same real requirement
                 existing = d[new_req]
                 added_req = new_req.copy_requirement()

--- a/conan/internal/model/dependencies.py
+++ b/conan/internal/model/dependencies.py
@@ -98,11 +98,11 @@ class ConanFileDependencies(UserRequirementsDict):
         if node.replaced_requires:
             cant_be_removed = set()
             for old_req, new_req in node.replaced_requires.items():
-                # skip replace_requires that do not apply to this node
-                if new_req not in d:
-                    continue
                 # Two different replaced_requires can point to the same real requirement
-                existing = d[new_req]
+                try:
+                    existing = d[new_req]
+                except KeyError:
+                    continue  # skip replace_requires that do not apply to this node (override=True)
                 added_req = new_req.copy_requirement()
                 added_req.ref = RecipeReference.loads(old_req)
                 # copy_requirement() doesn't propagate these, as they shouldn't transitively

--- a/test/integration/graph/test_replace_requires.py
+++ b/test/integration/graph/test_replace_requires.py
@@ -1004,3 +1004,27 @@ class TestReplaceRequiresCLIPriority:
         # CLI-specified pkg/1.0 must not be replaced by pkgng/1.0
         assert "Replaced requires" not in c.out
         c.assert_listed_require({"pkg/1.0": "Cache"})
+
+
+def test_replace_requires_unused_override():
+    c = TestClient(light=True)
+    conanfile = textwrap.dedent("""
+    from conan import ConanFile
+
+    class Test(ConanFile):
+
+        def requirements(self):
+            self.requires("openssl/1.0")
+            self.requires("zlib/1.0", override=True)
+
+        def generate(self):
+            self.dependencies["openssl"]
+
+    """)
+    c.save({"zlib/conanfile.py": GenConanfile("zlib", "1.0"),
+            "openssl/conanfile.py": GenConanfile("openssl", "1.0"),
+            "conanfile.py": conanfile,
+            "profile": "include(default)\n[replace_requires]\nzlib/*: zlib/1.0"})
+    c.run("create zlib")
+    c.run("create openssl")
+    c.run("install -pr=profile")

--- a/test/integration/graph/test_replace_requires.py
+++ b/test/integration/graph/test_replace_requires.py
@@ -1006,28 +1006,32 @@ class TestReplaceRequiresCLIPriority:
         c.assert_listed_require({"pkg/1.0": "Cache"})
 
 
-def test_replace_requires_unused_override():
-    c = TestClient(light=True)
-    conanfile = textwrap.dedent("""
-    from conan import ConanFile
+class TestReplaceRequiresRecipeOverride:
+    def test_unused_override(self):
+        c = TestClient(light=True)
+        c.save({"zlib/conanfile.py": GenConanfile("zlib", "1.0"),
+                "openssl/conanfile.py": GenConanfile("openssl", "1.0"),
+                "conanfile.py": GenConanfile().with_requirement("openssl/1.0")
+                                              .with_requirement("zlib/1.0", override=True),
+                "profile": "include(default)\n[replace_requires]\nzlib/*: zlib/1.0"})
+        c.run("create zlib")
+        c.run("create openssl")
+        c.run("install -pr=profile")
+        # it doesn't fail
 
-    class Test(ConanFile):
-
-        def requirements(self):
-            self.requires("openssl/1.0")
-            self.requires("zlib/1.0", override=True)
-
-        def generate(self):
-            self.dependencies["openssl"]
-
-    """)
-    c.save({"zlib/conanfile.py": GenConanfile("zlib", "1.0"),
-            "openssl/conanfile.py": GenConanfile("openssl", "1.0"),
-            "conanfile.py": conanfile,
-            "profile": "include(default)\n[replace_requires]\nzlib/*: zlib/1.0"})
-    c.run("create zlib")
-    c.run("create openssl")
-    c.run("install -pr=profile")
+    def test_replace_requires_override_priority(self):
+        # the profile replace_requires has more priority
+        c = TestClient(light=True)
+        c.save({"zlib/conanfile.py": GenConanfile("zlib"),
+                "openssl/conanfile.py": GenConanfile("openssl", "1.0").with_requires("zlib/1.0"),
+                "conanfile.py": GenConanfile().with_requirement("openssl/1.0")
+                                              .with_requirement("zlib/1.1", override=True),
+                "profile": "include(default)\n[replace_requires]\nzlib/*: zlib/1.0"})
+        c.run("create zlib --version=1.0")
+        c.run("create zlib --version=1.1")
+        c.run("create openssl")
+        c.run("install -pr=profile")
+        c.assert_listed_require({"zlib": ("1.0", "Cache")})
 
 
 @pytest.mark.parametrize("replace", [True, False])


### PR DESCRIPTION
Changelog: Bugfix: Fix crash in `replace_requires` when the graph had an override to a replaced requirement that did not apply.
Docs: Omit

For details and minimal example, see linked issue

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.

Attempts to fix #20145
