### PR TITLE
Fix deprecation warning when building with emscripten 6.0.1 or higher

### DIFF
--- a/conan/tools/build/flags.py
+++ b/conan/tools/build/flags.py
@@ -83,6 +83,15 @@ def architecture_flag(conanfile):
                 "e2k-v7": "-march=elbrus-v7"}.get(arch, "")
     elif compiler == "emcc":
         if arch == "wasm64":
+            # Emscripten 6.0.0 added the standard `-m64` flag as an alias for
+            # the legacy `-sMEMORY64` setting (emscripten-core/emscripten#26765),
+            # and 6.0.1 deprecated `-sMEMORY64` in favor of it (#27025), which
+            # makes emcc emit a deprecation warning on every compile and link
+            # invocation. Prefer `-m64` on toolchains that understand it, and
+            # fall back to `-sMEMORY64=1` on older Emscripten that does not.
+            compiler_version = settings.get_safe("compiler.version")
+            if compiler_version and Version(compiler_version) >= "6.0.0":
+                return "-m64"
             return "-sMEMORY64=1"
     return ""
 

--- a/conan/tools/build/flags.py
+++ b/conan/tools/build/flags.py
@@ -84,11 +84,8 @@ def architecture_flag(conanfile):
     elif compiler == "emcc":
         if arch == "wasm64":
             # Emscripten 6.0.0 added the standard `-m64` flag as an alias for
-            # the legacy `-sMEMORY64` setting (emscripten-core/emscripten#26765),
-            # and 6.0.1 deprecated `-sMEMORY64` in favor of it (#27025), which
-            # makes emcc emit a deprecation warning on every compile and link
-            # invocation. Prefer `-m64` on toolchains that understand it, and
-            # fall back to `-sMEMORY64=1` on older Emscripten that does not.
+            # the legacy `-sMEMORY64` setting and 6.0.1 deprecated `-sMEMORY64`
+            # in favor of it, which makes emcc emit a deprecation warning.
             compiler_version = settings.get_safe("compiler.version")
             if compiler_version and Version(compiler_version) >= "6.0.0":
                 return "-m64"

--- a/test/unittests/client/build/compiler_flags_test.py
+++ b/test/unittests/client/build/compiler_flags_test.py
@@ -83,6 +83,16 @@ class TestCompilerFlags:
         conanfile.settings = settings
         assert architecture_flag(conanfile) == "--target=arm64-apple-ios13.1-macabi"
 
+    def test_arch_flag_emcc(self):
+        settings = {"compiler": "emcc", "arch": "wasm64", "compiler.version": "5.0"}
+        conanfile = ConanFileMock()
+        conanfile.settings = MockSettings(settings)
+        assert architecture_flag(conanfile) == "-sMEMORY64=1"
+        settings["compiler.version"] = "6.0"
+        conanfile = ConanFileMock()
+        conanfile.settings = MockSettings(settings)
+        assert architecture_flag(conanfile) == "-m64"
+
     @pytest.mark.parametrize("os_,arch,flag",
                              [("Linux", "x86", "-m32"),
                               ("Linux", "x86_64", "-m64"),


### PR DESCRIPTION
Changelog: Fix: Fix deprecation warning for emcc/em++ >= 6.0.1, changing ``-sMEMORY64`` flag with the modern ``-m64`` one.
Docs: Omit

When building with em++/emcc 6.0.1 or higher you'll get this deprecation warning constantly:
`em++: warning: MEMORY64 is deprecated (prefer the standard -m64 or --target=wasm64 flags). Please open a bug if you have a continuing need for this setting [-Wdeprecated]`

Version 6 introduced the standard `-m64` flag, which other compilers also use, so I changed to code to prefer this setting for versions starting with 6.0.0. See https://github.com/emscripten-core/emscripten/blob/main/ChangeLog.md#600---060426
6.0.1 then deprecated the old `-sMEMORY64` flag: https://github.com/emscripten-core/emscripten/blob/main/ChangeLog.md#601---062226 this is why a warning is emitted.