### PR TITLE
Raise an exception when layout() fails in the Docker runner

### DIFF
--- a/conan/internal/runner/docker.py
+++ b/conan/internal/runner/docker.py
@@ -15,6 +15,7 @@ from conan.errors import ConanException
 from pathlib import Path
 from conan.internal.model.profile import Profile
 from conan.internal.model.version import Version
+from conan.internal.errors import conanfile_exception_formatter
 from conan.internal.runner.output import RunnerOutput
 
 
@@ -252,19 +253,15 @@ class DockerRunner:
         # In this case, mount the root folder as the base path and update the abs_docker_path to the
         # new relative path
         if hasattr(conanfile, "layout"):
-            try:
+            with conanfile_exception_formatter(conanfile, "layout"):
                 conanfile.layout()
-                if conanfile.folders.root:
-                    abs_path = self._get_abs_host_path(conanfile.folders.root)
-                    if self.abs_host_path.is_relative_to(abs_path):
-                        abs_docker_base_path /= abs_path.name
-                        volumes = {abs_path: {'bind': abs_docker_base_path.as_posix(), 'mode': 'rw'}}
-                        abs_docker_path = abs_docker_base_path / self.abs_host_path.relative_to(abs_path)
-                        return volumes, abs_docker_path.as_posix()
-            except Exception as e:
-                self.logger.warning(
-                    f"Could not evaluate layout() for Docker volume mounts. (Using default mount):\n\n{e}."
-                )
+            if conanfile.folders.root:
+                abs_path = self._get_abs_host_path(conanfile.folders.root)
+                if self.abs_host_path.is_relative_to(abs_path):
+                    abs_docker_base_path /= abs_path.name
+                    volumes = {abs_path: {'bind': abs_docker_base_path.as_posix(), 'mode': 'rw'}}
+                    abs_docker_path = abs_docker_base_path / self.abs_host_path.relative_to(abs_path)
+                    return volumes, abs_docker_path.as_posix()
         abs_docker_path = (abs_docker_base_path / self.abs_host_path.name).as_posix()
         volumes = {self.abs_host_path: {'bind': abs_docker_path, 'mode': 'rw'}}
         return volumes, abs_docker_path

--- a/conan/internal/runner/docker.py
+++ b/conan/internal/runner/docker.py
@@ -261,8 +261,10 @@ class DockerRunner:
                         volumes = {abs_path: {'bind': abs_docker_base_path.as_posix(), 'mode': 'rw'}}
                         abs_docker_path = abs_docker_base_path / self.abs_host_path.relative_to(abs_path)
                         return volumes, abs_docker_path.as_posix()
-            except:
-                pass
+            except Exception as e:
+                self.logger.warning(
+                    f"Could not evaluate layout() for Docker volume mounts. (Using default mount):\n\n{e}."
+                )
         abs_docker_path = (abs_docker_base_path / self.abs_host_path.name).as_posix()
         volumes = {self.abs_host_path: {'bind': abs_docker_path, 'mode': 'rw'}}
         return volumes, abs_docker_path

--- a/conan/internal/runner/docker.py
+++ b/conan/internal/runner/docker.py
@@ -7,7 +7,7 @@ import shutil
 from typing import Optional, NamedTuple, Dict, List
 import yaml
 from conan.api.conan_api import ConanAPI
-from conan.api.model import ListPattern
+from conan.api.model import ListPattern, RecipeReference
 from conan.api.output import Color, ConanOutput
 from conan.cli import make_abs_path
 from conan.internal.runner import RunnerException
@@ -16,6 +16,8 @@ from pathlib import Path
 from conan.internal.model.profile import Profile
 from conan.internal.model.version import Version
 from conan.internal.errors import conanfile_exception_formatter
+from conan.internal.graph.graph import CONTEXT_HOST
+from conan.internal.graph.profile_node_definer import initialize_conanfile_profile
 from conan.internal.runner.output import RunnerOutput
 
 
@@ -82,6 +84,7 @@ class DockerRunner:
         self.docker_client = self._initialize_docker_client()
         self.docker_api = self.docker_client.api
         self.conan_api = conan_api
+        self.host_profile = host_profile
         self.build_profile = build_profile
         self.abs_host_path = self._get_abs_host_path(args.path)
         self.args = args
@@ -248,6 +251,11 @@ class DockerRunner:
         loader = self.conan_api._api_helpers.loader  # noqa
         remotes = self.conan_api.remotes.list(self.args.remote) if not self.args.no_remote else []
         conanfile = loader.load_consumer(self.abs_host_path / "conanfile.py", remotes=remotes)
+        ref = RecipeReference(conanfile.name, conanfile.version, conanfile.user, conanfile.channel)
+        initialize_conanfile_profile(conanfile, self.build_profile, self.host_profile,
+                                     CONTEXT_HOST, False, ref)
+        if ref.name:
+            self.host_profile.options.scope(ref)
         abs_docker_base_path = Path('/') / self.docker_user_name / 'conanrunner'
         # Check if recipe has defined a root folder
         # In this case, mount the root folder as the base path and update the abs_docker_path to the

--- a/test/functional/command/runner_test.py
+++ b/test/functional/command/runner_test.py
@@ -731,7 +731,7 @@ def test_create_docker_runner_broken_layout_warns():
         '        raise RuntimeError("broken layout")',
     )
     client.save({"conanfile.py": conanfile})
-    client.run("create . -pr:h host -pr:b build")
+    client.run("create . -pr:h host -pr:b build", assert_error=True)
 
     assert "Could not evaluate layout() for Docker volume mounts" in client.out
-    assert "[100%] Built target example" in client.out
+    assert "Using default mount." in client.out

--- a/test/functional/command/runner_test.py
+++ b/test/functional/command/runner_test.py
@@ -734,4 +734,4 @@ def test_create_docker_runner_broken_layout_warns():
     client.run("create . -pr:h host -pr:b build", assert_error=True)
 
     assert "Could not evaluate layout() for Docker volume mounts" in client.out
-    assert "Using default mount." in client.out
+    assert "(Using default mount)" in client.out

--- a/test/functional/command/runner_test.py
+++ b/test/functional/command/runner_test.py
@@ -687,3 +687,51 @@ def test_create_docker_runner_in_subfolder():
 
     assert "Restore: pkg/1.0" in client.out
     assert "Removing container" in client.out
+
+
+@pytest.mark.docker_runner
+@pytest.mark.skipif(docker_skip(), reason="Only docker running")
+def test_create_docker_runner_broken_layout_warns():
+    # https://github.com/conan-io/conan/issues/20143
+    client = TestClient()
+    profile_build = textwrap.dedent(f"""\
+    [settings]
+    arch={{{{ detect_api.detect_arch() }}}}
+    build_type=Release
+    compiler=gcc
+    compiler.cppstd=gnu17
+    compiler.libcxx=libstdc++11
+    compiler.version=11
+    os=Linux
+    """)
+
+    profile_host = textwrap.dedent(f"""\
+    [settings]
+    arch={{{{ detect_api.detect_arch() }}}}
+    build_type=Release
+    compiler=gcc
+    compiler.cppstd=gnu17
+    compiler.libcxx=libstdc++11
+    compiler.version=11
+    os=Linux
+    [runner]
+    type=docker
+    dockerfile={dockerfile_path()}
+    build_context={conan_base_path()}
+    image=conan-runner-default-test
+    cache=shared
+    remove=True
+    """)
+
+    client.save({"host": profile_host, "build": profile_build})
+    client.run("new cmake_lib -d name=pkg -d version=0.2")
+    conanfile = client.load("conanfile.py")
+    conanfile = conanfile.replace(
+        "        cmake_layout(self)",
+        '        raise RuntimeError("broken layout")',
+    )
+    client.save({"conanfile.py": conanfile})
+    client.run("create . -pr:h host -pr:b build")
+
+    assert "Could not evaluate layout() for Docker volume mounts" in client.out
+    assert "[100%] Built target example" in client.out

--- a/test/functional/command/runner_test.py
+++ b/test/functional/command/runner_test.py
@@ -691,7 +691,7 @@ def test_create_docker_runner_in_subfolder():
 
 @pytest.mark.docker_runner
 @pytest.mark.skipif(docker_skip(), reason="Only docker running")
-def test_create_docker_runner_broken_layout_warns():
+def test_create_docker_runner_broken_layout_fails():
     # https://github.com/conan-io/conan/issues/20143
     client = TestClient()
     profile_build = textwrap.dedent(f"""\
@@ -733,5 +733,5 @@ def test_create_docker_runner_broken_layout_warns():
     client.save({"conanfile.py": conanfile})
     client.run("create . -pr:h host -pr:b build", assert_error=True)
 
-    assert "Could not evaluate layout() for Docker volume mounts" in client.out
-    assert "(Using default mount)" in client.out
+    assert "Error in layout() method" in client.out
+    assert "broken layout" in client.out


### PR DESCRIPTION
Changelog: Bugfix: Raise an exception when `layout()` fails in the Docker runner.
Docs: omit
