### PR TITLE
Assert invalid parameters in ConanFile.run() method

### DIFF
--- a/conan/internal/model/conan_file.py
+++ b/conan/internal/model/conan_file.py
@@ -387,7 +387,7 @@ class ConanFile:
             order to source files)
         :parameter scope: The scope of the command, either ``"build"`` or ``"run"``.
         """
-        assert env is None or shell, "ConanFile.run(..., shell=False) needs env=False"
+        assert env is None or shell, "ConanFile.run(..., shell=False) needs env=None"
         assert isinstance(command, str), (
             "ConanFile.run() requires command to be a string.\n"
             "Tip: use ' '.join(f'\"{arg}\"' for arg in args) to format your parameter list"

--- a/conan/internal/model/conan_file.py
+++ b/conan/internal/model/conan_file.py
@@ -368,7 +368,7 @@ class ConanFile:
             shell=True, scope="build", stderr=None):
         """ Run a command in the current package context.
 
-        :parameter command: The command to run.
+        :parameter command: The command to run formatted as a plain string
         :parameter stdout: The output stream to write the command output. If ``None``, it defaults to
             the standard output stream.
         :parameter stderr: The error output stream to write the command error output. If ``None``,
@@ -383,8 +383,16 @@ class ConanFile:
         :parameter quiet: If ``True``, suppress the output of the command.
         :parameter shell: If ``True``, run the command in a shell. This is passed to the
             underlying ``Popen`` function.
+            If set to ``False``, ``env`` parameter should be set to ``None`` (a shell is needed in
+            order to source files)
         :parameter scope: The scope of the command, either ``"build"`` or ``"run"``.
         """
+        assert env is None or shell, "ConanFile.run(..., shell=False) needs env=False"
+        assert isinstance(command, str), (
+            "ConanFile.run() requires command to be a string.\n"
+            "Tip: use ' '.join(f'\"{arg}\"' for arg in args) to format your parameter list"
+        )
+
         # NOTE: "self.win_bash" is the new parameter "win_bash" for Conan 2.0
         command = self._conan_helpers.cmd_wrapper.wrap(command, conanfile=self)
         if env == "":  # This default allows not breaking for users with ``env=None`` indicating

--- a/test/integration/conanfile/runner_test.py
+++ b/test/integration/conanfile/runner_test.py
@@ -59,3 +59,27 @@ class Pkg(ConanFile):
         client.save({"conanfile.py": conanfile})
         client.run("source .")
         assert 'conanfile.py: Buffer got stderr msgs Hello' in client.out
+
+    def test_run_command_not_a_string(self):
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            class Pkg(ConanFile):
+                def source(self):
+                    self.run(["echo", "Hello"])
+            """)
+        client = TestClient()
+        client.save({"conanfile.py": conanfile})
+        client.run("source", assert_error=True)
+        assert "ConanFile.run() requires command to be a string" in client.out
+
+    def test_run_shell_false_with_env(self):
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            class Pkg(ConanFile):
+                def source(self):
+                    self.run("echo Hello", shell=False, env="conanbuild")
+            """)
+        client = TestClient()
+        client.save({"conanfile.py": conanfile})
+        client.run("source", assert_error=True)
+        assert "ConanFile.run(..., shell=False) needs env=False" in client.out

--- a/test/integration/conanfile/runner_test.py
+++ b/test/integration/conanfile/runner_test.py
@@ -82,4 +82,5 @@ class Pkg(ConanFile):
         client = TestClient(light=True)
         client.save({"conanfile.py": conanfile})
         client.run("source", assert_error=True)
-        assert "ConanFile.run(..., shell=False) needs env=False" in client.out
+        print(client.out)
+        assert "ConanFile.run(..., shell=False) needs env=None" in client.out

--- a/test/integration/conanfile/runner_test.py
+++ b/test/integration/conanfile/runner_test.py
@@ -67,7 +67,7 @@ class Pkg(ConanFile):
                 def source(self):
                     self.run(["echo", "Hello"])
             """)
-        client = TestClient()
+        client = TestClient(light=True)
         client.save({"conanfile.py": conanfile})
         client.run("source", assert_error=True)
         assert "ConanFile.run() requires command to be a string" in client.out
@@ -79,7 +79,7 @@ class Pkg(ConanFile):
                 def source(self):
                     self.run("echo Hello", shell=False, env="conanbuild")
             """)
-        client = TestClient()
+        client = TestClient(light=True)
         client.save({"conanfile.py": conanfile})
         client.run("source", assert_error=True)
         assert "ConanFile.run(..., shell=False) needs env=False" in client.out


### PR DESCRIPTION
Changelog: Feature: Assert invalid parameters in `ConanFile.run()` method.
Docs: omit

Fix https://github.com/conan-io/conan/issues/20141
