### PR TITLE
Populate download cache on upload

### DIFF
--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -46,7 +46,9 @@ BUILT_IN_CONFS = {
     "core.download:parallel": "Number of concurrent threads to download packages",
     "core.download:retry": " (int, default: 2) Number of retries in case of failure when downloading from Conan server",
     "core.download:retry_wait": "(int, default: 1s) Seconds to wait between download attempts from Conan server",
-    "core.download:download_cache": "Define path to a file download cache",
+    "core.download:download_cache": "Define path to a file download cache. Files uploaded to a "
+                                    "server are also stored here, so a later download of the same "
+                                    "artifact can be skipped",
     "core.cache:storage_path": "Absolute path where the packages and database are stored",
     "core:update_policy": "(Legacy). If equal 'legacy' when multiple remotes, update based on order of remotes, only the timestamp of the first occurrence of each revision counts.",
     "core:policies": policies_msg,

--- a/conan/internal/rest/download_cache.py
+++ b/conan/internal/rest/download_cache.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import os
+import shutil
 from contextlib import contextmanager
 from threading import Lock
 
@@ -8,7 +9,7 @@ import fasteners
 
 from conan.errors import ConanException
 from conan.internal.util.dates import timestamp_now
-from conan.internal.util.files import load, save, remove_if_dirty
+from conan.internal.util.files import load, save, remove_if_dirty, set_dirty_context_manager
 
 
 class DownloadCache:
@@ -32,6 +33,15 @@ class DownloadCache:
         md.update(url.encode())
         h = md.hexdigest()
         return os.path.join(self._path, self._CONAN_CACHE, h), h
+
+    def cache_file(self, url, src_path):
+        """ Store a local file in the cache under the same key a download() of ``url`` would use"""
+        cached_path, h = self.cached_path(url)
+        with self.lock(h):
+            remove_if_dirty(cached_path)
+            if not os.path.exists(cached_path):
+                with set_dirty_context_manager(cached_path):
+                    shutil.copy2(src_path, cached_path)
 
     _thread_locks = {}  # Needs to be shared among all instances
 

--- a/conan/internal/rest/rest_client_v2.py
+++ b/conan/internal/rest/rest_client_v2.py
@@ -9,9 +9,11 @@ from requests.auth import AuthBase, HTTPBasicAuth
 from uuid import getnode as get_mac
 
 from conan.api.output import ConanOutput
+from conan.internal.cache.conan_reference_layout import METADATA
 from conan.internal.paths import EXPORT_SOURCES_FILE_NAME, CONANINFO, CONAN_MANIFEST, \
     EXPORT_FILE_NAME, PACKAGE_FILE_NAME
 from conan.internal.rest.caching_file_downloader import ConanInternalCacheDownloader
+from conan.internal.rest.download_cache import DownloadCache
 from conan.internal.rest import response_to_str
 from conan.internal.rest.client_routes import ClientV2Router
 from conan.internal.rest.file_uploader import FileUploader
@@ -285,6 +287,7 @@ class RestV2Methods:
     def _upload_files(self, files, urls, ref):
         failed = []
         uploader = FileUploader(self.requester, self.verify_ssl, self._config)
+        download_cache = self._get_download_cache()
         # conan_package.tgz and conan_export.tgz are uploaded first to avoid uploading conaninfo.txt
         # or conanamanifest.txt with missing files due to a network failure
         for filename in sorted(files):
@@ -299,10 +302,28 @@ class RestV2Methods:
                 ConanOutput().error(f"\nError uploading file: {filename}, '{exc}'",
                                     error_type="exception")
                 failed.append(filename)
+            else:
+                # metadata files are mutable without a new revision, ConanInternalCacheDownloader
+                # never serves them from the cache either, so don't populate it here
+                if download_cache is not None and not filename.startswith(f"{METADATA}/"):
+                    self._populate_download_cache(download_cache, resource_url, files[filename])
 
         if failed:
             raise ConanException("Execute upload again to retry upload the failed files: %s"
                                  % ", ".join(failed))
+
+    def _get_download_cache(self):
+        download_cache_folder = self._config.get("core.download:download_cache")
+        if download_cache_folder and os.path.isabs(download_cache_folder):
+            return DownloadCache(download_cache_folder)
+        return None
+
+    @staticmethod
+    def _populate_download_cache(download_cache, url, src_path):
+        try:
+            download_cache.cache_file(url, src_path)
+        except Exception as e:
+            ConanOutput().warning(f"Could not store the uploaded file in the download cache: {e}")
 
     def _download_and_save_files(self, urls, dest_folder, files, parallel=False, scope=None,
                                  metadata=False):

--- a/conan/internal/rest/rest_client_v2.py
+++ b/conan/internal/rest/rest_client_v2.py
@@ -306,7 +306,7 @@ class RestV2Methods:
                 # metadata files are mutable without a new revision, ConanInternalCacheDownloader
                 # never serves them from the cache either, so don't populate it here
                 if download_cache is not None and not filename.startswith(f"{METADATA}/"):
-                    self._populate_download_cache(download_cache, resource_url, files[filename])
+                    download_cache.cache_file(resource_url, files[filename])
 
         if failed:
             raise ConanException("Execute upload again to retry upload the failed files: %s"
@@ -314,16 +314,11 @@ class RestV2Methods:
 
     def _get_download_cache(self):
         download_cache_folder = self._config.get("core.download:download_cache")
-        if download_cache_folder and os.path.isabs(download_cache_folder):
-            return DownloadCache(download_cache_folder)
-        return None
-
-    @staticmethod
-    def _populate_download_cache(download_cache, url, src_path):
-        try:
-            download_cache.cache_file(url, src_path)
-        except Exception as e:
-            ConanOutput().warning(f"Could not store the uploaded file in the download cache: {e}")
+        if not download_cache_folder:
+            return None
+        if not os.path.isabs(download_cache_folder):
+            raise ConanException("core.download:download_cache must be an absolute path")
+        return DownloadCache(download_cache_folder)
 
     def _download_and_save_files(self, urls, dest_folder, files, parallel=False, scope=None,
                                  metadata=False):

--- a/test/integration/cache/download_cache_test.py
+++ b/test/integration/cache/download_cache_test.py
@@ -158,3 +158,70 @@ class TestDownloadCache:
         c.save_home({"global.conf": f"core.download:download_cache=mytmp_folder"})
         c.run("install --requires=mypkg/0.1@user/testing", assert_error=True)
         assert 'core.download:download_cache must be an absolute path' in c.out
+
+    def test_upload_populates_download_cache(self):
+        """ uploading with a download cache configured leaves the uploaded files in the cache
+        too, so a later download of the same artifacts doesn't hit the network at all
+        """
+        client = TestClient(default_server_user=True)
+        # generate large random package file, like in test_download_skip, to get the
+        # "from download cache" trace, only emitted for files > 10MB
+        conanfile = textwrap.dedent("""
+            import os
+            from conan import ConanFile
+            class Pkg(ConanFile):
+                def package(self):
+                    fileSizeInBytes = 11000000
+                    with open(os.path.join(self.package_folder, "data.txt"), 'wb') as fout:
+                        fout.write(os.urandom(fileSizeInBytes))
+                """)
+        client.save({"conanfile.py": conanfile})
+        client.run("create . --name=mypkg --version=0.1 --user=user --channel=testing")
+
+        tmp_folder = temp_folder()
+        client.save_home({"global.conf": f"core.download:download_cache={tmp_folder}"})
+        client.run("upload * --confirm -r default")
+        # conanfile.py + conanmanifest.txt (recipe) and conaninfo.txt + conanmanifest.txt +
+        # conan_package.tgz (package): nothing was ever downloaded, only uploaded
+        assert len(os.listdir(os.path.join(tmp_folder, "c"))) == 5
+
+        client.run("remove * -c")
+        client.run("install --requires=mypkg/0.1@user/testing")
+        assert "mypkg/0.1@user/testing: Downloading" not in client.out
+        assert "conan_package.tgz from download cache, instead of downloading it" in client.out
+
+    def test_upload_download_cache_skips_metadata(self):
+        """ metadata files can be overwritten without a new revision, so they are never served
+        from the cache by ConanInternalCacheDownloader: they must not be cached on upload either
+        """
+        client = TestClient(default_server_user=True)
+        conanfile = textwrap.dedent("""
+            import os
+            from conan import ConanFile
+            from conan.tools.files import save
+            class Pkg(ConanFile):
+                def export(self):
+                    save(self, os.path.join(self.recipe_metadata_folder, "logs", "build.log"),
+                        "log contents!")
+                """)
+        client.save({"conanfile.py": conanfile})
+        client.run("create . --name=mypkg --version=0.1")
+
+        tmp_folder = temp_folder()
+        client.save_home({"global.conf": f"core.download:download_cache={tmp_folder}"})
+        client.run("upload * --confirm -r default")
+
+        # metadata/logs/build.log must be excluded, only the 2 recipe + 3 package files are cached
+        assert len(os.listdir(os.path.join(tmp_folder, "c"))) == 5
+
+    def test_upload_relative_download_cache_is_ignored(self):
+        """ unlike download, upload must not fail because of a misconfigured (relative) download
+        cache: populating the cache is a best-effort optimization on upload, not a requirement
+        """
+        client = TestClient(default_server_user=True)
+        client.save({"conanfile.py": GenConanfile().with_package_file("file.txt", "content")})
+        client.run("create . --name=mypkg --version=0.1")
+
+        client.save_home({"global.conf": "core.download:download_cache=mytmp_folder"})
+        client.run("upload * --confirm -r default")
+        assert "ERROR" not in client.out

--- a/test/integration/cache/download_cache_test.py
+++ b/test/integration/cache/download_cache_test.py
@@ -1,5 +1,6 @@
 import os
 import textwrap
+from unittest.mock import patch
 
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.file_server import TestFileServer
@@ -9,6 +10,17 @@ from conan.internal.util.files import save, set_dirty
 
 
 class TestDownloadCache:
+    # a package containing a file > 10MB, the only case that leaves a trace in the output
+    # of whether a file was really downloaded, or served from the download cache instead
+    _big_file_conanfile = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+        class Pkg(ConanFile):
+            def package(self):
+                fileSizeInBytes = 11000000
+                with open(os.path.join(self.package_folder, "data.txt"), 'wb') as fout:
+                    fout.write(os.urandom(fileSizeInBytes))
+        """)
 
     def test_download_skip(self):
         """ basic proof that enabling download_cache avoids downloading things again
@@ -164,18 +176,7 @@ class TestDownloadCache:
         too, so a later download of the same artifacts doesn't hit the network at all
         """
         client = TestClient(default_server_user=True)
-        # generate large random package file, like in test_download_skip, to get the
-        # "from download cache" trace, only emitted for files > 10MB
-        conanfile = textwrap.dedent("""
-            import os
-            from conan import ConanFile
-            class Pkg(ConanFile):
-                def package(self):
-                    fileSizeInBytes = 11000000
-                    with open(os.path.join(self.package_folder, "data.txt"), 'wb') as fout:
-                        fout.write(os.urandom(fileSizeInBytes))
-                """)
-        client.save({"conanfile.py": conanfile})
+        client.save({"conanfile.py": self._big_file_conanfile})
         client.run("create . --name=mypkg --version=0.1 --user=user --channel=testing")
 
         tmp_folder = temp_folder()
@@ -189,6 +190,25 @@ class TestDownloadCache:
         client.run("install --requires=mypkg/0.1@user/testing")
         assert "mypkg/0.1@user/testing: Downloading" not in client.out
         assert "conan_package.tgz from download cache, instead of downloading it" in client.out
+
+    def test_upload_without_cache_conf_stores_nothing(self):
+        """ the opposite of test_upload_populates_download_cache: without
+        core.download:download_cache configured, upload must not write a cache anywhere,
+        neither in some default/implicit location nor by ever touching DownloadCache at all
+        """
+        client = TestClient(default_server_user=True)
+        client.save({"conanfile.py": self._big_file_conanfile})
+        client.run("create . --name=mypkg --version=0.1 --user=user --channel=testing")
+
+        # no core.download:download_cache set at all
+        with patch("conan.internal.rest.download_cache.DownloadCache.cache_file") as cache_file:
+            client.run("upload * --confirm -r default")
+        cache_file.assert_not_called()
+
+        # and a later install must still really download the package over the network
+        client.run("remove * -c")
+        client.run("install --requires=mypkg/0.1@user/testing")
+        assert "mypkg/0.1@user/testing: Downloading" in client.out
 
     def test_upload_download_cache_skips_metadata(self):
         """ metadata files can be overwritten without a new revision, so they are never served

--- a/test/integration/cache/download_cache_test.py
+++ b/test/integration/cache/download_cache_test.py
@@ -2,25 +2,27 @@ import os
 import textwrap
 from unittest.mock import patch
 
+from conan.errors import ConanException
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.file_server import TestFileServer
 from conan.test.utils.test_files import temp_folder
-from conan.test.utils.tools import TestClient
+from conan.test.utils.tools import TestClient, TestRequester
 from conan.internal.util.files import save, set_dirty
 
 
+class NoFileDownloadsRequester(TestRequester):
+    """ Fails any attempt to download the contents of an artifact, while still allowing the
+    endpoints needed to resolve what to install (revision and file listings).
+    An install succeeding with this requester proves every file came from the download cache.
+    """
+    def get(self, url, **kwargs):
+        # ".../revisions/<rev>/files/<path>" downloads contents, ".../files" is only the listing
+        if "/files/" in url:
+            raise ConanException(f"Tried to download {url} instead of using the download cache")
+        return super().get(url, **kwargs)
+
+
 class TestDownloadCache:
-    # a package containing a file > 10MB, the only case that leaves a trace in the output
-    # of whether a file was really downloaded, or served from the download cache instead
-    _big_file_conanfile = textwrap.dedent("""
-        import os
-        from conan import ConanFile
-        class Pkg(ConanFile):
-            def package(self):
-                fileSizeInBytes = 11000000
-                with open(os.path.join(self.package_folder, "data.txt"), 'wb') as fout:
-                    fout.write(os.urandom(fileSizeInBytes))
-        """)
 
     def test_download_skip(self):
         """ basic proof that enabling download_cache avoids downloading things again
@@ -172,12 +174,12 @@ class TestDownloadCache:
         assert 'core.download:download_cache must be an absolute path' in c.out
 
     def test_upload_populates_download_cache(self):
-        """ uploading with a download cache configured leaves the uploaded files in the cache
-        too, so a later download of the same artifacts doesn't hit the network at all
+        """ uploading with a download cache configured leaves the uploaded files in the cache,
+        so a later install can be served entirely from it, without downloading anything
         """
-        client = TestClient(default_server_user=True)
-        client.save({"conanfile.py": self._big_file_conanfile})
-        client.run("create . --name=mypkg --version=0.1 --user=user --channel=testing")
+        client = TestClient(default_server_user=True, requester_class=NoFileDownloadsRequester)
+        client.save({"conanfile.py": GenConanfile("mypkg", "0.1").with_package_file("f.txt", "c")})
+        client.run("create .")
 
         tmp_folder = temp_folder()
         client.save_home({"global.conf": f"core.download:download_cache={tmp_folder}"})
@@ -186,29 +188,31 @@ class TestDownloadCache:
         # conan_package.tgz (package): nothing was ever downloaded, only uploaded
         assert len(os.listdir(os.path.join(tmp_folder, "c"))) == 5
 
+        # the requester forbids downloading contents, so this can only work from the cache
         client.run("remove * -c")
-        client.run("install --requires=mypkg/0.1@user/testing")
-        assert "mypkg/0.1@user/testing: Downloading" not in client.out
-        assert "conan_package.tgz from download cache, instead of downloading it" in client.out
+        client.run("install --requires=mypkg/0.1")
+        # the install really happened, it did not silently resolve to something already in the cache
+        assert "mypkg/0.1: Package installed" in client.out
 
     def test_upload_without_cache_conf_stores_nothing(self):
         """ the opposite of test_upload_populates_download_cache: without
         core.download:download_cache configured, upload must not write a cache anywhere,
         neither in some default/implicit location nor by ever touching DownloadCache at all
         """
-        client = TestClient(default_server_user=True)
-        client.save({"conanfile.py": self._big_file_conanfile})
-        client.run("create . --name=mypkg --version=0.1 --user=user --channel=testing")
+        client = TestClient(default_server_user=True, requester_class=NoFileDownloadsRequester)
+        client.save({"conanfile.py": GenConanfile("mypkg", "0.1").with_package_file("f.txt", "c")})
+        client.run("create .")
 
         # no core.download:download_cache set at all
         with patch("conan.internal.rest.download_cache.DownloadCache.cache_file") as cache_file:
             client.run("upload * --confirm -r default")
         cache_file.assert_not_called()
 
-        # and a later install must still really download the package over the network
+        # nothing was cached, so the install has nowhere to get the files from but the server
         client.run("remove * -c")
-        client.run("install --requires=mypkg/0.1@user/testing")
-        assert "mypkg/0.1@user/testing: Downloading" in client.out
+        client.save_home({"global.conf": "core.download:retry=0"})
+        client.run("install --requires=mypkg/0.1", assert_error=True)
+        assert "instead of using the download cache" in client.out
 
     def test_upload_download_cache_skips_metadata(self):
         """ metadata files can be overwritten without a new revision, so they are never served
@@ -234,14 +238,13 @@ class TestDownloadCache:
         # metadata/logs/build.log must be excluded, only the 2 recipe + 3 package files are cached
         assert len(os.listdir(os.path.join(tmp_folder, "c"))) == 5
 
-    def test_upload_relative_download_cache_is_ignored(self):
-        """ unlike download, upload must not fail because of a misconfigured (relative) download
-        cache: populating the cache is a best-effort optimization on upload, not a requirement
+    def test_upload_relative_error(self):
+        """ relative paths are not allowed, same as when downloading
         """
         client = TestClient(default_server_user=True)
-        client.save({"conanfile.py": GenConanfile().with_package_file("file.txt", "content")})
-        client.run("create . --name=mypkg --version=0.1")
+        client.save({"conanfile.py": GenConanfile("mypkg", "0.1").with_package_file("f.txt", "c")})
+        client.run("create .")
 
         client.save_home({"global.conf": "core.download:download_cache=mytmp_folder"})
-        client.run("upload * --confirm -r default")
-        assert "ERROR" not in client.out
+        client.run("upload * --confirm -r default", assert_error=True)
+        assert "core.download:download_cache must be an absolute path" in client.out


### PR DESCRIPTION
Changelog: Feature: Populate the download cache with uploaded artifacts if `core.download:download_cache` is set.
Docs: https://github.com/conan-io/docs/pull/4518

Closes https://github.com/conan-io/conan/issues/13840, continues https://github.com/conan-io/conan/pull/15223
