### PR TITLE
[PkgConfigDeps] Requires `default_components` or all the components if they exist when root `pkg_config_name="none"`

### DIFF
--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -170,6 +170,28 @@ class _PCFilesDeps:
         defines = ["-D%s" % var.replace('"', '\\"') for var in cpp_info.defines]
         return " ".join(includedirsflags + cxxflags + cflags + defines)
 
+    def _get_none_requirement_names(self, dep):
+        """
+        When a package has pkg_config_name="none", return the pkg-config names that should
+        replace a root requirement (pkg::pkg). If the package has no components, return [].
+        """
+        if not dep.cpp_info.has_components:
+            self._conanfile.output.warning(
+                f"You're requiring {str(dep.ref)} that has pkg_config_name='none' and no components "
+                f"defined."
+            )
+            return []
+        if dep.cpp_info.default_components is not None:
+            comp_names = dep.cpp_info.default_components
+        else:
+            comp_names = list(dep.cpp_info.get_sorted_components().keys())
+        ret = []
+        for comp_ref_name in comp_names:
+            comp_name = self._get_name(dep, dep.ref.name, comp_ref_name)
+            if comp_name not in ret:
+                ret.append(comp_name)
+        return ret
+
     def _get_component_requirement_names(self, cpp_info):
         """
         Get all the pkg-config valid names from the requirements ones given a CppInfo object.
@@ -203,7 +225,11 @@ class _PCFilesDeps:
             else:  # For instance, dep == "hello/1.0" and req == "hello::cmp1" -> hello == hello
                 req_conanfile = self._dep
             comp_name = self._get_name(req_conanfile, pkg_ref_name, comp_ref_name)
-            if comp_name not in ret:
+            if comp_name == "none":
+                for none_req in self._get_none_requirement_names(req_conanfile):
+                    if none_req not in ret:
+                        ret.append(none_req)
+            elif comp_name not in ret:
                 ret.append(comp_name)
         return ret
 

--- a/conan/tools/gnu/pkgconfigdeps.py
+++ b/conan/tools/gnu/pkgconfigdeps.py
@@ -176,10 +176,6 @@ class _PCFilesDeps:
         replace a root requirement (pkg::pkg). If the package has no components, return [].
         """
         if not dep.cpp_info.has_components:
-            self._conanfile.output.warning(
-                f"You're requiring {str(dep.ref)} that has pkg_config_name='none' and no components "
-                f"defined."
-            )
             return []
         if dep.cpp_info.default_components is not None:
             comp_names = dep.cpp_info.default_components

--- a/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -1281,6 +1281,8 @@ def test_pkg_skip_component():
     assert "pkg_c.pc" in install_contents
     # Components can not skip the PC file creation
     assert "none.pc" in install_contents
+    # Related issue: https://github.com/conan-io/conan-center-index/issues/30526
+    assert "none" not in b_cmp1_content
 
 
 def test_pkg_none_requirement_with_default_components():

--- a/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -1246,6 +1246,7 @@ def test_pkg_skip_component():
             requires = "pkg_a/0.1"
             def package_info(self):
                 self.cpp_info.components["cmp1"].set_property("pkg_config_name", "b-cmp1")
+                self.cpp_info.components["cmp1"].requires = ["pkg_a::pkg_a"]
         """)
 
     conanfile_c = textwrap.dedent("""
@@ -1280,3 +1281,96 @@ def test_pkg_skip_component():
     assert "pkg_c.pc" in install_contents
     # Components can not skip the PC file creation
     assert "none.pc" in install_contents
+
+
+def test_pkg_none_requirement_with_default_components():
+    """
+    When a requirement points to a package with pkg_config_name="none" and
+    cpp_info.default_components is defined, "none" is replaced by the default
+    components pkg-config names.
+    """
+    conanfile_a = textwrap.dedent("""
+        from conan import ConanFile
+        class PkgConfigConan(ConanFile):
+            name = "pkg_a"
+            version = "0.1"
+            def package_info(self):
+                self.cpp_info.set_property("pkg_config_name", "none")
+                self.cpp_info.components["cmp1"].set_property("pkg_config_name", "a-cmp1")
+                self.cpp_info.components["cmp2"].set_property("pkg_config_name", "a-cmp2")
+                self.cpp_info.default_components = ["cmp1"]
+        """)
+    conanfile_b = textwrap.dedent("""
+        from conan import ConanFile
+        class PkgConfigConan(ConanFile):
+            name = "pkg_b"
+            version = "0.1"
+            requires = "pkg_a/0.1"
+            def package_info(self):
+                self.cpp_info.components["cmp1"].set_property("pkg_config_name", "b-cmp1")
+                self.cpp_info.components["cmp1"].requires = ["pkg_a::pkg_a"]
+        """)
+    tc = TestClient(light=True)
+    tc.save({"a/conanfile.py": conanfile_a, "b/conanfile.py": conanfile_b})
+    tc.run("create a")
+    tc.run("create b")
+    tc.run("install --requires=pkg_b/0.1 --generator=PkgConfigDeps -of=out")
+
+    install_contents = os.listdir(os.path.join(tc.current_folder, "out"))
+    assert "pkg_a.pc" not in install_contents
+    assert "a-cmp1.pc" in install_contents
+    assert "a-cmp2.pc" in install_contents
+    assert "none.pc" not in install_contents
+
+    b_cmp1_content = tc.load(os.path.join("out", "b-cmp1.pc"))
+    b_cmp1_requires = get_requires_from_content(b_cmp1_content)
+    assert "a-cmp1" in b_cmp1_requires
+    assert "a-cmp2" not in b_cmp1_requires
+    assert "none" not in b_cmp1_requires
+    assert "pkg_a" not in b_cmp1_requires
+
+
+def test_pkg_none_requirement_with_all_components():
+    """
+    When a requirement points to a package with pkg_config_name="none" without
+    default_components but with components, "none" is replaced by all component
+    pkg-config names.
+    """
+    conanfile_a = textwrap.dedent("""
+        from conan import ConanFile
+        class PkgConfigConan(ConanFile):
+            name = "pkg_a"
+            version = "0.1"
+            def package_info(self):
+                self.cpp_info.set_property("pkg_config_name", "none")
+                self.cpp_info.components["cmp1"].set_property("pkg_config_name", "a-cmp1")
+                self.cpp_info.components["cmp2"].set_property("pkg_config_name", "a-cmp2")
+        """)
+    conanfile_b = textwrap.dedent("""
+        from conan import ConanFile
+        class PkgConfigConan(ConanFile):
+            name = "pkg_b"
+            version = "0.1"
+            requires = "pkg_a/0.1"
+            def package_info(self):
+                self.cpp_info.components["cmp1"].set_property("pkg_config_name", "b-cmp1")
+                self.cpp_info.components["cmp1"].requires = ["pkg_a::pkg_a"]
+        """)
+    tc = TestClient(light=True)
+    tc.save({"a/conanfile.py": conanfile_a, "b/conanfile.py": conanfile_b})
+    tc.run("create a")
+    tc.run("create b")
+    tc.run("install --requires=pkg_b/0.1 --generator=PkgConfigDeps -of=out")
+
+    install_contents = os.listdir(os.path.join(tc.current_folder, "out"))
+    assert "pkg_a.pc" not in install_contents
+    assert "a-cmp1.pc" in install_contents
+    assert "a-cmp2.pc" in install_contents
+    assert "none.pc" not in install_contents
+
+    b_cmp1_content = tc.load(os.path.join("out", "b-cmp1.pc"))
+    b_cmp1_requires = get_requires_from_content(b_cmp1_content)
+    assert "a-cmp1" in b_cmp1_requires
+    assert "a-cmp2" in b_cmp1_requires
+    assert "none" not in b_cmp1_requires
+    assert "pkg_a" not in b_cmp1_requires

--- a/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -1280,8 +1280,6 @@ def test_pkg_none_requirement_without_components():
     # Related issue: https://github.com/conan-io/conan-center-index/issues/30526
     assert "Requires:" not in b_cmp1_content
     assert "none" not in b_cmp1_content  # redundant, but just in case
-    assert ("You're requiring pkg_a/0.1 that has pkg_config_name='none' "
-            "and no components defined") in tc.out
     assert "pkg_c.pc" in install_contents
     # Components can not skip the PC file creation
     assert "none.pc" in install_contents

--- a/test/integration/toolchains/gnu/test_pkgconfigdeps.py
+++ b/test/integration/toolchains/gnu/test_pkgconfigdeps.py
@@ -1229,7 +1229,7 @@ def test_pkg_with_duplicated_component_requires():
     assert "Requires: mylib-mycomponent" == get_requires_from_content(pc_content)
 
 
-def test_pkg_skip_component():
+def test_pkg_none_requirement_without_components():
     conanfile_a = textwrap.dedent("""
         from conan import ConanFile
         class PkgConfigConan(ConanFile):
@@ -1277,12 +1277,14 @@ def test_pkg_skip_component():
     assert "none" not in pkg_b_requires
     assert "b-cmp1.pc" in install_contents
     b_cmp1_content = tc.load(os.path.join("out", "b-cmp1.pc"))
+    # Related issue: https://github.com/conan-io/conan-center-index/issues/30526
     assert "Requires:" not in b_cmp1_content
+    assert "none" not in b_cmp1_content  # redundant, but just in case
+    assert ("You're requiring pkg_a/0.1 that has pkg_config_name='none' "
+            "and no components defined") in tc.out
     assert "pkg_c.pc" in install_contents
     # Components can not skip the PC file creation
     assert "none.pc" in install_contents
-    # Related issue: https://github.com/conan-io/conan-center-index/issues/30526
-    assert "none" not in b_cmp1_content
 
 
 def test_pkg_none_requirement_with_default_components():
@@ -1327,7 +1329,7 @@ def test_pkg_none_requirement_with_default_components():
     b_cmp1_content = tc.load(os.path.join("out", "b-cmp1.pc"))
     b_cmp1_requires = get_requires_from_content(b_cmp1_content)
     assert "a-cmp1" in b_cmp1_requires
-    assert "a-cmp2" not in b_cmp1_requires
+    assert "a-cmp2" not in b_cmp1_requires  # not in default_components
     assert "none" not in b_cmp1_requires
     assert "pkg_a" not in b_cmp1_requires
 


### PR DESCRIPTION
Changelog: Bugfix: Require `default_components`, or all existing components, in `PkgConfigDeps` when root `pkg_config_name="none"`.
Docs: omit
Related to: https://github.com/conan-io/conan-center-index/pull/30591