### PR TITLE
avoid shadows in Options.xxx methods

### DIFF
--- a/conan/api/subapi/graph.py
+++ b/conan/api/subapi/graph.py
@@ -38,7 +38,7 @@ class GraphAPI:
             initialize_conanfile_profile(conanfile, profile_build, profile_host, CONTEXT_HOST,
                                          is_build_require, ref)
             if ref.name:
-                profile_host.options.scope(ref)
+                profile_host.options.conan_scope(ref)
             root_node = Node(ref, conanfile, context=context, recipe=RECIPE_CONSUMER, path=path)
             root_node.should_build = True  # It is a consumer, this is something we are building
         else:
@@ -67,7 +67,7 @@ class GraphAPI:
         # necessary for correct resolution and update of remote python_requires
 
         loader = self._helpers.loader
-        profile_host.options.scope(tested_reference)
+        profile_host.options.conan_scope(tested_reference)
 
         # do not try apply lock_python_requires for test_package/conanfile.py consumer
         conanfile = loader.load_consumer(path, user=tested_reference.user,
@@ -114,7 +114,7 @@ class GraphAPI:
             if str(ref.version).startswith("["):
                 ref = ref.copy()
                 ref.version = "*"
-            profile.options.scope(ref)
+            profile.options.conan_scope(ref)
 
     def load_graph_requires(self, requires, tool_requires, profile_host, profile_build,
                             lockfile, remotes, update, check_updates=False, python_requires=None):

--- a/conan/internal/graph/graph_builder.py
+++ b/conan/internal/graph/graph_builder.py
@@ -454,7 +454,7 @@ class DepsGraphBuilder:
             # If the consumer has specified "requires(options=xxx)", we need to use it
             # It will have less priority than downstream consumers
             down_options = Options(options_values=require.options)
-            down_options.scope(new_ref)
+            down_options.conan_scope(new_ref)
             # At the moment, the behavior is the most restrictive one: default_options and
             # options["dep"].opt=value only propagate to visible and host dependencies
             # we will evaluate if necessary a potential "build_options", but recall that it is

--- a/conan/internal/model/info.py
+++ b/conan/internal/model/info.py
@@ -477,7 +477,7 @@ class ConanInfo:
     def validate(self):
         # If the options are not fully defined, this is also an invalid case
         try:
-            self.options.validate()
+            self.options.conan_validate()
         except ConanException as e:
             self.invalid = str(e)
 

--- a/conan/internal/model/options.py
+++ b/conan/internal/model/options.py
@@ -131,7 +131,7 @@ class _PackageOptions:
         # for header_only() clearing
         self._data.clear()
 
-    def freeze(self):
+    def conan_freeze(self):
         self._freeze = True
 
     def __contains__(self, option):
@@ -144,7 +144,7 @@ class _PackageOptions:
         # This should never raise any exception, in any case
         self._data.pop(field, None)
 
-    def validate(self):
+    def conan_validate(self):
         for child in self._data.values():
             child.validate()
 
@@ -331,7 +331,7 @@ class Options:
                 item += "/*"
         return self._deps_package_options.setdefault(item, _PackageOptions())
 
-    def scope(self, ref):
+    def conan_scope(self, ref):
         """ when there are free options like "shared=True", they apply to the "consumer" package
         Once we know the name of such consumer package, it can be defined in the data, so it will
         be later correctly apply when processing options """
@@ -389,7 +389,7 @@ class Options:
                     if ref_matches(own_ref, pattern, is_consumer=is_consumer):
                         self._package_options.update_options(options, is_pattern="*" in pattern)
 
-        self._package_options.freeze()
+        self._package_options.conan_freeze()
 
     def get_upstream_options(self, down_options, own_ref, is_consumer):
         """ compute which options should be propagated to the dependencies, a combination of the

--- a/test/unittests/model/options_test.py
+++ b/test/unittests/model/options_test.py
@@ -81,7 +81,7 @@ class TestOptions:
     def test_freeze(self):
         assert self.sut.static
 
-        self.sut.freeze()
+        self.sut.conan_freeze()
         # Should be freezed now
         # same value should not raise
         self.sut.static = True
@@ -99,7 +99,7 @@ class TestOptions:
         # Test None is possible to change
         sut2 = Options({"static": [True, False],
                         "other": [True, False]})
-        sut2.freeze()
+        sut2.conan_freeze()
         sut2.static = True
         assert "static=True" in sut2.dumps()
         # But not twice
@@ -243,15 +243,26 @@ class TestOptionsNone:
         """
         package_options = Options({"path": ["ANY"]})
         with pytest.raises(ConanException):
-            package_options.validate()
+            package_options.conan_validate()
         package_options.path = "Something"
-        package_options.validate()
+        package_options.conan_validate()
 
     def test_undefined_value_none(self):
         """ The value None is allowed as default, not necessary to default to it
         """
         package_options = Options({"path": [None, "Other"]})
-        package_options.validate()
+        package_options.conan_validate()
         package_options = Options({"path": ["None", "Other"]})
         with pytest.raises(ConanException):  # Literal "None" string not good to be undefined
-            package_options.validate()
+            package_options.conan_validate()
+
+
+def test_options_reserved_names():
+    options = {"freeze": ["potato", "tomato"],
+               "validate": [True, False],
+               "scope": [1, 2, 3]}
+    values = {"freeze": "potato", "validate": True, "scope": 2}
+    sut = Options(options, values)
+    assert sut.freeze == "potato"
+    assert sut.scope == 2
+    assert sut.validate == True # noqa


### PR DESCRIPTION
Changelog: Fix: Avoid option names shadowing internal `Options` implementation methods.
Docs: https://github.com/conan-io/docs/pull/4490

Close https://github.com/conan-io/conan/issues/20117
