### PR TITLE
fix test_autotools_relocatable_libs_darwin_downloaded (Fix Autotools rpath flag)

### DIFF
--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -31,7 +31,7 @@ class AutotoolsDeps:
         flags = []
         for dep in self.ordered_deps:
             if dep.package_type is PackageType.SHARED:
-                flags.extend(["-Wl,-rpath -Wl,{}".format(libdir) for libdir in
+                flags.extend(["-Wl,-rpath,{}".format(libdir) for libdir in
                               dep.cpp_info.aggregated_components().libdirs])
         return flags
 

--- a/test/functional/toolchains/gnu/test_v2_autotools_template.py
+++ b/test/functional/toolchains/gnu/test_v2_autotools_template.py
@@ -118,10 +118,8 @@ def test_autotools_relocatable_libs_darwin():
     assert "hello/0.1: Hello World Release!" in client.out
 
 
-# FIXME: investigate this test
 @pytest.mark.skipif(platform.system() not in ["Darwin"], reason="Requires Autotools")
 @pytest.mark.tool("autotools")
-@pytest.mark.xfail(reason="This test is failing for newer MacOS versions, but used to pass in the ci")
 def test_autotools_relocatable_libs_darwin_downloaded():
     client = TestClient(default_server_user=True, path_with_spaces=False)
     client2 = TestClient(servers=client.servers, path_with_spaces=False)
@@ -183,9 +181,6 @@ def test_autotools_relocatable_libs_darwin_downloaded():
 
     client2.run("install . -o hello/*:shared=True -r default")
     client2.run("build . -o hello/*:shared=True -r default")
-    # for some reason this is failing for newer macos
-    # although -Wl,-rpath -Wl, if passed to set the rpath when building
-    # it fails with LC_RPATH's not found
     client2.run_command("build-release/greet")
     # activating the environment should not be needed as the rpath is set when linking greet
     #client2.run_command(". build-release/conan/conanrun.sh && build-release/greet")

--- a/test/integration/toolchains/gnu/test_autotoolsdeps.py
+++ b/test/integration/toolchains/gnu/test_autotoolsdeps.py
@@ -159,7 +159,7 @@ def test_autotoolsdeps_macos_rpath_by_package_type(package_type, use_shared_opti
     t.run("install --profile:host=macos")
     deps = t.load("conanautotoolsdeps.sh")
     if expect_rpath:
-        assert f"-Wl,-rpath -Wl,{dp_pkg_package_path}" in deps
+        assert f"-Wl,-rpath,{dp_pkg_package_path}" in deps
     else:
         assert "-Wl,-rpath" not in deps
 
@@ -199,4 +199,4 @@ def test_autotoolsdeps_macos_rpath_shared_dep_with_components():
     t.run("install --profile:host=macos")
     deps = t.load("conanautotoolsdeps.sh")
     assert "nested" in deps
-    assert f"-Wl,-rpath -Wl,{dp_pkg_package_path}" in deps
+    assert f"-Wl,-rpath,{dp_pkg_package_path}" in deps


### PR DESCRIPTION
Fixes a bug in AutotoolsDeps that broke shared library relocatability (@rpath) when building executables with Autotools on macOS. The rpath flag format (-Wl,-rpath -Wl,{libdir}) was silently dropped by Libtool during linking, leaving binaries without LC_RPATH and failing at runtime with Library not loaded: @rpath/.... The flag format was adjusted so Libtool preserves it correctly.

Changelog: Fix: Fix rpath flags from `AutotoolsDeps` being dropped by Libtool on macOS, causing missing `LC_RPATH` in executables.

Docs: omit
