### PR TITLE
Recover `test_xcodebuild_test_different_sdk` test

### DIFF
--- a/conan/internal/runner/docker.py
+++ b/conan/internal/runner/docker.py
@@ -255,7 +255,7 @@ class DockerRunner:
         initialize_conanfile_profile(conanfile, self.build_profile, self.host_profile,
                                      CONTEXT_HOST, False, ref)
         if ref.name:
-            self.host_profile.options.scope(ref)
+            self.host_profile.options.conan_scope(ref)
         abs_docker_base_path = Path('/') / self.docker_user_name / 'conanrunner'
         # Check if recipe has defined a root folder
         # In this case, mount the root folder as the base path and update the abs_docker_path to the

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -202,6 +202,10 @@ tools_locations = {
             "path": {"Linux": "/opt/intel/oneapi/compiler/2026.0/bin"},
             "root": {"Linux": "/opt/intel/oneapi"}
         }
+    },
+    'xcode_sdk': {
+        "26.0": {"path": {"Darwin": "/Applications/Xcode_26.0.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.0.sdk"}},
+        "26.5": {"path": {"Darwin": "/Applications/Xcode_26.5.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.5.sdk"}},
     }
 }
 

--- a/test/functional/toolchains/apple/test_xcodebuild.py
+++ b/test/functional/toolchains/apple/test_xcodebuild.py
@@ -141,7 +141,7 @@ def test_xcodebuild_test_different_sdk(client):
     client.run("install . --build=missing")
     client.run("install . -s build_type=Debug --build=missing")
     client.run_command("xcodegen generate")
-    client.run("create . --build=missing -s os.sdk=macosx -s os.sdk_version=26.0 "
+    client.run("create . --build=missing -s os.sdk_version=26.0 "
                f"-c tools.apple:sdk_path='{tools_locations['xcode_sdk']['26.0']['path']['Darwin']}'")
     assert "sdk 26.0" in client.out
     client.run("create . --build=missing -s os.sdk_version=26.5 "

--- a/test/functional/toolchains/apple/test_xcodebuild.py
+++ b/test/functional/toolchains/apple/test_xcodebuild.py
@@ -5,6 +5,7 @@ import textwrap
 import pytest
 
 from conan.test.utils.tools import TestClient
+from test.conftest import tools_locations
 
 xcode_project = textwrap.dedent("""
     name: app
@@ -116,7 +117,6 @@ def test_project_xcodebuild(client):
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
 @pytest.mark.tool("xcodebuild")
 @pytest.mark.tool("xcodegen")
-@pytest.mark.skip(reason="Different sdks not installed in CI")
 def test_xcodebuild_test_different_sdk(client):
 
     conanfile = textwrap.dedent("""
@@ -141,12 +141,12 @@ def test_xcodebuild_test_different_sdk(client):
     client.run("install . --build=missing")
     client.run("install . -s build_type=Debug --build=missing")
     client.run_command("xcodegen generate")
-    client.run("create . --build=missing -s os.sdk=macosx -s os.sdk_version=10.15 "
-               "-c tools.apple:sdk_path='/Applications/Xcode11.7.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk'")
-    assert "sdk 10.15.6" in client.out
-    client.run("create . --build=missing -s os.sdk_version=11.3 "
-               "-c tools.apple:sdk_path='/Applications/Xcode12.5.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk'")
-    assert "sdk 11.3" in client.out
+    client.run("create . --build=missing -s os.sdk=macosx -s os.sdk_version=26.0 "
+               f"-c tools.apple:sdk_path='{tools_locations['xcode_sdk']['26.0']['path']['Darwin']}'")
+    assert "sdk 26.0" in client.out
+    client.run("create . --build=missing -s os.sdk_version=26.5 "
+               f"-c tools.apple:sdk_path='{tools_locations['xcode_sdk']['26.5']['path']['Darwin']}'")
+    assert "sdk 26.5" in client.out
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")

--- a/test/functional/toolchains/apple/test_xcodebuild.py
+++ b/test/functional/toolchains/apple/test_xcodebuild.py
@@ -131,7 +131,8 @@ def test_xcodebuild_test_different_sdk(client):
             exports_sources = "app.xcodeproj/*", "app/*"
             def build(self):
                 xcode = XcodeBuild(self)
-                xcode.build("app.xcodeproj")
+                # macOS 26 SDK requires signing/entitlements for a Command-line Tool, not needed for this test
+                xcode.build("app.xcodeproj", cli_args=["CODE_SIGNING_ALLOWED=NO"])
                 self.run("otool -l build/Release/app")
         """)
 


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

Github runners have different Xcode SDK's installed, so it should be possible to run this test.