### PR TITLE
warn with config-install after config-install-pkg

### DIFF
--- a/conan/api/subapi/config.py
+++ b/conan/api/subapi/config.py
@@ -58,6 +58,15 @@ class ConfigAPI:
         from conan.internal.api.config.config_installer import configuration_install
         cache_folder = self._conan_api.cache_folder
         requester = self._helpers.requester
+        config_version_file = HomePaths(self._conan_api.home_folder).config_version_path
+        if os.path.exists(config_version_file):
+            ConanOutput().warning(
+                "You are installing configuration from a non-package source, but "
+                "'config_version.json' already exists from a previous 'conan config install-pkg'. "
+                "This installation will not be tracked in 'config_version.json' and may result "
+                "in a configuration that is inconsistent with the tracked versions. "
+                "Consider running 'conan config clean' first, or avoid mixing "
+                "'conan config install' with 'conan config install-pkg'.")
         configuration_install(cache_folder, requester, path_or_url, verify_ssl,
                               config_type=config_type, args=args,
                               source_folder=source_folder, target_folder=target_folder)

--- a/test/integration/command/config/config_test.py
+++ b/test/integration/command/config/config_test.py
@@ -67,6 +67,23 @@ def test_config_install():
     tc.run("config install config --superinsecure", assert_error=True)
 
 
+def test_config_install_warns_when_config_version_exists():
+    """When 'conan config install' runs and config_version.json exists (from a previous
+    'conan config install-pkg'), warn the user that this install won't be tracked."""
+    tc = TestClient(light=True)
+    tc.save({'config/foo': ''})
+    # No previous config_version.json -> no warning
+    tc.run("config install config")
+    assert "config_version.json" not in tc.out
+
+    # Simulate a previous 'conan config install-pkg'
+    tc.save_home({"config_version.json": json.dumps(
+        {"config_version": ["myconf/1.0#aabbcc"]})})
+    tc.run("config install config")
+    assert "'config_version.json' already exists" in tc.out
+    assert "will not be tracked" in tc.out
+
+
 def test_config_install_conanignore():
     tc = TestClient()
     conanignore = textwrap.dedent("""


### PR DESCRIPTION
Changelog: Feature: Warn when `conan config install` is used after `conan config install-pkg`.
Docs: https://github.com/conan-io/docs/pull/4493

Close https://github.com/conan-io/conan/issues/20183