### PR TITLE
Test for AutotoolsDeps msvc LINK/Automake collision

### DIFF
--- a/conan/tools/gnu/autotoolsdeps.py
+++ b/conan/tools/gnu/autotoolsdeps.py
@@ -74,7 +74,7 @@ class AutotoolsDeps:
             env.append("CPPFLAGS", cpp_flags)
             env.append("LIBS", libs)
             if is_msvc(self._conanfile):
-                env.append("LINK", ldflags)
+                env.append("_LINK_", ldflags)
             else:
                 env.append("LDFLAGS", ldflags)
             env.append("CXXFLAGS", cxxflags)

--- a/test/functional/toolchains/gnu/autotools/test_basic.py
+++ b/test/functional/toolchains/gnu/autotools/test_basic.py
@@ -10,7 +10,7 @@ from conan.test.utils.mocks import ConanFileMock
 from conan.tools.env.environment import environment_wrap_command
 from conan.test.assets.autotools import gen_makefile_am, gen_configure_ac, gen_makefile
 from conan.test.assets.genconanfile import GenConanfile
-from conan.test.assets.sources import gen_function_cpp
+from conan.test.assets.sources import gen_function_cpp, gen_function_c
 from test.functional.utils import check_exe_run, check_vs_runtime
 from conan.test.utils.tools import TestClient, default_msvc_version
 
@@ -111,6 +111,122 @@ def test_autotools_msvc():
     assert "main _MSVC_LANG20" in client.out
     assert "matrix/1.0: _MSC_VER19" in client.out
     assert "matrix/1.0: _MSVC_LANG20" in client.out
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(platform.system() != "Windows", reason="Requires windows msys2")
+@pytest.mark.tool("msys2")
+def test_autotools_msvc_c():
+    """ Same as test_autotools_msvc, but the *consumer* is plain C instead of C++.
+    Automake emits a global "LINK" variable for C targets (it uses "CXXLINK" for
+    C++), which collides with the "LINK" environment variable AutotoolsDeps
+    exports for msvc, silently dropping the -LIBPATH flags before they reach
+    link.exe.
+    """
+    client = TestClient(path_with_spaces=False)
+
+    dep_conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+
+        class MatrixCConan(ConanFile):
+            name = "matrixc"
+            version = "1.0"
+            settings = "os", "compiler", "build_type", "arch"
+            exports_sources = "CMakeLists.txt", "matrixc.c", "matrixc.h"
+
+            def layout(self):
+                cmake_layout(self)
+
+            def generate(self):
+                CMakeToolchain(self).generate()
+
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+                cmake.build()
+
+            def package(self):
+                CMake(self).install()
+
+            def package_info(self):
+                self.cpp_info.libs = ["matrixc"]
+        """)
+    cmakelists = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.15)
+        project(matrixc LANGUAGES C)
+        add_library(matrixc STATIC matrixc.c)
+        install(TARGETS matrixc)
+        install(FILES matrixc.h DESTINATION include)
+        """)
+    matrixc_h = "int matrixc(void);\n"
+    matrixc_c = textwrap.dedent("""
+        #include "matrixc.h"
+        #include <stdio.h>
+        int matrixc(void) {
+            printf("matrixc/1.0: Hello World!\\n");
+            return 0;
+        }
+        """)
+    client.save({"conanfile.py": dep_conanfile,
+                 "CMakeLists.txt": cmakelists,
+                 "matrixc.h": matrixc_h,
+                 "matrixc.c": matrixc_c})
+
+    profile = textwrap.dedent("""
+          include(default)
+
+          [conf]
+          tools.microsoft.bash:subsystem=msys2
+          tools.microsoft.bash:path=bash.exe
+          """)
+    client.save({"windows": profile})
+    client.run("create . -pr=windows")
+
+    main = gen_function_c(name="main", includes=["matrixc"], calls=["matrixc"])
+    makefile_am = gen_makefile_am(main="main", main_srcs="main.c")
+    # NOTE: not using gen_configure_ac() here: it hardcodes AC_PROG_CXX, which
+    # would still let Automake pick "LINK" for a .c target, but AC_PROG_CC is the
+    # correct/explicit check to request for a pure-C project.
+    configure_ac = textwrap.dedent("""
+        AC_INIT([main], [1.0], [some@email.com])
+        AM_INIT_AUTOMAKE([-Wall -Werror foreign])
+        AC_PROG_CC
+        AC_PROG_RANLIB
+        AM_PROG_AR
+        AC_CONFIG_FILES([Makefile])
+        AC_OUTPUT
+        """)
+
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.gnu import Autotools
+
+        class TestConan(ConanFile):
+            requires = "matrixc/1.0"
+            settings = "os", "compiler", "arch", "build_type"
+            exports_sources = "configure.ac", "Makefile.am", "main.c"
+            generators = "AutotoolsDeps", "AutotoolsToolchain"
+            win_bash = True
+
+            def build(self):
+                self.run("aclocal")
+                self.run("autoconf")
+                self.run("automake --add-missing --foreign")
+                autotools = Autotools(self)
+                autotools.configure()
+                autotools.make()
+        """)
+
+    client.save({"conanfile.py": conanfile,
+                 "configure.ac": configure_ac,
+                 "Makefile.am": makefile_am,
+                 "main.c": main,
+                 "windows": profile}, clean_first=True)
+
+    client.run("build . -pr=windows")
+    client.run_command(r".\main")
+    assert "matrixc/1.0: Hello World!" in client.out
 
 
 def build_windows_subsystem(profile, make_program, subsystem):


### PR DESCRIPTION
Changelog: Fix: Avoid conflict with Automake's `LINK` var when using `AutotoolsDeps` with MSVC by using `_LINK_` for linker flags.
Docs: https://github.com/conan-io/docs/pull/4495

Check in CI whether the `LINK` env-var fix from #20130 works for plain-C Autotools projects, not just C++.

#20130 fixes `AutotoolsDeps` for msvc by exporting the linker flags via the `LINK` environment variable instead of `LDFLAGS`. However, Automake defines its own global `LINK` make variable for C link recipes (it uses `CXXLINK` for C++), and GNU Make re-exports that overridden value to the recipe's environment. So for a C (not C++) consumer, the ` LIBPATH:` flags Conan puts in `LINK` are silently clobbered by Automake before they ever reach `link.exe`. The existing `test_autotools_msvc` test only builds a `.cpp` file, so it goes through `CXXLINK` and never exercises this collision.

~~Testing that the new test fails, not to be merged as-is.~~ --> test failed

The fix is to use `_LINK_` instead of `LINK`. This avoids the collision with Automake, where [`LINK` is the C linker command while `CXXLINK` is used for C++](https://github.com/autotools-mirror/automake/blob/f8880e297a3ed9c265ba41e61e5fae9fb1914b9f/bin/automake.in#L690-L713), and is consistent with the existing use of `_LINK_` in [`NMakeToolchain`](https://github.com/conan-io/conan/blob/fc5ee647c7d23ffd109cb967b67747fbc077ffb9/conan/tools/microsoft/nmaketoolchain.py#L84-L90) and [`NMakeDeps`](https://github.com/conan-io/conan/blob/fc5ee647c7d23ffd109cb967b67747fbc077ffb9/conan/tools/microsoft/nmakedeps.py#L76-L79).

It also provides the intended precedence: according to the [MSVC linker documentation](https://learn.microsoft.com/en-us/cpp/build/reference/linking?view=msvc-170#link-environment-variables), `LINK` is prepended to the command line, whereas `_LINK_` is appended, allowing Conan-provided link requirements to take precedence when an option is repeated.

$runslowtests