### PR TITLE
replace_in_file with regex

### DIFF
--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -552,14 +552,12 @@ def replace_in_file(conanfile, file_path, search, replace, strict=True, encoding
     content = load(conanfile, file_path, encoding=encoding)
     if regex:
         try:
-            new_content, n = re.subn(search, replace, content, flags=flags)
+            new_content = re.sub(search, replace, content, flags=flags)
         except re.error as e:
             raise ConanException("replace_in_file invalid regex '%s': %s" % (search, e))
-        found = n > 0
     else:
-        found = content.find(search) != -1
         new_content = content.replace(search, replace)
-    if not found:
+    if new_content == content:
         message = "replace_in_file didn't find pattern '%s' in '%s' file." % (search, file_path)
         if strict:
             raise ConanException(message)

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -1,5 +1,6 @@
 import gzip
 import os
+import re
 import stat
 import platform
 import shutil
@@ -526,31 +527,50 @@ def check_sha256(conanfile, file_path, signature):
     check_with_algorithm_sum("sha256", file_path, signature)
 
 
-def replace_in_file(conanfile, file_path, search, replace, strict=True, encoding="utf-8"):
+def replace_in_file(conanfile, file_path, search, replace, strict=True, encoding="utf-8",
+                    regex=False, flags=re.MULTILINE):
     """
     Replace a string ``search`` in the contents of the file ``file_path`` with the string replace.
 
     :param conanfile: The current recipe object. Always use ``self``.
     :param file_path: File path of the file to perform the replacing.
-    :param search: String you want to be replaced.
-    :param replace: String to replace the searched string.
+    :param search: String you want to be replaced, or a compiled ``re.Pattern`` for regex
+           replacement (flags from the pattern are used as-is).
+    :param replace: String to replace the searched string. With regex mode, backreferences
+           (``\\1``, ``\\g<name>``) are supported.
     :param strict: (Optional, Defaulted to ``True``) If ``True``, it raises an error if the searched
            string is not found, so nothing is actually replaced.
     :param encoding: (Optional, Defaulted to utf-8): Specifies the input and output files text
            encoding.
+    :param regex: (Optional, Defaulted to ``False``) If ``True``, ``search`` is treated as a
+           regular expression and applied with ``re.sub``. Ignored when ``search`` is already a
+           compiled ``re.Pattern``.
+    :param flags: (Optional, Defaulted to ``re.MULTILINE``) Flags passed to ``re.sub`` when
+           ``regex=True`` and ``search`` is a string. Ignored for compiled patterns.
     :return: ``True`` if the pattern was found, ``False`` otherwise if `strict` is ``False``.
     """
     output = conanfile.output
     content = load(conanfile, file_path, encoding=encoding)
-    if -1 == content.find(search):
+    if isinstance(search, re.Pattern):
+        new_content, n = re.subn(search, replace, content)
+        found = n > 0
+    elif regex:
+        try:
+            new_content, n = re.subn(search, replace, content, flags=flags)
+        except re.error as e:
+            raise ConanException("replace_in_file invalid regex '%s': %s" % (search, e))
+        found = n > 0
+    else:
+        found = content.find(search) != -1
+        new_content = content.replace(search, replace)
+    if not found:
         message = "replace_in_file didn't find pattern '%s' in '%s' file." % (search, file_path)
         if strict:
             raise ConanException(message)
         else:
             output.warning(message)
             return False
-    content = content.replace(search, replace)
-    save(conanfile, file_path, content, encoding=encoding)
+    save(conanfile, file_path, new_content, encoding=encoding)
     return True
 
 

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -534,8 +534,8 @@ def replace_in_file(conanfile, file_path, search, replace, strict=True, encoding
 
     :param conanfile: The current recipe object. Always use ``self``.
     :param file_path: File path of the file to perform the replacing.
-    :param search: String you want to be replaced, or a compiled ``re.Pattern`` for regex
-           replacement (flags from the pattern are used as-is).
+    :param search: String you want to be replaced. With ``regex=True``, treated as a regular
+           expression.
     :param replace: String to replace the searched string. With regex mode, backreferences
            (``\\1``, ``\\g<name>``) are supported.
     :param strict: (Optional, Defaulted to ``True``) If ``True``, it raises an error if the searched
@@ -543,18 +543,14 @@ def replace_in_file(conanfile, file_path, search, replace, strict=True, encoding
     :param encoding: (Optional, Defaulted to utf-8): Specifies the input and output files text
            encoding.
     :param regex: (Optional, Defaulted to ``False``) If ``True``, ``search`` is treated as a
-           regular expression and applied with ``re.sub``. Ignored when ``search`` is already a
-           compiled ``re.Pattern``.
+           regular expression and applied with ``re.sub``.
     :param flags: (Optional, Defaulted to ``re.MULTILINE``) Flags passed to ``re.sub`` when
-           ``regex=True`` and ``search`` is a string. Ignored for compiled patterns.
+           ``regex=True``.
     :return: ``True`` if the pattern was found, ``False`` otherwise if `strict` is ``False``.
     """
     output = conanfile.output
     content = load(conanfile, file_path, encoding=encoding)
-    if isinstance(search, re.Pattern):
-        new_content, n = re.subn(search, replace, content)
-        found = n > 0
-    elif regex:
+    if regex:
         try:
             new_content, n = re.subn(search, replace, content, flags=flags)
         except re.error as e:

--- a/test/unittests/tools/files/test_file_read_and_write.py
+++ b/test/unittests/tools/files/test_file_read_and_write.py
@@ -2,7 +2,6 @@
 
 
 import os
-import re
 
 import pytest
 
@@ -100,13 +99,3 @@ def test_replace_in_file_regex():
     save(conanfile, file_path, "foo.*bar")
     assert replace_in_file(conanfile, file_path, "foo.*", "baz", regex=False)
     assert load(conanfile, file_path) == "bazbar"
-
-
-def test_replace_in_file_compiled_pattern():
-    conanfile = ConanFileMock({})
-    tmp = temp_folder()
-    file_path = os.path.join(tmp, "file.txt")
-    save(conanfile, file_path, "foo\nbar=123\nbaz\n")
-    pattern = re.compile(r"^bar=.*$", re.MULTILINE)
-    assert replace_in_file(conanfile, file_path, pattern, "bar=")
-    assert load(conanfile, file_path) == "foo\nbar=\nbaz\n"

--- a/test/unittests/tools/files/test_file_read_and_write.py
+++ b/test/unittests/tools/files/test_file_read_and_write.py
@@ -2,6 +2,7 @@
 
 
 import os
+import re
 
 import pytest
 
@@ -66,3 +67,46 @@ def test_replace_in_file():
 
     assert not replace_in_file(conanfile, file_path, "not existing", "0",
                                encoding="utf-16", strict=False)
+
+
+def test_replace_in_file_regex():
+    conanfile = ConanFileMock({})
+    tmp = temp_folder()
+    file_path = os.path.join(tmp, "file.txt")
+    save(conanfile, file_path, "foo\nbar=123\nbaz\n")
+
+    # Search with regex
+    assert replace_in_file(conanfile, file_path, r"^bar=.*", "bar=", regex=True)
+    assert load(conanfile, file_path) == "foo\nbar=\nbaz\n"
+
+    # Search and replace with regex
+    save(conanfile, file_path, "foo=hello\nbar\n")
+    assert replace_in_file(conanfile, file_path, r"^foo=(.*)", r"foo=pre_\1", regex=True)
+    assert load(conanfile, file_path) == "foo=pre_hello\nbar\n"
+
+    # Not found replace with strict=False
+    assert not replace_in_file(conanfile, file_path, r"^missing=.*", "x",
+                               regex=True, strict=False)
+
+    # Not found with strict=True
+    with pytest.raises(ConanException, match="didn't find pattern"):
+        replace_in_file(conanfile, file_path, r"^missing=.*", "x", regex=True)
+
+    # Not valid regex
+    with pytest.raises(ConanException, match="invalid regex"):
+        replace_in_file(conanfile, file_path, r"[unclosed", "x", regex=True)
+
+    # regex=False keeps literal match even if search looks like a regex
+    save(conanfile, file_path, "foo.*bar")
+    assert replace_in_file(conanfile, file_path, "foo.*", "baz", regex=False)
+    assert load(conanfile, file_path) == "bazbar"
+
+
+def test_replace_in_file_compiled_pattern():
+    conanfile = ConanFileMock({})
+    tmp = temp_folder()
+    file_path = os.path.join(tmp, "file.txt")
+    save(conanfile, file_path, "foo\nbar=123\nbaz\n")
+    pattern = re.compile(r"^bar=.*$", re.MULTILINE)
+    assert replace_in_file(conanfile, file_path, pattern, "bar=")
+    assert load(conanfile, file_path) == "foo\nbar=\nbaz\n"


### PR DESCRIPTION
Changelog: Feature: `replace_in_file` now supports regex patterns.
Docs: https://github.com/conan-io/docs/pull/4498

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
