### PR TITLE
fix upload with empty uploads from pattern, to make it equal to package lists

### DIFF
--- a/conan/cli/commands/upload.py
+++ b/conan/cli/commands/upload.py
@@ -108,12 +108,10 @@ def upload(conan_api: ConanAPI, parser, *args):
 
         conan_api.upload.upload_full(package_list, remote, enabled_remotes, args.check,
                                      args.force, args.metadata, args.dry_run)
-    elif args.list:
+    else:
         # Don't error on no recipes for automated workflows using list,
         # but warn to tell the user that no packages were uploaded
         ConanOutput().warning(f"No packages were uploaded because the package list is empty.")
-    else:
-        raise ConanException("No recipes found matching pattern '{}'".format(args.pattern))
 
     pkglist = MultiPackagesList()
     pkglist.add(remote.name, package_list)

--- a/conan/cli/commands/upload.py
+++ b/conan/cli/commands/upload.py
@@ -111,7 +111,7 @@ def upload(conan_api: ConanAPI, parser, *args):
     else:
         # Don't error on no recipes for automated workflows using list,
         # but warn to tell the user that no packages were uploaded
-        ConanOutput().warning(f"No packages were uploaded because the package list is empty.")
+        ConanOutput().warning("No packages were uploaded because the selection is empty.")
 
     pkglist = MultiPackagesList()
     pkglist.add(remote.name, package_list)

--- a/test/integration/command/list/test_combined_pkglist_flows.py
+++ b/test/integration/command/list/test_combined_pkglist_flows.py
@@ -49,7 +49,7 @@ class TestListUpload:
         # No binaries should be uploaded since the pkglist is empty, but the command
         # should not error
         client.run("upload --list=pkglist.json -r=default")
-        assert "No packages were uploaded because the package list is empty." in client.out
+        assert "No packages were uploaded because the selection is empty." in client.out
 
 
 class TestGraphCreatedUpload:

--- a/test/integration/command/upload/test_upload_patterns.py
+++ b/test/integration/command/upload/test_upload_patterns.py
@@ -179,9 +179,3 @@ class TestUploadPatternErrors:
     def test_bad_package_query(self, client):
         error = "Invalid package query: blah. Invalid expression: blah"
         self.assert_error("* -p blah", error, client)
-
-
-def test_error_empty():
-    c = TestClient(default_server_user=True, light=True)
-    c.run("upload * -c -r=default")
-    print(c.out)

--- a/test/integration/command/upload/test_upload_patterns.py
+++ b/test/integration/command/upload/test_upload_patterns.py
@@ -179,3 +179,9 @@ class TestUploadPatternErrors:
     def test_bad_package_query(self, client):
         error = "Invalid package query: blah. Invalid expression: blah"
         self.assert_error("* -p blah", error, client)
+
+
+def test_error_empty():
+    c = TestClient(default_server_user=True, light=True)
+    c.run("upload * -c -r=default")
+    print(c.out)

--- a/test/integration/command/upload/upload_test.py
+++ b/test/integration/command/upload/upload_test.py
@@ -106,7 +106,6 @@ class TestUpload:
 
     def test_pattern_upload_no_recipes(self):
         client = TestClient(default_server_user=True, light=True)
-        client.save({"conanfile.py": conanfile})
         client.run("upload bogus/*@dummy/testing --confirm -r default")
         assert "WARN: No packages were uploaded because the package list is empty." in client.out
 

--- a/test/integration/command/upload/upload_test.py
+++ b/test/integration/command/upload/upload_test.py
@@ -107,7 +107,7 @@ class TestUpload:
     def test_pattern_upload_no_recipes(self):
         client = TestClient(default_server_user=True, light=True)
         client.run("upload bogus/*@dummy/testing --confirm -r default")
-        assert "WARN: No packages were uploaded because the package list is empty." in client.out
+        assert "WARN: No packages were uploaded because the selection is empty." in client.out
 
     def test_broken_sources_tgz(self):
         # https://github.com/conan-io/conan/issues/2854

--- a/test/integration/command/upload/upload_test.py
+++ b/test/integration/command/upload/upload_test.py
@@ -107,8 +107,8 @@ class TestUpload:
     def test_pattern_upload_no_recipes(self):
         client = TestClient(default_server_user=True, light=True)
         client.save({"conanfile.py": conanfile})
-        client.run("upload bogus/*@dummy/testing --confirm -r default", assert_error=True)
-        assert "No recipes found matching pattern 'bogus/*@dummy/testing'" in client.out
+        client.run("upload bogus/*@dummy/testing --confirm -r default")
+        assert "WARN: No packages were uploaded because the package list is empty." in client.out
 
     def test_broken_sources_tgz(self):
         # https://github.com/conan-io/conan/issues/2854


### PR DESCRIPTION
Changelog: Fix: Fix upload with empty uploads from pattern, to make it equal to package lists behavior
Docs: Omit

Close https://github.com/conan-io/conan/issues/20196
