### PR TITLE
fixing CMakeConfigDeps host+build

### DIFF
--- a/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
+++ b/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
@@ -122,14 +122,20 @@ class CMakeConfigDeps:
             base_filename = self.get_cmake_filename(dep)
             cmake_config_properties = self._get_cmake_config_properties(dep, full_cpp_info,
                                                                         is_build_context=require.build)
+            # Shared files (config, config-version, targets) have a context-independent
+            # filename. When the same package is both requires and tool_requires, keep the
+            # host-context version so legacy variables (<pkg>_LIBRARIES, ...) are preserved.
             config_version = ConfigVersionTemplate2(base_filename, dep.ref, cmake_config_properties)
-            ret[config_version.filename] = config_version.content()
+            if config_version.filename not in ret:
+                ret[config_version.filename] = config_version.content()
             config = ConfigTemplate2(base_filename, dep.ref, self._conanfile,
                                      full_cpp_info, cmake_config_properties,
                                      is_build_context=require.build)
-            ret[config.filename] = config.content()
+            if config.filename not in ret:
+                ret[config.filename] = config.content()
             targets = TargetsTemplate2(base_filename, dep.ref)
-            ret[targets.filename] = targets.content()
+            if targets.filename not in ret:
+                ret[targets.filename] = targets.content()
             target_configuration = TargetConfigurationTemplate2(self, dep, require, full_cpp_info)
             ret[target_configuration.filename] = target_configuration.content()
 

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -805,6 +805,62 @@ class TestLegacyVariables:
         # mypkg::lib2 is not added to the list of libraries
         assert "set(mypkg_LIBRARIES mypkg::mypkg mypkg::lib2 )" in mypkg_config
 
+    def test_legacy_libraries_requires_and_tool_requires(self):
+        # https://github.com/conan-io/conan/issues/20195
+        # When the same package is both requires and tool_requires, the legacy
+        # global variables (like <pkg>_LIBRARIES) must still be generated in the
+        # host-context <pkg>-config.cmake
+        tc = TestClient()
+        app = textwrap.dedent("""
+             from conan import ConanFile
+             class App(ConanFile):
+                 settings = "os", "arch", "compiler", "build_type"
+                 def requirements(self):
+                     self.requires("mylib/1.0")
+                 def build_requirements(self):
+                     self.tool_requires("mylib/1.0")
+             """)
+        tc.save({"mylib/conanfile.py": GenConanfile("mylib", "1.0")
+                 .with_package_file("lib/mylib.a", "library")
+                 .with_package_info({"libs": ["mylib"]}),
+                 "app/conanfile.py": app})
+        tc.run("create mylib")
+        tc.run("install app -g CMakeConfigDeps")
+        mylib_config = tc.load("app/mylib-config.cmake")
+        print(mylib_config)
+        assert "set(mylib_LIBRARIES mylib::mylib )" in mylib_config
+
+    def test_build_modules_requires_and_tool_requires(self):
+        # https://github.com/conan-io/conan/issues/20195
+        # When the same package is both requires and tool_requires, the shared
+        # <pkg>-config.cmake file is generated once, taking the host-context
+        # cmake_build_modules (the file is included via find_package() in the
+        # host CMakeLists.txt).
+        tc = TestClient()
+        app = textwrap.dedent("""
+            from conan import ConanFile
+            from conan.tools.cmake import CMakeConfigDeps
+            class App(ConanFile):
+                settings = "os", "arch", "compiler", "build_type"
+                def requirements(self):
+                    self.requires("mylib/1.0")
+                def build_requirements(self):
+                    self.tool_requires("mylib/1.0")
+                def generate(self):
+                    deps = CMakeConfigDeps(self)
+                    deps.set_property("mylib", "cmake_build_modules", ["host_mod.cmake"])
+                    deps.set_property("mylib", "cmake_build_modules", ["build_mod.cmake"],
+                                      build_context=True)
+                    deps.generate()
+            """)
+        tc.save({"mylib/conanfile.py": GenConanfile("mylib", "1.0"),
+                 "app/conanfile.py": app})
+        tc.run("create mylib")
+        tc.run("install app")
+        mylib_config = tc.load("app/mylib-config.cmake")
+        assert 'include("host_mod.cmake")' in mylib_config
+        assert 'include("build_mod.cmake")' not in mylib_config
+
 
 class TestPropertiesBuildContext:
     def test_property_build_context(self):


### PR DESCRIPTION
Changelog: Bugfix: Make `CMakeConfigDeps` generate common files only for the host context, avoiding lost CMake variables.
Docs: Omit

Close https://github.com/conan-io/conan/issues/20195

This might have other side effects, like what happens with ``cmake_build_modules``? The current test checks that only the "host" one prevails. Maybe we want to check the ``cmake_build_modules`` in ConanCenter use cases.

It also seems that ``cmake_extra_variables`` could be different, which ones should have priority?
