### PR TITLE
Fix replace_in_file false "pattern not found" on no-op replace

### DIFF
--- a/conan/__init__.py
+++ b/conan/__init__.py
@@ -2,5 +2,5 @@ from conan.internal.model.conan_file import ConanFile
 from conan.internal.model.workspace import Workspace
 from conan.internal.model.version import Version
 
-__version__ = '2.31.0'
+__version__ = '2.31.1'
 conan_version = Version(__version__)

--- a/conan/tools/files/files.py
+++ b/conan/tools/files/files.py
@@ -552,12 +552,14 @@ def replace_in_file(conanfile, file_path, search, replace, strict=True, encoding
     content = load(conanfile, file_path, encoding=encoding)
     if regex:
         try:
-            new_content = re.sub(search, replace, content, flags=flags)
+            new_content, count = re.subn(search, replace, content, flags=flags)
         except re.error as e:
             raise ConanException("replace_in_file invalid regex '%s': %s" % (search, e))
+        found = count > 0
     else:
+        found = search in content
         new_content = content.replace(search, replace)
-    if new_content == content:
+    if not found:
         message = "replace_in_file didn't find pattern '%s' in '%s' file." % (search, file_path)
         if strict:
             raise ConanException(message)

--- a/test/unittests/tools/files/test_file_read_and_write.py
+++ b/test/unittests/tools/files/test_file_read_and_write.py
@@ -103,21 +103,20 @@ def test_replace_in_file_regex():
 
 def test_replace_in_file_noop_replace():
     """ Regression test for a replace that matches but produces identical content, e.g.
-    replace_in_file(conanfile, path, "AC_CHECK_LIB(z,", f"AC_CHECK_LIB({zlib_name},") when
-    zlib_name == "z", as happens in the libcurl recipe. This must not be reported as
-    "pattern not found" (https://github.com/conan-io/conan/pull/20194 regression).
+    replace_in_file(conanfile, path, search, replace) when search == replace, or when replace
+    reconstructs the exact same text. This must not be reported as "pattern not found"
+    (https://github.com/conan-io/conan/pull/20194 regression).
     """
     conanfile = ConanFileMock({})
     tmp = temp_folder()
     file_path = os.path.join(tmp, "file.txt")
-    save(conanfile, file_path, "AC_CHECK_LIB(z, deflate)\n")
+    save(conanfile, file_path, "foo bar baz\n")
 
     # search is present, but replace happens to produce the same text back
-    assert replace_in_file(conanfile, file_path, "AC_CHECK_LIB(z,", "AC_CHECK_LIB(z,")
-    assert load(conanfile, file_path) == "AC_CHECK_LIB(z, deflate)\n"
+    assert replace_in_file(conanfile, file_path, "bar", "bar")
+    assert load(conanfile, file_path) == "foo bar baz\n"
 
     # same, but for regex mode
-    save(conanfile, file_path, "AC_CHECK_LIB(z, deflate)\n")
-    assert replace_in_file(conanfile, file_path, r"AC_CHECK_LIB\(z,", "AC_CHECK_LIB(z,",
-                            regex=True)
-    assert load(conanfile, file_path) == "AC_CHECK_LIB(z, deflate)\n"
+    save(conanfile, file_path, "foo bar baz\n")
+    assert replace_in_file(conanfile, file_path, r"ba(r)", r"ba\1", regex=True)
+    assert load(conanfile, file_path) == "foo bar baz\n"

--- a/test/unittests/tools/files/test_file_read_and_write.py
+++ b/test/unittests/tools/files/test_file_read_and_write.py
@@ -99,3 +99,25 @@ def test_replace_in_file_regex():
     save(conanfile, file_path, "foo.*bar")
     assert replace_in_file(conanfile, file_path, "foo.*", "baz", regex=False)
     assert load(conanfile, file_path) == "bazbar"
+
+
+def test_replace_in_file_noop_replace():
+    """ Regression test for a replace that matches but produces identical content, e.g.
+    replace_in_file(conanfile, path, "AC_CHECK_LIB(z,", f"AC_CHECK_LIB({zlib_name},") when
+    zlib_name == "z", as happens in the libcurl recipe. This must not be reported as
+    "pattern not found" (https://github.com/conan-io/conan/pull/20194 regression).
+    """
+    conanfile = ConanFileMock({})
+    tmp = temp_folder()
+    file_path = os.path.join(tmp, "file.txt")
+    save(conanfile, file_path, "AC_CHECK_LIB(z, deflate)\n")
+
+    # search is present, but replace happens to produce the same text back
+    assert replace_in_file(conanfile, file_path, "AC_CHECK_LIB(z,", "AC_CHECK_LIB(z,")
+    assert load(conanfile, file_path) == "AC_CHECK_LIB(z, deflate)\n"
+
+    # same, but for regex mode
+    save(conanfile, file_path, "AC_CHECK_LIB(z, deflate)\n")
+    assert replace_in_file(conanfile, file_path, r"AC_CHECK_LIB\(z,", "AC_CHECK_LIB(z,",
+                            regex=True)
+    assert load(conanfile, file_path) == "AC_CHECK_LIB(z, deflate)\n"


### PR DESCRIPTION
Changelog: Fix: Fixed `replace_in_file()` raising a false "pattern not found" error when the replacement produced the same content as the original (no-op replace).
Docs: Omit

Closes: https://github.com/conan-io/conan/issues/20212

`replace_in_file` could wrongly raise "didn't find pattern" even when the pattern was found, if the replacement text happened to be identical to the original (a no-op replace, e.g. `replace_in_file(conanfile, path, "bar", "bar")`).

This was a regression from #20194: it now checks whether the pattern was found by comparing content before and after the replace, instead of just checking if the pattern exists. So a no-op replace looks the same as "nothing found".

To fix, now we check if the pattern was found independently of whether the content actually changes.

Found out, because building libcurl/8.12.1 broke here: https://github.com/conan-io/examples2/actions/runs/30057043101/job/89370826155