### PR TITLE
qbs: add support for the qbs_file_name property

### DIFF
--- a/conan/tools/qbs/qbsdeps.py
+++ b/conan/tools/qbs/qbsdeps.py
@@ -68,7 +68,9 @@ class _QbsDepGenerator:
         def _get_package_name(dep):
             # TODO: pkgconfig uses suffix, do we need it? see:
             # https://github.com/conan-io/conan/blob/develop2/conan/tools/gnu/pkgconfigdeps.py#L319
-            return dep.cpp_info.get_property("pkg_config_name") or dep.ref.name
+            return (dep.cpp_info.get_property("qbs_file_name") or
+                    dep.cpp_info.get_property("pkg_config_name") or
+                    dep.ref.name)
 
         def _get_component_name(dep, comp_name):
             if comp_name not in dep.cpp_info.components:

--- a/test/integration/toolchains/qbs/test_qbsdeps.py
+++ b/test/integration/toolchains/qbs/test_qbsdeps.py
@@ -104,6 +104,26 @@ def test_pkg_config_name():
     assert os.path.exists(module_path)
 
 
+def test_qbs_file_name():
+    # Checks we can override module name using the "qbs_file_name" property
+    conanfile = textwrap.dedent('''
+        from conan import ConanFile
+
+        class Recipe(ConanFile):
+            name = 'mylib'
+            version = '0.1'
+            def package_info(self):
+                self.cpp_info.set_property("qbs_file_name", "MyFirstLib")
+        ''')
+    client = TestClient()
+    client.save({'conanfile.py': conanfile})
+    client.run('create .')
+    client.run('install --requires=mylib/0.1@ -g QbsDeps')
+
+    module_path = os.path.join(client.current_folder, 'conan-qbs-deps', 'MyFirstLib.json')
+    assert os.path.exists(module_path)
+
+
 @pytest.mark.parametrize('host_os, arch, build_type', [
     ('Linux', 'x86_64', 'Debug'),
     ('Linux', 'x86_64', 'Release'),


### PR DESCRIPTION
This property allows to change the generated module name and avoid collisions with Qbs naming. An example of such collision is the "protobuf" module - the Qbs module and Conan runtime library both share the same name; currently, Qbs renames the runtime to "protobuflib".

Changelog: Feature: Add `qbs_file_name` property to override the generated Qbs module name and avoid collisions.
Docs: https://github.com/conan-io/docs/pull/4520

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
