### PR TITLE
conan editable add --ref

### DIFF
--- a/conan/cli/commands/editable.py
+++ b/conan/cli/commands/editable.py
@@ -1,9 +1,11 @@
 import json
 import os
 
+from conan.api.model import RecipeReference
 from conan.api.output import ConanOutput, cli_out_write
 from conan.cli.args import add_reference_args
 from conan.cli.command import conan_command, conan_subcommand
+from conan.errors import ConanException
 
 
 @conan_command(group="Creator")
@@ -22,6 +24,9 @@ def editable_add(conan_api, parser, subparser, *args):
     subparser.add_argument('path', help='Path to the package folder in the user workspace',
                            default=".", nargs='?')
     add_reference_args(subparser)
+    subparser.add_argument("--ref",
+                           help='Full package reference (e.g. pkg/1.0@user/channel), as a '
+                                'shortcut for --name/--version/--user/--channel')
     subparser.add_argument("-of", "--output-folder",
                            help='The root output folder for generated and build files')
     group = subparser.add_mutually_exclusive_group()
@@ -31,9 +36,18 @@ def editable_add(conan_api, parser, subparser, *args):
                        help='Do not use remote, resolve exclusively in the cache')
     args = parser.parse_args(*args)
 
+    name, version, user, channel = args.name, args.version, args.user, args.channel
+    if args.ref:
+        if any((name, version, user, channel)):
+            raise ConanException("--ref is incompatible with --name/--version/--user/--channel")
+        ref = RecipeReference.loads(args.ref)
+        if ref.revision is not None:
+            raise ConanException(f"--ref '{args.ref}' cannot contain a revision")
+        name, version, user, channel = ref.name, str(ref.version), ref.user, ref.channel
+
     remotes = conan_api.remotes.list(args.remote) if not args.no_remote else []
     cwd = os.getcwd()
-    ref = conan_api.local.editable_add(args.path, args.name, args.version, args.user, args.channel,
+    ref = conan_api.local.editable_add(args.path, name, version, user, channel,
                                        cwd, args.output_folder, remotes=remotes)
     ConanOutput().success("Reference '{}' in editable mode".format(ref))
 

--- a/test/integration/editable/editable_add_test.py
+++ b/test/integration/editable/editable_add_test.py
@@ -33,6 +33,32 @@ class TestEditablePackageTest:
         t.run('install --requires=lib/version@user/name')
         t.assert_listed_require({"lib/version@user/name": "Editable"})
 
+    def test_ref_shortcut(self):
+        t = TestClient()
+        t.save({'conanfile.py': GenConanfile()})
+        t.run('editable add . --ref=lib/1.0@user/channel')
+        assert "Reference 'lib/1.0@user/channel' in editable mode" in t.out
+        t.run("editable list")
+        assert "lib/1.0@user/channel" in t.out
+
+    def test_ref_shortcut_no_user_channel(self):
+        t = TestClient()
+        t.save({'conanfile.py': GenConanfile()})
+        t.run('editable add . --ref=lib/1.0')
+        assert "Reference 'lib/1.0' in editable mode" in t.out
+
+    def test_ref_incompatible_with_name(self):
+        t = TestClient()
+        t.save({'conanfile.py': GenConanfile()})
+        t.run('editable add . --ref=lib/1.0 --name=other', assert_error=True)
+        assert "--ref is incompatible with --name/--version/--user/--channel" in t.out
+
+    def test_ref_rejects_revision(self):
+        t = TestClient()
+        t.save({'conanfile.py': GenConanfile()})
+        t.run('editable add . --ref=lib/1.0#abc123', assert_error=True)
+        assert "cannot contain a revision" in t.out
+
     def test_pyrequires_remote(self):
         t = TestClient(default_server_user=True)
         t.save({"conanfile.py": GenConanfile("pyreq", "1.0")})


### PR DESCRIPTION
Changelog: Feature: Add `--ref` argument to `conan editable add <path>` as a shortcut to define name, version, etc.
Docs: Omit

Close https://github.com/conan-io/conan/issues/18851
