### PR TITLE
compiler executables UX

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -972,6 +972,11 @@ class CompilersBlock(Block):
         compilers_mapping = {"c": "C", "cuda": "CUDA", "cpp": "CXX", "objc": "OBJC",
                              "objcpp": "OBJCXX", "rc": "RC", 'fortran': "Fortran", 'asm': "ASM",
                              "hip": "HIP", "ispc": "ISPC"}
+        unknown = [k for k in compilers_by_conf if k not in compilers_mapping]
+        if unknown:
+            self._conanfile.output.warning(
+                f"tools.build:compiler_executables: ignoring unknown key(s) {sorted(unknown)}, "
+                f"expected one of {sorted(compilers_mapping)}", warn_tag="risk")
         for comp, lang in compilers_mapping.items():
             # To set CMAKE_<LANG>_COMPILER
             if comp in compilers_by_conf:

--- a/conan/tools/gnu/autotoolstoolchain.py
+++ b/conan/tools/gnu/autotoolstoolchain.py
@@ -298,7 +298,13 @@ class AutotoolsToolchain:
                                                          check_type=dict)
             if compilers_by_conf:
                 compilers_mapping = {"c": "CC", "cpp": "CXX", "cuda": "NVCC", "fortran": "FC",
-                                     "rc": "RC"}
+                                     "rc": "RC", "objc": "OBJC", "objcpp": "OBJCXX", "asm": "AS"}
+                unknown = [k for k in compilers_by_conf if k not in compilers_mapping]
+                if unknown:
+                    self._conanfile.output.warning(
+                        f"tools.build:compiler_executables: ignoring unknown key(s) "
+                        f"{sorted(unknown)}, expected one of {sorted(compilers_mapping)}",
+                        warn_tag="risk")
                 for comp, env_var in compilers_mapping.items():
                     if comp in compilers_by_conf:
                         compiler = compilers_by_conf[comp]

--- a/conan/tools/gnu/gnutoolchain.py
+++ b/conan/tools/gnu/gnutoolchain.py
@@ -209,12 +209,19 @@ class GnuToolchain:
         ret = {}
         # Configuration map
         compilers_mapping = {"c": "CC", "cpp": "CXX", "cuda": "NVCC", "fortran": "FC",
-                             "rc": "RC", "nm": "NM", "ranlib": "RANLIB",
+                             "rc": "RC", "objc": "OBJC", "objcpp": "OBJCXX", "asm": "AS",
+                             "nm": "NM", "ranlib": "RANLIB",
                              "objdump": "OBJDUMP", "strip": "STRIP"}
         # Compiler definitions by conf
         compilers_by_conf = self._conanfile.conf.get("tools.build:compiler_executables",
                                                      default={}, check_type=dict)
         if compilers_by_conf:
+            unknown = [k for k in compilers_by_conf if k not in compilers_mapping]
+            if unknown:
+                self._conanfile.output.warning(
+                    f"tools.build:compiler_executables: ignoring unknown key(s) "
+                    f"{sorted(unknown)}, expected one of {sorted(compilers_mapping)}",
+                    warn_tag="risk")
             for comp, env_var in compilers_mapping.items():
                 if comp in compilers_by_conf:
                     compiler = compilers_by_conf[comp]

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -560,6 +560,55 @@ def test_cmaketoolchain_rcflags():
     assert 'string(APPEND CMAKE_RC_FLAGS_INIT " ${CONAN_RC_FLAGS}")' in toolchain
 
 
+def test_cmaketoolchain_compiler_executables_unknown_key_warning():
+    """https://github.com/conan-io/conan/issues/19142
+    Keys in tools.build:compiler_executables must be lowercase and match the known languages.
+    Unknown keys (e.g. "RC" uppercase) should produce a risk warning instead of being silently
+    ignored.
+    """
+    profile = textwrap.dedent("""
+        [settings]
+        os=Linux
+        arch=x86_64
+        compiler=gcc
+        compiler.version=6
+        compiler.libcxx=libstdc++11
+        build_type=Release
+
+        [conf]
+        tools.build:compiler_executables = {"RC": "rc", "bogus": "x", "c": "gcc"}
+        """)
+    client = TestClient()
+    conanfile = GenConanfile().with_settings("os", "arch", "compiler", "build_type")\
+        .with_generator("CMakeToolchain")
+    client.save({"conanfile.py": conanfile, "profile": profile})
+    client.run("install . --profile:host=profile")
+    assert "compiler_executables: ignoring unknown key(s) ['RC', 'bogus']" in client.out
+    # Known lowercase key still works
+    assert 'set(CMAKE_C_COMPILER "gcc")' in client.load("conan_toolchain.cmake")
+
+
+def test_cmaketoolchain_compiler_executables_no_warning_for_known_keys():
+    profile = textwrap.dedent("""
+        [settings]
+        os=Linux
+        arch=x86_64
+        compiler=gcc
+        compiler.version=6
+        compiler.libcxx=libstdc++11
+        build_type=Release
+
+        [conf]
+        tools.build:compiler_executables = {"c": "gcc", "cpp": "g++", "rc": "rc"}
+        """)
+    client = TestClient()
+    conanfile = GenConanfile().with_settings("os", "arch", "compiler", "build_type")\
+        .with_generator("CMakeToolchain")
+    client.save({"conanfile.py": conanfile, "profile": profile})
+    client.run("install . --profile:host=profile")
+    assert "ignoring unknown key" not in client.out
+
+
 def test_cmaketoolchain_asmflags():
     """Test that tools.build:asmflags is applied to CONAN_ASM_FLAGS and CMAKE_ASM_FLAGS_INIT"""
     profile = textwrap.dedent("""

--- a/test/integration/toolchains/gnu/test_autotoolstoolchain.py
+++ b/test/integration/toolchains/gnu/test_autotoolstoolchain.py
@@ -223,7 +223,8 @@ def test_unknown_compiler():
     assert "Generator 'AutotoolsToolchain' calling 'generate()'" in client.out
 
 
-def test_autotoolstoolchain_compiler_executables_unknown_key_warning():
+@pytest.mark.parametrize("generator", ["AutotoolsToolchain", "GnuToolchain"])
+def test_autotoolstoolchain_compiler_executables_unknown_key_warning(generator):
     """https://github.com/conan-io/conan/issues/19142 -- same guarantee for AutotoolsToolchain."""
     client = TestClient()
     profile = textwrap.dedent("""
@@ -240,7 +241,7 @@ def test_autotoolstoolchain_compiler_executables_unknown_key_warning():
         """)
     client.save({"conanfile.py": GenConanfile().with_settings("os", "arch", "compiler",
                                                               "build_type")
-                                              .with_generator("AutotoolsToolchain"),
+                                               .with_generator(generator),
                  "profile": profile})
     client.run("install . --profile:host=profile")
     assert "compiler_executables: ignoring unknown key(s) ['RC', 'bogus']" in client.out

--- a/test/integration/toolchains/gnu/test_autotoolstoolchain.py
+++ b/test/integration/toolchains/gnu/test_autotoolstoolchain.py
@@ -223,6 +223,29 @@ def test_unknown_compiler():
     assert "Generator 'AutotoolsToolchain' calling 'generate()'" in client.out
 
 
+def test_autotoolstoolchain_compiler_executables_unknown_key_warning():
+    """https://github.com/conan-io/conan/issues/19142 -- same guarantee for AutotoolsToolchain."""
+    client = TestClient()
+    profile = textwrap.dedent("""
+        [settings]
+        os=Linux
+        arch=x86_64
+        compiler=gcc
+        compiler.version=6
+        compiler.libcxx=libstdc++11
+        build_type=Release
+
+        [conf]
+        tools.build:compiler_executables={"RC": "rc", "bogus": "x", "c": "gcc"}
+        """)
+    client.save({"conanfile.py": GenConanfile().with_settings("os", "arch", "compiler",
+                                                              "build_type")
+                                              .with_generator("AutotoolsToolchain"),
+                 "profile": profile})
+    client.run("install . --profile:host=profile")
+    assert "compiler_executables: ignoring unknown key(s) ['RC', 'bogus']" in client.out
+
+
 def test_toolchain_and_compilers_build_context():
     """
     Tests how AutotoolsToolchain manages the build context profile if the build profile is

--- a/test/unittests/tools/gnu/autotoolschain_test.py
+++ b/test/unittests/tools/gnu/autotoolschain_test.py
@@ -131,9 +131,9 @@ def test_get_gnu_triplet_for_cross_building_raise_error():
 
 
 def test_compilers_mapping():
-    autotools_mapping = {"c": "CC", "cpp": "CXX", "cuda": "NVCC", "fortran": "FC"}
-    compilers = {"c": "path_to_c", "cpp": "path_to_cpp", "cuda": "path_to_cuda",
-                 "fortran": "path_to_fortran"}
+    autotools_mapping = {"c": "CC", "cpp": "CXX", "cuda": "NVCC", "fortran": "FC",
+                         "rc": "RC", "objc": "OBJC", "objcpp": "OBJCXX", "asm": "AS"}
+    compilers = {k: f"path_to_{k}" for k in autotools_mapping}
     settings = MockSettings({"build_type": "Release",
                              "os": "Windows",
                              "arch": "x86_64",

--- a/test/unittests/tools/gnu/test_gnutoolchain.py
+++ b/test/unittests/tools/gnu/test_gnutoolchain.py
@@ -134,9 +134,10 @@ def test_get_gnu_triplet_for_cross_building_raise_error():
 
 
 def test_compilers_mapping():
-    autotools_mapping = {"c": "CC", "cpp": "CXX", "cuda": "NVCC", "fortran": "FC"}
-    compilers = {"c": "path_to_c", "cpp": "path_to_cpp", "cuda": "path_to_cuda",
-                 "fortran": "path_to_fortran"}
+    autotools_mapping = {"c": "CC", "cpp": "CXX", "cuda": "NVCC", "fortran": "FC",
+                         "rc": "RC", "objc": "OBJC", "objcpp": "OBJCXX", "asm": "AS",
+                         "nm": "NM", "ranlib": "RANLIB", "objdump": "OBJDUMP", "strip": "STRIP"}
+    compilers = {k: f"path_to_{k}" for k in autotools_mapping}
     settings = MockSettings({"build_type": "Release",
                              "os": "Windows",
                              "arch": "x86_64",


### PR DESCRIPTION
Changelog: Fix: Warn when `tools.build:compiler_executables` keys are unknown or unused by `CMakeToolchain`/`AutotoolsToolchain`.
Changelog: Fix: Add `objc`, `objcpp` and `asm` as `tools.build:compiler_executables` for `AutotoolsToolchain`.
Docs: https://github.com/conan-io/docs/pull/4513

Close https://github.com/conan-io/conan/issues/19142
