### PR TITLE
Improve copy performance on patterns

### DIFF
--- a/conan/tools/files/copy_pattern.py
+++ b/conan/tools/files/copy_pattern.py
@@ -15,8 +15,9 @@ def copy(conanfile, pattern, src, dst, keep_path=True, excludes=None,
     :param conanfile: The current recipe object. Always use ``self``.
     :param pattern: (Required) An fnmatch file pattern, or a list/tuple of fnmatch patterns,
            of the files that should be copied. When a list is given the src folder is walked
-           only once and files matching any of the patterns are copied. Patterns must not
-           start with ``..`` relative path or an exception will be raised.
+           only once, and every file matching any of the patterns is copied exactly once, even
+           if several patterns match it. Patterns must not start with ``..`` relative path or
+           an exception will be raised.
     :param src: (Required) Source folder in which those files will be searched. This folder
            will be stripped from the dst parameter. E.g., lib/Debug/x86.
     :param dst: (Required) Destination local folder. It must be different from src value or an
@@ -105,14 +106,20 @@ def _filter_files(src, patterns, excludes, ignore_case, excluded_folder):
             relative_name = os.path.normpath(os.path.join(relative_path, f))
             filenames.append(relative_name)
 
-    if ignore_case:
-        files_to_copy = [n for n in filenames
-                         if any(fnmatch.fnmatch(os.path.normpath(n.lower()), p)
-                                for p in patterns)]
-    else:
-        files_to_copy = [n for n in filenames
-                         if any(fnmatch.fnmatchcase(os.path.normpath(n), p)
-                                for p in patterns)]
+    # Normalize each name once, not once per pattern tried. fnmatch() normcases both sides
+    # (relevant on Windows) while fnmatchcase() does not, so the matcher is selected instead
+    # TODO: matching is O(patterns) per file, around a fifth of this function. Joining the
+    #  patterns into one compiled regex (fnmatch.translate() each + "|") makes it O(1) per file,
+    #  measured 10x instead of 8x with 10 patterns. Blocked while we support < 3.10: translate()
+    #  emits named groups in 3.9/3.10, so the joined pattern differs on every call and would need
+    #  a cache, and 3.8/3.9 compile it eagerly, so a malformed range like "[a-.]" would raise
+    #  instead of being skipped. It also needs os.path.normcase() by hand, untested on Windows
+    matcher = fnmatch.fnmatch if ignore_case else fnmatch.fnmatchcase
+    files_to_copy = []
+    for n in filenames:
+        name = os.path.normpath(n.lower()) if ignore_case else os.path.normpath(n)
+        if any(matcher(name, p) for p in patterns):
+            files_to_copy.append(n)
 
     for exclude in excludes:
         if ignore_case:

--- a/test/integration/command/export/export_sources_test.py
+++ b/test/integration/command/export/export_sources_test.py
@@ -2,6 +2,7 @@ import os
 import textwrap
 
 from conan.api.model import RecipeReference
+from conan.internal.util.files import gather_files
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
 
@@ -60,42 +61,62 @@ def test_exports_sources():
     assert_files(ref_layout.export_sources(), ['hello.h'])
 
 
-def test_exports_sources_multiple_patterns_single_scan():
-    """Multiple include patterns and excludes must yield the union of matches minus excludes,
-    and must not require re-walking the tree per pattern (see #18981).
+def test_exports_sources_multiple_patterns():
+    """ Several exports_sources patterns export the union of what they match, minus the excludes
     """
-    conanfile = textwrap.dedent("""
-        from conan import ConanFile
-
-        class HelloConan(ConanFile):
-            name = "hello"
-            version = "0.1"
-            exports_sources = "*.h", "src/*.cpp", "docs/*.md", "!docs/private.md"
-        """)
     c = TestClient(light=True)
-    c.save({"conanfile.py": conanfile,
-            "hello.h": "hello",
-            "other.h": "other",
-            "src/lib.cpp": "lib",
-            "src/util.cpp": "util",
-            "docs/readme.md": "readme",
-            "docs/private.md": "secret",
-            "unmatched.txt": "nope"})
-    c.run("create .")
-    ref = RecipeReference.loads("hello/0.1")
-    ref_layout = c.get_latest_ref_layout(ref)
+    c.save({"conanfile.py": GenConanfile("hello", "0.1")
+                            .with_exports_sources("*.h", "src/*.cpp", "docs/*.md",
+                                                  "!docs/private.md"),
+            "hello.h": "", "other.h": "",
+            "src/lib.cpp": "", "src/util.cpp": "",
+            "docs/readme.md": "", "docs/private.md": "",
+            "unmatched.txt": ""})
+    c.run("export .")
 
-    exported = []
-    for root, _, files in os.walk(ref_layout.export_sources()):
-        for f in files:
-            rel = os.path.relpath(os.path.join(root, f), ref_layout.export_sources())
-            exported.append(rel.replace(os.sep, "/"))
+    ref_layout = c.get_latest_ref_layout(RecipeReference.loads("hello/0.1"))
+    exported, _ = gather_files(ref_layout.export_sources())
+    assert sorted(exported) == ["docs/readme.md", "hello.h", "other.h",
+                                "src/lib.cpp", "src/util.cpp"]
 
-    assert sorted(exported) == sorted([
-        "hello.h", "other.h",
-        "src/lib.cpp", "src/util.cpp",
-        "docs/readme.md",
-    ])
+
+def test_exports_multiple_patterns():
+    """ Same for the ``exports`` attribute: union of all the patterns, minus the excludes
+    """
+    c = TestClient(light=True)
+    c.save({"conanfile.py": GenConanfile("hello", "0.1")
+                            .with_exports("*.h", "src/*.cpp", "docs/*.md", "!docs/private.md"),
+            "hello.h": "", "other.h": "",
+            "src/lib.cpp": "", "src/util.cpp": "",
+            "docs/readme.md": "", "docs/private.md": "",
+            "unmatched.txt": ""})
+    c.run("export .")
+
+    ref_layout = c.get_latest_ref_layout(RecipeReference.loads("hello/0.1"))
+    exported, _ = gather_files(ref_layout.export())
+    assert sorted(exported) == ["conanfile.py", "conanmanifest.txt", "docs/readme.md",
+                                "hello.h", "other.h", "src/lib.cpp", "src/util.cpp"]
+
+
+def test_export_walks_recipe_folder_once_per_exports_attribute():
+    """ All the patterns of one attribute are passed to a single copy() call, so the recipe
+    folder is walked once for exports_sources and once for exports, not once per pattern.
+    copy() traces one "copy(pattern=...)" line per call, visible with -vv (debug)
+    """
+    c = TestClient(light=True)
+    c.save({"conanfile.py": GenConanfile("hello", "0.1")
+                            .with_exports_sources("*.h", "src/*.cpp")
+                            .with_exports("*.txt", "docs/*.md"),
+            "hello.h": "", "src/lib.cpp": "",
+            "notes.txt": "", "docs/readme.md": ""})
+    c.run("export . -vv")
+
+    walks = [line for line in c.out.splitlines() if "copy(pattern=" in line]
+    trace = "\n".join(walks)
+    assert len(walks) == 2, f"Expected 1 walk for exports_sources + 1 for exports, got:\n{trace}"
+    # and each pair of patterns travelled together, in the very same copy() call
+    assert any("*.h" in w and "src/*.cpp" in w for w in walks), trace
+    assert any("*.txt" in w and "docs/*.md" in w for w in walks), trace
 
 
 def test_test_package_copied():

--- a/test/unittests/tools/files/test_tool_copy.py
+++ b/test/unittests/tools/files/test_tool_copy.py
@@ -1,6 +1,8 @@
 from unittest import mock
 import os
 import platform
+import sys
+
 import pytest
 
 from conan.errors import ConanException
@@ -290,23 +292,29 @@ class TestToolCopy:
         assert copy2_mock.call_count == 2, \
             f"2 files, {copy2_mock.call_count} copies: a.h is being copied once per pattern"
 
+    @pytest.mark.skipif(sys.version_info < (3, 9),
+                        reason="Before 3.9 os.walk() recurses calling the patched os.walk() itself")
     def test_multiple_patterns_single_scan(self):
         # A list of patterns walks the src tree once, not once per pattern like a loop of copy()
-        # calls did, which is the point of accepting a list, see #18981. os.scandir() is what is
-        # counted because os.walk() calls it exactly once per folder in every Python version
+        # calls did, which is the point of accepting a list, see #18981.
+        # Counting os.walk() calls only works from 3.9 on: before that os.walk() is a recursive
+        # generator that descends by calling the module-global os.walk(), the very name patched
+        # here, so the count would be 1 + one per subfolder. Counting os.scandir() instead would
+        # be version independent, but it is called by any directory listing in the process, and
+        # patching it (like patching os.walk) is process wide, so a concurrent one would count too
         src_folder = temp_folder()
         for i in range(5):
             save(os.path.join(src_folder, f"dir{i}/file.h"), "h")
             save(os.path.join(src_folder, f"dir{i}/file.cpp"), "cpp")
+        dst_folder = temp_folder()
         patterns = [f"dir{i}/*.h" for i in range(5)] + [f"dir{i}/*.cpp" for i in range(5)]
 
-        with mock.patch("os.scandir", wraps=os.scandir) as scandir_mock:
-            copy(None, patterns, src_folder, temp_folder())
+        with mock.patch("conan.tools.files.copy_pattern.os.walk", wraps=os.walk) as walk_mock:
+            copy(None, patterns, src_folder, dst_folder)
 
-        # the src folder itself plus its 5 subfolders, opened once each, for all 10 patterns
-        assert scandir_mock.call_count == 6, \
-            f"{len(patterns)} patterns opened {scandir_mock.call_count} folders instead of 6: " \
-            f"the src tree is being scanned once per pattern again"
+        assert walk_mock.call_count == 1, \
+            f"{len(patterns)} patterns walked the src tree {walk_mock.call_count} times " \
+            f"instead of once: it is being scanned once per pattern again"
 
     @pytest.mark.skipif(platform.system() == "Windows", reason="Requires Symlinks")
     def test_multiple_patterns_symlinked_folder(self):

--- a/test/unittests/tools/files/test_tool_copy.py
+++ b/test/unittests/tools/files/test_tool_copy.py
@@ -3,6 +3,7 @@ import os
 import platform
 import pytest
 
+from conan.errors import ConanException
 from conan.tools.files import copy
 from conan.test.utils.test_files import temp_folder
 from conan.internal.util.files import load, save, mkdir, save_files, chdir
@@ -277,41 +278,117 @@ class TestToolCopy:
 
     @mock.patch('shutil.copy2')
     def test_multiple_patterns_dedup(self, copy2_mock):
-        # Files matched by more than one pattern must only be copied once
+        """ A file matched by several patterns is still copied (and reported) only once """
         src_folder = temp_folder()
-        save(os.path.join(src_folder, "a.h"), "x")
-        save(os.path.join(src_folder, "b.h"), "x")
+        save(os.path.join(src_folder, "a.h"), "x")   # matches both patterns below
+        save(os.path.join(src_folder, "b.h"), "x")   # matches only "*.h"
         dst_folder = temp_folder()
 
-        copy(None, ["*.h", "a.*"], src_folder, dst_folder)
-        assert copy2_mock.call_count == 2  # a.h counted once, b.h counted once
+        copied = copy(None, ["*.h", "a.*"], src_folder, dst_folder)
+        assert sorted(os.path.basename(f) for f in copied) == ["a.h", "b.h"], \
+            f"copy() reported {len(copied)} files: a.h is handled once per matching pattern"
+        assert copy2_mock.call_count == 2, \
+            f"2 files, {copy2_mock.call_count} copies: a.h is being copied once per pattern"
 
     def test_multiple_patterns_single_scan(self):
-        # A list of patterns must walk the src tree exactly once, regardless of pattern count.
-        # This is the performance guarantee behind #18981.
+        # A list of patterns walks the src tree once, not once per pattern like a loop of copy()
+        # calls did, which is the point of accepting a list, see #18981. os.scandir() is what is
+        # counted because os.walk() calls it exactly once per folder in every Python version
         src_folder = temp_folder()
         for i in range(5):
             save(os.path.join(src_folder, f"dir{i}/file.h"), "h")
             save(os.path.join(src_folder, f"dir{i}/file.cpp"), "cpp")
-        dst_folder = temp_folder()
-
         patterns = [f"dir{i}/*.h" for i in range(5)] + [f"dir{i}/*.cpp" for i in range(5)]
 
-        with mock.patch("conan.tools.files.copy_pattern.os.walk",
-                        wraps=os.walk) as walk_mock:
-            copy(None, patterns, src_folder, dst_folder)
-            single_scan_calls = walk_mock.call_count
+        with mock.patch("os.scandir", wraps=os.scandir) as scandir_mock:
+            copy(None, patterns, src_folder, temp_folder())
 
-        # Baseline: calling copy() once per pattern would walk once per pattern
-        dst_folder2 = temp_folder()
-        with mock.patch("conan.tools.files.copy_pattern.os.walk",
-                        wraps=os.walk) as walk_mock:
-            for p in patterns:
-                copy(None, p, src_folder, dst_folder2)
-            loop_calls = walk_mock.call_count
+        # the src folder itself plus its 5 subfolders, opened once each, for all 10 patterns
+        assert scandir_mock.call_count == 6, \
+            f"{len(patterns)} patterns opened {scandir_mock.call_count} folders instead of 6: " \
+            f"the src tree is being scanned once per pattern again"
 
-        assert single_scan_calls == 1
-        assert loop_calls == len(patterns)
+    @pytest.mark.skipif(platform.system() == "Windows", reason="Requires Symlinks")
+    def test_multiple_patterns_symlinked_folder(self):
+        # A symlink to a folder is copied when ANY of the patterns matches it, not just the first
+        src_folder = temp_folder()
+        target_folder = os.path.join(src_folder, "target")
+        mkdir(target_folder)
+        os.symlink(target_folder, os.path.join(src_folder, "alink"))
+        os.symlink(target_folder, os.path.join(src_folder, "blink"))
+
+        dst_folder = temp_folder()
+        copied = copy(None, ["a*", "b*"], src_folder, dst_folder)
+
+        # both symlinks are copied: "alink" only matches the 1st pattern, "blink" only the 2nd
+        assert sorted(os.path.relpath(f, dst_folder) for f in copied) == ["alink", "blink"]
+        assert os.path.islink(os.path.join(dst_folder, "alink"))
+        assert os.path.islink(os.path.join(dst_folder, "blink"))
+
+    def test_multiple_patterns_ignore_case(self):
+        # Every pattern of the list is matched, not only the first one, and ignore_case
+        # case-folds all of them. The first pattern never matches, so if any assert below
+        # sees a file it can only be because the *second* pattern was honoured.
+        src_folder = temp_folder()
+        save(os.path.join(src_folder, "FooBar.txt"), "x")
+
+        # ignore_case=True: the trailing pattern is case-folded too (POSIX only: on Windows
+        # fnmatch() normcases the pattern by itself, so the mixed case is already irrelevant)
+        dst_folder = temp_folder()
+        copy(None, ["*.zzz", "FOOBAR.TXT"], src_folder, dst_folder)
+        assert os.listdir(dst_folder) == ["FooBar.txt"]
+
+        # ignore_case=False: the trailing pattern is still matched, but case-sensitively
+        dst_folder = temp_folder()
+        copy(None, ["*.zzz", "FooBar.txt"], src_folder, dst_folder, ignore_case=False)
+        assert os.listdir(dst_folder) == ["FooBar.txt"]
+
+        dst_folder = temp_folder()
+        copy(None, ["*.zzz", "FOOBAR.TXT"], src_folder, dst_folder, ignore_case=False)
+        assert os.listdir(dst_folder) == []
+
+    def test_multiple_patterns_accepts_tuple_and_validates_every_pattern(self):
+        src_folder = temp_folder()
+        save(os.path.join(src_folder, "hello.h"), "h")
+        dst_folder = temp_folder()
+
+        # Any collection works, not only a list: recipes do copy(self, ("*.h", "*.cpp"), ...)
+        copied = copy(None, ("*.h", "*.cpp"), src_folder, dst_folder)
+        assert [os.path.basename(f) for f in copied] == ["hello.h"]
+        # An empty collection copies nothing instead of failing, so callers building the
+        # pattern list dynamically (like the export of conanfile.exports) don't have to guard it
+        assert copy(None, [], src_folder, dst_folder) == []
+        # Every pattern of the collection is validated, not only the first one
+        with pytest.raises(ConanException) as exc:
+            copy(None, ["*.h", "../*.cpp"], src_folder, dst_folder)
+        assert "not possible to use relative patterns" in str(exc.value)
+
+    def test_multiple_patterns_repeated_pattern(self):
+        # The same pattern twice in the list still copies each file once. Patterns with a star in
+        # the middle are the interesting shape here: fnmatch.translate() compiles those into a
+        # named group, so repeating one is what breaks a naive caching of the translated patterns
+        src_folder = temp_folder()
+        save(os.path.join(src_folder, "src/mylib.cpp"), "cpp")
+        save(os.path.join(src_folder, "src/other.cpp"), "cpp")
+        dst_folder = temp_folder()
+
+        copied = copy(None, ["src/*lib*.cpp", "src/*lib*.cpp"], src_folder, dst_folder)
+        assert [os.path.relpath(f, dst_folder).replace(os.sep, "/") for f in copied] == \
+               ["src/mylib.cpp"]
+
+    def test_multiple_patterns_excludes_any_pattern(self):
+        # An exclude applies to a file whichever pattern matched it, not only the first one
+        src_folder = temp_folder()
+        save(os.path.join(src_folder, "docs/readme.md"), "md")
+        save(os.path.join(src_folder, "docs/private.md"), "secret")
+        save(os.path.join(src_folder, "hello.h"), "h")
+        dst_folder = temp_folder()
+
+        # "docs/private.md" is matched by the *last* pattern and must still be excluded
+        copied = copy(None, ["*.h", "docs/*.md"], src_folder, dst_folder,
+                      excludes=["*/private.md"])
+        assert sorted(os.path.relpath(f, dst_folder).replace(os.sep, "/") for f in copied) == \
+               ["docs/readme.md", "hello.h"]
 
     @mock.patch('shutil.copy2')
     def test_avoid_repeat_copies(self, copy2_mock):


### PR DESCRIPTION
Changelog: Fix: Improve `copy()` performance when using lists of patterns.
Docs: Omit

Also fixes develop2 tests