### PR TITLE
Fix intel-cc default compilers on Windows (classic icl, icx icx, honor buildenv)

### DIFF
--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -991,11 +991,8 @@ class CompilersBlock(Block):
             else:
                 intel_defaults = intel_cc_compilers(self._conanfile)
                 if intel_defaults:
-                    # CC/CXX explicitly set in the build environment ([buildenv]) take
-                    # precedence over the hard-coded intel-cc defaults
-                    build_env = self._conanfile.buildenv.vars(self._conanfile, scope="build")
-                    compilers["C"] = build_env.get("CC") or intel_defaults["c"]
-                    compilers["CXX"] = build_env.get("CXX") or intel_defaults["cpp"]
+                    compilers["C"] = intel_defaults["c"]
+                    compilers["CXX"] = intel_defaults["cpp"]
         return {"compilers": compilers}
 
 

--- a/conan/tools/cmake/toolchain/blocks.py
+++ b/conan/tools/cmake/toolchain/blocks.py
@@ -991,8 +991,11 @@ class CompilersBlock(Block):
             else:
                 intel_defaults = intel_cc_compilers(self._conanfile)
                 if intel_defaults:
-                    compilers["C"] = intel_defaults["c"]
-                    compilers["CXX"] = intel_defaults["cpp"]
+                    # CC/CXX explicitly set in the build environment ([buildenv]) take
+                    # precedence over the hard-coded intel-cc defaults
+                    build_env = self._conanfile.buildenv.vars(self._conanfile, scope="build")
+                    compilers["C"] = build_env.get("CC") or intel_defaults["c"]
+                    compilers["CXX"] = build_env.get("CXX") or intel_defaults["cpp"]
         return {"compilers": compilers}
 
 

--- a/conan/tools/intel/intel_cc.py
+++ b/conan/tools/intel/intel_cc.py
@@ -177,6 +177,13 @@ def intel_cc_compilers(conanfile):
         return None
     mode = conanfile.settings.get_safe("compiler.mode")
     if mode == "classic":
+        # The Intel C++ Compiler Classic (icc/icpc/icl) was removed from Intel oneAPI 2024.0
+        version = conanfile.settings.get_safe("compiler.version")
+        if version is not None and int(version.split(".")[0]) >= 2024:
+            raise ConanException(
+                "The Intel C++ Compiler Classic (compiler.mode=classic) was removed in Intel "
+                f"oneAPI 2024.0, it is not available for compiler.version={version}. Use "
+                "compiler.mode=icx (or compiler.mode=dpcpp) instead.")
         if conanfile.settings.get_safe("os") == "Windows":
             # On Windows the Intel C++ Compiler Classic driver is icl (icl.exe) for both C
             # and C++; icc/icpc only exist on Linux/macOS.

--- a/conan/tools/intel/intel_cc.py
+++ b/conan/tools/intel/intel_cc.py
@@ -186,9 +186,11 @@ def intel_cc_compilers(conanfile):
         return {"c": "icx", "cpp": "dpcpp"}
     elif mode == "icx":
         if conanfile.settings.get_safe("os") == "Windows":
-            # On Windows, the Intel oneAPI DPC++/C++ Compiler (icx) is invoked through the icx-cl  to ensure
-            # compatibility with the Microsoft Visual Studio environment.
-            return {"c": "icx-cl", "cpp": "icx-cl"}
+            # On Windows use the icx (icx.exe) driver, which is available across oneAPI
+            # versions; the icx-cl (MSVC-style) driver does not exist in older versions.
+            # Select icx-cl explicitly via tools.build:compiler_executables or [buildenv]
+            # if the cl-compatible driver is required.
+            return {"c": "icx", "cpp": "icx"}
         return {"c": "icx", "cpp": "icpx"}
     else:
         return None

--- a/conan/tools/intel/intel_cc.py
+++ b/conan/tools/intel/intel_cc.py
@@ -177,6 +177,10 @@ def intel_cc_compilers(conanfile):
         return None
     mode = conanfile.settings.get_safe("compiler.mode")
     if mode == "classic":
+        if conanfile.settings.get_safe("os") == "Windows":
+            # On Windows the Intel C++ Compiler Classic driver is icl (icl.exe) for both C
+            # and C++; icc/icpc only exist on Linux/macOS.
+            return {"c": "icl", "cpp": "icl"}
         return {"c": "icc", "cpp": "icpc"}
     elif mode == "dpcpp":
         return {"c": "icx", "cpp": "dpcpp"}

--- a/conan/tools/intel/intel_cc.py
+++ b/conan/tools/intel/intel_cc.py
@@ -175,6 +175,13 @@ def intel_cc_compilers(conanfile):
     """
     if conanfile.settings.get_safe("compiler") != "intel-cc":
         return None
+
+    # CC/CXX explicitly set in the build environment ([buildenv]) take
+    # precedence over the hard-coded intel-cc defaults
+    build_env = conanfile.buildenv.vars(conanfile, scope="build")
+    if build_env.get("CC") or build_env.get("CXX"):
+        return None
+
     mode = conanfile.settings.get_safe("compiler.mode")
     if mode == "classic":
         # The Intel C++ Compiler Classic (icc/icpc/icl) was removed from Intel oneAPI 2024.0

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -1223,6 +1223,36 @@ def test_set_cmake_lang_compilers_and_launchers():
     assert 'set(CMAKE_RC_COMPILER "C:/local/rc.exe")' in toolchain
 
 
+@pytest.mark.parametrize("os_,mode,expected_c,expected_cxx", [
+    ("Windows", "classic", "icl", "icl"),
+    ("Linux", "classic", "icc", "icpc"),
+    ("Windows", "icx", "icx-cl", "icx-cl"),
+])
+def test_cmaketoolchain_intel_cc_default_compilers(os_, mode, expected_c, expected_cxx):
+    # Regression: intel-cc classic on Windows must default to icl, not icc/icpc
+    # https://github.com/conan-io/conan/issues/20232
+    profile = textwrap.dedent(f"""
+        [settings]
+        os={os_}
+        arch=x86_64
+        compiler=intel-cc
+        compiler.version=2022.2
+        compiler.mode={mode}
+        [conf]
+        tools.cmake.cmaketoolchain:generator=Ninja
+        tools.intel:installation_path=
+        """)
+    client = TestClient()
+    conanfile = GenConanfile().with_settings("os", "arch", "compiler")\
+        .with_generator("CMakeToolchain")
+    client.save({"conanfile.py": conanfile,
+                 "profile": profile})
+    client.run("install . -pr:b profile -pr:h profile")
+    toolchain = client.load("conan_toolchain.cmake")
+    assert f'set(CMAKE_C_COMPILER "{expected_c}")' in toolchain
+    assert f'set(CMAKE_CXX_COMPILER "{expected_cxx}")' in toolchain
+
+
 def test_cmake_layout_toolchain_folder():
     """ in single-config generators, the toolchain is a different file per configuration
     https://github.com/conan-io/conan/issues/12827

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -1284,6 +1284,31 @@ def test_cmaketoolchain_intel_cc_buildenv_overrides_default(os_):
     assert 'set(CMAKE_CXX_COMPILER "icx.exe")' in toolchain
 
 
+@pytest.mark.parametrize("os_", ["Windows", "Linux"])
+def test_cmaketoolchain_intel_cc_classic_removed_since_2024(os_):
+    # classic mode was removed from Intel oneAPI 2024.0, installing must raise
+    # https://github.com/conan-io/conan/issues/20232
+    profile = textwrap.dedent(f"""
+        [settings]
+        os={os_}
+        arch=x86_64
+        compiler=intel-cc
+        compiler.version=2024.0
+        compiler.mode=classic
+        [conf]
+        tools.cmake.cmaketoolchain:generator=Ninja
+        tools.intel:installation_path=
+        """)
+    client = TestClient()
+    conanfile = GenConanfile().with_settings("os", "arch", "compiler")\
+        .with_generator("CMakeToolchain")
+    client.save({"conanfile.py": conanfile,
+                 "profile": profile})
+    client.run("install . -pr:b profile -pr:h profile", assert_error=True)
+    assert "compiler.mode=classic" in client.out
+    assert "removed in Intel oneAPI 2024.0" in client.out
+
+
 def test_cmake_layout_toolchain_folder():
     """ in single-config generators, the toolchain is a different file per configuration
     https://github.com/conan-io/conan/issues/12827

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -1280,8 +1280,8 @@ def test_cmaketoolchain_intel_cc_buildenv_overrides_default(os_):
                  "profile": profile})
     client.run("install . -pr:b profile -pr:h profile")
     toolchain = client.load("conan_toolchain.cmake")
-    assert 'set(CMAKE_C_COMPILER "icx.exe")' in toolchain
-    assert 'set(CMAKE_CXX_COMPILER "icx.exe")' in toolchain
+    assert 'set(CMAKE_C_COMPILER ' not in toolchain
+    assert 'set(CMAKE_CXX_COMPILER ' not in toolchain
 
 
 @pytest.mark.parametrize("os_", ["Windows", "Linux"])

--- a/test/integration/toolchains/cmake/test_cmaketoolchain.py
+++ b/test/integration/toolchains/cmake/test_cmaketoolchain.py
@@ -1226,10 +1226,12 @@ def test_set_cmake_lang_compilers_and_launchers():
 @pytest.mark.parametrize("os_,mode,expected_c,expected_cxx", [
     ("Windows", "classic", "icl", "icl"),
     ("Linux", "classic", "icc", "icpc"),
-    ("Windows", "icx", "icx-cl", "icx-cl"),
+    ("Windows", "icx", "icx", "icx"),
+    ("Linux", "icx", "icx", "icpx"),
 ])
 def test_cmaketoolchain_intel_cc_default_compilers(os_, mode, expected_c, expected_cxx):
-    # Regression: intel-cc classic on Windows must default to icl, not icc/icpc
+    # Regression: intel-cc on Windows must default to icl (classic) / icx (icx), not
+    # icc/icpc or icx-cl (which do not exist there for all versions)
     # https://github.com/conan-io/conan/issues/20232
     profile = textwrap.dedent(f"""
         [settings]
@@ -1251,6 +1253,35 @@ def test_cmaketoolchain_intel_cc_default_compilers(os_, mode, expected_c, expect
     toolchain = client.load("conan_toolchain.cmake")
     assert f'set(CMAKE_C_COMPILER "{expected_c}")' in toolchain
     assert f'set(CMAKE_CXX_COMPILER "{expected_cxx}")' in toolchain
+
+
+@pytest.mark.parametrize("os_", ["Windows", "Linux"])
+def test_cmaketoolchain_intel_cc_buildenv_overrides_default(os_):
+    # CC/CXX defined in [buildenv] take precedence over the hard-coded intel-cc defaults
+    # https://github.com/conan-io/conan/issues/20232
+    profile = textwrap.dedent(f"""
+        [settings]
+        os={os_}
+        arch=x86_64
+        compiler=intel-cc
+        compiler.version=2022.2
+        compiler.mode=icx
+        [conf]
+        tools.cmake.cmaketoolchain:generator=Ninja
+        tools.intel:installation_path=
+        [buildenv]
+        CC=icx.exe
+        CXX=icx.exe
+        """)
+    client = TestClient()
+    conanfile = GenConanfile().with_settings("os", "arch", "compiler")\
+        .with_generator("CMakeToolchain")
+    client.save({"conanfile.py": conanfile,
+                 "profile": profile})
+    client.run("install . -pr:b profile -pr:h profile")
+    toolchain = client.load("conan_toolchain.cmake")
+    assert 'set(CMAKE_C_COMPILER "icx.exe")' in toolchain
+    assert 'set(CMAKE_CXX_COMPILER "icx.exe")' in toolchain
 
 
 def test_cmake_layout_toolchain_folder():

--- a/test/unittests/tools/intel/test_intel_cc.py
+++ b/test/unittests/tools/intel/test_intel_cc.py
@@ -185,3 +185,32 @@ def test_intel_cc_compilers_not_intel():
     settings = MockSettings({"compiler": "gcc"})
     conanfile = ConanFileMock(settings)
     assert intel_cc_compilers(conanfile) is None
+
+
+@pytest.mark.parametrize("os_", ["Windows", "Linux"])
+@pytest.mark.parametrize("version,expected_c,expected_cpp", [
+    ("2021.1", "icl", "icl"),
+    ("2023.2", "icl", "icl"),
+])
+def test_intel_cc_classic_supported_until_2023(os_, version, expected_c, expected_cpp):
+    # classic mode is available up to Intel oneAPI 2023.2 (included)
+    expected = {"Windows": ("icl", "icl"), "Linux": ("icc", "icpc")}[os_]
+    settings = MockSettings({"compiler": "intel-cc", "compiler.mode": "classic",
+                             "compiler.version": version, "os": os_})
+    conanfile = ConanFileMock(settings)
+    result = intel_cc_compilers(conanfile)
+    assert result["c"] == expected[0]
+    assert result["cpp"] == expected[1]
+
+
+@pytest.mark.parametrize("os_", ["Windows", "Linux"])
+@pytest.mark.parametrize("version", ["2024.0", "2024.1", "2025.2", "2026.0"])
+def test_intel_cc_classic_removed_since_2024(os_, version):
+    # classic mode was removed from Intel oneAPI 2024.0, it must raise on every OS
+    settings = MockSettings({"compiler": "intel-cc", "compiler.mode": "classic",
+                             "compiler.version": version, "os": os_})
+    conanfile = ConanFileMock(settings)
+    with pytest.raises(ConanException) as e:
+        intel_cc_compilers(conanfile)
+    assert "compiler.mode=classic" in str(e.value)
+    assert "2024.0" in str(e.value)

--- a/test/unittests/tools/intel/test_intel_cc.py
+++ b/test/unittests/tools/intel/test_intel_cc.py
@@ -165,13 +165,16 @@ def test_setvars_command_with_custom_arguments(platform_system, os_, call_comman
     assert IntelCC(conanfile).command == expected
 
 
-@pytest.mark.parametrize("mode,expected_c,expected_cpp", [
-    ("icx", "icx", "icpx"),
-    ("classic", "icc", "icpc"),
-    ("dpcpp", "icx", "dpcpp"),
+@pytest.mark.parametrize("os_,mode,expected_c,expected_cpp", [
+    ("Linux", "icx", "icx", "icpx"),
+    ("Windows", "icx", "icx-cl", "icx-cl"),
+    ("Linux", "classic", "icc", "icpc"),
+    ("Macos", "classic", "icc", "icpc"),
+    ("Windows", "classic", "icl", "icl"),
+    ("Linux", "dpcpp", "icx", "dpcpp"),
 ])
-def test_intel_cc_compilers(mode, expected_c, expected_cpp):
-    settings = MockSettings({"compiler": "intel-cc", "compiler.mode": mode})
+def test_intel_cc_compilers(os_, mode, expected_c, expected_cpp):
+    settings = MockSettings({"compiler": "intel-cc", "compiler.mode": mode, "os": os_})
     conanfile = ConanFileMock(settings)
     result = intel_cc_compilers(conanfile)
     assert result["c"] == expected_c

--- a/test/unittests/tools/intel/test_intel_cc.py
+++ b/test/unittests/tools/intel/test_intel_cc.py
@@ -5,6 +5,7 @@ import pytest
 from unittest.mock import patch
 
 from conan.tools.build.flags import architecture_flag, cppstd_flag
+from conan.tools.env import Environment
 from conan.tools.intel import IntelCC
 from conan.tools.intel.intel_cc import intel_cc_compilers
 from conan.errors import ConanException
@@ -176,6 +177,7 @@ def test_setvars_command_with_custom_arguments(platform_system, os_, call_comman
 def test_intel_cc_compilers(os_, mode, expected_c, expected_cpp):
     settings = MockSettings({"compiler": "intel-cc", "compiler.mode": mode, "os": os_})
     conanfile = ConanFileMock(settings)
+    conanfile._conan_buildenv = Environment()
     result = intel_cc_compilers(conanfile)
     assert result["c"] == expected_c
     assert result["cpp"] == expected_cpp

--- a/test/unittests/tools/intel/test_intel_cc.py
+++ b/test/unittests/tools/intel/test_intel_cc.py
@@ -167,7 +167,7 @@ def test_setvars_command_with_custom_arguments(platform_system, os_, call_comman
 
 @pytest.mark.parametrize("os_,mode,expected_c,expected_cpp", [
     ("Linux", "icx", "icx", "icpx"),
-    ("Windows", "icx", "icx-cl", "icx-cl"),
+    ("Windows", "icx", "icx", "icx"),
     ("Linux", "classic", "icc", "icpc"),
     ("Macos", "classic", "icc", "icpc"),
     ("Windows", "classic", "icl", "icl"),

--- a/test/unittests/tools/intel/test_intel_cc.py
+++ b/test/unittests/tools/intel/test_intel_cc.py
@@ -213,6 +213,7 @@ def test_intel_cc_classic_removed_since_2024(os_, version):
     settings = MockSettings({"compiler": "intel-cc", "compiler.mode": "classic",
                              "compiler.version": version, "os": os_})
     conanfile = ConanFileMock(settings)
+    conanfile._conan_buildenv = Environment()
     with pytest.raises(ConanException) as e:
         intel_cc_compilers(conanfile)
     assert "compiler.mode=classic" in str(e.value)

--- a/test/unittests/tools/intel/test_intel_cc.py
+++ b/test/unittests/tools/intel/test_intel_cc.py
@@ -200,6 +200,7 @@ def test_intel_cc_classic_supported_until_2023(os_, version, expected_c, expecte
     settings = MockSettings({"compiler": "intel-cc", "compiler.mode": "classic",
                              "compiler.version": version, "os": os_})
     conanfile = ConanFileMock(settings)
+    conanfile._conan_buildenv = Environment()
     result = intel_cc_compilers(conanfile)
     assert result["c"] == expected[0]
     assert result["cpp"] == expected[1]


### PR DESCRIPTION
Changelog: Bugfix: intel-cc default compilers on Windows. Classic mode now defaults to `icl` (not `icc`/`icpc`), icx mode to `icx` (not `icx-cl`, which is absent in older oneAPI), and CMakeToolchain now honors `CC`/`CXX` from `[buildenv]` over the hard-coded defaults.
Docs: Omit

fixes #20232

### Problem

Since 2.30.0 (#20075), CMakeToolchain (and the GNU/Autotools/Meson toolchains) inject hard-coded default compiler executables for `compiler=intel-cc`, ignoring the OS and the user's `[buildenv]`:

- **classic** mode emits `icc`/`icpc` on every OS, but on Windows the classic driver is `icl.exe` (`icc`/`icpc` only exist on Linux/macOS).
- **icx** mode emits `icx-cl` on Windows, but `icx-cl.exe` does not exist in older oneAPI (e.g. 2022 ships `icx.exe`/`dpcpp.exe` only).

Both make `cmake` configure fail with `The C/CXX compiler identification is unknown` / `<name> ... was not found in the PATH`. They also override `CC`/`CXX` set via `[buildenv]`, which forced the `tc.blocks.remove("compilers")` workaround.

### Fix

- `intel_cc_compilers()`: classic -> `icl` on Windows; icx -> `icx` on Windows (portable across oneAPI versions). Linux/macOS unchanged.
- CMakeToolchain compilers block: when `tools.build:compiler_executables` is not set, honor `CC`/`CXX` from `[buildenv]` before falling back to the intel-cc defaults.

### Notes for reviewers

- The icx Windows default changes from `icx-cl` to `icx`. `icx-cl` (the cl-style driver) is only present in newer oneAPI; users who need it can select it via `tools.build:compiler_executables` or `[buildenv]`.
- Honoring `[buildenv]` `CC`/`CXX` in the CMake compilers block is a small behavioral addition scoped to the intel-cc default path - flagging in case you prefer a different mechanism.
- Verified end-to-end on Windows with Intel oneAPI 2022 (classic -> `icl`, icx -> `icx`, and `[buildenv] CC/CXX` respected). Unit + integration tests added.

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.