### PR TITLE
download metadata to folder API

### DIFF
--- a/conan/api/subapi/download.py
+++ b/conan/api/subapi/download.py
@@ -29,8 +29,8 @@ class DownloadAPI:
         else:
             output.info(f"Skip recipe {ref.repr_notime()} download, already in cache")
             if metadata:
-                self._api_helpers.remote_manager.get_recipe_metadata(recipe_layout, ref, remote,
-                                                                     metadata)
+                self._api_helpers.remote_manager.get_recipe_metadata(
+                    ref, remote, metadata, recipe_layout.download_export())
             return False
 
         output.info(f"Downloading recipe '{ref.repr_notime()}'")
@@ -64,7 +64,9 @@ class DownloadAPI:
         if skip_download:
             output.info(f"Skip package {pref.repr_notime()} download, already in cache")
             if metadata:
-                self._api_helpers.remote_manager.get_package_metadata(pref, remote, metadata)
+                pkg_layout = self._api_helpers.cache.pkg_layout(pref)
+                self._api_helpers.remote_manager.get_package_metadata(
+                    pref, remote, metadata, pkg_layout.download_package())
             return False
 
         if pref.timestamp is None:  # we didn't obtain the timestamp before (in general it should be)
@@ -76,6 +78,25 @@ class DownloadAPI:
         output.info(f"Downloading package '{pref.repr_notime()}'")
         self._api_helpers.remote_manager.get_package(pref, remote, metadata)
         return True
+
+    def recipe_metadata(self, ref: RecipeReference, remote: Remote, metadata: List[str],
+                        folder: str):
+        """Download only the recipe metadata files into ``folder``, without using the Conan cache.
+        Files are always fetched from the server and written under ``<folder>/metadata/``.
+        """
+        assert ref.revision, "recipe reference must have revision resolved"
+        assert metadata, "metadata patterns must be provided"
+        self._api_helpers.remote_manager.get_recipe_metadata(ref, remote, metadata, folder)
+
+    def package_metadata(self, pref: PkgReference, remote: Remote, metadata: List[str],
+                         folder: str):
+        """Download only the package metadata files into ``folder``, without using the Conan cache.
+        Files are always fetched from the server and written under ``<folder>/metadata/``.
+        """
+        assert pref.ref.revision and pref.revision, \
+            "package reference must have recipe and package revisions resolved"
+        assert metadata, "metadata patterns must be provided"
+        self._api_helpers.remote_manager.get_package_metadata(pref, remote, metadata, folder)
 
     def download_full(self, package_list: PackagesList, remote: Remote,
                       metadata: Optional[List[str]] = None):

--- a/conan/internal/rest/remote_manager.py
+++ b/conan/internal/rest/remote_manager.py
@@ -104,16 +104,16 @@ class RemoteManager:
         for file_name, file_path in zipped_files.items():  # copy CONANFILE
             shutil.move(file_path, os.path.join(export_folder, file_name))
 
-    def get_recipe_metadata(self, recipe_layout, ref, remote, metadata):
+    def get_recipe_metadata(self, ref, remote, metadata, dest_folder):
         """
-        Get only the metadata for a locally existing recipe in Cache
+        Download only the recipe metadata into ``dest_folder``. The caller decides where
+        it lands (a cache layout folder, or an arbitrary user folder).
         """
         assert ref.revision, "get_recipe without revision specified"
         output = ConanOutput(scope=str(ref))
         output.info("Retrieving recipe metadata from remote '%s'" % remote.name)
-        download_export = recipe_layout.download_export()
         try:
-            self._call_remote(remote, "get_recipe", ref, download_export, metadata,
+            self._call_remote(remote, "get_recipe", ref, dest_folder, metadata,
                               only_metadata=True)
         except BaseException:  # So KeyboardInterrupt also cleans things
             output.error(f"Error downloading metadata from remote '{remote.name}'",
@@ -149,19 +149,18 @@ class RemoteManager:
             mkdir(pkg_layout.metadata())
             self._get_package(pkg_layout, pref, remote, output, metadata)
 
-    def get_package_metadata(self, pref, remote, metadata):
+    def get_package_metadata(self, pref, remote, metadata, dest_folder):
         """
-        only download the metadata, not the packge itself
+        Download only the package metadata into ``dest_folder``. The caller decides where
+        it lands (a cache layout folder, or an arbitrary user folder).
         """
         output = ConanOutput(scope=str(pref.ref))
         output.info("Retrieving package metadata %s from remote '%s'"
                     % (pref.package_id, remote.name))
 
         assert pref.revision is not None
-        pkg_layout = self._cache.pkg_layout(pref)
         try:
-            download_pkg_folder = pkg_layout.download_package()
-            self._call_remote(remote, "get_package", pref, download_pkg_folder,
+            self._call_remote(remote, "get_package", pref, dest_folder,
                               metadata, only_metadata=True)
         except BaseException as e:  # So KeyboardInterrupt also cleans things
             output.error(f"Exception while getting package metadata: {str(pref.package_id)}",

--- a/test/integration/metadata/test_metadata_download_folder.py
+++ b/test/integration/metadata/test_metadata_download_folder.py
@@ -1,0 +1,65 @@
+import os
+import textwrap
+
+from conan.test.assets.genconanfile import GenConanfile
+from conan.test.utils.tools import TestClient
+from conan.internal.util.files import save, load
+
+
+custom_command = textwrap.dedent("""
+    import os
+    from conan.api.model import PkgReference, RecipeReference
+    from conan.cli.command import conan_command
+
+
+    @conan_command(group="custom commands")
+    def metadata_download(conan_api, parser, *args):
+        \"\"\"Download the metadata of one recipe/package revision to cwd (no cache).\"\"\"
+        parser.add_argument("reference")
+        parser.add_argument("-r", "--remote", required=True)
+        a = parser.parse_args(*args)
+        remote = conan_api.remotes.get(a.remote)
+        if ":" in a.reference:
+            pref = PkgReference.loads(a.reference)
+            if pref.ref.revision is None:
+                pref.ref = conan_api.list.latest_recipe_revision(pref.ref, remote)
+            if pref.revision is None:
+                pref = conan_api.list.latest_package_revision(pref, remote)
+            conan_api.download.package_metadata(pref, remote, ["*"], os.getcwd())
+        else:
+            ref = RecipeReference.loads(a.reference)
+            if ref.revision is None:
+                ref = conan_api.list.latest_recipe_revision(ref, remote)
+            conan_api.download.recipe_metadata(ref, remote, ["*"], os.getcwd())
+    """)
+
+
+def _server_with_metadata():
+    c = TestClient(default_server_user=True, light=True)
+    c.save({"conanfile.py": GenConanfile("pkg", "0.1")})
+    c.run("create .")
+    pid = c.created_package_id("pkg/0.1")
+    c.run("cache path pkg/0.1 --folder=metadata")
+    save(os.path.join(str(c.stdout).strip(), "logs", "recipe.log"), "recipe-log")
+    c.run(f"cache path pkg/0.1:{pid} --folder=metadata")
+    save(os.path.join(str(c.stdout).strip(), "logs", "build.log"), "build-log")
+    c.run("upload * -c -r=default --metadata=*")
+    c.run("remove * -c")
+    c.save_home({"extensions/commands/cmd_metadata_download.py": custom_command})
+    return c, pid
+
+
+def test_metadata_download_recipe():
+    c, _ = _server_with_metadata()
+    c.run("metadata-download pkg/0.1 -r=default")
+    assert load(os.path.join(c.current_folder, "metadata", "logs", "recipe.log")) == "recipe-log"
+    c.run("list *")
+    assert "There are no matching recipe references" in c.out
+
+
+def test_metadata_download_package():
+    c, pid = _server_with_metadata()
+    c.run(f"metadata-download pkg/0.1:{pid} -r=default")
+    assert load(os.path.join(c.current_folder, "metadata", "logs", "build.log")) == "build-log"
+    c.run("list *")
+    assert "There are no matching recipe references" in c.out


### PR DESCRIPTION
Changelog: Feature: Add `recipe_metadata()`/`package_metadata()` API to download metadata to a user folder.
Docs: https://github.com/conan-io/docs/pull/4514

For https://github.com/conan-io/conan/issues/18757
