### PR TITLE
test pwsh support for empty enviroment variables

### DIFF
--- a/test/functional/toolchains/env/test_virtualenv_powershell.py
+++ b/test/functional/toolchains/env/test_virtualenv_powershell.py
@@ -26,6 +26,8 @@ def client():
     def package_info(self):
         self.buildenv_info.define_path("MYPATH1", "c:/path/to/ar")
         self.runenv_info.define("MYVAR1", 'some nice content\" with quotes')
+
+        self.runenv_info.append("EMPTYLIST", [])
     """
     client.save({"conanfile.py": conanfile})
     client.run("create .")
@@ -251,3 +253,23 @@ def test_powershell_deactivation():
     assert "conanbuild.ps1" not in files
     assert "conanrunenv.ps1" not in files
     assert "conanbuildenv.ps1" not in files
+
+@pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows powershell")
+@pytest.mark.parametrize("powershell", ["pwsh", "powershell.exe"])
+def test_pwsh_support_empty_variables(client, powershell):
+    conanfile = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+        class ConanFileToolsTest(ConanFile):
+            name = "app"
+            version = "0.1"
+            requires = "pkg/0.1"
+            def build(self):
+                self.run("set", env="conanrun")
+        """)
+    client.save({"conanfile.py": conanfile})
+    client.run(f'create . -c tools.env.virtualenv:powershell={powershell}')
+    print(client.out)
+    assert 'MYVAR1' in client.out
+    # powershell does not define this variable, but pwsh does
+    assert 'EMPTYLIST' in client.out

--- a/test/functional/toolchains/env/test_virtualenv_powershell.py
+++ b/test/functional/toolchains/env/test_virtualenv_powershell.py
@@ -26,8 +26,6 @@ def client():
     def package_info(self):
         self.buildenv_info.define_path("MYPATH1", "c:/path/to/ar")
         self.runenv_info.define("MYVAR1", 'some nice content\" with quotes')
-
-        self.runenv_info.append("EMPTYLIST", [])
     """
     client.save({"conanfile.py": conanfile})
     client.run("create .")
@@ -254,22 +252,41 @@ def test_powershell_deactivation():
     assert "conanrunenv.ps1" not in files
     assert "conanbuildenv.ps1" not in files
 
+
 @pytest.mark.skipif(platform.system() != "Windows", reason="Requires Windows powershell")
 @pytest.mark.parametrize("powershell", ["pwsh", "powershell.exe"])
-def test_pwsh_support_empty_variables(client, powershell):
-    conanfile = textwrap.dedent("""
+def test_pwsh_support_empty_variables(powershell):
+    # Generators may append FOO even when empty, so the .ps1 sets $env:FOO="".
+    # Scripts that only apply defaults when the var is undefined then skip those defaults.
+    client = TestClient()
+    check_py = textwrap.dedent("""\
+        import os
+        user = [os.environ["FOO"]] if "FOO" in os.environ else None
+        config = user or ["-default-flag"]
+        print("DEFAULT_SKIPPED" if config == [""] else "DEFAULT_APPLIED")
+        """)
+    conanfile = textwrap.dedent("""\
         import os
         from conan import ConanFile
-        class ConanFileToolsTest(ConanFile):
+        from conan.tools.env import Environment
+
+        class Pkg(ConanFile):
             name = "app"
             version = "0.1"
-            requires = "pkg/0.1"
+            exports_sources = "check.py"
+
+            def generate(self):
+                env = Environment()
+                env.append("FOO", [])
+                env.vars(self, scope="build").save_script("conanmytoolchain")
+
             def build(self):
-                self.run("set", env="conanrun")
+                self.run(f'python "{os.path.join(self.source_folder, "check.py")}"')
         """)
-    client.save({"conanfile.py": conanfile})
+    client.save({"conanfile.py": conanfile, "check.py": check_py})
+    client.run(f'install . -c tools.env.virtualenv:powershell={powershell}')
+    with open(os.path.join(client.current_folder, "conanmytoolchain.ps1"), "r", encoding="utf-16") as f:
+        assert '$env:FOO=""' in f.read()
+
     client.run(f'create . -c tools.env.virtualenv:powershell={powershell}')
-    print(client.out)
-    assert 'MYVAR1' in client.out
-    # powershell does not define this variable, but pwsh does
-    assert 'EMPTYLIST' in client.out
+    assert ("DEFAULT_SKIPPED" if powershell == "pwsh" else "DEFAULT_APPLIED") in client.out


### PR DESCRIPTION
Changelog: Omit
Docs: Omit

https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/9.0/empty-env-variable

