### PR TITLE
workspace alias cmd

### DIFF
--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -20,6 +20,9 @@ from conan.errors import ConanException, ConanInvalidConfiguration, ConanMigrati
 
 _CONAN_INTERNAL_CUSTOM_COMMANDS_PATH = "_CONAN_INTERNAL_CUSTOM_COMMANDS_PATH"
 
+# Short aliases mapped to their canonical command names
+_COMMAND_ALIASES = {"ws": "workspace"}
+
 
 class Cli:
     """A single command of the conan application, with all the first level commands. Manages the
@@ -174,6 +177,7 @@ class Cli:
         except IndexError:  # No parameters
             self._output_help_cli()
             return
+        command_argument = _COMMAND_ALIASES.get(command_argument, command_argument)
         try:
             command = self._commands[command_argument]
         except KeyError as exc:

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -15,6 +15,26 @@ from conan.internal.util.files import save_files
 from conan.tools.files import replace_in_file
 
 
+class TestWorkspaceAlias:
+
+    def test_ws_alias_dispatches_to_workspace(self):
+        # 'ws' behaves as 'workspace' for both the base command and its subcommands
+        c = TestClient(light=True)
+        c.save({"conanws.yml": ""})
+        c.run("ws root")
+        assert c.current_folder in c.stdout
+
+        c.run("ws info")
+        assert "packages: (empty)" in c.out
+
+    def test_ws_alias_not_in_help_listing(self):
+        c = TestClient(light=True)
+        c.run("-h")
+        assert "workspace" in c.stdout
+        for line in c.stdout.splitlines():
+            assert not line.strip().startswith("ws "), line
+
+
 class TestWorkspaceRoot:
 
     def test_workspace_root(self):


### PR DESCRIPTION
Changelog: Feature: ``conan ws`` as ``conan workspace`` alias
Docs: https://github.com/conan-io/docs/pull/XXXX

Got tired of typing "conan workspace xxxx", maybe this? or a full rename of the command?