### PR TITLE
fix: change permissions of read-only files before extracting in cache restore (#20241)

### DIFF
--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -396,6 +396,16 @@ class CacheAPI:
             fileobj = the_tar.extractfile("pkglist.json")
             pkglist = fileobj.read()
             the_tar.extraction_filter = (lambda member, _: member)  # fully_trusted (Py 3.14)
+            
+            import stat
+            for member in the_tar.getmembers():
+                target_path = os.path.join(cache_folder, member.name)
+                if os.path.exists(target_path):
+                    try:
+                        os.chmod(target_path, stat.S_IWRITE | stat.S_IREAD)
+                    except Exception:
+                        pass
+
             the_tar.extractall(path=cache_folder)
             the_tar.close()
 


### PR DESCRIPTION
Closes #20241.

This PR fixes a `PermissionError` that occurs on Windows when running `conan cache restore` to extract an archive that contains read-only files (e.g., from an MSYS2 environment or a Git pack idx). Python's `tarfile.extractall()` is unable to overwrite these existing read-only files if they already exist in the cache folder, which causes the restore process to fail with `PermissionError: [Errno 13] Permission denied`.

### Changes
- Updated `conan/api/subapi/cache.py` to iterate through the members of the tar archive and explicitly set the read/write permissions (`os.chmod(target_path, stat.S_IWRITE | stat.S_IREAD)`) on existing files in the cache destination before `extractall()` attempts to overwrite them.
