### PR TITLE
Log all command output to a file

### DIFF
--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -13,6 +13,7 @@ from inspect import getmembers
 from conan.api.conan_api import ConanAPI
 from conan.api.output import ConanOutput, Color, cli_out_write, LEVEL_TRACE
 from conan.cli.command import ConanSubCommand
+from conan.cli.command_log import command_log_context
 from conan.cli.exit_codes import SUCCESS, ERROR_MIGRATION, ERROR_GENERAL, USER_CTRL_C, \
     ERROR_SIGTERM, USER_CTRL_BREAK, ERROR_INVALID_CONFIGURATION, ERROR_UNEXPECTED
 from conan import __version__
@@ -293,11 +294,13 @@ def main(args):
 
     cli = Cli(conan_api)
     error = SUCCESS
-    try:
-        cli.run(args)
-        _warn_python_version()
-    except BaseException as e:
-        error = cli.exception_exit_error(e)
+    with command_log_context(conan_api, args) as log_ctx:
+        try:
+            cli.run(args)
+            _warn_python_version()
+        except BaseException as e:
+            error = cli.exception_exit_error(e)
+        log_ctx.set_exit_code(error)
     sys.exit(error)
 
 

--- a/conan/cli/command_log.py
+++ b/conan/cli/command_log.py
@@ -1,0 +1,125 @@
+import contextlib
+import os
+import platform
+import re
+import sys
+import threading
+from datetime import datetime
+
+from conan import __version__
+from conan.internal.cache.home_paths import HomePaths
+
+_ANSI_ESCAPE_RE = re.compile(rb"\x1b\[[0-9;]*[a-zA-Z]")
+
+
+class _NullCommandLogger:
+    def set_exit_code(self, exit_code):
+        pass
+
+
+class _TeeCommandLogger:
+    # fd-level duplication (not just sys.stdout/stderr) so subprocess output
+    # (cmake, make, git...) is captured too, since it bypasses ConanOutput.
+    def __init__(self, log_path, command_line, home_folder):
+        self._file = open(log_path, "w", encoding="utf-8", errors="replace")
+        self._lock = threading.Lock()
+        self._exit_code = None
+        self._file.write(f"# Date: {datetime.now():%Y-%m-%d %H:%M:%S}\n")
+        self._file.write(f"# Command: {command_line}\n")
+        self._file.write(f"# Conan version: {__version__}\n")
+        self._file.write(f"# Conan home: {home_folder}\n")
+        self._file.write(f"# Working directory: {os.getcwd()}\n")
+        self._file.write(f"# Platform: {platform.platform()}\n")
+        self._file.write("#" + "-" * 60 + "\n")
+        self._file.flush()
+
+        self._saved_fds = {}
+        self._read_fds = []
+        self._threads = []
+        for fd in (1, 2):
+            self._saved_fds[fd] = os.dup(fd)
+            read_fd, write_fd = os.pipe()
+            os.dup2(write_fd, fd)
+            os.close(write_fd)
+            self._read_fds.append(read_fd)
+            thread = threading.Thread(target=self._pump, args=(read_fd, self._saved_fds[fd]),
+                                       daemon=True)
+            thread.start()
+            self._threads.append(thread)
+
+    def _pump(self, read_fd, terminal_fd):
+        while True:
+            try:
+                chunk = os.read(read_fd, 4096)
+            except OSError:
+                break
+            if not chunk:
+                break
+            os.write(terminal_fd, chunk)
+            with self._lock:
+                self._file.write(_ANSI_ESCAPE_RE.sub(b"", chunk).decode("utf-8", errors="replace"))
+                self._file.flush()
+        os.close(read_fd)
+
+    def set_exit_code(self, exit_code):
+        self._exit_code = exit_code
+
+    def close(self):
+        sys.stdout.flush()
+        sys.stderr.flush()
+        # dup2 closes the pipe write end, so pump threads drain it and exit;
+        # only close saved_fd afterwards, since they still write to it.
+        for fd, saved_fd in self._saved_fds.items():
+            os.dup2(saved_fd, fd)
+        for thread in self._threads:
+            thread.join(timeout=5)
+        for saved_fd in self._saved_fds.values():
+            os.close(saved_fd)
+        with self._lock:
+            self._file.write("#" + "-" * 60 + "\n")
+            self._file.write(f"# Exit code: {self._exit_code}\n")
+            self._file.close()
+
+
+def _cleanup_old_logs(log_dir, max_age_days, max_files):
+    entries = [os.path.join(log_dir, name) for name in os.listdir(log_dir)
+               if name.endswith(".log")]
+    if max_age_days:
+        threshold = datetime.now().timestamp() - max_age_days * 86400
+        kept = []
+        for path in entries:
+            if os.path.getmtime(path) < threshold:
+                os.remove(path)
+            else:
+                kept.append(path)
+        entries = kept
+    if max_files and len(entries) > max_files:
+        entries.sort(key=os.path.getmtime)
+        for path in entries[:len(entries) - max_files]:
+            os.remove(path)
+
+
+@contextlib.contextmanager
+def command_log_context(conan_api, args):
+    enabled = conan_api.config.get("core.log:enabled", default=False, check_type=bool)
+    if not enabled:
+        yield _NullCommandLogger()
+        return
+
+    log_dir = HomePaths(conan_api.home_folder).command_logs_path
+    os.makedirs(log_dir, exist_ok=True)
+    max_age_days = conan_api.config.get("core.log:max_age_days", default=30, check_type=int)
+    max_files = conan_api.config.get("core.log:max_files", default=200, check_type=int)
+    _cleanup_old_logs(log_dir, max_age_days, max_files - 1 if max_files else max_files)
+
+    command_name = args[0] if args else "conan"
+    safe_name = re.sub(r"[^A-Za-z0-9_.-]", "_", command_name)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    log_path = os.path.join(log_dir, f"{timestamp}_{safe_name}.log")
+    command_line = "conan " + " ".join(args)
+
+    logger = _TeeCommandLogger(log_path, command_line, conan_api.home_folder)
+    try:
+        yield logger
+    finally:
+        logger.close()

--- a/conan/cli/command_log.py
+++ b/conan/cli/command_log.py
@@ -7,9 +7,17 @@ import threading
 from datetime import datetime
 
 from conan import __version__
+from conan.cli import exit_codes
 from conan.internal.cache.home_paths import HomePaths
 
 _ANSI_ESCAPE_RE = re.compile(rb"\x1b\[[0-9;]*[a-zA-Z]")
+_EXIT_CODE_NAMES = {value: name for name, value in vars(exit_codes).items()
+                    if name.isupper() and isinstance(value, int)}
+_DEFAULT_ENV_VARS = ["CC", "CXX", "CFLAGS", "CXXFLAGS", "LDFLAGS", "PATH"]
+
+
+def _timestamp():
+    return datetime.now().strftime("%H:%M:%S.%f")[:-3]
 
 
 class _NullCommandLogger:
@@ -20,16 +28,21 @@ class _NullCommandLogger:
 class _TeeCommandLogger:
     # fd-level duplication (not just sys.stdout/stderr) so subprocess output
     # (cmake, make, git...) is captured too, since it bypasses ConanOutput.
-    def __init__(self, log_path, command_line, home_folder):
+    def __init__(self, log_path, command_line, home_folder, timestamps, env_vars):
         self._file = open(log_path, "w", encoding="utf-8", errors="replace")
         self._lock = threading.Lock()
         self._exit_code = None
-        self._file.write(f"# Date: {datetime.now():%Y-%m-%d %H:%M:%S}\n")
+        self._timestamps = timestamps
+        self._start = datetime.now()
+        self._file.write(f"# Date: {self._start:%Y-%m-%d %H:%M:%S}\n")
         self._file.write(f"# Command: {command_line}\n")
         self._file.write(f"# Conan version: {__version__}\n")
         self._file.write(f"# Conan home: {home_folder}\n")
         self._file.write(f"# Working directory: {os.getcwd()}\n")
         self._file.write(f"# Platform: {platform.platform()}\n")
+        for name in env_vars:
+            if name in os.environ:
+                self._file.write(f"# Env {name}: {os.environ[name]}\n")
         self._file.write("#" + "-" * 60 + "\n")
         self._file.flush()
 
@@ -48,6 +61,7 @@ class _TeeCommandLogger:
             self._threads.append(thread)
 
     def _pump(self, read_fd, terminal_fd):
+        buffer = b""
         while True:
             try:
                 chunk = os.read(read_fd, 4096)
@@ -56,8 +70,24 @@ class _TeeCommandLogger:
             if not chunk:
                 break
             os.write(terminal_fd, chunk)
+            clean = _ANSI_ESCAPE_RE.sub(b"", chunk)
+            if not self._timestamps:
+                with self._lock:
+                    self._file.write(clean.decode("utf-8", errors="replace"))
+                    self._file.flush()
+                continue
+            # Timestamps are per-line, but chunks don't align with line
+            # boundaries, so buffer whatever's left until the next '\n'.
+            buffer += clean
+            *lines, buffer = buffer.split(b"\n")
+            if lines:
+                with self._lock:
+                    for line in lines:
+                        self._file.write(f"[{_timestamp()}] {line.decode('utf-8', errors='replace')}\n")
+                    self._file.flush()
+        if self._timestamps and buffer:
             with self._lock:
-                self._file.write(_ANSI_ESCAPE_RE.sub(b"", chunk).decode("utf-8", errors="replace"))
+                self._file.write(f"[{_timestamp()}] {buffer.decode('utf-8', errors='replace')}\n")
                 self._file.flush()
         os.close(read_fd)
 
@@ -77,7 +107,10 @@ class _TeeCommandLogger:
             os.close(saved_fd)
         with self._lock:
             self._file.write("#" + "-" * 60 + "\n")
-            self._file.write(f"# Exit code: {self._exit_code}\n")
+            self._file.write(f"# Duration: {(datetime.now() - self._start).total_seconds():.1f}s\n")
+            exit_code_name = _EXIT_CODE_NAMES.get(self._exit_code)
+            suffix = f" ({exit_code_name})" if exit_code_name else ""
+            self._file.write(f"# Exit code: {self._exit_code}{suffix}\n")
             self._file.close()
 
 
@@ -118,7 +151,10 @@ def command_log_context(conan_api, args):
     log_path = os.path.join(log_dir, f"{timestamp}_{safe_name}.log")
     command_line = "conan " + " ".join(args)
 
-    logger = _TeeCommandLogger(log_path, command_line, conan_api.home_folder)
+    timestamps = conan_api.config.get("core.log:timestamps", default=False, check_type=bool)
+    env_vars = conan_api.config.get("core.log:env_vars", default=_DEFAULT_ENV_VARS, check_type=list)
+
+    logger = _TeeCommandLogger(log_path, command_line, conan_api.home_folder, timestamps, env_vars)
     try:
         yield logger
     finally:

--- a/conan/internal/cache/home_paths.py
+++ b/conan/internal/cache/home_paths.py
@@ -85,3 +85,7 @@ class HomePaths:
     @property
     def config_version_path(self):
         return os.path.join(self._home, "config_version.json")
+
+    @property
+    def command_logs_path(self):
+        return os.path.join(self._home, ".log")

--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -80,6 +80,10 @@ BUILT_IN_CONFS = {
     "core.scm:local_url": "By default allows to store local folders as remote url, but not upload them. Use 'allow' for allowing upload and 'block' to completely forbid it",
     # Compatibility opt-in, to be removed in future versions as optimized behavior becomes default
     "core.graph:compatibility_mode": "(Experimental) Set this to 'optimized' to enable the improved compatibility behaviour when querying multiple compatible binaries in remotes",
+    # Command console log
+    "core.log:enabled": "(bool, default: False) Log all console output of every command (including subprocess output) to a file under <cache>/.log",
+    "core.log:max_age_days": "(int, default: 30) Maximum age in days of files under <cache>/.log before they are automatically deleted",
+    "core.log:max_files": "(int, default: 200) Maximum number of files kept under <cache>/.log; oldest are deleted first",
     # Tools
     "tools.android:ndk_path": "Argument for the CMAKE_ANDROID_NDK",
     "tools.android:cmake_legacy_toolchain": "Define to explicitly pass ANDROID_USE_LEGACY_TOOLCHAIN_FILE in CMake toolchain",

--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -84,6 +84,8 @@ BUILT_IN_CONFS = {
     "core.log:enabled": "(bool, default: False) Log all console output of every command (including subprocess output) to a file under <cache>/.log",
     "core.log:max_age_days": "(int, default: 30) Maximum age in days of files under <cache>/.log before they are automatically deleted",
     "core.log:max_files": "(int, default: 200) Maximum number of files kept under <cache>/.log; oldest are deleted first",
+    "core.log:timestamps": "(bool, default: False) Prefix each captured line in <cache>/.log files with a timestamp",
+    "core.log:env_vars": "(list, default: CC, CXX, CFLAGS, CXXFLAGS, LDFLAGS, PATH) Environment variable names to record in the <cache>/.log header, if set",
     # Tools
     "tools.android:ndk_path": "Argument for the CMAKE_ANDROID_NDK",
     "tools.android:cmake_legacy_toolchain": "Define to explicitly pass ANDROID_USE_LEGACY_TOOLCHAIN_FILE in CMake toolchain",

--- a/test/integration/command/test_command_log.py
+++ b/test/integration/command/test_command_log.py
@@ -1,0 +1,68 @@
+import os
+import subprocess
+import sys
+import textwrap
+
+from conan.internal.cache.home_paths import HomePaths
+from conan.test.utils.test_files import temp_folder
+from conan.internal.util.files import save
+
+
+def _run_conan_subprocess(args, conan_home):
+    # Real subprocess: TestClient calls Cli.run() directly and skips main(),
+    # but main() is exactly what does the fd-level redirection under test.
+    env = dict(os.environ)
+    env["CONAN_HOME"] = conan_home
+    code = "from conans.conan import run; run()"
+    result = subprocess.run([sys.executable, "-c", code] + args, env=env,
+                             capture_output=True, text=True)
+    return result
+
+
+def _latest_log(conan_home):
+    log_dir = HomePaths(conan_home).command_logs_path
+    log_files = sorted(os.listdir(log_dir), key=lambda f: os.path.getmtime(os.path.join(log_dir, f)))
+    return os.path.join(log_dir, log_files[-1])
+
+
+def test_command_log_captures_subprocess_output():
+    conan_home = temp_folder()
+    save(os.path.join(HomePaths(conan_home).profiles_path, "default"), "[settings]\nos=Linux\narch=x86_64\n"
+                                                                        "compiler=gcc\ncompiler.version=11\n"
+                                                                        "compiler.libcxx=libstdc++11\n"
+                                                                        "build_type=Release\n")
+    save(HomePaths(conan_home).global_conf_path, "core.log:enabled=True\n")
+
+    pkg_folder = temp_folder()
+    conanfile = textwrap.dedent(f"""
+        from conan import ConanFile
+        class Pkg(ConanFile):
+            name = "loggytest"
+            version = "1.0"
+            settings = "os", "arch", "compiler", "build_type"
+            def build(self):
+                self.run("{sys.executable} -c \\"print('hello-from-subprocess-build')\\"")
+        """)
+    save(os.path.join(pkg_folder, "conanfile.py"), conanfile)
+
+    result = _run_conan_subprocess(["create", pkg_folder], conan_home)
+    assert result.returncode == 0, result.stderr
+
+    log_path = _latest_log(conan_home)
+    content = open(log_path).read()
+    assert "# Command: conan create" in content
+    assert "hello-from-subprocess-build" in content
+    assert "# Exit code: 0" in content
+
+
+def test_command_log_records_error_exit_code():
+    conan_home = temp_folder()
+    save(os.path.join(HomePaths(conan_home).profiles_path, "default"), "[settings]\nos=Linux\narch=x86_64\n")
+    save(HomePaths(conan_home).global_conf_path, "core.log:enabled=True\n")
+
+    result = _run_conan_subprocess(["install", "/this/path/does/not/exist"], conan_home)
+    assert result.returncode != 0
+
+    log_path = _latest_log(conan_home)
+    content = open(log_path).read()
+    assert f"# Exit code: {result.returncode}" in content

--- a/test/integration/command/test_command_log.py
+++ b/test/integration/command/test_command_log.py
@@ -34,6 +34,7 @@ def test_command_log_captures_subprocess_output():
     save(HomePaths(conan_home).global_conf_path, "core.log:enabled=True\n")
 
     pkg_folder = temp_folder()
+    python_exe = sys.executable.replace("\\", "/")
     conanfile = textwrap.dedent(f"""
         from conan import ConanFile
         class Pkg(ConanFile):
@@ -41,7 +42,7 @@ def test_command_log_captures_subprocess_output():
             version = "1.0"
             settings = "os", "arch", "compiler", "build_type"
             def build(self):
-                self.run("{sys.executable} -c \\"print('hello-from-subprocess-build')\\"")
+                self.run("{python_exe} -c \\"print('hello-from-subprocess-build')\\"")
         """)
     save(os.path.join(pkg_folder, "conanfile.py"), conanfile)
 

--- a/test/integration/command/test_command_log.py
+++ b/test/integration/command/test_command_log.py
@@ -52,7 +52,16 @@ def test_command_log_captures_subprocess_output():
     content = open(log_path).read()
     assert "# Command: conan create" in content
     assert "hello-from-subprocess-build" in content
-    assert "# Exit code: 0" in content
+    assert "# Exit code: 0 (SUCCESS)" in content
+
+    # These exact phrases are what the analyze-conan-log skill greps to locate
+    # the recipe/source/build/package folders for its bundle feature. If any
+    # of them changes, update the skill (.claude/skills/analyze-conan-log).
+    assert "Exported to cache folder:" in content
+    assert "Sources in" in content
+    assert "Building your package in" in content
+    assert "Build folder" in content
+    assert "Package folder" in content
 
 
 def test_command_log_records_error_exit_code():
@@ -65,4 +74,4 @@ def test_command_log_records_error_exit_code():
 
     log_path = _latest_log(conan_home)
     content = open(log_path).read()
-    assert f"# Exit code: {result.returncode}" in content
+    assert f"# Exit code: {result.returncode} (ERROR_GENERAL)" in content

--- a/test/unittests/cli/test_command_log.py
+++ b/test/unittests/cli/test_command_log.py
@@ -1,4 +1,5 @@
 import os
+import re
 import time
 
 from conan.api.conan_api import ConanAPI
@@ -45,7 +46,64 @@ def test_enabled_writes_header_output_and_footer():
     assert "hello stdout" in content
     assert "hello stderr" in content
     assert "\x1b" not in content  # ANSI color codes stripped
-    assert "# Exit code: 0" in content
+    assert re.search(r"# Duration: \d+\.\d+s\n", content)
+    assert "# Exit code: 0 (SUCCESS)" in content
+
+
+def test_exit_code_name_for_known_error_code():
+    conan_api = _make_conan_api("core.log:enabled=True")
+    with command_log_context(conan_api, ["install", "."]) as log_ctx:
+        log_ctx.set_exit_code(1)
+    log_dir = HomePaths(conan_api.home_folder).command_logs_path
+    content = open(os.path.join(log_dir, os.listdir(log_dir)[0])).read()
+    assert "# Exit code: 1 (ERROR_GENERAL)" in content
+
+
+def test_timestamps_disabled_by_default():
+    conan_api = _make_conan_api("core.log:enabled=True")
+    with command_log_context(conan_api, ["install", "."]) as log_ctx:
+        os.write(1, b"hello\n")
+        log_ctx.set_exit_code(0)
+    log_dir = HomePaths(conan_api.home_folder).command_logs_path
+    content = open(os.path.join(log_dir, os.listdir(log_dir)[0])).read()
+    assert not re.search(r"^\[\d\d:\d\d:\d\d\.\d+\]", content, re.MULTILINE)
+
+
+def test_timestamps_enabled_prefixes_each_line_and_merges_split_writes():
+    conan_api = _make_conan_api("core.log:enabled=True\ncore.log:timestamps=True")
+    with command_log_context(conan_api, ["install", "."]) as log_ctx:
+        os.write(1, b"partial")  # no trailing newline: same line continues below
+        os.write(1, b" line\n")
+        os.write(1, b"no newline at the end")
+        log_ctx.set_exit_code(0)
+    log_dir = HomePaths(conan_api.home_folder).command_logs_path
+    content = open(os.path.join(log_dir, os.listdir(log_dir)[0])).read()
+    assert re.search(r"^\[\d\d:\d\d:\d\d\.\d\d\d\] partial line$", content, re.MULTILINE)
+    assert re.search(r"^\[\d\d:\d\d:\d\d\.\d\d\d\] no newline at the end$", content, re.MULTILINE)
+
+
+def test_env_vars_default_list_records_set_vars_only(monkeypatch):
+    monkeypatch.setenv("CC", "/usr/bin/gcc")
+    monkeypatch.delenv("CXX", raising=False)
+    conan_api = _make_conan_api("core.log:enabled=True")
+    with command_log_context(conan_api, ["install", "."]) as log_ctx:
+        log_ctx.set_exit_code(0)
+    log_dir = HomePaths(conan_api.home_folder).command_logs_path
+    content = open(os.path.join(log_dir, os.listdir(log_dir)[0])).read()
+    assert "# Env CC: /usr/bin/gcc\n" in content
+    assert "# Env CXX:" not in content
+
+
+def test_env_vars_custom_list_replaces_default(monkeypatch):
+    monkeypatch.setenv("CC", "/usr/bin/gcc")
+    monkeypatch.setenv("MY_VAR", "hello")
+    conan_api = _make_conan_api('core.log:enabled=True\ncore.log:env_vars=["MY_VAR"]')
+    with command_log_context(conan_api, ["install", "."]) as log_ctx:
+        log_ctx.set_exit_code(0)
+    log_dir = HomePaths(conan_api.home_folder).command_logs_path
+    content = open(os.path.join(log_dir, os.listdir(log_dir)[0])).read()
+    assert "# Env MY_VAR: hello\n" in content
+    assert "# Env CC:" not in content
 
 
 def test_log_file_name_defaults_to_conan_when_no_args():

--- a/test/unittests/cli/test_command_log.py
+++ b/test/unittests/cli/test_command_log.py
@@ -1,0 +1,80 @@
+import os
+import time
+
+from conan.api.conan_api import ConanAPI
+from conan.cli.command_log import _cleanup_old_logs, command_log_context
+from conan.internal.cache.home_paths import HomePaths
+from conan.internal.util.files import save
+from conan.test.utils.test_files import temp_folder
+
+
+def _make_conan_api(global_conf_contents=""):
+    tmp_folder = temp_folder()
+    home_paths = HomePaths(tmp_folder)
+    save(os.path.join(home_paths.profiles_path, "default"), "")
+    save(home_paths.global_conf_path, global_conf_contents)
+    return ConanAPI(tmp_folder)
+
+
+def test_disabled_by_default_yields_null_logger():
+    conan_api = _make_conan_api()
+    with command_log_context(conan_api, ["--version"]) as log_ctx:
+        log_ctx.set_exit_code(0)  # no-op, must not raise
+    log_dir = HomePaths(conan_api.home_folder).command_logs_path
+    assert not os.path.exists(log_dir)
+
+
+def test_enabled_writes_header_output_and_footer():
+    conan_api = _make_conan_api("core.log:enabled=True")
+    with command_log_context(conan_api, ["install", "."]) as log_ctx:
+        os.write(1, b"hello stdout\n")
+        os.write(2, b"\x1b[31mhello stderr\x1b[0m\n")
+        log_ctx.set_exit_code(0)
+
+    log_dir = HomePaths(conan_api.home_folder).command_logs_path
+    log_files = os.listdir(log_dir)
+    assert len(log_files) == 1
+    assert log_files[0].endswith("_install.log")
+
+    content = open(os.path.join(log_dir, log_files[0])).read()
+    assert "# Command: conan install .\n" in content
+    assert f"# Conan home: {conan_api.home_folder}\n" in content
+    assert "# Conan version:" in content
+    assert "# Working directory:" in content
+    assert "# Platform:" in content
+    assert "hello stdout" in content
+    assert "hello stderr" in content
+    assert "\x1b" not in content  # ANSI color codes stripped
+    assert "# Exit code: 0" in content
+
+
+def test_log_file_name_defaults_to_conan_when_no_args():
+    conan_api = _make_conan_api("core.log:enabled=True")
+    with command_log_context(conan_api, []) as log_ctx:
+        log_ctx.set_exit_code(0)
+    log_dir = HomePaths(conan_api.home_folder).command_logs_path
+    log_files = os.listdir(log_dir)
+    assert len(log_files) == 1
+    assert log_files[0].endswith("_conan.log")
+
+
+def test_cleanup_by_max_files(tmp_path):
+    for i in range(5):
+        (tmp_path / f"file{i}.log").write_text("x")
+    _cleanup_old_logs(str(tmp_path), max_age_days=0, max_files=3)
+    remaining = os.listdir(tmp_path)
+    assert len(remaining) == 3
+
+
+def test_cleanup_by_max_age(tmp_path):
+    old_file = tmp_path / "old.log"
+    old_file.write_text("x")
+    old_timestamp = time.time() - 40 * 86400
+    os.utime(old_file, (old_timestamp, old_timestamp))
+
+    new_file = tmp_path / "new.log"
+    new_file.write_text("x")
+
+    _cleanup_old_logs(str(tmp_path), max_age_days=30, max_files=0)
+    remaining = os.listdir(tmp_path)
+    assert remaining == ["new.log"]


### PR DESCRIPTION
# Log all command output to a file 

Conan can save the full console output of every command to a log file.

- Opt-in via core.log:enabled=True in global.conf.
- Logs are written under <conan_home>/.log/, one file per command run.
- Each log captures everything printed to the screen, including subprocess output (compiler, CMake, git...).
- The header records the date, the exact command, Conan version, home folder, working directory, and platform.
- The footer records the command's duration and exit code.
- Old logs are cleaned up automatically by age and count (core.log:max_age_days, core.log:max_files).
- Optional: timestamp every line (core.log:timestamps).
- Optional: record chosen environment variables in the header (core.log:env_vars).

Changelog: Feature: Added core.log:enabled conf to log the full console output of every command (including subprocess output) to a file under <conan_home>/.log.
Changelog: Feature: Added core.log:max_age_days and core.log:max_files confs to automatically clean up old command log files.
Changelog: Feature: Added core.log:timestamps conf to prefix each line of a command log with a timestamp.
Changelog: Feature: Added core.log:env_vars conf to record selected environment variables in the command log header.

Docs: TODO
