### PR TITLE
Fix ``conan cache restore`` crashing with ``PermissionError`` when the cache contains read-only files

### DIFF
--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -1,6 +1,7 @@
 import json
 import os
 import shutil
+import stat
 import tarfile
 import tempfile
 
@@ -396,6 +397,11 @@ class CacheAPI:
             fileobj = the_tar.extractfile("pkglist.json")
             pkglist = fileobj.read()
             the_tar.extraction_filter = (lambda member, _: member)  # fully_trusted (Py 3.14)
+            for member in the_tar.getmembers():
+                # Extraction opens the destination for writing, read-only files would fail
+                dest = os.path.join(cache_folder, member.name)
+                if member.isfile() and os.path.isfile(dest) and not os.access(dest, os.W_OK):
+                    os.chmod(dest, os.stat(dest).st_mode | stat.S_IWRITE)
             the_tar.extractall(path=cache_folder)
             the_tar.close()
 
@@ -434,7 +440,7 @@ class CacheAPI:
                 if db_pkg_folder != unzipped_pkg_folder:
                     # If a previous package exists, like a previous restore, then remove it
                     if os.path.exists(pkg_layout.package()):
-                        shutil.rmtree(pkg_layout.package())
+                        rmdir(pkg_layout.package())
                     shutil.move(os.path.join(cache_folder, unzipped_pkg_folder),
                                 pkg_layout.package())
                     pref_bundle["package_folder"] = db_pkg_folder
@@ -447,7 +453,7 @@ class CacheAPI:
                     if db_metadata_folder != unzipped_metadata_folder:
                         # We need to put the package in the final location in the cache
                         if os.path.exists(pkg_layout.metadata()):
-                            shutil.rmtree(pkg_layout.metadata())
+                            rmdir(pkg_layout.metadata())
                         shutil.move(os.path.join(cache_folder, unzipped_metadata_folder),
                                     pkg_layout.metadata())
                         pref_bundle["metadata_folder"] = db_metadata_folder

--- a/test/integration/command/cache/test_cache_save_restore.py
+++ b/test/integration/command/cache/test_cache_save_restore.py
@@ -2,6 +2,7 @@ import json
 import os
 import platform
 import shutil
+import stat
 import sys
 import tarfile
 import textwrap
@@ -84,13 +85,16 @@ _READ_ONLY_CONANFILE = textwrap.dedent("""
     """)
 
 
-def _check_restored_read_only(client):
-    client.run("list *:*#*")
-    assert "pkg/1.0" in client.out
+def _assert_read_only_file(client):
+    """ Check the packaged file and return its permission mode. """
     ref_layout = client.get_latest_ref_layout(RecipeReference.loads("pkg/1.0"))
     pkg_layout = client.get_latest_pkg_layout(PkgReference(ref_layout.reference,
                                                            NO_SETTINGS_PACKAGE_ID))
-    assert load(os.path.join(pkg_layout.package(), "bin", "readonly.txt")) == "content!!"
+    f = os.path.join(pkg_layout.package(), "bin", "readonly.txt")
+    assert load(f) == "content!!"
+    mode = stat.S_IMODE(os.stat(f).st_mode)
+    assert (mode & stat.S_IWRITE) == 0
+    return mode
 
 
 def test_cache_restore_read_only_files_in_place():
@@ -101,9 +105,11 @@ def test_cache_restore_read_only_files_in_place():
     c = TestClient()
     c.save({"conanfile.py": _READ_ONLY_CONANFILE})
     c.run("create .")
+    mode = _assert_read_only_file(c)
     c.run("cache save *:*")
     c.run("cache restore conan_cache_save.tgz")
-    _check_restored_read_only(c)
+    # Files are made writable just to overwrite them, extraction restores the archived mode
+    assert _assert_read_only_file(c) == mode
 
 
 def test_cache_save_restore_read_only_files():
@@ -114,6 +120,7 @@ def test_cache_save_restore_read_only_files():
     c = TestClient()
     c.save({"conanfile.py": _READ_ONLY_CONANFILE})
     c.run("create .")
+    mode = _assert_read_only_file(c)
     c.run("cache save *:*")
     cache_path = os.path.join(c.current_folder, "conan_cache_save.tgz")
 
@@ -121,7 +128,7 @@ def test_cache_save_restore_read_only_files():
     c2.run(f'cache restore "{cache_path}"')
     # The restored files are read-only, restoring again over them must still work
     c2.run(f'cache restore "{cache_path}"')
-    _check_restored_read_only(c2)
+    assert _assert_read_only_file(c2) == mode
 
 
 def test_cache_save_downloaded_restore():

--- a/test/integration/command/cache/test_cache_save_restore.py
+++ b/test/integration/command/cache/test_cache_save_restore.py
@@ -4,6 +4,7 @@ import platform
 import shutil
 import sys
 import tarfile
+import textwrap
 import time
 
 import pytest
@@ -66,6 +67,61 @@ def test_cache_save_restore_with_package_file():
     tree2 = _get_directory_tree(c2.base_folder)
 
     assert tree2 == tree
+
+
+_READ_ONLY_CONANFILE = textwrap.dedent("""
+    import os, stat
+    from conan import ConanFile
+    from conan.tools.files import save
+
+    class Pkg(ConanFile):
+        name = "pkg"
+        version = "1.0"
+        def package(self):
+            f = os.path.join(self.package_folder, "bin", "readonly.txt")
+            save(self, f, "content!!")
+            os.chmod(f, stat.S_IREAD)
+    """)
+
+
+def _check_restored_read_only(client):
+    client.run("list *:*#*")
+    assert "pkg/1.0" in client.out
+    ref_layout = client.get_latest_ref_layout(RecipeReference.loads("pkg/1.0"))
+    pkg_layout = client.get_latest_pkg_layout(PkgReference(ref_layout.reference,
+                                                           NO_SETTINGS_PACKAGE_ID))
+    assert load(os.path.join(pkg_layout.package(), "bin", "readonly.txt")) == "content!!"
+
+
+def test_cache_restore_read_only_files_in_place():
+    """ restoring over a cache that already contains those same read-only files, the extraction
+    happens in place, over the existing read-only files
+    https://github.com/conan-io/conan/issues/20241
+    """
+    c = TestClient()
+    c.save({"conanfile.py": _READ_ONLY_CONANFILE})
+    c.run("create .")
+    c.run("cache save *:*")
+    c.run("cache restore conan_cache_save.tgz")
+    _check_restored_read_only(c)
+
+
+def test_cache_save_restore_read_only_files():
+    """ restoring in a different cache, the package folder is relocated, so a previously
+    restored package folder with read-only files has to be removed
+    https://github.com/conan-io/conan/issues/20241
+    """
+    c = TestClient()
+    c.save({"conanfile.py": _READ_ONLY_CONANFILE})
+    c.run("create .")
+    c.run("cache save *:*")
+    cache_path = os.path.join(c.current_folder, "conan_cache_save.tgz")
+
+    c2 = TestClient()
+    c2.run(f'cache restore "{cache_path}"')
+    # The restored files are read-only, restoring again over them must still work
+    c2.run(f'cache restore "{cache_path}"')
+    _check_restored_read_only(c2)
 
 
 def test_cache_save_downloaded_restore():


### PR DESCRIPTION
Changelog: Bugfix: Fix ``conan cache restore`` crashing with ``PermissionError`` when the cache contains read-only files.
Docs: Omit

- [x] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [x] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.

Fixes https://github.com/conan-io/conan/issues/20241
Close https://github.com/conan-io/conan/pull/20249

There are two different points where this happens, and the second one was only reachable
after fixing the first:

- `tarfile.extractall()` opens each destination file in `wb` mode, which fails when the file
  already exists and is read-only. This is the traceback reported in the issue, and it happens
  when the package folder is restored *in place* (a package downloaded from a server, or an
  archive restored over the same cache it was saved from).
- `shutil.rmtree()` is used to remove a previously restored package/metadata folder when the
  package has to be relocated to a different folder in the destination cache. It has no
  handler for read-only files, so it raises `PermissionError: [WinError 5] Access is denied`.

The fix makes pre-existing destination files writable before extracting, preserving the rest
of the permission bits so group/other permissions are not dropped on Linux and macOS. Files
keep the mode stored in the archive after extraction, so read-only files stay read-only.

There is a pull-request opened some days ago at https://github.com/conan-io/conan/pull/20249 but it misses the second issue mentioned in this one plus some tests that reproduce the issue, so I'd rather open this new one.