### PR TITLE
Add `XcodeToolchain.build_settings` for settings without a dedicated conf

### DIFF
--- a/conan/tools/apple/xcodetoolchain.py
+++ b/conan/tools/apple/xcodetoolchain.py
@@ -46,7 +46,7 @@ class XcodeToolchain:
         sharedlinkflags = self._conanfile.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)
         exelinkflags = self._conanfile.conf.get("tools.build:exelinkflags", default=[], check_type=list)
         self._global_ldflags = sharedlinkflags + exelinkflags
-        self.extra_xcconfig = {}
+        self.build_settings = {}
 
     def generate(self):
         check_duplicated_generator(self, self._conanfile)
@@ -118,7 +118,7 @@ class XcodeToolchain:
     @property
     def _check_if_extra_flags(self):
         return (self._global_cflags or self._global_cxxflags or self._global_ldflags
-                or self._global_defines or self.extra_xcconfig)
+                or self._global_defines or self.build_settings)
 
     @property
     def _flags_xcconfig_content(self):
@@ -129,7 +129,7 @@ class XcodeToolchain:
         cflags = "OTHER_CFLAGS{} = $(inherited) {}".format(condition, " ".join(self._global_cflags)) if self._global_cflags else ""
         cppflags = "OTHER_CPLUSPLUSFLAGS{} = $(inherited) {}".format(condition, " ".join(self._global_cxxflags)) if self._global_cxxflags else ""
         ldflags = "OTHER_LDFLAGS{} = $(inherited) {}".format(condition, " ".join(self._global_ldflags)) if self._global_ldflags else ""
-        extra = "\n".join("{}{} = {}".format(k, condition, v) for k, v in self.extra_xcconfig.items())
+        extra = "\n".join("{}{} = {}".format(k, condition, v) for k, v in self.build_settings.items())
         ret = self._flags_xconfig.format(defines=defines, cflags=cflags, cppflags=cppflags, ldflags=ldflags,
                                          extra=extra)
         return ret

--- a/conan/tools/apple/xcodetoolchain.py
+++ b/conan/tools/apple/xcodetoolchain.py
@@ -51,7 +51,8 @@ class XcodeToolchain:
         save(self._agreggated_xconfig_filename, self._agreggated_xconfig_content)
         save(self._vars_xconfig_filename, self._vars_xconfig_content)
         if self._check_if_extra_flags:
-            save(self._flags_xcconfig_filename, self._flags_xcconfig_content)
+            save(self._flags_props_xconfig_filename, self._flags_xcconfig_content)
+            save(self._flags_xcconfig_filename, self._flags_xcconfig_aggregated_content)
         save(GLOBAL_XCCONFIG_FILENAME, self._global_xconfig_content)
 
     @property
@@ -118,12 +119,27 @@ class XcodeToolchain:
 
     @property
     def _flags_xcconfig_content(self):
-        defines = "GCC_PREPROCESSOR_DEFINITIONS = $(inherited) {}".format(" ".join(self._global_defines)) if self._global_defines else ""
-        cflags = "OTHER_CFLAGS = $(inherited) {}".format(" ".join(self._global_cflags)) if self._global_cflags else ""
-        cppflags = "OTHER_CPLUSPLUSFLAGS = $(inherited) {}".format(" ".join(self._global_cxxflags)) if self._global_cxxflags else ""
-        ldflags = "OTHER_LDFLAGS = $(inherited) {}".format(" ".join(self._global_ldflags)) if self._global_ldflags else ""
+        # Conditioned like the vars props file, so flags from different installed
+        # (config, arch, sdk) combinations don't overwrite each other.
+        condition = _xcconfig_conditional(self._conanfile.settings, self.configuration)
+        defines = "GCC_PREPROCESSOR_DEFINITIONS{} = $(inherited) {}".format(condition, " ".join(self._global_defines)) if self._global_defines else ""
+        cflags = "OTHER_CFLAGS{} = $(inherited) {}".format(condition, " ".join(self._global_cflags)) if self._global_cflags else ""
+        cppflags = "OTHER_CPLUSPLUSFLAGS{} = $(inherited) {}".format(condition, " ".join(self._global_cxxflags)) if self._global_cxxflags else ""
+        ldflags = "OTHER_LDFLAGS{} = $(inherited) {}".format(condition, " ".join(self._global_ldflags)) if self._global_ldflags else ""
         ret = self._flags_xconfig.format(defines=defines, cflags=cflags, cppflags=cppflags, ldflags=ldflags)
         return ret
+
+    @property
+    def _flags_props_xconfig_filename(self):
+        return "conan_global_flags{}{}".format(_xcconfig_settings_filename(self._conanfile.settings,
+                                                                            self.configuration),
+                                               self.extension)
+
+    @property
+    def _flags_xcconfig_aggregated_content(self):
+        return _add_includes_to_file_or_create(self._flags_xcconfig_filename,
+                                               self._agreggated_xconfig,
+                                               [self._flags_props_xconfig_filename])
 
     @property
     def _flags_xcconfig_filename(self):

--- a/conan/tools/apple/xcodetoolchain.py
+++ b/conan/tools/apple/xcodetoolchain.py
@@ -46,9 +46,6 @@ class XcodeToolchain:
         sharedlinkflags = self._conanfile.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)
         exelinkflags = self._conanfile.conf.get("tools.build:exelinkflags", default=[], check_type=list)
         self._global_ldflags = sharedlinkflags + exelinkflags
-        # Escape hatch for settings XcodeToolchain has no conf for, e.g. Swift's
-        # OTHER_SWIFT_FLAGS. The recipe sets the full value, no $(inherited) is
-        # assumed, since not every setting is additive.
         self.extra_xcconfig = {}
 
     def generate(self):

--- a/conan/tools/apple/xcodetoolchain.py
+++ b/conan/tools/apple/xcodetoolchain.py
@@ -24,6 +24,7 @@ class XcodeToolchain:
         {cflags}
         {cppflags}
         {ldflags}
+        {extra}
         """)
 
     _agreggated_xconfig = textwrap.dedent("""\
@@ -45,6 +46,10 @@ class XcodeToolchain:
         sharedlinkflags = self._conanfile.conf.get("tools.build:sharedlinkflags", default=[], check_type=list)
         exelinkflags = self._conanfile.conf.get("tools.build:exelinkflags", default=[], check_type=list)
         self._global_ldflags = sharedlinkflags + exelinkflags
+        # Escape hatch for settings XcodeToolchain has no conf for, e.g. Swift's
+        # OTHER_SWIFT_FLAGS. The recipe sets the full value, no $(inherited) is
+        # assumed, since not every setting is additive.
+        self.extra_xcconfig = {}
 
     def generate(self):
         check_duplicated_generator(self, self._conanfile)
@@ -115,7 +120,8 @@ class XcodeToolchain:
 
     @property
     def _check_if_extra_flags(self):
-        return self._global_cflags or self._global_cxxflags or self._global_ldflags or self._global_defines
+        return (self._global_cflags or self._global_cxxflags or self._global_ldflags
+                or self._global_defines or self.extra_xcconfig)
 
     @property
     def _flags_xcconfig_content(self):
@@ -126,7 +132,9 @@ class XcodeToolchain:
         cflags = "OTHER_CFLAGS{} = $(inherited) {}".format(condition, " ".join(self._global_cflags)) if self._global_cflags else ""
         cppflags = "OTHER_CPLUSPLUSFLAGS{} = $(inherited) {}".format(condition, " ".join(self._global_cxxflags)) if self._global_cxxflags else ""
         ldflags = "OTHER_LDFLAGS{} = $(inherited) {}".format(condition, " ".join(self._global_ldflags)) if self._global_ldflags else ""
-        ret = self._flags_xconfig.format(defines=defines, cflags=cflags, cppflags=cppflags, ldflags=ldflags)
+        extra = "\n".join("{}{} = {}".format(k, condition, v) for k, v in self.extra_xcconfig.items())
+        ret = self._flags_xconfig.format(defines=defines, cflags=cflags, cppflags=cppflags, ldflags=ldflags,
+                                         extra=extra)
         return ret
 
     @property

--- a/test/integration/toolchains/apple/test_xcodetoolchain.py
+++ b/test/integration/toolchains/apple/test_xcodetoolchain.py
@@ -94,9 +94,7 @@ def test_toolchain_flags():
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
-def test_toolchain_extra_xcconfig():
-    # Escape hatch for settings with no dedicated conf, e.g. Swift's
-    # OTHER_SWIFT_FLAGS: the recipe sets it directly on the toolchain.
+def test_toolchain_build_settings():
     client = TestClient()
     conanfile = textwrap.dedent("""
         from conan import ConanFile
@@ -105,7 +103,7 @@ def test_toolchain_extra_xcconfig():
             settings = "os", "arch", "compiler", "build_type"
             def generate(self):
                 tc = XcodeToolchain(self)
-                tc.extra_xcconfig["OTHER_SWIFT_FLAGS"] = "$(inherited) -cxx-interoperability-mode=default"
+                tc.build_settings["OTHER_SWIFT_FLAGS"] = "$(inherited) -cxx-interoperability-mode=default"
                 tc.generate()
         """)
     client.save({"conanfile.py": conanfile})

--- a/test/integration/toolchains/apple/test_xcodetoolchain.py
+++ b/test/integration/toolchains/apple/test_xcodetoolchain.py
@@ -58,53 +58,54 @@ def test_toolchain_files(configuration, os_version, cppstd, libcxx, arch, sdk_ve
         assert 'CLANG_CXX_LANGUAGE_STANDARD{}={}'.format(condition, clang_cppstd) in toolchain_vars
 
 
+@pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
 def test_toolchain_flags():
     client = TestClient()
     client.save({"conanfile.txt": "[generators]\nXcodeToolchain\n"})
-    cmd = "install . -c 'tools.build:cxxflags=[\"flag1\"]' " \
+    cmd = "install . -s build_type=Release -s arch=x86_64 " \
+          "-c 'tools.build:cxxflags=[\"flag1\"]' " \
           "-c 'tools.build:defines=[\"MYDEFINITION\"]' " \
           "-c 'tools.build:cflags=[\"flag2\"]' " \
           "-c 'tools.build:sharedlinkflags=[\"flag3\"]' " \
           "-c 'tools.build:exelinkflags=[\"flag4\"]'"
     client.run(cmd)
+    filename = _get_filename("Release", "x86_64", None)
+    condition = _condition("Release", "x86_64", None)
+
+    conan_global_flags_props = client.load("conan_global_flags{}.xcconfig".format(filename))
+    assert "GCC_PREPROCESSOR_DEFINITIONS{} = $(inherited) MYDEFINITION".format(condition) in conan_global_flags_props
+    assert "OTHER_CFLAGS{} = $(inherited) flag2".format(condition) in conan_global_flags_props
+    assert "OTHER_CPLUSPLUSFLAGS{} = $(inherited) flag1".format(condition) in conan_global_flags_props
+    assert "OTHER_LDFLAGS{} = $(inherited) flag3 flag4".format(condition) in conan_global_flags_props
+
+    # A second install, for a different configuration, must not overwrite the
+    # first one's flags -- each stays reachable under its own condition.
+    client.run("install . -s build_type=Debug -s arch=x86_64 -c 'tools.build:cxxflags=[\"debugflag\"]'")
+    debug_filename = _get_filename("Debug", "x86_64", None)
+    debug_flags = client.load("conan_global_flags{}.xcconfig".format(debug_filename))
+    assert "debugflag" in debug_flags
+    assert "flag1" not in debug_flags
+
     conan_global_flags = client.load("conan_global_flags.xcconfig")
-    assert "GCC_PREPROCESSOR_DEFINITIONS = $(inherited) MYDEFINITION" in conan_global_flags
-    assert "OTHER_CFLAGS = $(inherited) flag2" in conan_global_flags
-    assert "OTHER_CPLUSPLUSFLAGS = $(inherited) flag1" in conan_global_flags
-    assert "OTHER_LDFLAGS = $(inherited) flag3 flag4" in conan_global_flags
+    assert '#include "conan_global_flags{}.xcconfig"'.format(filename) in conan_global_flags
+    assert '#include "conan_global_flags{}.xcconfig"'.format(debug_filename) in conan_global_flags
     conan_global_file = client.load("conan_config.xcconfig")
     assert '#include "conan_global_flags.xcconfig"' in conan_global_file
 
 
+@pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
 def test_flags_generated_if_only_defines():
     # https://github.com/conan-io/conan/issues/16422
     client = TestClient()
     client.save({"conanfile.txt": "[generators]\nXcodeToolchain\n"})
-    client.run("install . -c 'tools.build:defines=[\"MYDEFINITION\"]'")
-    conan_global_flags = client.load("conan_global_flags.xcconfig")
-    assert "GCC_PREPROCESSOR_DEFINITIONS = $(inherited) MYDEFINITION" in conan_global_flags
+    client.run("install . -s build_type=Release -s arch=x86_64 -c 'tools.build:defines=[\"MYDEFINITION\"]'")
+    filename = _get_filename("Release", "x86_64", None)
+    condition = _condition("Release", "x86_64", None)
+
+    conan_global_flags_props = client.load("conan_global_flags{}.xcconfig".format(filename))
+    assert "GCC_PREPROCESSOR_DEFINITIONS{} = $(inherited) MYDEFINITION".format(condition) in conan_global_flags_props
     conan_global_file = client.load("conan_config.xcconfig")
     assert '#include "conan_global_flags.xcconfig"' in conan_global_file
-
-
-def test_toolchain_flags_lost_across_configurations():
-    # conan_global_flags.xcconfig has a fixed name and is fully overwritten on
-    # every install, unlike conantoolchain_<config>_<arch>.xcconfig, which is
-    # named per [config][arch][sdk] and accumulated. Installing Debug and then
-    # Release for the same project silently drops the Debug flags: the file on
-    # disk, and therefore what Xcode sees regardless of the active
-    # configuration, only ever reflects the *last* install.
-    client = TestClient()
-    client.save({"conanfile.txt": "[generators]\nXcodeToolchain\n"})
-    client.run("install . -s build_type=Debug -c 'tools.build:cxxflags=[\"-DDEBUG_FLAG\"]'")
-    client.run("install . -s build_type=Release -c 'tools.build:cxxflags=[\"-DRELEASE_FLAG\"]'")
-
-    conan_global_flags = client.load("conan_global_flags.xcconfig")
-    # Both configurations were installed, so both flags should still be
-    # reachable, each scoped to its own configuration -- the same guarantee
-    # the vars file already gives CLANG_CXX_LANGUAGE_STANDARD/CLANG_CXX_LIBRARY.
-    assert "-DDEBUG_FLAG" in conan_global_flags
-    assert "-DRELEASE_FLAG" in conan_global_flags
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")

--- a/test/integration/toolchains/apple/test_xcodetoolchain.py
+++ b/test/integration/toolchains/apple/test_xcodetoolchain.py
@@ -87,6 +87,26 @@ def test_flags_generated_if_only_defines():
     assert '#include "conan_global_flags.xcconfig"' in conan_global_file
 
 
+def test_toolchain_flags_lost_across_configurations():
+    # conan_global_flags.xcconfig has a fixed name and is fully overwritten on
+    # every install, unlike conantoolchain_<config>_<arch>.xcconfig, which is
+    # named per [config][arch][sdk] and accumulated. Installing Debug and then
+    # Release for the same project silently drops the Debug flags: the file on
+    # disk, and therefore what Xcode sees regardless of the active
+    # configuration, only ever reflects the *last* install.
+    client = TestClient()
+    client.save({"conanfile.txt": "[generators]\nXcodeToolchain\n"})
+    client.run("install . -s build_type=Debug -c 'tools.build:cxxflags=[\"-DDEBUG_FLAG\"]'")
+    client.run("install . -s build_type=Release -c 'tools.build:cxxflags=[\"-DRELEASE_FLAG\"]'")
+
+    conan_global_flags = client.load("conan_global_flags.xcconfig")
+    # Both configurations were installed, so both flags should still be
+    # reachable, each scoped to its own configuration -- the same guarantee
+    # the vars file already gives CLANG_CXX_LANGUAGE_STANDARD/CLANG_CXX_LIBRARY.
+    assert "-DDEBUG_FLAG" in conan_global_flags
+    assert "-DRELEASE_FLAG" in conan_global_flags
+
+
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
 @pytest.mark.parametrize("os_name, sdk, min_version, deployment_target_flag", [
     ("Macos", None, "11.0", "MACOSX_DEPLOYMENT_TARGET"),

--- a/test/integration/toolchains/apple/test_xcodetoolchain.py
+++ b/test/integration/toolchains/apple/test_xcodetoolchain.py
@@ -63,28 +63,28 @@ def test_toolchain_flags():
     client = TestClient()
     client.save({"conanfile.txt": "[generators]\nXcodeToolchain\n"})
     cmd = "install . -s build_type=Release -s arch=x86_64 " \
-          "-c 'tools.build:cxxflags=[\"releaseflag\"]' " \
-          "-c 'tools.build:defines=[\"MYDEFINITION\"]' " \
-          "-c 'tools.build:cflags=[\"flag2\"]' " \
-          "-c 'tools.build:sharedlinkflags=[\"flag3\"]' " \
-          "-c 'tools.build:exelinkflags=[\"flag4\"]'"
+          "-c 'tools.build:cxxflags=[\"cxxflags_release\"]' " \
+          "-c 'tools.build:defines=[\"defines_release\"]' " \
+          "-c 'tools.build:cflags=[\"cflags_release\"]' " \
+          "-c 'tools.build:sharedlinkflags=[\"sharedlinkflags_release\"]' " \
+          "-c 'tools.build:exelinkflags=[\"exelinkflags_release\"]'"
     client.run(cmd)
     filename = _get_filename("Release", "x86_64", None)
     condition = _condition("Release", "x86_64", None)
 
     conan_global_flags_props = client.load("conan_global_flags{}.xcconfig".format(filename))
-    assert "GCC_PREPROCESSOR_DEFINITIONS{} = $(inherited) MYDEFINITION".format(condition) in conan_global_flags_props
-    assert "OTHER_CFLAGS{} = $(inherited) flag2".format(condition) in conan_global_flags_props
-    assert "OTHER_CPLUSPLUSFLAGS{} = $(inherited) releaseflag".format(condition) in conan_global_flags_props
-    assert "OTHER_LDFLAGS{} = $(inherited) flag3 flag4".format(condition) in conan_global_flags_props
+    assert "GCC_PREPROCESSOR_DEFINITIONS{} = $(inherited) defines_release".format(condition) in conan_global_flags_props
+    assert "OTHER_CFLAGS{} = $(inherited) cflags_release".format(condition) in conan_global_flags_props
+    assert "OTHER_CPLUSPLUSFLAGS{} = $(inherited) cxxflags_release".format(condition) in conan_global_flags_props
+    assert "OTHER_LDFLAGS{} = $(inherited) sharedlinkflags_release exelinkflags_release".format(condition) in conan_global_flags_props
 
     # A second install, for a different configuration, must not overwrite the
     # first one's flags -- each stays reachable under its own condition.
-    client.run("install . -s build_type=Debug -s arch=x86_64 -c 'tools.build:cxxflags=[\"debugflag\"]'")
+    client.run("install . -s build_type=Debug -s arch=x86_64 -c 'tools.build:cxxflags=[\"cxxflags_debug\"]'")
     debug_filename = _get_filename("Debug", "x86_64", None)
     debug_flags = client.load("conan_global_flags{}.xcconfig".format(debug_filename))
-    assert "debugflag" in debug_flags
-    assert "releaseflag" not in debug_flags
+    assert "cxxflags_debug" in debug_flags
+    assert "cxxflags_release" not in debug_flags
 
     conan_global_flags = client.load("conan_global_flags.xcconfig")
     assert '#include "conan_global_flags{}.xcconfig"'.format(filename) in conan_global_flags

--- a/test/integration/toolchains/apple/test_xcodetoolchain.py
+++ b/test/integration/toolchains/apple/test_xcodetoolchain.py
@@ -63,7 +63,7 @@ def test_toolchain_flags():
     client = TestClient()
     client.save({"conanfile.txt": "[generators]\nXcodeToolchain\n"})
     cmd = "install . -s build_type=Release -s arch=x86_64 " \
-          "-c 'tools.build:cxxflags=[\"flag1\"]' " \
+          "-c 'tools.build:cxxflags=[\"releaseflag\"]' " \
           "-c 'tools.build:defines=[\"MYDEFINITION\"]' " \
           "-c 'tools.build:cflags=[\"flag2\"]' " \
           "-c 'tools.build:sharedlinkflags=[\"flag3\"]' " \
@@ -75,7 +75,7 @@ def test_toolchain_flags():
     conan_global_flags_props = client.load("conan_global_flags{}.xcconfig".format(filename))
     assert "GCC_PREPROCESSOR_DEFINITIONS{} = $(inherited) MYDEFINITION".format(condition) in conan_global_flags_props
     assert "OTHER_CFLAGS{} = $(inherited) flag2".format(condition) in conan_global_flags_props
-    assert "OTHER_CPLUSPLUSFLAGS{} = $(inherited) flag1".format(condition) in conan_global_flags_props
+    assert "OTHER_CPLUSPLUSFLAGS{} = $(inherited) releaseflag".format(condition) in conan_global_flags_props
     assert "OTHER_LDFLAGS{} = $(inherited) flag3 flag4".format(condition) in conan_global_flags_props
 
     # A second install, for a different configuration, must not overwrite the
@@ -84,7 +84,7 @@ def test_toolchain_flags():
     debug_filename = _get_filename("Debug", "x86_64", None)
     debug_flags = client.load("conan_global_flags{}.xcconfig".format(debug_filename))
     assert "debugflag" in debug_flags
-    assert "flag1" not in debug_flags
+    assert "releaseflag" not in debug_flags
 
     conan_global_flags = client.load("conan_global_flags.xcconfig")
     assert '#include "conan_global_flags{}.xcconfig"'.format(filename) in conan_global_flags

--- a/test/integration/toolchains/apple/test_xcodetoolchain.py
+++ b/test/integration/toolchains/apple/test_xcodetoolchain.py
@@ -94,6 +94,30 @@ def test_toolchain_flags():
 
 
 @pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
+def test_toolchain_extra_xcconfig():
+    # Escape hatch for settings with no dedicated conf, e.g. Swift's
+    # OTHER_SWIFT_FLAGS: the recipe sets it directly on the toolchain.
+    client = TestClient()
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        from conan.tools.apple import XcodeToolchain
+        class Demo(ConanFile):
+            settings = "os", "arch", "compiler", "build_type"
+            def generate(self):
+                tc = XcodeToolchain(self)
+                tc.extra_xcconfig["OTHER_SWIFT_FLAGS"] = "$(inherited) -cxx-interoperability-mode=default"
+                tc.generate()
+        """)
+    client.save({"conanfile.py": conanfile})
+    client.run("install . -s build_type=Release -s arch=x86_64")
+    filename = _get_filename("Release", "x86_64", None)
+    condition = _condition("Release", "x86_64", None)
+
+    conan_global_flags_props = client.load("conan_global_flags{}.xcconfig".format(filename))
+    assert "OTHER_SWIFT_FLAGS{} = $(inherited) -cxx-interoperability-mode=default".format(condition) in conan_global_flags_props
+
+
+@pytest.mark.skipif(platform.system() != "Darwin", reason="Only for MacOS")
 def test_flags_generated_if_only_defines():
     # https://github.com/conan-io/conan/issues/16422
     client = TestClient()


### PR DESCRIPTION
Changelog: Feature: `XcodeToolchain` now accepts arbitrary extra xcconfig settings via `tc.build_settings`, for build settings with no dedicated conf.
Docs: https://github.com/conan-io/docs/pull/4524

Named `.build_settings` that is the official name Apple gives to this variables: https://developer.apple.com/documentation/xcode/build-settings-reference

There was no way for a recipe to set an Xcode-only build setting through `XcodeToolchain`, the way e.g. `CMakeToolchain.variables` lets you set arbitrary CMake variables, for example `OTHER_SWIFT_FLAGS`.

This adds `self.build_settings`, a plain dict a recipe can populate before calling `tc.generate()`:

```
tc = XcodeToolchain(self)
tc.build_settings["OTHER_SWIFT_FLAGS"] = "$(inherited) -cxx-interoperability-mode=default ..."
tc.generate()
```

