### PR TITLE
Fix flaky assertion in test_linker_script for meson >= 1.12

### DIFF
--- a/test/functional/toolchains/meson/test_cross_compilation.py
+++ b/test/functional/toolchains/meson/test_cross_compilation.py
@@ -289,5 +289,9 @@ def test_linker_script():
             "mylinkscript.ld": "",
             "profile": profile})
     c.run('build . -pr=profile', assert_error=True)
-    # This error means the linker script was fonud and loaded, it failed because empty
-    assert "PHDR segment not covered by LOAD segment" in c.out
+    # This error means the linker script was found and loaded by the linker, it failed
+    # because it is empty. The exact ld diagnostic text is not asserted because it depends
+    # on the linker/meson version (e.g. meson >=1.12 duplicates the -T flag in its sanity
+    # check, which makes ld fail with a different message: "appears multiple times")
+    assert "mylinkscript.ld" in c.out
+    assert "Error 1 while executing" in c.out


### PR DESCRIPTION
Changelog: Fix: Make `test_linker_script` test resilient to the exact linker error text, which changed with Meson >= 1.12.
Docs: Omit

This test has been breaking Linux CI on almost every open PR since August 11th:

- #20253
- #20254
- #20255
- #20256

Always the same failure:

FAILED test/functional/toolchains/meson/test_cross_compilation.py::test_linker_script

Meson 1.12.0 (released August 10th) changed how it runs its compiler sanity check during `setup()`: it now duplicates the `-T<script>` flag when a custom linker script is passed. `ld` then fails with a different message than the one the test expected (`PHDR segment not covered by LOAD segment`). 

The test only needs to check that the linker script actually got passed to the linker, not the exact `ld` error text. Updated the assertion to check that instead of the specific message.
