### PR TITLE
[fix] Accept .dll.a extension for deduce_full_cpp_info

### DIFF
--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -597,6 +597,7 @@ class _Component:
         libname, ext = os.path.splitext(libname)
         lib_sanitized = re.escape(libname)
         component_sanitized = re.escape(library_name)
+        # At first, exact matc
         regex_static = re.compile(rf"(?:lib)?{lib_sanitized}\.(?:a|lib|dll\.a)")
         regex_shared = re.compile(rf"(?:lib)?{lib_sanitized}\.(?:so|dylib)")
         regex_dll = re.compile(rf".*(?:{lib_sanitized}|{component_sanitized}).*\.dll")

--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -597,15 +597,14 @@ class _Component:
         libname, ext = os.path.splitext(libname)
         lib_sanitized = re.escape(libname)
         component_sanitized = re.escape(library_name)
-        # At first, exact match
-        regex_static = re.compile(rf"(?:lib)?{lib_sanitized}\.(?:a|lib)")
+        regex_static = re.compile(rf"(?:lib)?{lib_sanitized}\.(?:a|lib|dll\.a)")
         regex_shared = re.compile(rf"(?:lib)?{lib_sanitized}\.(?:so|dylib)")
         regex_dll = re.compile(rf".*(?:{lib_sanitized}|{component_sanitized}).*\.dll")
         static_location = _find_matching(libdirs, regex_static)
         shared_location = _find_matching(libdirs, regex_shared)
         if not any([static_location, shared_location]):
             # Let's extend a little bit the pattern search
-            regex_wider_static = re.compile(rf"(?:lib)?{lib_sanitized}(?:[._-].+)?\.(?:a|lib)")
+            regex_wider_static = re.compile(rf"(?:lib)?{lib_sanitized}(?:[._-].+)?\.(?:a|lib|dll\.a)")
             regex_wider_shared = re.compile(rf"(?:lib)?{lib_sanitized}(?:[._-].+)?\.(?:so|dylib)")
             static_location = _find_matching(libdirs, regex_wider_static)
             shared_location = _find_matching(libdirs, regex_wider_shared)

--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -597,7 +597,7 @@ class _Component:
         libname, ext = os.path.splitext(libname)
         lib_sanitized = re.escape(libname)
         component_sanitized = re.escape(library_name)
-        # At first, exact matc
+        # At first, exact match
         regex_static = re.compile(rf"(?:lib)?{lib_sanitized}\.(?:a|lib|dll\.a)")
         regex_shared = re.compile(rf"(?:lib)?{lib_sanitized}\.(?:so|dylib)")
         regex_dll = re.compile(rf".*(?:{lib_sanitized}|{component_sanitized}).*\.dll")

--- a/test/unittests/model/build_info/test_deduce_locations.py
+++ b/test/unittests/model/build_info/test_deduce_locations.py
@@ -268,6 +268,27 @@ def test_multiple_matches_exact_match(prefix, conanfile):
     assert result.type == "static-library"
 
 
+def test_multiple_matches_exact_match_mingw_dll_a(conanfile):
+    """
+    Validate .dll.a extension (MingW) used for static import libraries
+    """
+    folder = temp_folder()
+    save(os.path.join(folder, "libdir", "libmylib.dll.a"), "")
+    save(os.path.join(folder, "libdir", "libmylib_setup.dll.a"), "")
+
+    cppinfo = CppInfo()
+    cppinfo.libdirs = ["libdir"]
+    cppinfo.libs = ["mylib"]
+    cppinfo.set_relative_base_folder(folder)
+    folder = folder.replace("\\", "/")
+    output = RedirectedTestOutput()
+    with redirect_output(output):
+        result = cppinfo.deduce_full_cpp_info(conanfile)
+    assert "WARN: There were several matches for Lib mylib" not in output
+    assert result.location == f"{folder}/libdir/libmylib.dll.a"
+    assert result.type == "static-library"
+
+
 @pytest.mark.parametrize("lib_name, libs", [
     ("harfbuzz", ["harfbuzz-icu.lib", "harfbuzz.lib"]),
 ])


### PR DESCRIPTION
Hi!

When building Boost 1.92.0 for some validations, mainly when using Mingw with static libraries, I had the following warning:

> "There were several matches for Lib boost_log: ['C:\...\libboost_log.dll.a', 'C:\...\libboost_log_setup.dll.a']"

This warning comes from [deduce_full_cpp_info](https://github.com/conan-io/conan/blob/2.31.2/conan/internal/model/cpp_info.py#L878) which is used as a hook to validate installed libraries vs cpp_info content. For this very specific case, when building on Windows with MingW and shared library, those generated import libraries end with the extension `.dll.a` (shared are `.dll`), which is not covered by `deduce_full_cpp_info` internals. 

This PR adds that missing extension and adds a new test to cover this reported case. 

Regards! 

Changelog: Fix: Match the `dll.a` extension (MinGW) in `deduce_full_cpp_info`.
Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
