### PR TITLE
fix sbom no description

### DIFF
--- a/conan/tools/sbom/cyclonedx.py
+++ b/conan/tools/sbom/cyclonedx.py
@@ -61,7 +61,7 @@ def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, **kwar
         **({"components": [{
             "author": node.conanfile.author or "Unknown",
             "bom-ref": _calculate_bomref(node),
-            "description": node.conanfile.description,
+            **({"description": node.conanfile.description} if node.conanfile.description else {}),
             **({"externalReferences": [{
                 "type": "website",
                 "url": node.conanfile.homepage
@@ -158,7 +158,7 @@ def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, **kwar
         **({"components": [{
             **({"authors": [{"name": node.conanfile.author}]} if node.conanfile.author else {}),
             "bom-ref": _calculate_bomref(node),
-            "description": node.conanfile.description,
+            **({"description": node.conanfile.description} if node.conanfile.description else {}),
             **({"externalReferences": [{
                 "type": "website",
                 "url": node.conanfile.homepage

--- a/test/integration/sbom/test_cyclonedx.py
+++ b/test/integration/sbom/test_cyclonedx.py
@@ -313,6 +313,7 @@ class TestCyclonedx:
         cyclone_path = os.path.join(create_layout.metadata(), "sbom.cdx.json")
         content = tc.load(cyclone_path)
         content_json = json.loads(content)
+        assert "description" not in content_json["components"][0]
         if cyclone_version == 'cyclonedx_1_4':
             assert content_json["metadata"]["component"]["author"] == 'conan-dev'
             assert content_json["metadata"]["component"]["type"] == 'application'


### PR DESCRIPTION
Changelog: Fix: Generate valid CycloneDX SBOMs for recipes without a `description` attribute.
Docs: Omit

close: https://github.com/conan-io/conan/issues/20262

- [x] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
