### PR TITLE
Add support for python requires in remotes for `conan workspace create`

### DIFF
--- a/conan/cli/commands/workspace.py
+++ b/conan/cli/commands/workspace.py
@@ -352,7 +352,7 @@ def workspace_create(conan_api: ConanAPI, parser, subparser, *args):
 
     build_mode = args.build if args.build else []
     ConanOutput().box("Exporting workspace recipes to Conan cache")
-    exported_refs = conan_api.workspace.export()
+    exported_refs = conan_api.workspace.export(lockfile=lockfile, remotes=remotes)
     build_mode.extend(f"missing:{r}" for r in exported_refs)
 
     all_packages = conan_api.workspace.packages()

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -2040,6 +2040,7 @@ class TestPyRequires:
 
     def test_ws_python_requires_only_in_remote(self):
         # https://github.com/conan-io/conan/issues/20170
+        # "workspace create" case: https://github.com/conan-io/conan/issues/20260
         c = TestClient(light=True, default_server_user=True)
         pyreq = textwrap.dedent("""\
             from conan import ConanFile
@@ -2083,6 +2084,10 @@ class TestPyRequires:
         c.run("remove * -c")
         c.run("workspace super-install")
         assert "pyreq/0.1: Downloaded" in c.out
+        c.run("remove * -c")
+        c.run("workspace create")
+        assert "pyreq/0.1: Downloaded" in c.out
+        assert "Exported: pkg/0.1" in c.out
 
     def test_ws_python_requires_editable(self):
         c = TestClient(light=True)


### PR DESCRIPTION
Changelog: Fix: Add support for python requires in remotes for `conan workspace create`.
Docs: Omit

Closes https://github.com/conan-io/conan/issues/20260