### PR TITLE
Add `raise_on_errors` to `CommandAPI.run`

### DIFF
--- a/conan/api/subapi/command.py
+++ b/conan/api/subapi/command.py
@@ -19,7 +19,7 @@ class CommandAPI:
         self._conan_api = conan_api
         self.cli = None
 
-    def run(self, cmd, raise_on_errors=False):
+    def run(self, cmd, raise_on_errors=True):
         """ Runs another Conan command via API
 
         :param cmd: Conan command to run. It can be either a string, or a list of strings.

--- a/conan/api/subapi/command.py
+++ b/conan/api/subapi/command.py
@@ -25,6 +25,18 @@ class CommandAPI:
         :param cmd: Conan command to run. It can be either a string, or a list of strings.
         :return: It will return what that command returns. Note that different commands can
            return different things, so the caller needs to process it accordingly.
+
+        .. warning::
+
+            Some commands (e.g. "create", "install") do not raise directly on a build/install
+            error, but defer it, returning it instead as a ``"conan_error"`` entry in their
+            result, so formatters can still run (e.g. to write "graph.json" even after a
+            failure). Unlike the regular CLI entry point, this method does **not**
+            automatically re-raise that deferred error: it is the caller's responsibility to
+            check the result for a ``"conan_error"`` entry (and optionally a
+            ``"conan_warning"`` one) and to raise/report it if the same behavior as running
+            that command directly from the command line is desired, especially when chaining
+            several commands where a failure in one should stop the rest.
         """
         if isinstance(cmd, str):
             cmd = shlex.split(cmd)

--- a/conan/api/subapi/command.py
+++ b/conan/api/subapi/command.py
@@ -19,24 +19,15 @@ class CommandAPI:
         self._conan_api = conan_api
         self.cli = None
 
-    def run(self, cmd):
+    def run(self, cmd, raise_on_errors=False):
         """ Runs another Conan command via API
 
         :param cmd: Conan command to run. It can be either a string, or a list of strings.
+        :param raise_on_errors: If True, it will raise an exception on errors.
+           By default, some command will return errors as ``conan_error`` entries in the result,
+           and it will be the caller's responsibility to check for them and raise/report them if desired.
         :return: It will return what that command returns. Note that different commands can
            return different things, so the caller needs to process it accordingly.
-
-        .. warning::
-
-            Some commands (e.g. "create", "install") do not raise directly on a build/install
-            error, but defer it, returning it instead as a ``"conan_error"`` entry in their
-            result, so formatters can still run (e.g. to write "graph.json" even after a
-            failure). Unlike the regular CLI entry point, this method does **not**
-            automatically re-raise that deferred error: it is the caller's responsibility to
-            check the result for a ``"conan_error"`` entry (and optionally a
-            ``"conan_warning"`` one) and to raise/report it if the same behavior as running
-            that command directly from the command line is desired, especially when chaining
-            several commands where a failure in one should stop the rest.
         """
         if isinstance(cmd, str):
             cmd = shlex.split(cmd)
@@ -64,6 +55,14 @@ class CommandAPI:
             ConanOutput._conan_output_level = _conan_output_level
             ConanOutput._silent_warn_tags = _silent_warn_tags
             ConanOutput._warnings_as_errors = _warnings_as_errors
+        if raise_on_errors and result and isinstance(result, dict):
+            if result.get("conan_error"):
+                e = result["conan_error"]
+                if isinstance(e, Exception):
+                    raise e
+                raise ConanException(e)
+            if result.get("conan_warning"):
+                ConanOutput().warning(result["conan_warning"])
         return result
 
     @staticmethod

--- a/conan/cli/commands/workspace.py
+++ b/conan/cli/commands/workspace.py
@@ -156,6 +156,23 @@ def workspace_install(conan_api: ConanAPI, parser, subparser, *args):
     _install_build(conan_api, parser, subparser, False, *args)
 
 
+def _run_command(conan_api, cmd):
+    """ Run a command via ``conan_api.command.run()``, raising if it returned a deferred error.
+
+    ``conan_api.command.run()`` does not automatically raise on a build/install error (see its
+    docstring): some commands (e.g. "create", "install") defer it, returning it instead as a
+    "conan_error" entry in their result. This wrapper does that check, so a failure in one
+    workspace package stops the whole command immediately, instead of continuing to
+    build/install further packages that depend on the one that failed.
+    https://github.com/conan-io/conan/issues/20258
+    """
+    result = conan_api.command.run(cmd)
+    if isinstance(result, dict) and result.get("conan_error"):
+        e = result["conan_error"]
+        raise e if isinstance(e, Exception) else ConanException(e)
+    return result
+
+
 def _install_build(conan_api: ConanAPI, parser, subparser, build, *args):
     subparser.add_argument("--pkg", action="append", help='Define specific packages')
     add_common_install_arguments(subparser)
@@ -214,7 +231,7 @@ def _install_build(conan_api: ConanAPI, parser, subparser, build, *args):
                                    f'{lockfile_args} {verbose_args}')
                             ConanOutput().box(f"Workspace building external {ref}")
                             ConanOutput().info(f"Command: {cmd}\n")
-                            conan_api.command.run(cmd)
+                            _run_command(conan_api, cmd)
                     else:
                         path = ws_pkg["path"]
                         output_folder = ws_pkg.get("output_folder")
@@ -229,7 +246,7 @@ def _install_build(conan_api: ConanAPI, parser, subparser, build, *args):
                                f'{lockfile_args} {verbose_args}')
                         ConanOutput().box(f"Workspace {command}: {ref}")
                         ConanOutput().info(f"Command: {cmd}\n")
-                        conan_api.command.run(cmd)
+                        _run_command(conan_api, cmd)
 
 
 @conan_subcommand(formatters={"json": format_graph_json})
@@ -384,7 +401,7 @@ def workspace_create(conan_api: ConanAPI, parser, subparser, *args):
                         cmd = f'install {package["build_args"]} {profile_args}'
                         ConanOutput().box(f"Workspace building external {ref}")
                         ConanOutput().info(f"Build command: {cmd}\n")
-                        conan_api.command.run(cmd)
+                        _run_command(conan_api, cmd)
                     else:  # Package in workspace
                         path = packages[ref]["path"]
                         # TODO: Missing --lockfile-overrides arg here
@@ -395,7 +412,7 @@ def workspace_create(conan_api: ConanAPI, parser, subparser, *args):
                         cmd = f'create "{path}" {profile_args} {build} {ref_args}'
                         ConanOutput().box(f"Workspace create {ref}")
                         ConanOutput().info(f"Conan create command: {cmd}\n")
-                        conan_api.command.run(cmd)
+                        _run_command(conan_api, cmd)
 
 
 @conan_subcommand()

--- a/conan/cli/commands/workspace.py
+++ b/conan/cli/commands/workspace.py
@@ -156,23 +156,6 @@ def workspace_install(conan_api: ConanAPI, parser, subparser, *args):
     _install_build(conan_api, parser, subparser, False, *args)
 
 
-def _run_command(conan_api, cmd):
-    """ Run a command via ``conan_api.command.run()``, raising if it returned a deferred error.
-
-    ``conan_api.command.run()`` does not automatically raise on a build/install error (see its
-    docstring): some commands (e.g. "create", "install") defer it, returning it instead as a
-    "conan_error" entry in their result. This wrapper does that check, so a failure in one
-    workspace package stops the whole command immediately, instead of continuing to
-    build/install further packages that depend on the one that failed.
-    https://github.com/conan-io/conan/issues/20258
-    """
-    result = conan_api.command.run(cmd)
-    if isinstance(result, dict) and result.get("conan_error"):
-        e = result["conan_error"]
-        raise e if isinstance(e, Exception) else ConanException(e)
-    return result
-
-
 def _install_build(conan_api: ConanAPI, parser, subparser, build, *args):
     subparser.add_argument("--pkg", action="append", help='Define specific packages')
     add_common_install_arguments(subparser)
@@ -231,7 +214,7 @@ def _install_build(conan_api: ConanAPI, parser, subparser, build, *args):
                                    f'{lockfile_args} {verbose_args}')
                             ConanOutput().box(f"Workspace building external {ref}")
                             ConanOutput().info(f"Command: {cmd}\n")
-                            _run_command(conan_api, cmd)
+                            conan_api.command.run(cmd, raise_on_errors=True)
                     else:
                         path = ws_pkg["path"]
                         output_folder = ws_pkg.get("output_folder")
@@ -246,7 +229,7 @@ def _install_build(conan_api: ConanAPI, parser, subparser, build, *args):
                                f'{lockfile_args} {verbose_args}')
                         ConanOutput().box(f"Workspace {command}: {ref}")
                         ConanOutput().info(f"Command: {cmd}\n")
-                        _run_command(conan_api, cmd)
+                        conan_api.command.run(cmd, raise_on_errors=True)
 
 
 @conan_subcommand(formatters={"json": format_graph_json})
@@ -401,7 +384,7 @@ def workspace_create(conan_api: ConanAPI, parser, subparser, *args):
                         cmd = f'install {package["build_args"]} {profile_args}'
                         ConanOutput().box(f"Workspace building external {ref}")
                         ConanOutput().info(f"Build command: {cmd}\n")
-                        _run_command(conan_api, cmd)
+                        conan_api.command.run(cmd, raise_on_errors=True)
                     else:  # Package in workspace
                         path = packages[ref]["path"]
                         # TODO: Missing --lockfile-overrides arg here
@@ -412,7 +395,7 @@ def workspace_create(conan_api: ConanAPI, parser, subparser, *args):
                         cmd = f'create "{path}" {profile_args} {build} {ref_args}'
                         ConanOutput().box(f"Workspace create {ref}")
                         ConanOutput().info(f"Conan create command: {cmd}\n")
-                        _run_command(conan_api, cmd)
+                        conan_api.command.run(cmd, raise_on_errors=True)
 
 
 @conan_subcommand()

--- a/test/integration/command/create_test.py
+++ b/test/integration/command/create_test.py
@@ -935,3 +935,32 @@ def test_create_build_fail_generate_outfile(command, out_file):
     assert "revisions" in rrev["packages"]["47a5f20ec8fb480e1c5794462089b01a3548fdc5"]
     rrev = pkglist["Local Cache"]["pkga/0.1"]["revisions"]["57ece23aeb368b634896004ad579767a"]
     assert "revisions" in rrev["packages"]["da39a3ee5e6b4b0d3255bfef95601890afd80709"]
+
+
+@pytest.mark.parametrize("command", ["create", "install"])
+def test_create_build_fail_via_command_api(command):
+    """ Same build failure as ``test_create_build_fail_generate_outfile`` above, but invoked
+    through ``conan_api.command.run()`` (the mechanism "workspace create"/"workspace install"
+    use to chain commands) instead of directly via the CLI. Unlike the direct CLI invocation,
+    this does NOT raise by itself: the error is deferred into a "conan_error" entry of the
+    result, and it is the caller's responsibility to check for it (as documented in
+    ``CommandAPI.run()``'s docstring, and as "workspace create"/"workspace install" now do).
+    https://github.com/conan-io/conan/issues/20258
+    """
+    c = TestClient()
+    c.save({"pkga/conanfile.py": GenConanfile("pkga", "0.1"),
+            "pkgb/conanfile.py": GenConanfile("pkgb", "0.1").with_requires("pkga/0.1"),
+            "pkgc/conanfile.py": GenConanfile("pkgc", "0.1")
+           .with_requires("pkgb/0.1")
+           .with_package("raise Exception('myerror')"),
+            "pkgd/conanfile.py": GenConanfile("pkgd", "0.1").with_requires("pkgc/0.1")
+                                                            .with_settings("build_type")
+                                                            .with_generator("CMakeDeps"),
+            })
+    c.run("export pkga")
+    c.run("export pkgb")
+    c.run("export pkgc")
+    # api.command.run() does not manage the cwd like TestClient.run() does, needs an abs path
+    pkgd_path = os.path.join(c.current_folder, "pkgd")
+    result = c.api.command.run([command, pkgd_path, "--build=missing"])
+    assert "Error in package() method, line 8" in str(result["conan_error"])

--- a/test/integration/command/create_test.py
+++ b/test/integration/command/create_test.py
@@ -935,32 +935,3 @@ def test_create_build_fail_generate_outfile(command, out_file):
     assert "revisions" in rrev["packages"]["47a5f20ec8fb480e1c5794462089b01a3548fdc5"]
     rrev = pkglist["Local Cache"]["pkga/0.1"]["revisions"]["57ece23aeb368b634896004ad579767a"]
     assert "revisions" in rrev["packages"]["da39a3ee5e6b4b0d3255bfef95601890afd80709"]
-
-
-@pytest.mark.parametrize("command", ["create", "install"])
-def test_create_build_fail_via_command_api(command):
-    """ Same build failure as ``test_create_build_fail_generate_outfile`` above, but invoked
-    through ``conan_api.command.run()`` (the mechanism "workspace create"/"workspace install"
-    use to chain commands) instead of directly via the CLI. Unlike the direct CLI invocation,
-    this does NOT raise by itself: the error is deferred into a "conan_error" entry of the
-    result, and it is the caller's responsibility to check for it (as documented in
-    ``CommandAPI.run()``'s docstring, and as "workspace create"/"workspace install" now do).
-    https://github.com/conan-io/conan/issues/20258
-    """
-    c = TestClient()
-    c.save({"pkga/conanfile.py": GenConanfile("pkga", "0.1"),
-            "pkgb/conanfile.py": GenConanfile("pkgb", "0.1").with_requires("pkga/0.1"),
-            "pkgc/conanfile.py": GenConanfile("pkgc", "0.1")
-           .with_requires("pkgb/0.1")
-           .with_package("raise Exception('myerror')"),
-            "pkgd/conanfile.py": GenConanfile("pkgd", "0.1").with_requires("pkgc/0.1")
-                                                            .with_settings("build_type")
-                                                            .with_generator("CMakeDeps"),
-            })
-    c.run("export pkga")
-    c.run("export pkgb")
-    c.run("export pkgc")
-    # api.command.run() does not manage the cwd like TestClient.run() does, needs an abs path
-    pkgd_path = os.path.join(c.current_folder, "pkgd")
-    result = c.api.command.run([command, pkgd_path, "--build=missing"])
-    assert "Error in package() method, line 8" in str(result["conan_error"])

--- a/test/integration/conan_api/test_cli.py
+++ b/test/integration/conan_api/test_cli.py
@@ -52,7 +52,8 @@ def test_api_command():
     assert result[0].name == "conancenter"
 
 
-def test_api_command_error():
+@pytest.mark.parametrize("raise_on_errors", [True, False])
+def test_api_command_error(raise_on_errors):
     """ ``conan_api.command.run()`` does NOT raise a build/install error by itself: "create"/
     "install" defer it into a "conan_error" entry of their result instead of raising directly
     (so formatters can still run, e.g. to write "graph.json" on failure, see #19204). It is the
@@ -64,9 +65,14 @@ def test_api_command_error():
     c = TestClient()
     c.save({"conanfile.py": GenConanfile("pkg", "0.1").with_package("raise Exception('boom')")})
     c.run("export .")
-    result = c.api.command.run(["create", c.current_folder])
-    assert isinstance(result["conan_error"], ConanException)
-    assert "boom" in str(result["conan_error"])
+    if raise_on_errors:
+        with pytest.raises(ConanException) as e:
+            c.api.command.run(["create", c.current_folder], raise_on_errors=raise_on_errors)
+        assert "boom" in str(e.value)
+    else:
+        result = c.api.command.run(["create", c.current_folder], raise_on_errors=raise_on_errors)
+        assert isinstance(result["conan_error"], ConanException)
+        assert "boom" in str(result["conan_error"])
 
 
 def test_main():

--- a/test/integration/conan_api/test_cli.py
+++ b/test/integration/conan_api/test_cli.py
@@ -67,10 +67,10 @@ def test_api_command_error(raise_on_errors):
     c.run("export .")
     if raise_on_errors:
         with pytest.raises(ConanException) as e:
-            c.api.command.run(["create", c.current_folder], raise_on_errors=raise_on_errors)
+            c.api.command.run(["create", c.current_folder])
         assert "boom" in str(e.value)
     else:
-        result = c.api.command.run(["create", c.current_folder], raise_on_errors=raise_on_errors)
+        result = c.api.command.run(["create", c.current_folder], raise_on_errors=False)
         assert isinstance(result["conan_error"], ConanException)
         assert "boom" in str(result["conan_error"])
 

--- a/test/integration/conan_api/test_cli.py
+++ b/test/integration/conan_api/test_cli.py
@@ -4,10 +4,12 @@ import pytest
 
 from conan.api.conan_api import ConanAPI
 from conan.cli.cli import Cli, main
+from conan.errors import ConanException
+from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.env import environment_update
 from conan.test.utils.mocks import RedirectedTestOutput
 from conan.test.utils.test_files import temp_folder
-from conan.test.utils.tools import redirect_output
+from conan.test.utils.tools import redirect_output, TestClient
 
 
 def test_cli():
@@ -48,6 +50,23 @@ def test_api_command():
     cli.add_commands()
     result = api.command.run(["remote", "list"])
     assert result[0].name == "conancenter"
+
+
+def test_api_command_error():
+    """ ``conan_api.command.run()`` does NOT raise a build/install error by itself: "create"/
+    "install" defer it into a "conan_error" entry of their result instead of raising directly
+    (so formatters can still run, e.g. to write "graph.json" on failure, see #19204). It is the
+    caller's responsibility to check the result and raise/report it if desired, as documented
+    in this method's docstring. See https://github.com/conan-io/conan/issues/20258, where
+    "workspace create"/"workspace install" needed to start doing exactly that, since they
+    chain commands via this API and a failure in one must stop the rest.
+    """
+    c = TestClient()
+    c.save({"conanfile.py": GenConanfile("pkg", "0.1").with_package("raise Exception('boom')")})
+    c.run("export .")
+    result = c.api.command.run(["create", c.current_folder])
+    assert isinstance(result["conan_error"], ConanException)
+    assert "boom" in str(result["conan_error"])
 
 
 def test_main():

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -1476,6 +1476,40 @@ class TestCreate:
         assert "protobuf/0.1: Building for: Windows!!!" in c.out
         assert "protobuf/0.1: Building for: Linux!!!" in c.out
 
+    def test_create_stops_on_build_error(self):
+        # https://github.com/conan-io/conan/issues/20258
+        c = TestClient(light=True)
+        pkga = textwrap.dedent("""\
+            from conan import ConanFile
+            class Pkga(ConanFile):
+                name = "pkga"
+                version = "0.1"
+                def build(self):
+                    raise Exception("boom")
+            """)
+        pkgb = textwrap.dedent("""\
+            from conan import ConanFile
+            class Pkgb(ConanFile):
+                name = "pkgb"
+                version = "0.1"
+                def requirements(self):
+                    self.requires("pkga/0.1")
+                def build(self):
+                    self.output.warning("BUILD PKGB SHOULD NOT HAPPEN")
+            """)
+        c.save({"conanws.yml": "",
+                "pkga/conanfile.py": pkga,
+                "pkgb/conanfile.py": pkgb})
+        c.run("workspace add pkga")
+        c.run("workspace add pkgb")
+        c.run("workspace create", assert_error=True)
+        assert "Error in build() method" in c.out
+        assert "boom" in c.out
+        # It must stop right after pkga's build fails, never attempting pkgb
+        assert "Workspace create pkgb/0.1" not in c.out
+        assert "BUILD PKGB SHOULD NOT HAPPEN" not in c.out
+        assert "Missing binary" not in c.out
+
 
 class TestSource:
     def test_source(self):
@@ -1617,6 +1651,32 @@ class TestInstall:
         assert "Using lockfile" in c.out
         assert f"hello/0.1#{rev1}" in c.out
         assert rev2 not in c.out
+
+    def test_install_stops_on_external_build_error(self):
+        # https://github.com/conan-io/conan/issues/20258
+        c = TestClient(light=True)
+        c.save({"conanws.yml": ""})
+        hello = textwrap.dedent("""\
+            from conan import ConanFile
+            class Hello(ConanFile):
+                name = "hello"
+                version = "0.1"
+                def build(self):
+                    raise Exception("boom")
+            """)
+        app = GenConanfile("app", "0.1").with_requires("hello/0.1").with_build_msg("APP BUILT!")
+        c.save({"hello_src/conanfile.py": hello,
+                "app/conanfile.py": app})
+        c.run("export hello_src")
+        c.run("workspace add app")
+        c.run("workspace install --build=missing", assert_error=True)
+        assert "Error in build() method" in c.out
+        assert "boom" in c.out
+        # It must stop right after hello's build fails, never attempting to install app
+        # (which depends on it)
+        assert "Workspace install: app/0.1" not in c.out
+        assert "APP BUILT!" not in c.out
+        assert "Missing binary" not in c.out
 
 
 def test_keep_core_conf():


### PR DESCRIPTION
Changelog: Feature: Add ``raise_on_errors=True`` arg to ``CommandAPI.run``, it now raises on all errors returned by commands.
Changelog: Fix: Failed creates in ``workspace`` subcommands now raise errors as expected.
Docs: Omit

Closes https://github.com/conan-io/conan/issues/20258

In https://github.com/conan-io/conan/pull/19204 the behaviour of the install API changed not to raise, and let the CLI entrypoint do it (so that formatters could run). This change was not propagated here so the `run` calls (which does not have the auto-raise on `conan_error` keys) now did not stop execution when something failed, which could make it so a failed `workspace create` command returned success status codes without having actually succesfully compiled
