### PR TITLE
Fix: Improve `conan cache restore` folder extraction to avoid overwrites

### DIFF
--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -510,19 +510,35 @@ def _cache_path(folder, cache_folder):
 class _RestorePlan:
     """ Where every folder of a "conan cache save" archive has to be extracted in this cache,
     which is not necessarily the folder it had in the cache that created the archive
+
+    The plan is built first, adding every folder of the archive that has to be restored, and
+    then it is executed with "extract()". Only the folders added to the plan are extracted, and
+    they are extracted directly to the destination the cache DB assigned to them in this cache,
+    so no other contents of the archive are written to the cache store.
     """
 
     def __init__(self, cache_folder):
+        """
+        :param cache_folder: The cache store folder, the root all the extractions are relative to
+        """
         self._cache_folder = cache_folder
         self._folders = {}  # {folder in the archive: folder in the cache, relative to the store}
         self._dirty = set()  # Folders marked while they are extracted, to detect incomplete ones
         self._restored = set()  # Folders already extracted
 
     def add_contents(self, folder, dest, replace, dirty=False):
-        """ Recipes and packages are immutable, if the revision is already in this cache the
+        """ Add a folder of recipe or package contents to the plan, unless it is already in this
+        cache. Recipes and packages are immutable, if the revision is already in this cache the
         contents are the same, and they are not extracted again, so their files are never
         overwritten. The contents of a revision that is not in the DB are leftovers, not valid
         contents, and they are replaced
+
+        :param folder: The folder in the archive, as it was in the cache that created it
+        :param dest: The absolute folder in this cache where those contents have to be extracted
+        :param replace: If True, existing contents in ``dest`` are leftovers and are removed
+           before extracting. If False, ``dest`` contents are valid and nothing is extracted
+        :param dirty: If True, ``dest`` is marked as dirty while it is extracted, so an
+           interrupted extraction leaves incomplete contents that will not be used
         """
         if os.path.exists(dest):
             if not replace:
@@ -533,15 +549,29 @@ class _RestorePlan:
             self._dirty.add(folder)
 
     def add_metadata(self, folder, dest):
-        """ Metadata is not immutable, it is always restored, adding to the existing one """
+        """ Add a metadata folder to the plan. Metadata is not immutable, it is always restored,
+        adding to the existing one
+
+        :param folder: The metadata folder in the archive
+        :param dest: The absolute metadata folder in this cache where it has to be extracted
+        """
         self._folders[folder] = _cache_path(dest, self._cache_folder)
 
     def restored(self, folder):
+        """ If the contents of an archive folder were already extracted, used after a failure to
+        know which new DB entries have contents and which ones have to be removed
+
+        :param folder: The folder in the archive
+        :return: True if that folder was already extracted
+        """
         return folder in self._restored
 
     def extract(self, the_tar):
-        """ Extract one folder at a time, in the order they are in the archive, so the stream
-        is read forwards, and an interrupted extraction only leaves one incomplete folder
+        """ Extract the planned folders, one folder at a time, in the order they are in the
+        archive, so the stream is read forwards, and an interrupted extraction only leaves one
+        incomplete folder. Members that do not belong to any planned folder are not extracted
+
+        :param the_tar: The open tarfile of the "conan cache save" archive to restore
         """
         groups = {}  # {folder in the archive: [members]}, in the order of the archive
         for member in the_tar.getmembers():
@@ -560,15 +590,26 @@ class _RestorePlan:
 
     def _locate(self, name):
         """ The folder to restore this archive member belongs to, and the path, relative to the
-        cache store, where it has to be extracted. None if the member is not restored
+        cache store, where it has to be extracted
+
+        The member is a path in the archive, and only its folders are known, so the member path
+        is checked from the longest to the shortest prefix, until one of them is a folder to
+        restore, and the rest of the member path is appended to that folder destination:
+           "abcde1234/e/conanfile.py" with {"abcde1234/e": "fghij5678/e"} is extracted as
+           "fghij5678/e/conanfile.py"
+
+        :param name: The member path in the archive
+        :return: A tuple (folder in the archive, path relative to the cache store where the
+           member has to be extracted), or None if the member does not belong to any planned
+           folder, so it is not restored, like "pkglist.json" or the contents already in this
+           cache, but also any member trying to escape the folders of the plan
         """
-        path, tail = name, ""
-        while path:
-            dest = self._folders.get(path)
+        parts = name.split("/")
+        for i in range(len(parts), 0, -1):
+            folder = "/".join(parts[:i])
+            dest = self._folders.get(folder)
             if dest is not None:
-                return path, dest + tail
-            path, _, last = path.rpartition("/")
-            tail = f"/{last}{tail}"
+                return folder, "/".join([dest] + parts[i:])
         return None
 
 

--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -521,16 +521,16 @@ class _RestorePlan:
     def add_contents(self, folder, dest, replace, dirty=False):
         """ Recipes and packages are immutable, if the revision is already in this cache the
         contents are the same, and they are not extracted again, so their files are never
-        overwritten. Returns True if the folder is going to be extracted
+        overwritten. The contents of a revision that is not in the DB are leftovers, not valid
+        contents, and they are replaced
         """
         if os.path.exists(dest):
             if not replace:
-                return False
-            rmdir(dest)  # Leftovers of an interrupted restore, not valid contents
+                return
+            rmdir(dest)
         self._folders[folder] = _cache_path(dest, self._cache_folder)
         if dirty:
             self._dirty.add(folder)
-        return True
 
     def add_metadata(self, folder, dest):
         """ Metadata is not immutable, it is always restored, adding to the existing one """

--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -2,6 +2,7 @@ import json
 import os
 import tarfile
 import tempfile
+from contextlib import nullcontext
 
 from conan.api.model import PackagesList
 from conan.api.output import ConanOutput
@@ -20,8 +21,8 @@ from conan.api.model import RecipeReference
 from conan.internal.api.uploader import PackagePreparator
 from conan.internal.rest.pkg_sign import PkgSignaturesPlugin
 from conan.internal.util.dates import revision_timestamp_now
-from conan.internal.util.files import (clean_dirty, mkdir, remove, remove_if_dirty, rmdir, save,
-                                       set_dirty)
+from conan.internal.util.files import (mkdir, remove, remove_if_dirty, rmdir, save,
+                                       set_dirty_context_manager)
 
 
 class CacheAPI:
@@ -551,13 +552,10 @@ class _RestorePlan:
 
         for folder, members in groups.items():
             dest = os.path.join(self._cache_folder, self._folders[folder])
-            dirty = folder in self._dirty
-            if dirty:
-                remove_if_dirty(dest)  # Stale mark of a previous interrupted restore
-                set_dirty(dest)
-            the_tar.extractall(path=self._cache_folder, members=members)
-            if dirty:
-                clean_dirty(dest)
+            # The mark stays if the extraction is interrupted, so the contents are not used
+            mark = set_dirty_context_manager(dest) if folder in self._dirty else nullcontext()
+            with mark:
+                the_tar.extractall(path=self._cache_folder, members=members)
             self._restored.add(folder)
 
     def _locate(self, name):

--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -2,7 +2,6 @@ import json
 import os
 import tarfile
 import tempfile
-from contextlib import nullcontext
 
 from conan.api.model import PackagesList
 from conan.api.output import ConanOutput
@@ -21,8 +20,7 @@ from conan.api.model import RecipeReference
 from conan.internal.api.uploader import PackagePreparator
 from conan.internal.rest.pkg_sign import PkgSignaturesPlugin
 from conan.internal.util.dates import revision_timestamp_now
-from conan.internal.util.files import (mkdir, remove, remove_if_dirty, rmdir, save,
-                                       set_dirty_context_manager)
+from conan.internal.util.files import mkdir, remove, remove_if_dirty, rmdir, save
 
 
 class CacheAPI:
@@ -387,6 +385,9 @@ class CacheAPI:
         directly to its final location. Recipes and packages are immutable, so the revisions
         already in this cache are not extracted again, only the missing ones.
 
+        The restore is expected to fully succeed. If it fails, this cache can be left with
+        incomplete recipes or packages, it is corrupted and it has to be removed.
+
         :param path: The archive file to restore. Based on the extension of the file, different
            compression formats can be used (.tgz, .txz and .tzst, the latter only for Python>=3.14).
         :return: a PackageLists with the recipes and packages that have been restored to the cache
@@ -397,8 +398,7 @@ class CacheAPI:
         cache = PkgCache(self._conan_api.cache_folder, self._api_helpers.global_conf)
         cache_folder = cache.store  # Note, this is not the home, but the actual package cache
         out = ConanOutput()
-        plan = _RestorePlan(cache_folder)
-        new_recipes, new_packages = [], []  # New DB entries, removed if they are not restored
+        folders = {}  # {folder in the archive: (destination folder in this cache, replace)}
 
         with open(path, mode='rb') as file_handler:
             the_tar = tarfile.open(fileobj=file_handler)
@@ -412,27 +412,25 @@ class CacheAPI:
                 ref.timestamp = revision_timestamp_now()
                 ref_bundle["timestamp"] = ref.timestamp
                 recipe_folder = ref_bundle["recipe_folder"]  # The folder in the archive
-                export_folder = f"{recipe_folder}/{EXPORT_FOLDER}"
                 try:
                     recipe_layout = cache.recipe_layout(ref)
                     replace = False
                 except ConanException:
                     recipe_layout = cache.create_ref_layout(ref)  # new DB folder entry
                     replace = True  # not in the DB, whatever is in the folder is a leftover
-                    new_recipes.append((recipe_layout, export_folder))
                 dest_folder = _cache_path(recipe_layout.base_folder, cache_folder)
                 ref_bundle["recipe_folder"] = dest_folder
                 out.info(f"Restore: {ref} in {dest_folder}")
-                plan.add_contents(export_folder, recipe_layout.export(), replace)
-                plan.add_contents(f"{recipe_folder}/{EXPORT_SRC_FOLDER}",
-                                  recipe_layout.export_sources(), replace)
-                # The sources get the same dirty protection they have when they are obtained
-                # by "conan source", incomplete ones are discarded, not used as valid sources
+                # Sources left dirty by an interrupted "conan source" are not valid sources
                 remove_if_dirty(recipe_layout.source())
-                plan.add_contents(f"{recipe_folder}/{SRC_FOLDER}", recipe_layout.source(),
-                                  replace, dirty=True)
-                plan.add_metadata(f"{recipe_folder}/{DOWNLOAD_EXPORT_FOLDER}/{METADATA}",
-                                  recipe_layout.metadata())
+                for f, dest in ((EXPORT_FOLDER, recipe_layout.export()),
+                                (EXPORT_SRC_FOLDER, recipe_layout.export_sources()),
+                                (SRC_FOLDER, recipe_layout.source())):
+                    if replace or not os.path.exists(dest):  # immutable, don't extract it again
+                        folders[f"{recipe_folder}/{f}"] = (dest, replace)
+                # Metadata is not immutable, it is always restored, over the existing one
+                metadata = f"{recipe_folder}/{DOWNLOAD_EXPORT_FOLDER}/{METADATA}"
+                folders[metadata] = (recipe_layout.metadata(), False)
 
                 for pref in packages:
                     pref.timestamp = revision_timestamp_now()
@@ -441,32 +439,31 @@ class CacheAPI:
                     pkg_folder = pref_bundle["package_folder"]  # The folder in the archive
                     try:
                         pkg_layout = cache.pkg_layout(pref)
-                        # A dirty package is incomplete, the leftover of an interrupted restore
-                        # or download, it is removed to restore it again
+                        # A dirty package is the incomplete leftover of an interrupted download,
+                        # it is removed to restore it again
                         remove_if_dirty(pkg_layout.package())
                         replace = False
                     except ConanException:
                         pkg_layout = cache.create_pkg_layout(pref)  # new DB folder entry
                         replace = True
-                        new_packages.append((pkg_layout, pkg_folder))
-                    dest_folder = _cache_path(pkg_layout.package(), cache_folder)
+                    dest = pkg_layout.package()
+                    dest_folder = _cache_path(dest, cache_folder)
                     pref_bundle["package_folder"] = dest_folder
                     out.info(f"Restore: {pref} in {dest_folder}")
-                    plan.add_contents(pkg_folder, pkg_layout.package(), replace, dirty=True)
-                    metadata_folder = pref_bundle.get("metadata_folder")
-                    if metadata_folder:
+                    if replace or not os.path.exists(dest):  # immutable, don't extract it again
+                        folders[pkg_folder] = (dest, replace)
+                    metadata = pref_bundle.get("metadata_folder")
+                    if metadata:
                         dest_folder = _cache_path(pkg_layout.metadata(), cache_folder)
                         pref_bundle["metadata_folder"] = dest_folder
                         out.info(f"Restore: {pref} metadata in {dest_folder}")
-                        plan.add_metadata(metadata_folder, pkg_layout.metadata())
+                        folders[metadata] = (pkg_layout.metadata(), False)
 
             try:
-                plan.extract(the_tar)
-            except BaseException:
-                # A new DB entry without contents would be a broken recipe or package in the
-                # cache, remove the ones that couldn't be restored, leaving the rest usable
-                _remove_not_restored(cache, plan, new_recipes, new_packages)
-                raise
+                _extract(the_tar, folders)
+            except Exception as e:
+                raise ConanException(f"Error restoring the cache: {e}\nThe restore is incomplete, "
+                                     "this cache is corrupted, remove it and restore it again")
             the_tar.close()
 
         return package_list
@@ -507,125 +504,63 @@ def _cache_path(folder, cache_folder):
     return os.path.relpath(folder, cache_folder).replace("\\", "/")  # make win paths portable
 
 
-class _RestorePlan:
-    """ Where every folder of a "conan cache save" archive has to be extracted in this cache,
-    which is not necessarily the folder it had in the cache that created the archive
-
-    The plan is built first, adding every folder of the archive that has to be restored, and
-    then it is executed with "extract()". Only the folders added to the plan are extracted, and
-    they are extracted directly to the destination the cache DB assigned to them in this cache,
-    so no other contents of the archive are written to the cache store.
+def _extract(the_tar, folders):
+    """ Extract the folders to restore, one at a time, in the order they are in the archive, so
+    the stream is read forwards. Every folder is extracted directly into its destination in this
+    cache, and members that don't belong to any of them, like "pkglist.json" or the contents
+    already in this cache, are not extracted at all
     """
+    groups = {}  # {folder in the archive: [members]}, in the order of the archive
+    for member in the_tar.getmembers():
+        located = _locate(folders, member.name)
+        if located is not None:
+            folder, member.name = located
+            groups.setdefault(folder, []).append(member)
 
-    def __init__(self, cache_folder):
-        """
-        :param cache_folder: The cache store folder, the root all the extractions are relative to
-        """
-        self._cache_folder = cache_folder
-        self._folders = {}  # {folder in the archive: folder in the cache, relative to the store}
-        self._dirty = set()  # Folders marked while they are extracted, to detect incomplete ones
-        self._restored = set()  # Folders already extracted
-
-    def add_contents(self, folder, dest, replace, dirty=False):
-        """ Add a folder of recipe or package contents to the plan, unless it is already in this
-        cache. Recipes and packages are immutable, if the revision is already in this cache the
-        contents are the same, and they are not extracted again, so their files are never
-        overwritten. The contents of a revision that is not in the DB are leftovers, not valid
-        contents, and they are replaced
-
-        :param folder: The folder in the archive, as it was in the cache that created it
-        :param dest: The absolute folder in this cache where those contents have to be extracted
-        :param replace: If True, existing contents in ``dest`` are leftovers and are removed
-           before extracting. If False, ``dest`` contents are valid and nothing is extracted
-        :param dirty: If True, ``dest`` is marked as dirty while it is extracted, so an
-           interrupted extraction leaves incomplete contents that will not be used
-        """
-        if os.path.exists(dest):
-            if not replace:
-                return
-            rmdir(dest)
-        self._folders[folder] = _cache_path(dest, self._cache_folder)
-        if dirty:
-            self._dirty.add(folder)
-
-    def add_metadata(self, folder, dest):
-        """ Add a metadata folder to the plan. Metadata is not immutable, it is always restored,
-        adding to the existing one
-
-        :param folder: The metadata folder in the archive
-        :param dest: The absolute metadata folder in this cache where it has to be extracted
-        """
-        self._folders[folder] = _cache_path(dest, self._cache_folder)
-
-    def restored(self, folder):
-        """ If the contents of an archive folder were already extracted, used after a failure to
-        know which new DB entries have contents and which ones have to be removed
-
-        :param folder: The folder in the archive
-        :return: True if that folder was already extracted
-        """
-        return folder in self._restored
-
-    def extract(self, the_tar):
-        """ Extract the planned folders, one folder at a time, in the order they are in the
-        archive, so the stream is read forwards, and an interrupted extraction only leaves one
-        incomplete folder. Members that do not belong to any planned folder are not extracted
-
-        :param the_tar: The open tarfile of the "conan cache save" archive to restore
-        """
-        groups = {}  # {folder in the archive: [members]}, in the order of the archive
-        for member in the_tar.getmembers():
-            located = self._locate(member.name)
-            if located is not None:  # Not restored, like "pkglist.json" or existing contents
-                folder, member.name = located
-                groups.setdefault(folder, []).append(member)
-
-        for folder, members in groups.items():
-            dest = os.path.join(self._cache_folder, self._folders[folder])
-            # The mark stays if the extraction is interrupted, so the contents are not used
-            mark = set_dirty_context_manager(dest) if folder in self._dirty else nullcontext()
-            with mark:
-                the_tar.extractall(path=self._cache_folder, members=members)
-            self._restored.add(folder)
-
-    def _locate(self, name):
-        """ The folder to restore this archive member belongs to, and the path, relative to the
-        cache store, where it has to be extracted
-
-        The member is a path in the archive, and only its folders are known, so the member path
-        is checked from the longest to the shortest prefix, until one of them is a folder to
-        restore, and the rest of the member path is appended to that folder destination:
-           "abcde1234/e/conanfile.py" with {"abcde1234/e": "fghij5678/e"} is extracted as
-           "fghij5678/e/conanfile.py"
-
-        :param name: The member path in the archive
-        :return: A tuple (folder in the archive, path relative to the cache store where the
-           member has to be extracted), or None if the member does not belong to any planned
-           folder, so it is not restored, like "pkglist.json" or the contents already in this
-           cache, but also any member trying to escape the folders of the plan
-        """
-        parts = name.split("/")
-        for i in range(len(parts), 0, -1):
-            folder = "/".join(parts[:i])
-            dest = self._folders.get(folder)
-            if dest is not None:
-                return folder, "/".join([dest] + parts[i:])
-        return None
+    for folder, members in groups.items():
+        dest, replace = folders[folder]
+        if replace:
+            # Leftovers removed right before extracting, so read-only files are not overwritten
+            rmdir(dest)  # https://github.com/conan-io/conan/issues/20241
+        the_tar.extractall(path=dest, members=members)
 
 
-def _remove_not_restored(cache, plan, recipes, packages):
-    """ Remove the new DB entries whose contents were not restored, so a failed restore doesn't
-    leave the cache with references to recipes or packages that are not there
+def _locate(folders, name):
+    """ Where an archive member has to be extracted: the folder to restore it belongs to, and
+    the path it has inside that folder
+
+    The members are full paths in the archive, like "abcde1234/e/conanfile.py", and the folders
+    to restore are also paths in the archive, like "abcde1234/e". So the member path is split in
+    the folder it belongs to, and the rest, "conanfile.py", which is the path that the member
+    will have inside the destination folder of "abcde1234/e" in this cache
+
+    :param folders: The folders to restore, {archive folder: (destination folder, replace)}
+    :param name: The path of a member in the archive
+    :return: A tuple (folder in the archive, path of the member inside that folder), or None if
+       this member must not be extracted
     """
-    removed_refs = set()
-    for recipe_layout, folder in recipes:
-        if not plan.restored(folder):
-            # It also removes its packages, all of them new, this recipe revision was not here
-            cache.remove_recipe_layout(recipe_layout)
-            removed_refs.add(repr(recipe_layout.reference))
-    for pkg_layout, folder in packages:
-        if not plan.restored(folder) and repr(pkg_layout.reference.ref) not in removed_refs:
-            cache.remove_package_layout(pkg_layout)
+    def _is_outside(member_path, dest_folder):
+        """ If a member with this path, extracted inside ``dest_folder``, ends up written
+        outside of that folder, because the path is absolute or it goes up with ".." parts
+        """
+        dest_folder = os.path.normpath(dest_folder)
+        target = os.path.normpath(os.path.join(dest_folder, member_path))
+        return target != dest_folder and not target.startswith(dest_folder + os.sep)
+
+    parts = name.split("/")
+    # Longest to shortest prefix, to match the most nested folder containing this member
+    for i in range(len(parts), 0, -1):
+        folder = "/".join(parts[:i])
+        if folder not in folders:
+            continue
+        path = "/".join(parts[i:])
+        if not path:  # The member is the folder itself, extracted as the destination folder
+            return folder, "."
+        dest_folder, _ = folders[folder]
+        if _is_outside(path, dest_folder):
+            return None
+        return folder, path
+    return None  # The member is not restored, like "pkglist.json" or an unknown folder
 
 
 def _resolve_latest_ref(cache, ref):

--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -397,7 +397,7 @@ class CacheAPI:
         cache_folder = cache.store  # Note, this is not the home, but the actual package cache
         out = ConanOutput()
         plan = _RestorePlan(cache_folder)
-        dirty_folders = []
+        new_recipes, new_packages = [], []  # New DB entries, removed if they are not restored
 
         with open(path, mode='rb') as file_handler:
             the_tar = tarfile.open(fileobj=file_handler)
@@ -410,25 +410,26 @@ class CacheAPI:
                 ref_bundle = package_list.recipe_dict(ref)
                 ref.timestamp = revision_timestamp_now()
                 ref_bundle["timestamp"] = ref.timestamp
+                recipe_folder = ref_bundle["recipe_folder"]  # The folder in the archive
+                export_folder = f"{recipe_folder}/{EXPORT_FOLDER}"
                 try:
                     recipe_layout = cache.recipe_layout(ref)
                     replace = False
                 except ConanException:
                     recipe_layout = cache.create_ref_layout(ref)  # new DB folder entry
                     replace = True  # not in the DB, whatever is in the folder is a leftover
-                recipe_folder = ref_bundle["recipe_folder"]  # The folder in the archive
+                    new_recipes.append((recipe_layout, export_folder))
                 dest_folder = _cache_path(recipe_layout.base_folder, cache_folder)
                 ref_bundle["recipe_folder"] = dest_folder
                 out.info(f"Restore: {ref} in {dest_folder}")
-                for folder, dest in ((EXPORT_FOLDER, recipe_layout.export()),
-                                     (EXPORT_SRC_FOLDER, recipe_layout.export_sources())):
-                    plan.add_contents(f"{recipe_folder}/{folder}", dest, replace)
+                plan.add_contents(export_folder, recipe_layout.export(), replace)
+                plan.add_contents(f"{recipe_folder}/{EXPORT_SRC_FOLDER}",
+                                  recipe_layout.export_sources(), replace)
                 # The sources get the same dirty protection they have when they are obtained
                 # by "conan source", incomplete ones are discarded, not used as valid sources
-                source_folder = recipe_layout.source()
-                remove_if_dirty(source_folder)
-                if plan.add_contents(f"{recipe_folder}/{SRC_FOLDER}", source_folder, replace):
-                    dirty_folders.append(source_folder)
+                remove_if_dirty(recipe_layout.source())
+                plan.add_contents(f"{recipe_folder}/{SRC_FOLDER}", recipe_layout.source(),
+                                  replace, dirty=True)
                 plan.add_metadata(f"{recipe_folder}/{DOWNLOAD_EXPORT_FOLDER}/{METADATA}",
                                   recipe_layout.metadata())
 
@@ -436,6 +437,7 @@ class CacheAPI:
                     pref.timestamp = revision_timestamp_now()
                     pref_bundle = package_list.package_dict(pref)
                     pref_bundle["timestamp"] = pref.timestamp
+                    pkg_folder = pref_bundle["package_folder"]  # The folder in the archive
                     try:
                         pkg_layout = cache.pkg_layout(pref)
                         # A dirty package is incomplete, the leftover of an interrupted restore
@@ -445,14 +447,11 @@ class CacheAPI:
                     except ConanException:
                         pkg_layout = cache.create_pkg_layout(pref)  # new DB folder entry
                         replace = True
-                    pkg_folder = pref_bundle["package_folder"]  # The folder in the archive
+                        new_packages.append((pkg_layout, pkg_folder))
                     dest_folder = _cache_path(pkg_layout.package(), cache_folder)
                     pref_bundle["package_folder"] = dest_folder
                     out.info(f"Restore: {pref} in {dest_folder}")
-                    if plan.add_contents(pkg_folder, pkg_layout.package(), replace):
-                        # If the extraction is interrupted, the package folder is incomplete,
-                        # the dirty mark makes it be discarded instead of used as a valid one
-                        dirty_folders.append(pkg_layout.package())
+                    plan.add_contents(pkg_folder, pkg_layout.package(), replace, dirty=True)
                     metadata_folder = pref_bundle.get("metadata_folder")
                     if metadata_folder:
                         dest_folder = _cache_path(pkg_layout.metadata(), cache_folder)
@@ -460,20 +459,14 @@ class CacheAPI:
                         out.info(f"Restore: {pref} metadata in {dest_folder}")
                         plan.add_metadata(metadata_folder, pkg_layout.metadata())
 
-            for folder in dirty_folders:
-                set_dirty(folder)
-            # One single extraction, in archive order, to not jump back and forth in the stream
-            members = []
-            for member in the_tar.getmembers():
-                dest = plan.dest(member.name)
-                if dest is not None:  # Not restored, like "pkglist.json" or existing contents
-                    member.name = dest
-                    members.append(member)
-            the_tar.extractall(path=cache_folder, members=members)
+            try:
+                plan.extract(the_tar)
+            except BaseException:
+                # A new DB entry without contents would be a broken recipe or package in the
+                # cache, remove the ones that couldn't be restored, leaving the rest usable
+                _remove_not_restored(cache, plan, new_recipes, new_packages)
+                raise
             the_tar.close()
-
-        for folder in dirty_folders:
-            clean_dirty(folder)
 
         return package_list
 
@@ -521,8 +514,10 @@ class _RestorePlan:
     def __init__(self, cache_folder):
         self._cache_folder = cache_folder
         self._folders = {}  # {folder in the archive: folder in the cache, relative to the store}
+        self._dirty = set()  # Folders marked while they are extracted, to detect incomplete ones
+        self._restored = set()  # Folders already extracted
 
-    def add_contents(self, folder, dest, replace):
+    def add_contents(self, folder, dest, replace, dirty=False):
         """ Recipes and packages are immutable, if the revision is already in this cache the
         contents are the same, and they are not extracted again, so their files are never
         overwritten. Returns True if the folder is going to be extracted
@@ -532,24 +527,66 @@ class _RestorePlan:
                 return False
             rmdir(dest)  # Leftovers of an interrupted restore, not valid contents
         self._folders[folder] = _cache_path(dest, self._cache_folder)
+        if dirty:
+            self._dirty.add(folder)
         return True
 
     def add_metadata(self, folder, dest):
         """ Metadata is not immutable, it is always restored, adding to the existing one """
         self._folders[folder] = _cache_path(dest, self._cache_folder)
 
-    def dest(self, name):
-        """ The path, relative to the cache store, where an archive member has to be extracted,
-        or None if that member doesn't belong to any of the folders to restore
+    def restored(self, folder):
+        return folder in self._restored
+
+    def extract(self, the_tar):
+        """ Extract one folder at a time, in the order they are in the archive, so the stream
+        is read forwards, and an interrupted extraction only leaves one incomplete folder
+        """
+        groups = {}  # {folder in the archive: [members]}, in the order of the archive
+        for member in the_tar.getmembers():
+            located = self._locate(member.name)
+            if located is not None:  # Not restored, like "pkglist.json" or existing contents
+                folder, member.name = located
+                groups.setdefault(folder, []).append(member)
+
+        for folder, members in groups.items():
+            dest = os.path.join(self._cache_folder, self._folders[folder])
+            dirty = folder in self._dirty
+            if dirty:
+                remove_if_dirty(dest)  # Stale mark of a previous interrupted restore
+                set_dirty(dest)
+            the_tar.extractall(path=self._cache_folder, members=members)
+            if dirty:
+                clean_dirty(dest)
+            self._restored.add(folder)
+
+    def _locate(self, name):
+        """ The folder to restore this archive member belongs to, and the path, relative to the
+        cache store, where it has to be extracted. None if the member is not restored
         """
         path, tail = name, ""
         while path:
             dest = self._folders.get(path)
             if dest is not None:
-                return dest + tail
+                return path, dest + tail
             path, _, last = path.rpartition("/")
             tail = f"/{last}{tail}"
         return None
+
+
+def _remove_not_restored(cache, plan, recipes, packages):
+    """ Remove the new DB entries whose contents were not restored, so a failed restore doesn't
+    leave the cache with references to recipes or packages that are not there
+    """
+    removed_refs = set()
+    for recipe_layout, folder in recipes:
+        if not plan.restored(folder):
+            # It also removes its packages, all of them new, this recipe revision was not here
+            cache.remove_recipe_layout(recipe_layout)
+            removed_refs.add(repr(recipe_layout.reference))
+    for pkg_layout, folder in packages:
+        if not plan.restored(folder) and repr(pkg_layout.reference.ref) not in removed_refs:
+            cache.remove_package_layout(pkg_layout)
 
 
 def _resolve_latest_ref(cache, ref):

--- a/conan/api/subapi/cache.py
+++ b/conan/api/subapi/cache.py
@@ -1,6 +1,5 @@
 import json
 import os
-import shutil
 import tarfile
 import tempfile
 
@@ -21,7 +20,8 @@ from conan.api.model import RecipeReference
 from conan.internal.api.uploader import PackagePreparator
 from conan.internal.rest.pkg_sign import PkgSignaturesPlugin
 from conan.internal.util.dates import revision_timestamp_now
-from conan.internal.util.files import rmdir, mkdir, remove, save
+from conan.internal.util.files import (clean_dirty, mkdir, remove, remove_if_dirty, rmdir, save,
+                                       set_dirty)
 
 
 class CacheAPI:
@@ -381,6 +381,11 @@ class CacheAPI:
         """Restore a compressed archive with recipes and packages previously saved from another
         Conan cache into the currently active Conan cache.
 
+        The folders of the origin cache are not necessarily the folders of this cache, so the
+        destination is resolved in the cache DB before extracting, and every folder is extracted
+        directly to its final location. Recipes and packages are immutable, so the revisions
+        already in this cache are not extracted again, only the missing ones.
+
         :param path: The archive file to restore. Based on the extension of the file, different
            compression formats can be used (.tgz, .txz and .tzst, the latter only for Python>=3.14).
         :return: a PackageLists with the recipes and packages that have been restored to the cache
@@ -390,67 +395,85 @@ class CacheAPI:
 
         cache = PkgCache(self._conan_api.cache_folder, self._api_helpers.global_conf)
         cache_folder = cache.store  # Note, this is not the home, but the actual package cache
+        out = ConanOutput()
+        plan = _RestorePlan(cache_folder)
+        dirty_folders = []
 
         with open(path, mode='rb') as file_handler:
             the_tar = tarfile.open(fileobj=file_handler)
-            fileobj = the_tar.extractfile("pkglist.json")
-            pkglist = fileobj.read()
             the_tar.extraction_filter = (lambda member, _: member)  # fully_trusted (Py 3.14)
-            the_tar.extractall(path=cache_folder)
+            pkglist = the_tar.extractfile("pkglist.json").read()
+            package_list = PackagesList.deserialize(json.loads(pkglist))
+
+            # First the DB, to know the final cache folder for every folder in the archive
+            for ref, packages in package_list.items():
+                ref_bundle = package_list.recipe_dict(ref)
+                ref.timestamp = revision_timestamp_now()
+                ref_bundle["timestamp"] = ref.timestamp
+                try:
+                    recipe_layout = cache.recipe_layout(ref)
+                    replace = False
+                except ConanException:
+                    recipe_layout = cache.create_ref_layout(ref)  # new DB folder entry
+                    replace = True  # not in the DB, whatever is in the folder is a leftover
+                recipe_folder = ref_bundle["recipe_folder"]  # The folder in the archive
+                dest_folder = _cache_path(recipe_layout.base_folder, cache_folder)
+                ref_bundle["recipe_folder"] = dest_folder
+                out.info(f"Restore: {ref} in {dest_folder}")
+                for folder, dest in ((EXPORT_FOLDER, recipe_layout.export()),
+                                     (EXPORT_SRC_FOLDER, recipe_layout.export_sources())):
+                    plan.add_contents(f"{recipe_folder}/{folder}", dest, replace)
+                # The sources get the same dirty protection they have when they are obtained
+                # by "conan source", incomplete ones are discarded, not used as valid sources
+                source_folder = recipe_layout.source()
+                remove_if_dirty(source_folder)
+                if plan.add_contents(f"{recipe_folder}/{SRC_FOLDER}", source_folder, replace):
+                    dirty_folders.append(source_folder)
+                plan.add_metadata(f"{recipe_folder}/{DOWNLOAD_EXPORT_FOLDER}/{METADATA}",
+                                  recipe_layout.metadata())
+
+                for pref in packages:
+                    pref.timestamp = revision_timestamp_now()
+                    pref_bundle = package_list.package_dict(pref)
+                    pref_bundle["timestamp"] = pref.timestamp
+                    try:
+                        pkg_layout = cache.pkg_layout(pref)
+                        # A dirty package is incomplete, the leftover of an interrupted restore
+                        # or download, it is removed to restore it again
+                        remove_if_dirty(pkg_layout.package())
+                        replace = False
+                    except ConanException:
+                        pkg_layout = cache.create_pkg_layout(pref)  # new DB folder entry
+                        replace = True
+                    pkg_folder = pref_bundle["package_folder"]  # The folder in the archive
+                    dest_folder = _cache_path(pkg_layout.package(), cache_folder)
+                    pref_bundle["package_folder"] = dest_folder
+                    out.info(f"Restore: {pref} in {dest_folder}")
+                    if plan.add_contents(pkg_folder, pkg_layout.package(), replace):
+                        # If the extraction is interrupted, the package folder is incomplete,
+                        # the dirty mark makes it be discarded instead of used as a valid one
+                        dirty_folders.append(pkg_layout.package())
+                    metadata_folder = pref_bundle.get("metadata_folder")
+                    if metadata_folder:
+                        dest_folder = _cache_path(pkg_layout.metadata(), cache_folder)
+                        pref_bundle["metadata_folder"] = dest_folder
+                        out.info(f"Restore: {pref} metadata in {dest_folder}")
+                        plan.add_metadata(metadata_folder, pkg_layout.metadata())
+
+            for folder in dirty_folders:
+                set_dirty(folder)
+            # One single extraction, in archive order, to not jump back and forth in the stream
+            members = []
+            for member in the_tar.getmembers():
+                dest = plan.dest(member.name)
+                if dest is not None:  # Not restored, like "pkglist.json" or existing contents
+                    member.name = dest
+                    members.append(member)
+            the_tar.extractall(path=cache_folder, members=members)
             the_tar.close()
 
-        # After unzipping the files, we need to update the DB that references these files
-        out = ConanOutput()
-        package_list = PackagesList.deserialize(json.loads(pkglist))
-        for ref, packages in package_list.items():
-            ref_bundle = package_list.recipe_dict(ref)
-            ref.timestamp = revision_timestamp_now()
-            ref_bundle["timestamp"] = ref.timestamp
-            try:
-                recipe_layout = cache.recipe_layout(ref)
-            except ConanException:
-                recipe_layout = cache.create_ref_layout(ref)  # new DB folder entry
-            recipe_folder = ref_bundle["recipe_folder"]
-            rel_path = os.path.relpath(recipe_layout.base_folder, cache_folder)
-            rel_path = rel_path.replace("\\", "/")
-            # In the case of recipes, they are always "in place", so just checking it
-            assert rel_path == recipe_folder, f"{rel_path}!={recipe_folder}"
-            out.info(f"Restore: {ref} in {recipe_folder}")
-            for pref in packages:
-                pref.timestamp = revision_timestamp_now()
-                pref_bundle = package_list.package_dict(pref)
-                pref_bundle["timestamp"] = pref.timestamp
-                try:
-                    pkg_layout = cache.pkg_layout(pref)
-                except ConanException:
-                    pkg_layout = cache.create_pkg_layout(pref)  # DB Folder entry
-                # FIXME: This is not taking into account the existence of previous package
-                unzipped_pkg_folder = pref_bundle["package_folder"]
-                out.info(f"Restore: {pref} in {unzipped_pkg_folder}")
-                # If the DB folder entry is different to the disk unzipped one, we need to move it
-                # This happens for built (not downloaded) packages in the source "conan cache save"
-                db_pkg_folder = os.path.relpath(pkg_layout.package(), cache_folder)
-                db_pkg_folder = db_pkg_folder.replace("\\", "/")
-                if db_pkg_folder != unzipped_pkg_folder:
-                    # If a previous package exists, like a previous restore, then remove it
-                    if os.path.exists(pkg_layout.package()):
-                        shutil.rmtree(pkg_layout.package())
-                    shutil.move(os.path.join(cache_folder, unzipped_pkg_folder),
-                                pkg_layout.package())
-                    pref_bundle["package_folder"] = db_pkg_folder
-                unzipped_metadata_folder = pref_bundle.get("metadata_folder")
-                if unzipped_metadata_folder:
-                    # FIXME: Restore metadata is not incremental, but destructive
-                    out.info(f"Restore: {pref} metadata in {unzipped_metadata_folder}")
-                    db_metadata_folder = os.path.relpath(pkg_layout.metadata(), cache_folder)
-                    db_metadata_folder = db_metadata_folder.replace("\\", "/")
-                    if db_metadata_folder != unzipped_metadata_folder:
-                        # We need to put the package in the final location in the cache
-                        if os.path.exists(pkg_layout.metadata()):
-                            shutil.rmtree(pkg_layout.metadata())
-                        shutil.move(os.path.join(cache_folder, unzipped_metadata_folder),
-                                    pkg_layout.metadata())
-                        pref_bundle["metadata_folder"] = db_metadata_folder
+        for folder in dirty_folders:
+            clean_dirty(folder)
 
         return package_list
 
@@ -484,6 +507,49 @@ class CacheAPI:
             base, folder = os.path.split(path)
             result = cache.path_to_ref(base)
         return result
+
+
+def _cache_path(folder, cache_folder):
+    return os.path.relpath(folder, cache_folder).replace("\\", "/")  # make win paths portable
+
+
+class _RestorePlan:
+    """ Where every folder of a "conan cache save" archive has to be extracted in this cache,
+    which is not necessarily the folder it had in the cache that created the archive
+    """
+
+    def __init__(self, cache_folder):
+        self._cache_folder = cache_folder
+        self._folders = {}  # {folder in the archive: folder in the cache, relative to the store}
+
+    def add_contents(self, folder, dest, replace):
+        """ Recipes and packages are immutable, if the revision is already in this cache the
+        contents are the same, and they are not extracted again, so their files are never
+        overwritten. Returns True if the folder is going to be extracted
+        """
+        if os.path.exists(dest):
+            if not replace:
+                return False
+            rmdir(dest)  # Leftovers of an interrupted restore, not valid contents
+        self._folders[folder] = _cache_path(dest, self._cache_folder)
+        return True
+
+    def add_metadata(self, folder, dest):
+        """ Metadata is not immutable, it is always restored, adding to the existing one """
+        self._folders[folder] = _cache_path(dest, self._cache_folder)
+
+    def dest(self, name):
+        """ The path, relative to the cache store, where an archive member has to be extracted,
+        or None if that member doesn't belong to any of the folders to restore
+        """
+        path, tail = name, ""
+        while path:
+            dest = self._folders.get(path)
+            if dest is not None:
+                return dest + tail
+            path, _, last = path.rpartition("/")
+            tail = f"/{last}{tail}"
+        return None
 
 
 def _resolve_latest_ref(cache, ref):

--- a/test/integration/command/cache/test_cache_save_restore.py
+++ b/test/integration/command/cache/test_cache_save_restore.py
@@ -4,6 +4,7 @@ import platform
 import shutil
 import sys
 import tarfile
+import textwrap
 import time
 
 import pytest
@@ -12,7 +13,7 @@ from conan.api.model import PkgReference, RecipeReference
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.test_files import temp_folder
 from conan.test.utils.tools import TestClient, NO_SETTINGS_PACKAGE_ID
-from conan.internal.util.files import save, load
+from conan.internal.util.files import is_dirty, load, save, set_dirty
 
 
 def test_cache_save_restore():
@@ -66,6 +67,151 @@ def test_cache_save_restore_with_package_file():
     tree2 = _get_directory_tree(c2.base_folder)
 
     assert tree2 == tree
+
+
+_READ_ONLY_CONANFILE = textwrap.dedent("""
+    import os, stat
+    from conan import ConanFile
+    from conan.tools.files import save
+
+    class Pkg(ConanFile):
+        name = "pkg"
+        version = "1.0"
+        def package(self):
+            f = os.path.join(self.package_folder, "bin", "readonly.txt")
+            save(self, f, "content!!")
+            d = os.path.join(self.package_folder, "readonlydir")
+            save(self, os.path.join(d, "inside.txt"), "inside!!")
+            os.chmod(f, stat.S_IREAD)
+            os.chmod(d, stat.S_IREAD | stat.S_IEXEC)
+    """)
+
+
+def _pkg_folder(client):
+    ref_layout = client.get_latest_ref_layout(RecipeReference.loads("pkg/1.0"))
+    pkg_layout = client.get_latest_pkg_layout(PkgReference(ref_layout.reference,
+                                                           NO_SETTINGS_PACKAGE_ID))
+    return pkg_layout.package()
+
+
+def _save_built_package():
+    """ a package built in this cache, so it lives in the "b" build folder, not in the final
+    package folder that it will have when it is restored in another cache """
+    c = TestClient()
+    c.save({"conanfile.py": GenConanfile("pkg", "1.0").with_exports_sources("*.c")
+                                                      .with_package_file("bin/f.txt", "content!!"),
+            "mysrc.c": "source!!"})
+    c.run("create .")
+    c.run("cache save *:*")
+    return c, os.path.join(c.current_folder, "conan_cache_save.tgz")
+
+
+def test_cache_restore_no_leftovers():
+    """ every folder is extracted directly in its final location, so the folders of the origin
+    cache are not created, and the "pkglist.json" is not left in the cache either """
+    _, cache_path = _save_built_package()
+
+    c2 = TestClient()
+    c2.run(f'cache restore "{cache_path}"')
+    store = os.path.join(c2.cache_folder, "p")
+    assert not os.path.exists(os.path.join(store, "b"))
+    assert not os.path.exists(os.path.join(store, "pkglist.json"))
+    assert load(os.path.join(_pkg_folder(c2), "bin", "f.txt")) == "content!!"
+
+
+def test_cache_restore_existing_contents_not_extracted():
+    """ recipes and packages are immutable, so a revision already in the cache is not extracted
+    again over the existing files """
+    _, cache_path = _save_built_package()
+
+    c2 = TestClient()
+    c2.run(f'cache restore "{cache_path}"')
+    f = os.path.join(_pkg_folder(c2), "bin", "f.txt")
+    save(f, "not overwritten")
+    c2.run(f'cache restore "{cache_path}"')
+    assert load(f) == "not overwritten"
+
+
+@pytest.mark.parametrize("same_cache", [True, False])
+def test_cache_restore_read_only_files(same_cache):
+    """ read-only files and folders are never overwritten, as their revision is already in the
+    cache and it is not extracted again
+    https://github.com/conan-io/conan/issues/20241
+    """
+    c = TestClient()
+    c.save({"conanfile.py": _READ_ONLY_CONANFILE})
+    c.run("create .")
+    c.run("cache save *:*")
+    cache_path = os.path.join(c.current_folder, "conan_cache_save.tgz")
+
+    c2 = c if same_cache else TestClient()
+    c2.run(f'cache restore "{cache_path}"')
+    c2.run(f'cache restore "{cache_path}"')  # over the read-only files of the previous restore
+    pkg_folder = _pkg_folder(c2)
+    assert load(os.path.join(pkg_folder, "bin", "readonly.txt")) == "content!!"
+    assert load(os.path.join(pkg_folder, "readonlydir", "inside.txt")) == "inside!!"
+
+
+def test_cache_restore_dirty_folders():
+    """ the folders left incomplete by an interrupted restore are dirty, so they are replaced
+    by the next restore, not skipped as if they were valid """
+    _, cache_path = _save_built_package()
+
+    c2 = TestClient()
+    c2.run(f'cache restore "{cache_path}"')
+    pkg_folder = _pkg_folder(c2)
+    src_folder = c2.get_latest_ref_layout(RecipeReference.loads("pkg/1.0")).source()
+    save(os.path.join(pkg_folder, "bin", "f.txt"), "incomplete")
+    save(os.path.join(src_folder, "mysrc.c"), "incomplete")
+    set_dirty(pkg_folder)
+    set_dirty(src_folder)
+
+    c2.run(f'cache restore "{cache_path}"')
+    assert load(os.path.join(pkg_folder, "bin", "f.txt")) == "content!!"
+    assert load(os.path.join(src_folder, "mysrc.c")) == "source!!"
+    assert not is_dirty(pkg_folder)
+    assert not is_dirty(src_folder)
+
+
+def test_cache_restore_missing_folders():
+    """ contents are skipped folder by folder, so an archive can complete a recipe revision
+    already in the cache, like adding the sources that it didn't have """
+    c = TestClient()
+    c.save({"conanfile.py": GenConanfile("pkg", "1.0").with_exports_sources("*.c"),
+            "mysrc.c": ""})
+    c.run("create .")
+    c.run("cache save *:* --no-source --file=nosource.tgz")
+    c.run("cache save *:* --file=full.tgz")
+    no_source = os.path.join(c.current_folder, "nosource.tgz")
+    full = os.path.join(c.current_folder, "full.tgz")
+
+    c2 = TestClient()
+    c2.run(f'cache restore "{no_source}"')
+    src = c2.get_latest_ref_layout(RecipeReference.loads("pkg/1.0")).source()
+    assert not os.path.exists(os.path.join(src, "mysrc.c"))
+    c2.run(f'cache restore "{full}"')
+    assert os.path.exists(os.path.join(src, "mysrc.c"))
+
+
+def test_cache_restore_metadata_incremental():
+    """ metadata is not immutable, it is restored adding to the existing metadata """
+    c = TestClient()
+    c.save({"conanfile.py": GenConanfile("pkg", "1.0")})
+    c.run("create .")
+    pid = c.created_package_id("pkg/1.0")
+    c.run(f"cache path pkg/1.0:{pid} --folder=metadata")
+    save(os.path.join(str(c.stdout).strip(), "logs", "saved.txt"), "saved!!")
+    c.run("cache save *:*")
+    cache_path = os.path.join(c.current_folder, "conan_cache_save.tgz")
+
+    c2 = TestClient()
+    c2.run(f'cache restore "{cache_path}"')
+    c2.run(f"cache path pkg/1.0:{pid} --folder=metadata")
+    metadata = str(c2.stdout).strip()
+    save(os.path.join(metadata, "logs", "mine.txt"), "mine!!")
+    c2.run(f'cache restore "{cache_path}"')
+    assert load(os.path.join(metadata, "logs", "saved.txt")) == "saved!!"
+    assert load(os.path.join(metadata, "logs", "mine.txt")) == "mine!!"
 
 
 def test_cache_save_downloaded_restore():

--- a/test/integration/command/cache/test_cache_save_restore.py
+++ b/test/integration/command/cache/test_cache_save_restore.py
@@ -135,6 +135,22 @@ def test_cache_restore_existing_contents_not_extracted():
     assert load(f) == "not overwritten"
 
 
+def test_cache_restore_stale_contents():
+    """ contents in the cache store that the DB doesn't know about are not valid contents, they
+    are leftovers, so they are replaced by the ones in the archive """
+    _, cache_path = _save_built_package()
+
+    c2 = TestClient()
+    c2.run(f'cache restore "{cache_path}"')
+    pkg_folder = _pkg_folder(c2)
+    save(os.path.join(pkg_folder, "stale.txt"), "stale!!")
+    os.remove(os.path.join(c2.cache_folder, "p", "cache.sqlite3"))  # The folders are orphans now
+
+    c2.run(f'cache restore "{cache_path}"')
+    assert not os.path.exists(os.path.join(pkg_folder, "stale.txt"))
+    assert load(os.path.join(pkg_folder, "bin", "f.txt")) == "content!!"
+
+
 def _assert_read_only_pkg(client):
     """ Check the packaged read-only contents and return their permission modes """
     pkg_folder = _pkg_folder(client)

--- a/test/integration/command/cache/test_cache_save_restore.py
+++ b/test/integration/command/cache/test_cache_save_restore.py
@@ -1,3 +1,4 @@
+import io
 import json
 import os
 import platform
@@ -217,6 +218,31 @@ def test_cache_restore_dirty_folders():
     assert load(os.path.join(src_folder, "mysrc.c")) == "source!!"
     assert not is_dirty(pkg_folder)
     assert not is_dirty(src_folder)
+
+
+def test_cache_restore_rejects_outside_paths():
+    """ a parent-directory tar member must not be written outside the package-cache store
+    """
+    _, cache_path = _save_built_package()
+    file_name = "../outside.txt"
+    tar_file = os.path.join(os.path.dirname(cache_path), "cache.tgz")
+
+    with tarfile.open(cache_path, "r:gz") as inn, tarfile.open(crafted, "w:gz") as out:
+        for member in inn.getmembers():
+            out.addfile(member, inn.extractfile(member) if member.isfile() else None)
+        payload = marker.encode()
+        info = tarfile.TarInfo(name=marker_name)
+        info.size = len(payload)
+        out.addfile(info, io.BytesIO("empty"))
+
+    c2 = TestClient()
+    c2.run(f'cache restore "{tar_file}"')
+    store = os.path.join(c2.cache_folder, "p")
+    outside = os.path.normpath(os.path.join(store, file_name))
+    # outside file is not restored
+    assert not os.path.exists(outside)
+    # check the package was restored
+    assert load(os.path.join(_pkg_folder(c2), "bin", "f.txt")) == "content!!"
 
 
 @pytest.mark.parametrize("extractions", [0, 2])

--- a/test/integration/command/cache/test_cache_save_restore.py
+++ b/test/integration/command/cache/test_cache_save_restore.py
@@ -227,7 +227,7 @@ def test_cache_restore_rejects_outside_paths():
     file_name = "../outside.txt"
     tar_file = os.path.join(os.path.dirname(cache_path), "cache.tgz")
 
-    with tarfile.open(cache_path, "r:gz") as inn, tarfile.open(crafted, "w:gz") as out:
+    with tarfile.open(cache_path, "r:gz") as inn, tarfile.open(tar_file, "w:gz") as out:
         for member in inn.getmembers():
             out.addfile(member, inn.extractfile(member) if member.isfile() else None)
         payload = marker.encode()

--- a/test/integration/command/cache/test_cache_save_restore.py
+++ b/test/integration/command/cache/test_cache_save_restore.py
@@ -2,6 +2,7 @@ import json
 import os
 import platform
 import shutil
+import stat
 import sys
 import tarfile
 import textwrap
@@ -132,24 +133,51 @@ def test_cache_restore_existing_contents_not_extracted():
     assert load(f) == "not overwritten"
 
 
-@pytest.mark.parametrize("same_cache", [True, False])
-def test_cache_restore_read_only_files(same_cache):
-    """ read-only files and folders are never overwritten, as their revision is already in the
-    cache and it is not extracted again
+def _assert_read_only_pkg(client):
+    """ Check the packaged read-only contents and return their permission modes """
+    pkg_folder = _pkg_folder(client)
+    f = os.path.join(pkg_folder, "bin", "readonly.txt")
+    d = os.path.join(pkg_folder, "readonlydir")
+    assert load(f) == "content!!"
+    assert load(os.path.join(d, "inside.txt")) == "inside!!"
+    modes = stat.S_IMODE(os.stat(f).st_mode), stat.S_IMODE(os.stat(d).st_mode)
+    assert (modes[0] & stat.S_IWRITE) == 0
+    assert (modes[1] & stat.S_IWRITE) == 0
+    return modes
+
+
+def test_cache_restore_read_only_files_in_place():
+    """ restoring over a cache that already contains those same read-only files
     https://github.com/conan-io/conan/issues/20241
     """
     c = TestClient()
     c.save({"conanfile.py": _READ_ONLY_CONANFILE})
     c.run("create .")
+    modes = _assert_read_only_pkg(c)
+    c.run("cache save *:*")
+    c.run("cache restore conan_cache_save.tgz")
+    # The revision is already in the cache, the read-only contents are not extracted again
+    assert _assert_read_only_pkg(c) == modes
+
+
+def test_cache_save_restore_read_only_files():
+    """ restoring in a different cache, the package folder is relocated, and restoring again
+    happens over the read-only files of the previous restore
+    https://github.com/conan-io/conan/issues/20241
+    """
+    c = TestClient()
+    c.save({"conanfile.py": _READ_ONLY_CONANFILE})
+    c.run("create .")
+    modes = _assert_read_only_pkg(c)
     c.run("cache save *:*")
     cache_path = os.path.join(c.current_folder, "conan_cache_save.tgz")
 
-    c2 = c if same_cache else TestClient()
+    c2 = TestClient()
     c2.run(f'cache restore "{cache_path}"')
-    c2.run(f'cache restore "{cache_path}"')  # over the read-only files of the previous restore
-    pkg_folder = _pkg_folder(c2)
-    assert load(os.path.join(pkg_folder, "bin", "readonly.txt")) == "content!!"
-    assert load(os.path.join(pkg_folder, "readonlydir", "inside.txt")) == "inside!!"
+    # The extraction restores the modes stored in the archive, they are still read-only
+    assert _assert_read_only_pkg(c2) == modes
+    c2.run(f'cache restore "{cache_path}"')
+    assert _assert_read_only_pkg(c2) == modes
 
 
 def test_cache_restore_dirty_folders():

--- a/test/integration/command/cache/test_cache_save_restore.py
+++ b/test/integration/command/cache/test_cache_save_restore.py
@@ -230,10 +230,10 @@ def test_cache_restore_rejects_outside_paths():
     with tarfile.open(cache_path, "r:gz") as inn, tarfile.open(tar_file, "w:gz") as out:
         for member in inn.getmembers():
             out.addfile(member, inn.extractfile(member) if member.isfile() else None)
-        payload = marker.encode()
-        info = tarfile.TarInfo(name=marker_name)
+        payload = b"outside!!"
+        info = tarfile.TarInfo(name=file_name)
         info.size = len(payload)
-        out.addfile(info, io.BytesIO("empty"))
+        out.addfile(info, io.BytesIO(payload))
 
     c2 = TestClient()
     c2.run(f'cache restore "{tar_file}"')

--- a/test/integration/command/cache/test_cache_save_restore.py
+++ b/test/integration/command/cache/test_cache_save_restore.py
@@ -7,10 +7,12 @@ import sys
 import tarfile
 import textwrap
 import time
+from unittest.mock import patch
 
 import pytest
 
 from conan.api.model import PkgReference, RecipeReference
+from conan.errors import ConanException
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.test_files import temp_folder
 from conan.test.utils.tools import TestClient, NO_SETTINGS_PACKAGE_ID
@@ -199,6 +201,35 @@ def test_cache_restore_dirty_folders():
     assert load(os.path.join(src_folder, "mysrc.c")) == "source!!"
     assert not is_dirty(pkg_folder)
     assert not is_dirty(src_folder)
+
+
+@pytest.mark.parametrize("extractions", [0, 2])
+def test_cache_restore_failure_removes_new_entries(extractions):
+    """ if the restore fails, the new DB entries whose contents were not restored are removed,
+    so the cache is never left with references to recipes or packages that are not there """
+    _, cache_path = _save_built_package()
+    extract_all = tarfile.TarFile.extractall
+    done = []
+
+    def failing_extractall(self, *args, **kwargs):
+        if len(done) == extractions:
+            raise ConanException("Interrupted!")
+        done.append(1)
+        return extract_all(self, *args, **kwargs)
+
+    c2 = TestClient()
+    with patch.object(tarfile.TarFile, "extractall", failing_extractall):
+        c2.run(f'cache restore "{cache_path}"', assert_error=True)
+    assert "Interrupted!" in c2.out
+    c2.run("list *:*#*")
+    assert "pkg/1.0" not in c2.out
+    assert os.listdir(os.path.join(c2.cache_folder, "p")) == ["cache.sqlite3"]
+
+    # The restore can be done again, and it works
+    c2.run(f'cache restore "{cache_path}"')
+    c2.run("list *:*#*")
+    assert "pkg/1.0" in c2.out
+    assert load(os.path.join(_pkg_folder(c2), "bin", "f.txt")) == "content!!"
 
 
 def test_cache_restore_missing_folders():

--- a/test/integration/command/cache/test_cache_save_restore.py
+++ b/test/integration/command/cache/test_cache_save_restore.py
@@ -200,8 +200,8 @@ def test_cache_save_restore_read_only_files():
 
 
 def test_cache_restore_dirty_folders():
-    """ the folders left incomplete by an interrupted restore are dirty, so they are replaced
-    by the next restore, not skipped as if they were valid """
+    """ the folders left incomplete by an interrupted download or "conan source" are dirty, so
+    they are replaced by the restore, not skipped as if they were valid """
     _, cache_path = _save_built_package()
 
     c2 = TestClient()
@@ -220,58 +220,49 @@ def test_cache_restore_dirty_folders():
     assert not is_dirty(src_folder)
 
 
-def test_cache_restore_rejects_outside_paths():
-    """ a parent-directory tar member must not be written outside the package-cache store
-    """
-    _, cache_path = _save_built_package()
-    file_name = "../outside.txt"
-    tar_file = os.path.join(os.path.dirname(cache_path), "cache.tgz")
+@pytest.mark.parametrize("member_name", ["../outside.txt",  # at the root of the archive
+                                         "{recipe}/e/../../../outside.txt"])  # inside a folder
+def test_cache_restore_rejects_outside_paths(member_name):
+    """ a tar member going up with ".." is not restored, it must not be written outside the
+    package cache store, neither from the root of the archive nor from a folder being restored"""
+    c, cache_path = _save_built_package()
+    # The recipe folder as it is named in the archive, which is the origin cache one
+    recipe = os.path.relpath(c.get_latest_ref_layout(RecipeReference.loads("pkg/1.0")).base_folder,
+                             os.path.join(c.cache_folder, "p"))
+    member_name = member_name.format(recipe=recipe)
+    tar_file = os.path.join(os.path.dirname(cache_path), "malicious.tgz")
 
     with tarfile.open(cache_path, "r:gz") as inn, tarfile.open(tar_file, "w:gz") as out:
+        assert f"{recipe}/e" in inn.getnames()  # the folder the member tries to escape from
         for member in inn.getmembers():
             out.addfile(member, inn.extractfile(member) if member.isfile() else None)
         payload = b"outside!!"
-        info = tarfile.TarInfo(name=file_name)
+        info = tarfile.TarInfo(name=member_name)
         info.size = len(payload)
         out.addfile(info, io.BytesIO(payload))
 
     c2 = TestClient()
     c2.run(f'cache restore "{tar_file}"')
-    store = os.path.join(c2.cache_folder, "p")
-    outside = os.path.normpath(os.path.join(store, file_name))
-    # outside file is not restored
+    # Both member names resolve to the parent of the cache store, that file is not created
+    outside = os.path.normpath(os.path.join(c2.cache_folder, "p", member_name))
     assert not os.path.exists(outside)
-    # check the package was restored
+    # The rest of the archive is restored as usual
     assert load(os.path.join(_pkg_folder(c2), "bin", "f.txt")) == "content!!"
 
 
-@pytest.mark.parametrize("extractions", [0, 2])
-def test_cache_restore_failure_removes_new_entries(extractions):
-    """ if the restore fails, the new DB entries whose contents were not restored are removed,
-    so the cache is never left with references to recipes or packages that are not there """
+def test_cache_restore_failure():
+    """ the restore is expected to fully succeed, if it fails the cache can contain incomplete
+    recipes or packages, so it is reported as corrupted """
     _, cache_path = _save_built_package()
-    extract_all = tarfile.TarFile.extractall
-    done = []
 
-    def failing_extractall(self, *args, **kwargs):
-        if len(done) == extractions:
-            raise ConanException("Interrupted!")
-        done.append(1)
-        return extract_all(self, *args, **kwargs)
+    def failing_extractall(*args, **kwargs):
+        raise ConanException("Interrupted!")
 
     c2 = TestClient()
     with patch.object(tarfile.TarFile, "extractall", failing_extractall):
         c2.run(f'cache restore "{cache_path}"', assert_error=True)
     assert "Interrupted!" in c2.out
-    c2.run("list *:*#*")
-    assert "pkg/1.0" not in c2.out
-    assert os.listdir(os.path.join(c2.cache_folder, "p")) == ["cache.sqlite3"]
-
-    # The restore can be done again, and it works
-    c2.run(f'cache restore "{cache_path}"')
-    c2.run("list *:*#*")
-    assert "pkg/1.0" in c2.out
-    assert load(os.path.join(_pkg_folder(c2), "bin", "f.txt")) == "content!!"
+    assert "this cache is corrupted, remove it and restore it again" in c2.out
 
 
 def test_cache_restore_missing_folders():


### PR DESCRIPTION
Changelog: Fix: Improve `conan cache restore` folder extraction to avoid overwrites.
Docs: Omit

Close https://github.com/conan-io/conan/issues/20241

`conan cache restore` unzipped the whole archive on top of the cache store and then moved the folders to their final location. That failed with read-only packaged files (#20241), and it also re-extracted revisions that were already in the cache, left the origin cache folders behind as leftovers, and had no protection against an interrupted extraction.

Now the destination of every folder is resolved before extracting anything:

- Recipe and package revisions already in the cache are not extracted again, their files are never overwritten. Metadata is still merged, as it is not immutable.
- Each folder is extracted straight to its cache location, one at a time, so nothing has to be moved afterwards and no leftovers are created.
- Package and source folders are marked dirty while they are filled, and dirty leftovers are discarded and restored again.
- If the extraction fails, the new DB entries whose contents were not restored are removed, so the cache is not left with references to packages that are not there.