### PR TITLE
Fix cyclonedx typo

### DIFF
--- a/conan/tools/sbom/cyclonedx.py
+++ b/conan/tools/sbom/cyclonedx.py
@@ -221,7 +221,7 @@ def _calculate_licenses(component):
 def _calculate_bomref(component):
     user = f"&user={component.ref.user}" if component.ref.user else ""
     channel = f"&channel={component.ref.channel}" if component.ref.channel else ""
-    return f"pkg:conan/{component.name}@{component.ref.version}?rref={component.ref.revision}{user}{channel}"
+    return f"pkg:conan/{component.name}@{component.ref.version}?rrev={component.ref.revision}{user}{channel}"
 
 
 def should_add_node(node, add_build, add_tests):

--- a/test/integration/command/test_audit.py
+++ b/test/integration/command/test_audit.py
@@ -15,7 +15,7 @@ _sbom_zlib_1_2_11 = """
 {
   "components" : [ {
     "author" : "<Put your name here> <And your email here>",
-    "bom-ref" : "pkg:conan/zlib@1.2.11?rref=6754320047c5dd54830baaaf9fc733c4",
+    "bom-ref" : "pkg:conan/zlib@1.2.11?rrev=6754320047c5dd54830baaaf9fc733c4",
     "description" : "<Description of zlib package here>",
     "licenses" : [ {
       "license" : {
@@ -28,12 +28,12 @@ _sbom_zlib_1_2_11 = """
     "version" : "1.2.11"
   } ],
   "dependencies" : [ {
-    "ref" : "pkg:conan/zlib@1.2.11?rref=6754320047c5dd54830baaaf9fc733c4"
+    "ref" : "pkg:conan/zlib@1.2.11?rrev=6754320047c5dd54830baaaf9fc733c4"
   } ],
   "metadata" : {
     "component" : {
       "author" : "<Put your name here> <And your email here>",
-      "bom-ref" : "pkg:conan/zlib@1.2.11?rref=6754320047c5dd54830baaaf9fc733c4",
+      "bom-ref" : "pkg:conan/zlib@1.2.11?rrev=6754320047c5dd54830baaaf9fc733c4",
       "name" : "zlib/1.2.11",
       "type" : "library"
     },

--- a/test/integration/sbom/test_cyclonedx.py
+++ b/test/integration/sbom/test_cyclonedx.py
@@ -86,7 +86,7 @@ class TestCyclonedx:
         cyclone_path = os.path.join(create_layout.metadata(), "sbom.cdx.json")
         content = tc.load(cyclone_path)
         # A skipped dependency also shows up in the sbom
-        assert "pkg:conan/dep@1.0?rref=6a99f55e933fb6feeb96df134c33af44" in content
+        assert "pkg:conan/dep@1.0?rrev=6a99f55e933fb6feeb96df134c33af44" in content
 
     @pytest.mark.parametrize("lic, n", [('"simple"', 1), ('"multi1", "multi2"', 2),
                                         ('("tuple1", "tuple2")', 2)])


### PR DESCRIPTION
Changelog: Fix: Correct a typo in the CycloneDX component recipe revision.
Docs: omit

closes #20268 
