### PR TITLE
Log all command output to a file

### DIFF
--- a/conan/api/subapi/command.py
+++ b/conan/api/subapi/command.py
@@ -3,7 +3,6 @@ import shlex
 
 from conan.api.output import ConanOutput
 from conan.errors import ConanException
-from conan.internal.conan_log import ConanLog
 
 
 class CommandAPI:
@@ -48,8 +47,7 @@ class CommandAPI:
         _warnings_as_errors = ConanOutput._warnings_as_errors  # noqa
 
         try:
-            with ConanLog.nested():
-                result = command.run_cli(self._conan_api, args)
+            result = command.run_cli(self._conan_api, args)
         finally:
             ConanOutput._conan_output_level = _conan_output_level
             ConanOutput._silent_warn_tags = _silent_warn_tags

--- a/conan/api/subapi/command.py
+++ b/conan/api/subapi/command.py
@@ -3,6 +3,7 @@ import shlex
 
 from conan.api.output import ConanOutput
 from conan.errors import ConanException
+from conan.internal.conan_log import ConanLog
 
 
 class CommandAPI:
@@ -47,7 +48,8 @@ class CommandAPI:
         _warnings_as_errors = ConanOutput._warnings_as_errors  # noqa
 
         try:
-            result = command.run_cli(self._conan_api, args)
+            with ConanLog.nested():
+                result = command.run_cli(self._conan_api, args)
         finally:
             ConanOutput._conan_output_level = _conan_output_level
             ConanOutput._silent_warn_tags = _silent_warn_tags

--- a/conan/cli/cli.py
+++ b/conan/cli/cli.py
@@ -17,6 +17,7 @@ from conan.cli.exit_codes import SUCCESS, ERROR_MIGRATION, ERROR_GENERAL, USER_C
     ERROR_SIGTERM, USER_CTRL_BREAK, ERROR_INVALID_CONFIGURATION, ERROR_UNEXPECTED
 from conan import __version__
 from conan.errors import ConanException, ConanInvalidConfiguration, ConanMigrationError
+from conan.internal.conan_log import ConanLog
 
 _CONAN_INTERNAL_CUSTOM_COMMANDS_PATH = "_CONAN_INTERNAL_CUSTOM_COMMANDS_PATH"
 
@@ -167,38 +168,40 @@ class Cli:
         """ Entry point for executing commands, dispatcher to class
         methods
         """
-        output = ConanOutput()
-        self.add_commands()
-        try:
-            command_argument = args[0][0]
-        except IndexError:  # No parameters
-            self._output_help_cli()
-            return
-        try:
-            command = self._commands[command_argument]
-        except KeyError as exc:
-            if command_argument in ["-v", "--version"]:
-                cli_out_write("Conan version %s" % __version__)
-                return
-
-            if command_argument in ["-h", "--help"]:
+        raw_args = args[0] if args else []
+        with ConanLog.activate(self._conan_api, raw_args):
+            output = ConanOutput()
+            self.add_commands()
+            try:
+                command_argument = raw_args[0]
+            except IndexError:  # No parameters
                 self._output_help_cli()
                 return
+            try:
+                command = self._commands[command_argument]
+            except KeyError as exc:
+                if command_argument in ["-v", "--version"]:
+                    cli_out_write("Conan version %s" % __version__)
+                    return
 
-            output.info("'%s' is not a Conan command. See 'conan --help'." % command_argument)
-            output.info("")
-            self._print_similar(command_argument)
-            raise ConanException("Unknown command %s" % str(exc))
+                if command_argument in ["-h", "--help"]:
+                    self._output_help_cli()
+                    return
 
-        try:
-            command.run(self._conan_api, args[0][1:])
-            _warn_frozen_center(self._conan_api)
-        except Exception as e:
-            # must be a local-import to get updated value
-            if ConanOutput.level_allowed(LEVEL_TRACE):
-                print(traceback.format_exc(), file=sys.stderr)
-            self._conan2_migrate_recipe_msg(e)
-            raise
+                output.info("'%s' is not a Conan command. See 'conan --help'." % command_argument)
+                output.info("")
+                self._print_similar(command_argument)
+                raise ConanException("Unknown command %s" % str(exc))
+
+            try:
+                command.run(self._conan_api, raw_args[1:])
+                _warn_frozen_center(self._conan_api)
+            except Exception as e:
+                # must be a local-import to get updated value
+                if ConanOutput.level_allowed(LEVEL_TRACE):
+                    print(traceback.format_exc(), file=sys.stderr)
+                self._conan2_migrate_recipe_msg(e)
+                raise
 
     @staticmethod
     def _conan2_migrate_recipe_msg(exception):

--- a/conan/cli/command.py
+++ b/conan/cli/command.py
@@ -145,11 +145,8 @@ class ConanArgumentParser(argparse.ArgumentParser):
             self._conan_api._api_helpers.set_core_confs(args.core_conf)  # noqa
 
         global_conf = self._conan_api._api_helpers.global_conf  # noqa
-        ConanLog.config(
-            self._conan_api.config.get("core.log:enabled", default=False, check_type=bool),
-            self._conan_api.home_folder, self.prog, raw_args,
-            [getattr(args, "password", None), getattr(args, "token", None)]
-        )
+        ConanLog.write_header(self.prog, raw_args,
+                              [getattr(args, "password", None), getattr(args, "token", None)])
         # TODO: This might be even better moved to the ConanAPI so users without doing custom
         #  commands can benefit from it
         ConanOutput.set_warnings_as_errors(global_conf.get("core:warnings_as_errors",

--- a/conan/cli/command.py
+++ b/conan/cli/command.py
@@ -5,6 +5,7 @@ from contextlib import redirect_stdout
 
 from conan.api.output import ConanOutput
 from conan.errors import ConanException
+from conan.internal.conan_log import ConanLog
 
 
 class OnceArgument(argparse.Action):
@@ -133,6 +134,8 @@ class ConanArgumentParser(argparse.ArgumentParser):
         super().__init__(*args, **kwargs)
 
     def parse_args(self, args=None, namespace=None):
+        raw_args = list(args) if args is not None else []
+
         args = super().parse_args(args)
         ConanOutput.define_log_level(args.v)
         if getattr(args, "lockfile_packages", None):
@@ -142,6 +145,11 @@ class ConanArgumentParser(argparse.ArgumentParser):
             self._conan_api._api_helpers.set_core_confs(args.core_conf)  # noqa
 
         global_conf = self._conan_api._api_helpers.global_conf  # noqa
+        ConanLog.config(
+            self._conan_api.config.get("core.log:enabled", default=False, check_type=bool),
+            self._conan_api.home_folder, self.prog, raw_args,
+            [getattr(args, "password", None), getattr(args, "token", None)]
+        )
         # TODO: This might be even better moved to the ConanAPI so users without doing custom
         #  commands can benefit from it
         ConanOutput.set_warnings_as_errors(global_conf.get("core:warnings_as_errors",

--- a/conan/internal/cache/home_paths.py
+++ b/conan/internal/cache/home_paths.py
@@ -85,3 +85,7 @@ class HomePaths:
     @property
     def config_version_path(self):
         return os.path.join(self._home, "config_version.json")
+
+    @property
+    def command_logs_path(self):
+        return os.path.join(self._home, ".log")

--- a/conan/internal/conan_log.py
+++ b/conan/internal/conan_log.py
@@ -1,0 +1,138 @@
+"""
+Implements core.log:enabled: installs an OutputTee over sys.stdout/sys.stderr for the
+duration of a command, so everything shown in the console (including subprocess output,
+captured by conan_run() via runners.py) ends up in a file under <conan_home>/.log.
+"""
+
+import io
+import os
+import re
+import sys
+import threading
+from contextlib import contextmanager
+from datetime import datetime
+
+from conan.internal.cache.home_paths import HomePaths
+
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
+
+
+class LogFile:
+    """The log file that receives a copy of everything shown in the console. A single
+    instance is shared by the OutputTee wrappers of stdout and stderr, so both streams
+    land in the same file, in the order the user actually saw them. Conan prints from
+    several threads at once (parallel downloads, uploads, installs), hence the lock."""
+
+    def __init__(self, path):
+        self._file = open(path, "w", encoding="utf-8", errors="replace", newline="")
+        self._lock = threading.Lock()
+        self.secrets = []
+
+    def redact(self, text):
+        for secret in self.secrets:
+            text = text.replace(secret, "********")
+        return text
+
+    def write(self, data):
+        data = self.redact(_ANSI_ESCAPE_RE.sub("", data))
+        if not data:
+            return
+        with self._lock:
+            if self._file.closed:
+                return
+            self._file.write(data)
+            self._file.flush()
+
+    def close(self):
+        with self._lock:
+            self._file.close()
+
+
+class OutputTee:
+    """Wraps sys.stdout/sys.stderr so everything written to them is also copied to a
+    LogFile. This happens at the Python level, not by duplicating file descriptors, so
+    isatty() keeps answering for the real console and colors are not lost."""
+
+    def __init__(self, stream, log_file):
+        self._stream = stream
+        self._log = log_file
+
+    def write(self, data):
+        ret = self._stream.write(data)
+        self._stream.flush()
+        self._log.write(data)
+        return ret
+
+    def flush(self):
+        self._stream.flush()
+
+    def isatty(self):
+        return hasattr(self._stream, "isatty") and self._stream.isatty()
+
+    def fileno(self):
+        # Not the descriptor of the console: writing to it would skip the log. This is
+        # also what tells conan_run() this stream needs piping to be captured
+        raise io.UnsupportedOperation("fileno")
+
+    def __getattr__(self, name):
+        if name.startswith("_"):  # never delegate internals, would recurse on _stream
+            raise AttributeError(name)
+        return getattr(self._stream, name)
+
+
+class ConanLog:
+    """config() is called once per command dispatch, from ConanArgumentParser.parse_args(),
+    with core.log:enabled read through conan_api.config: this way it sees --core-conf
+    overrides and a custom ConanAPI(cache_folder=...). A no-op while nested(): a command
+    calling another one in the same process shares the outer command's log instead of
+    installing its own."""
+
+    _log_file = None
+    _saved_stdout = None
+    _saved_stderr = None
+    _nesting = 0
+
+    @classmethod
+    def config(cls, enabled, home, command_name, raw_args, secrets=None):
+        if cls._nesting > 0:
+            return
+        cls._teardown()
+        if not enabled:
+            return
+        log_dir = HomePaths(home).command_logs_path
+        safe_name = re.sub(r"[^A-Za-z0-9_.-]", "_", command_name)
+        now = datetime.now()
+        path = os.path.join(log_dir, f"{now:%Y%m%d_%H%M%S}_{os.getpid()}_{safe_name}.log")
+        try:
+            os.makedirs(log_dir, exist_ok=True)
+            log_file = LogFile(path)
+        except Exception as e:
+            from conan.api.output import ConanOutput
+            ConanOutput().warning(f"core.log:enabled couldn't create the log file: {e}")
+            return
+        log_file.secrets = [s for s in (secrets or []) if s]
+        log_file.write(f"# Date: {now:%Y-%m-%d %H:%M:%S}\n"
+                       f"# Command: {log_file.redact(' '.join([command_name] + raw_args))}\n"
+                       f"{'#' + '-' * 60}\n")
+        cls._log_file = log_file
+        cls._saved_stdout, cls._saved_stderr = sys.stdout, sys.stderr
+        sys.stdout = OutputTee(sys.stdout, log_file)
+        sys.stderr = OutputTee(sys.stderr, log_file)
+
+    @classmethod
+    def _teardown(cls):
+        if cls._log_file is not None:
+            sys.stdout, sys.stderr = cls._saved_stdout, cls._saved_stderr
+            cls._log_file.close()
+            cls._log_file = None
+
+    @classmethod
+    @contextmanager
+    def nested(cls):
+        """Used by CommandAPI.run() when a command calls another one in the same
+        process, so the nested command's own config() call is a no-op."""
+        cls._nesting += 1
+        try:
+            yield
+        finally:
+            cls._nesting -= 1

--- a/conan/internal/conan_log.py
+++ b/conan/internal/conan_log.py
@@ -81,58 +81,48 @@ class OutputTee:
 
 
 class ConanLog:
-    """config() is called once per command dispatch, from ConanArgumentParser.parse_args(),
-    with core.log:enabled read through conan_api.config: this way it sees --core-conf
-    overrides and a custom ConanAPI(cache_folder=...). A no-op while nested(): a command
-    calling another one in the same process shares the outer command's log instead of
-    installing its own."""
+    """activate() wraps sys.stdout/sys.stderr for the whole lifetime of a top-level
+    Cli.run() call. core.log:enabled is read before any argument is parsed, so only
+    global.conf is used, not a `-cc core.log:enabled=True` override. write_header()
+    is called later, once the command's own arguments (e.g. --password) are known, to
+    redact them and write the command line as the log header."""
 
     _log_file = None
-    _saved_stdout = None
-    _saved_stderr = None
-    _nesting = 0
 
     @classmethod
-    def config(cls, enabled, home, command_name, raw_args, secrets=None):
-        if cls._nesting > 0:
+    @contextmanager
+    def activate(cls, conan_api, raw_args):
+        if not conan_api.config.get("core.log:enabled", default=False, check_type=bool):
+            yield
             return
-        cls._teardown()
-        if not enabled:
-            return
-        log_dir = HomePaths(home).command_logs_path
-        safe_name = re.sub(r"[^A-Za-z0-9_.-]", "_", command_name)
-        now = datetime.now()
-        path = os.path.join(log_dir, f"{now:%Y%m%d_%H%M%S}_{os.getpid()}_{safe_name}.log")
+        log_dir = HomePaths(conan_api.home_folder).command_logs_path
+        safe_name = re.sub(r"[^A-Za-z0-9_.-]", "_", raw_args[0]) if raw_args else "conan"
+        path = os.path.join(log_dir,
+                            f"{datetime.now():%Y%m%d_%H%M%S}_{os.getpid()}_{safe_name}.log")
         try:
             os.makedirs(log_dir, exist_ok=True)
-            log_file = LogFile(path)
+            cls._log_file = LogFile(path)
         except Exception as e:
             from conan.api.output import ConanOutput
             ConanOutput().warning(f"core.log:enabled couldn't create the log file: {e}")
+            yield
             return
-        log_file.secrets = [s for s in (secrets or []) if s]
-        log_file.write(f"# Date: {now:%Y-%m-%d %H:%M:%S}\n"
-                       f"# Command: {log_file.redact(' '.join([command_name] + raw_args))}\n"
-                       f"{'#' + '-' * 60}\n")
-        cls._log_file = log_file
-        cls._saved_stdout, cls._saved_stderr = sys.stdout, sys.stderr
-        sys.stdout = OutputTee(sys.stdout, log_file)
-        sys.stderr = OutputTee(sys.stderr, log_file)
-
-    @classmethod
-    def _teardown(cls):
-        if cls._log_file is not None:
-            sys.stdout, sys.stderr = cls._saved_stdout, cls._saved_stderr
+        saved_stdout, saved_stderr = sys.stdout, sys.stderr
+        sys.stdout = OutputTee(sys.stdout, cls._log_file)
+        sys.stderr = OutputTee(sys.stderr, cls._log_file)
+        try:
+            yield
+        finally:
+            sys.stdout, sys.stderr = saved_stdout, saved_stderr
             cls._log_file.close()
             cls._log_file = None
 
     @classmethod
-    @contextmanager
-    def nested(cls):
-        """Used by CommandAPI.run() when a command calls another one in the same
-        process, so the nested command's own config() call is a no-op."""
-        cls._nesting += 1
-        try:
-            yield
-        finally:
-            cls._nesting -= 1
+    def write_header(cls, command_name, raw_args, secrets):
+        if cls._log_file is None:
+            return
+        cls._log_file.secrets.extend(s for s in (secrets or []) if s)
+        cls._log_file.write(
+            f"# Date: {datetime.now():%Y-%m-%d %H:%M:%S}\n"
+            f"# Command: {cls._log_file.redact(' '.join([command_name] + raw_args))}\n"
+            f"{'#' + '-' * 60}\n")

--- a/conan/internal/model/conf.py
+++ b/conan/internal/model/conf.py
@@ -80,6 +80,8 @@ BUILT_IN_CONFS = {
     "core.scm:local_url": "By default allows to store local folders as remote url, but not upload them. Use 'allow' for allowing upload and 'block' to completely forbid it",
     # Compatibility opt-in, to be removed in future versions as optimized behavior becomes default
     "core.graph:compatibility_mode": "(Experimental) Set this to 'optimized' to enable the improved compatibility behaviour when querying multiple compatible binaries in remotes",
+    # Command logging
+    "core.log:enabled": "(Experimental) If True, logs everything a command prints, including subprocess output, to a file under <conan_home>/.log. These files are not cleaned up automatically, and they can contain information from the command output",
     # Tools
     "tools.android:ndk_path": "Argument for the CMAKE_ANDROID_NDK",
     "tools.android:cmake_legacy_toolchain": "Define to explicitly pass ANDROID_USE_LEGACY_TOOLCHAIN_FILE in CMake toolchain",

--- a/conan/internal/util/runners.py
+++ b/conan/internal/util/runners.py
@@ -1,12 +1,39 @@
+import codecs
 import os
 import subprocess
 import sys
 import tempfile
+import threading
 from contextlib import contextmanager
-from io import StringIO
 
 from conan.errors import ConanException
 from conan.internal.util.files import load
+
+
+def _needs_pipe(stream):
+    """Streams that are not a file the subprocess can write to on its own, so they need
+    a pipe and the output read from it has to be forwarded with write(): the StringIO a
+    recipe passes to capture output, subprocess.DEVNULL and the like, or the OutputTee
+    that copies the console to the command log when core.log:enabled."""
+    if isinstance(stream, int):  # subprocess.DEVNULL and the like
+        return False
+    try:
+        stream.fileno()
+    except (AttributeError, ValueError, OSError):  # io.UnsupportedOperation is also this
+        return True
+    return False
+
+
+def _forward(pipe, stream):
+    """Copies the subprocess output to a Python stream, in chunks and not lines, so a
+    progress bar that only writes '\\r' is not withheld until it finishes."""
+    decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+    with pipe:
+        for chunk in iter(lambda: pipe.read1(4096), b""):
+            stream.write(decoder.decode(chunk))
+    pending = decoder.decode(b"", final=True)
+    if pending:
+        stream.write(pending)
 
 
 if getattr(sys, 'frozen', False) and 'LD_LIBRARY_PATH' in os.environ:
@@ -43,8 +70,11 @@ def conan_run(command, stdout=None, stderr=None, cwd=None, shell=True):
     stdout = stdout or sys.stderr
     stderr = stderr or sys.stderr
 
-    out = subprocess.PIPE if isinstance(stdout, StringIO) else stdout
-    err = subprocess.PIPE if isinstance(stderr, StringIO) else stderr
+    piped_stdout, piped_stderr = _needs_pipe(stdout), _needs_pipe(stderr)
+    out = subprocess.PIPE if piped_stdout else stdout
+    # A single pipe keeps stdout/stderr in the order the subprocess produced them
+    merged = stdout is stderr and piped_stdout
+    err = subprocess.STDOUT if merged else (subprocess.PIPE if piped_stderr else stderr)
 
     with pyinstaller_bundle_env_cleaned():
         try:
@@ -52,14 +82,17 @@ def conan_run(command, stdout=None, stderr=None, cwd=None, shell=True):
         except Exception as e:
             raise ConanException("Error while running cmd\nError: %s" % (str(e)))
 
-        proc_stdout, proc_stderr = proc.communicate()
-        # If the output is piped, like user provided a StringIO or testing, the communicate
-        # will capture and return something when thing finished
-        if proc_stdout:
-            stdout.write(proc_stdout.decode("utf-8", errors="ignore"))
-        if proc_stderr:
-            stderr.write(proc_stderr.decode("utf-8", errors="ignore"))
-        return proc.returncode
+        pipes = [(pipe, stream) for pipe, stream in ((proc.stdout, stdout), (proc.stderr, stderr))
+                if pipe is not None]
+        # Both pipes have to be read at once, or the subprocess blocks when one fills up
+        threads = [threading.Thread(target=_forward, args=pipe) for pipe in pipes[1:]]
+        for thread in threads:
+            thread.start()
+        if pipes:
+            _forward(*pipes[0])
+        for thread in threads:
+            thread.join()
+        return proc.wait()
 
 
 def detect_runner(command):

--- a/test/integration/command/test_command_log.py
+++ b/test/integration/command/test_command_log.py
@@ -1,8 +1,6 @@
 import os
 import textwrap
 
-import pytest
-
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient
 
@@ -21,15 +19,13 @@ class TestCommandLog:
         c.run("create .")
         assert not _log_files(c)
 
-    @pytest.mark.parametrize("enable_via", ["core_conf", "global_conf"])
-    def test_enabled(self, enable_via):
+    def test_enabled(self):
+        # core.log:enabled is only honored from global.conf: it is read before any
+        # argument is parsed, so a `-cc core.log:enabled=True` override isn't seen yet
         c = TestClient()
         c.save({"conanfile.py": GenConanfile("pkg", "1.0")})
-        if enable_via == "global_conf":
-            c.save_home({"global.conf": "core.log:enabled=True"})
-            c.run("create .")
-        else:
-            c.run("create . -cc core.log:enabled=True")
+        c.save_home({"global.conf": "core.log:enabled=True"})
+        c.run("create .")
 
         logs = _log_files(c)
         assert len(logs) == 1
@@ -37,10 +33,19 @@ class TestCommandLog:
         assert "# Command: conan create ." in content
         assert "pkg/1.0" in content
 
+    def test_core_conf_override_not_honored(self):
+        # Trade-off of activating once, up front, in Cli.run(): core.log:enabled is
+        # read before any argument is parsed, so -cc can't be seen yet at that point
+        c = TestClient()
+        c.save({"conanfile.py": GenConanfile("pkg", "1.0")})
+        c.run("create . -cc core.log:enabled=True")
+        assert not _log_files(c)
+
     def test_bare_print_is_captured(self):
         # This is the whole point of wrapping sys.stdout/stderr instead of hooking
         # ConanOutput/cli_out_write: a recipe's plain print() has to show up too
         c = TestClient()
+        c.save_home({"global.conf": "core.log:enabled=True"})
         conanfile = textwrap.dedent("""
             from conan import ConanFile
             class Pkg(ConanFile):
@@ -51,7 +56,7 @@ class TestCommandLog:
                     self.output.info("hello-from-conanoutput")
             """)
         c.save({"conanfile.py": conanfile})
-        c.run("create . -cc core.log:enabled=True")
+        c.run("create .")
 
         content = open(_log_files(c)[0], encoding="utf-8").read()
         assert "hello-from-bare-print" in content
@@ -127,6 +132,7 @@ class TestCommandLog:
     def test_run_quiet_does_not_crash(self):
         # self.run(cmd, quiet=True) maps stdout/stderr to subprocess.DEVNULL
         c = TestClient()
+        c.save_home({"global.conf": "core.log:enabled=True"})
         conanfile = textwrap.dedent("""
             from conan import ConanFile
             class Pkg(ConanFile):
@@ -137,7 +143,7 @@ class TestCommandLog:
                     self.run("echo loud-output")
             """)
         c.save({"conanfile.py": conanfile})
-        c.run("create . -cc core.log:enabled=True")
+        c.run("create .")
 
         content = open(_log_files(c)[0], encoding="utf-8").read()
         assert "loud-output" in content
@@ -145,6 +151,7 @@ class TestCommandLog:
 
     def test_subprocess_output_captured(self):
         c = TestClient()
+        c.save_home({"global.conf": "core.log:enabled=True"})
         conanfile = textwrap.dedent("""
             from conan import ConanFile
             class Pkg(ConanFile):
@@ -154,7 +161,7 @@ class TestCommandLog:
                     self.run("echo hello-from-subprocess")
             """)
         c.save({"conanfile.py": conanfile})
-        c.run("create . -cc core.log:enabled=True")
+        c.run("create .")
 
         content = open(_log_files(c)[0], encoding="utf-8").read()
         assert "hello-from-subprocess" in content

--- a/test/integration/command/test_command_log.py
+++ b/test/integration/command/test_command_log.py
@@ -1,0 +1,160 @@
+import os
+import textwrap
+
+import pytest
+
+from conan.test.assets.genconanfile import GenConanfile
+from conan.test.utils.tools import TestClient
+
+
+def _log_files(client):
+    log_dir = os.path.join(client.cache_folder, ".log")
+    if not os.path.isdir(log_dir):
+        return []
+    return [os.path.join(log_dir, f) for f in os.listdir(log_dir)]
+
+
+class TestCommandLog:
+    def test_disabled_by_default(self):
+        c = TestClient()
+        c.save({"conanfile.py": GenConanfile("pkg", "1.0")})
+        c.run("create .")
+        assert not _log_files(c)
+
+    @pytest.mark.parametrize("enable_via", ["core_conf", "global_conf"])
+    def test_enabled(self, enable_via):
+        c = TestClient()
+        c.save({"conanfile.py": GenConanfile("pkg", "1.0")})
+        if enable_via == "global_conf":
+            c.save_home({"global.conf": "core.log:enabled=True"})
+            c.run("create .")
+        else:
+            c.run("create . -cc core.log:enabled=True")
+
+        logs = _log_files(c)
+        assert len(logs) == 1
+        content = open(logs[0], encoding="utf-8").read()
+        assert "# Command: conan create ." in content
+        assert "pkg/1.0" in content
+
+    def test_bare_print_is_captured(self):
+        # This is the whole point of wrapping sys.stdout/stderr instead of hooking
+        # ConanOutput/cli_out_write: a recipe's plain print() has to show up too
+        c = TestClient()
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "1.0"
+                def build(self):
+                    print("hello-from-bare-print")
+                    self.output.info("hello-from-conanoutput")
+            """)
+        c.save({"conanfile.py": conanfile})
+        c.run("create . -cc core.log:enabled=True")
+
+        content = open(_log_files(c)[0], encoding="utf-8").read()
+        assert "hello-from-bare-print" in content
+        assert "hello-from-conanoutput" in content
+
+    def test_independent_log_per_command_same_process(self):
+        c = TestClient()
+        c.save_home({"global.conf": "core.log:enabled=True"})
+        c.save({"conanfile.py": GenConanfile("pkg", "1.0")})
+        c.run("create .")
+        c.run("list pkg/1.0:*")
+
+        logs = _log_files(c)
+        assert len(logs) == 2
+        create_log = next(f for f in logs if "create" in f)
+        list_log = next(f for f in logs if "list" in f)
+        create_content = open(create_log, encoding="utf-8").read()
+        list_content = open(list_log, encoding="utf-8").read()
+        assert "# Command: conan create ." in create_content
+        assert "# Command: conan list " in list_content
+        assert "list pkg" not in create_content
+        assert "Created package" not in list_content
+
+    def test_nested_command_shares_the_outer_log(self):
+        c = TestClient()
+        c.save_home({
+            "global.conf": "core.log:enabled=True",
+            "extensions/commands/cmd_mybuild.py": textwrap.dedent("""
+                from conan.api.output import ConanOutput
+                from conan.cli.command import conan_command
+
+                @conan_command(group="Custom commands")
+                def mybuild(conan_api, parser, *args):
+                    \"\"\"mybuild\"\"\"
+                    parser.parse_args(args[0])
+                    ConanOutput().info("mybuild: before nested command")
+                    conan_api.command.run(["profile", "detect", "--force"])
+                    ConanOutput().info("mybuild: after nested command")
+                """),
+        })
+        c.run("mybuild")
+
+        logs = _log_files(c)
+        assert len(logs) == 1
+        content = open(logs[0], encoding="utf-8").read()
+        assert "# Command: conan mybuild" in content
+        assert "mybuild: before nested command" in content
+        assert "Detected profile" in content
+        assert "mybuild: after nested command" in content
+
+    def test_redacts_password_by_value_end_to_end(self):
+        c = TestClient(default_server_user=True)
+        c.save_home({"global.conf": "core.log:enabled=True"})
+        c.run("remote login default admin -p password")
+
+        content = open(_log_files(c)[0], encoding="utf-8").read()
+        assert "-p ********" in content
+        assert content.count("password") == 0
+
+    def test_p_flag_not_confused_with_password_in_other_commands(self):
+        # -p means --password in remote login, but --package-query in list; redacting
+        # by exact known value (not flag name) avoids this false positive
+        c = TestClient()
+        c.save_home({"global.conf": "core.log:enabled=True"})
+        c.save({"conanfile.py": GenConanfile("pkg", "1.0")})
+        c.run("create .")
+        c.run("list pkg/1.0:* -p os=Windows")
+
+        list_log = next(f for f in _log_files(c) if "list" in f)
+        content = open(list_log, encoding="utf-8").read()
+        assert "# Command: conan list pkg/1.0:* -p os=Windows" in content
+
+    def test_run_quiet_does_not_crash(self):
+        # self.run(cmd, quiet=True) maps stdout/stderr to subprocess.DEVNULL
+        c = TestClient()
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "1.0"
+                def build(self):
+                    self.run("echo quiet-output", quiet=True)
+                    self.run("echo loud-output")
+            """)
+        c.save({"conanfile.py": conanfile})
+        c.run("create . -cc core.log:enabled=True")
+
+        content = open(_log_files(c)[0], encoding="utf-8").read()
+        assert "loud-output" in content
+        assert "quiet-output" not in content
+
+    def test_subprocess_output_captured(self):
+        c = TestClient()
+        conanfile = textwrap.dedent("""
+            from conan import ConanFile
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "1.0"
+                def source(self):
+                    self.run("echo hello-from-subprocess")
+            """)
+        c.save({"conanfile.py": conanfile})
+        c.run("create . -cc core.log:enabled=True")
+
+        content = open(_log_files(c)[0], encoding="utf-8").read()
+        assert "hello-from-subprocess" in content

--- a/test/unittests/util/conan_log_test.py
+++ b/test/unittests/util/conan_log_test.py
@@ -1,0 +1,96 @@
+import os
+import threading
+
+from conan.internal.conan_log import LogFile, OutputTee
+from conan.test.utils.test_files import temp_folder
+
+
+class FakeStream:
+    def __init__(self):
+        self.data = ""
+
+    def write(self, data):
+        self.data += data
+        return len(data)
+
+    def flush(self):
+        pass
+
+
+def test_tee_writes_to_both_stream_and_log():
+    log_path = os.path.join(temp_folder(), "test.log")
+    log_file = LogFile(log_path)
+    fake = FakeStream()
+    tee = OutputTee(fake, log_file)
+
+    tee.write("hello\n")
+    log_file.close()
+
+    assert fake.data == "hello\n"
+    assert open(log_path, encoding="utf-8").read() == "hello\n"
+
+
+def test_log_strips_ansi_codes():
+    log_path = os.path.join(temp_folder(), "test.log")
+    log_file = LogFile(log_path)
+    log_file.write("\x1b[31mred text\x1b[0m\n")
+    log_file.close()
+    assert open(log_path, encoding="utf-8").read() == "red text\n"
+
+
+def test_log_redacts_known_secrets():
+    log_path = os.path.join(temp_folder(), "test.log")
+    log_file = LogFile(log_path)
+    log_file.secrets = ["s3cr3t"]
+    log_file.write("the password is s3cr3t, really\n")
+    log_file.close()
+    content = open(log_path, encoding="utf-8").read()
+    assert "s3cr3t" not in content
+    assert "the password is ********, really" in content
+
+
+def test_tee_fileno_raises_so_conan_run_knows_to_pipe():
+    log_path = os.path.join(temp_folder(), "test.log")
+    log_file = LogFile(log_path)
+    tee = OutputTee(FakeStream(), log_file)
+    try:
+        tee.fileno()
+        assert False, "should have raised"
+    except OSError:
+        pass
+    log_file.close()
+
+
+def test_tee_getattr_delegates_to_real_stream_not_internals():
+    class StreamWithEncoding(FakeStream):
+        encoding = "utf-8"
+
+    log_path = os.path.join(temp_folder(), "test.log")
+    log_file = LogFile(log_path)
+    tee = OutputTee(StreamWithEncoding(), log_file)
+    assert tee.encoding == "utf-8"
+    try:
+        tee._nonexistent_private_attr
+        assert False, "internals (leading underscore) should not be delegated"
+    except AttributeError:
+        pass
+    log_file.close()
+
+
+def test_concurrent_writes_are_not_lost():
+    log_path = os.path.join(temp_folder(), "test.log")
+    log_file = LogFile(log_path)
+
+    def worker(n):
+        for i in range(200):
+            log_file.write(f"thread{n}-line{i}\n")
+
+    threads = [threading.Thread(target=worker, args=(n,)) for n in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    log_file.close()
+
+    lines = open(log_path, encoding="utf-8").readlines()
+    assert len(lines) == 1600


### PR DESCRIPTION
## Second iteration on the conan logging feature (https://github.com/conan-io/conan/pull/20273)

**feature/conan_logs_std vs feature/conan_logs**

Same `core.log:enabled` feature, different capture strategy.

- feature/conan_logs (#20273) hooks a handful of specific call sites (ConanOutput.write()/_write_message(), cli_out_write(), conan_run()). Small and fully cross platform, but anything that writes to sys.stdout/sys.stderr outside those call sites, a bare print(), a third party library, warnings.warn(), never reaches the log.

- feature/conan_logs_std (this branch) installs an OutputTee over sys.stdout/sys.stderr for the duration of the command instead of hooking individual call sites. Still fully cross platform and Python only, no file descriptor duplication, but now a plain print() in a recipe (or any other direct write) ends up in the log too, since ConanOutput/cli_out_write already write to those names and get captured for free. conan/api/output.py needs zero changes.

Changelog: Feature: Added core.log:enabled conf to log the full console output of every command (including subprocess output and anything printed directly to stdout/stderr) to a file under <conan_home>/.log.

Docs: TODO
