### PR TITLE
Do not force CONFIG requires for transitive dependencies in CMakeConfigDeps

### DIFF
--- a/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
+++ b/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
@@ -416,9 +416,11 @@ class _CMakeContextGenerator:
             transitive_reqs = self._ctx.transitive_reqs
             def _get_dep_find_mode(d):
                 find_mode = self._ctx.get_property("cmake_find_mode", d)
+
                 if find_mode is None:
                     find_mode = FIND_MODE_CONFIG
-                return "" if find_mode.lower() == FIND_MODE_NONE else find_mode.upper()
+
+                return "" if find_mode.lower() in (FIND_MODE_NONE, FIND_MODE_BOTH) else find_mode.upper()
             dependencies = {self._ctx.get_cmake_filename(d): _get_dep_find_mode(d)
                             for d in transitive_reqs.values()}
             extra_mods = self._ctx.get_property("cmake_extra_dependencies", check_type=list) or []

--- a/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
+++ b/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
@@ -414,7 +414,12 @@ class _CMakeContextGenerator:
 
         def _get_dependencies_and_requires(self):
             transitive_reqs = self._ctx.transitive_reqs
-            dependencies = {self._ctx.get_cmake_filename(d): "CONFIG"
+            def _get_dep_find_mode(d):
+                find_mode = self._ctx.get_property("cmake_find_mode", d)
+                if find_mode is None:
+                    find_mode = FIND_MODE_CONFIG
+                return "" if find_mode.lower() == FIND_MODE_NONE else find_mode.upper()
+            dependencies = {self._ctx.get_cmake_filename(d): _get_dep_find_mode(d)
                             for d in transitive_reqs.values()}
             extra_mods = self._ctx.get_property("cmake_extra_dependencies", check_type=list) or []
             dependencies.update({extra_mod: "" for extra_mod in extra_mods})

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -1266,3 +1266,50 @@ class TestNoSoname:
         c.run("install --requires=dep/0.1 -g CMakeConfigDeps")
         cmake = c.load("dep-Targets-release.cmake")
         assert "IMPORTED_NO_SONAME" not in cmake
+
+
+def test_find_mode_none():
+    tc = TestClient()
+
+    dep = textwrap.dedent("""
+    from conan import ConanFile
+    class Dep(ConanFile):
+        name = "dep"
+        version = "0.1"
+        settings = "os", "arch", "compiler", "build_type"
+
+        def package_info(self):
+            self.cpp_info.set_property("cmake_find_mode", "none")
+    """)
+
+    a = textwrap.dedent("""
+    from conan import ConanFile
+    class A(ConanFile):
+        name = "liba"
+        version = "0.1"
+        settings = "os", "arch", "compiler", "build_type"
+        generators = "CMakeConfigDeps", "CMakeToolchain"
+        requires = "dep/0.1"
+    """)
+
+    consumer = textwrap.dedent("""
+    from conan import ConanFile
+    class Consumer(ConanFile):
+        name = "consumer"
+        version = "0.1"
+        requires = "liba/0.1"
+        settings = "os", "arch", "compiler", "build_type"
+        generators = "CMakeConfigDeps", "CMakeToolchain"
+
+    """)
+
+    tc.save({"dep/conanfile.py": dep,
+             "liba/conanfile.py": a,
+             "conanfile.py": consumer})
+
+    tc.run("create dep")
+    tc.run("create liba")
+    tc.run("install .")
+    target_dependency = tc.load("liba-Targets-release.cmake")
+    # The dependency should not have CONFIG requirement
+    assert "find_dependency(dep REQUIRED )" in target_dependency


### PR DESCRIPTION
Changelog: Fix: Do not force `CONFIG` requires for transitive dependencies in `CMakeConfigDeps`.
Docs: Omit

Closes https://github.com/conan-io/conan/issues/20282