### PR TITLE
Add LoongArch64 architecture setting and host detection

### DIFF
--- a/conan/internal/api/detect/detect_api.py
+++ b/conan/internal/api/detect/detect_api.py
@@ -56,6 +56,8 @@ def detect_arch():
         return "riscv64"
     elif "riscv32" in machine:
         return 'riscv32'
+    elif "loongarch64" in machine:
+        return "loongarch64"
     elif "64" in machine:
         return "x86_64"
     elif "86" in machine:

--- a/conan/internal/default_settings.py
+++ b/conan/internal/default_settings.py
@@ -106,6 +106,7 @@ arch: [x86, x86_64, ppc32be, ppc32, ppc64le, ppc64,
        mips, mips64, avr, s390, s390x, asm.js, wasm, wasm64, sh4le,
        e2k-v2, e2k-v3, e2k-v4, e2k-v5, e2k-v6, e2k-v7,
        riscv64, riscv32,
+       loongarch64,
        xtensalx6, xtensalx106, xtensalx7,
        tc131, tc16, tc161, tc162, tc18]
 compiler:

--- a/conan/tools/build/flags.py
+++ b/conan/tools/build/flags.py
@@ -103,7 +103,7 @@ def architecture_bits(conanfile):
     arch = conanfile.settings.get_safe("arch")
     if arch in ["x86_64", "ppc64le", "ppc64", "armv8", "armv8.3", "arm64ec", "sparcv9",
                 "mips64", "s390x", "wasm64", "e2k-v2", "e2k-v3", "e2k-v4", "e2k-v5",
-                "e2k-v6", "e2k-v7", "riscv64"]:
+                "e2k-v6", "e2k-v7", "riscv64", "loongarch64"]:
         return "64"
     elif arch in ["x86", "ppc32be", "ppc32", "armv4", "armv4i", "armv5el", "armv5hf",
                   "armv6", "armv7", "armv7hf", "armv7s", "armv7k", "armv8_32",

--- a/conan/tools/gnu/get_gnu_triplet.py
+++ b/conan/tools/gnu/get_gnu_triplet.py
@@ -51,6 +51,8 @@ def _get_gnu_arch(os_, arch):
             machine = 'riscv64'
         elif 'riscv32' in arch:
             machine = "riscv32"
+        elif "loongarch64" in arch:
+            machine = "loongarch64"
 
     if machine is None:
         raise ConanException("Unknown '%s' machine, Conan doesn't know how to "

--- a/conan/tools/system/package_manager.py
+++ b/conan/tools/system/package_manager.py
@@ -303,7 +303,8 @@ class Apt(_SystemPackageManagerTool):
                             "armv7hf": "armhf",
                             "armv8": "arm64",
                             "s390x": "s390x",
-                            "riscv64": "riscv64"} if arch_names is None else arch_names
+                            "riscv64": "riscv64",
+                            "loongarch64": "loong64"} if arch_names is None else arch_names
 
         self._arch_separator = ":"
 
@@ -355,7 +356,8 @@ class Yum(_SystemPackageManagerTool):
                             "armv7hf": "armv7hl",
                             "armv8": "aarch64",
                             "s390x": "s390x",
-                            "riscv64": "riscv64"} if arch_names is None else arch_names
+                            "riscv64": "riscv64",
+                            "loongarch64": "loongarch64"} if arch_names is None else arch_names
         self._arch_separator = "."
 
     def _is_valid_explicit_arch(self, explicit_arch):

--- a/test/unittests/tools/build/test_arch_bits.py
+++ b/test/unittests/tools/build/test_arch_bits.py
@@ -22,6 +22,7 @@ from conan.test.utils.mocks import MockSettings, ConanFileMock
     ("e2k-v6", "64"),
     ("e2k-v7", "64"),
     ("riscv64", "64"),
+    ("loongarch64", "64"),
     ("x86", "32"),
     ("ppc32be", "32"),
     ("ppc32", "32"),

--- a/test/unittests/tools/gnu/test_triplets.py
+++ b/test/unittests/tools/gnu/test_triplets.py
@@ -66,6 +66,7 @@ from conan.errors import ConanException
     ["Linux", "e2k-v7", None, "e2k-unknown-linux-gnu"],
     ["Linux", "riscv32", None, "riscv32-linux-gnu"],
     ["Linux", "riscv64", None, "riscv64-linux-gnu"],
+    ["Linux", "loongarch64", None, "loongarch64-linux-gnu"],
 ])
 def test_get_gnu_triplet(os_, arch, compiler, expected):
     info = _get_gnu_triplet(os_, arch, compiler)

--- a/test/unittests/util/detected_architecture_test.py
+++ b/test/unittests/util/detected_architecture_test.py
@@ -28,7 +28,8 @@ class TestDetectedArchitecture:
         ['aarch64', 'armv8'],
         ['ARM64', 'armv8'],
         ["riscv64", 'riscv64'],
-        ['riscv32', "riscv32"]
+        ['riscv32', "riscv32"],
+        ["loongarch64", "loongarch64"]
     ])
     def test_various(self, mocked_machine, expected_arch):
         with mock.patch("platform.machine", mock.MagicMock(return_value=mocked_machine)):


### PR DESCRIPTION
Changelog: Feature: Add basic LoongArch64 architecture support and host detection.
Docs: Omit

- [x] Refer to the issue that supports this Pull Request. https://github.com/conan-io/conan/issues/20286
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.

This PR adds basic LoongArch64 architecture support:

  - adds `loongarch64` to the default architecture settings
  - detects `platform.machine() == "loongarch64"` correctly
  - adds the `loongarch64-linux-gnu` GNU triplet

```text
pytest -q \
    test/unittests/util/detected_architecture_test.py \
    test/unittests/tools/build/test_arch_bits.py \
    test/unittests/tools/gnu/test_triplets.py

150 passed in 0.49s
```
```
pytest -q \
    test/integration/tools/system/package_manager_test.py

172 passed, 1 skipped in 0.67s
```
Tested on a native LoongArch64 Debian forky environment:
```
  Detected profile:
  [settings]
  arch=loongarch64
  build_type=Release
  os=Linux

```