### PR TITLE
fix rmdir windows folder permissions

### DIFF
--- a/conan/internal/util/files.py
+++ b/conan/internal/util/files.py
@@ -175,7 +175,9 @@ def load_user_encoded(path):
 
 
 def _change_permissions(func, path, exc_info):
-    if not os.access(path, os.W_OK):
+    # os.access(path, os.W_OK) is unreliable for directories on Windows: it reports them as
+    # writable even when their read-only attribute is set, which is exactly the case here
+    if not os.access(path, os.W_OK) or (platform.system() == "Windows" and os.path.isdir(path)):
         os.chmod(path, stat.S_IWUSR)
         func(path)
     else:

--- a/conan/internal/util/files.py
+++ b/conan/internal/util/files.py
@@ -174,35 +174,48 @@ def load_user_encoded(path):
     raise Exception(f"Unknown encoding of file: {path}\nIt is recommended to use utf-8 encoding")
 
 
-def _change_permissions(func, path, exc_info):
-    # os.access(path, os.W_OK) is unreliable for directories on Windows: it reports them as
-    # writable even when their read-only attribute is set, which is exactly the case here
-    if not os.access(path, os.W_OK) or (platform.system() == "Windows" and os.path.isdir(path)):
-        os.chmod(path, stat.S_IWUSR)
-        func(path)
-    else:
-        raise OSError("Cannot change permissions for {}! Exception info: {}".format(path, exc_info))
-
-
-if platform.system() == "Windows":
-    def rmdir(path):
-        if not os.path.isdir(path):
-            return
-
-        retries = 3
-        delay = 0.5
-        for i in range(retries):
+def _grant_write_permission(path):
+    # Best effort: a permission error can come from the failing entry itself (e.g. a
+    # read-only file, or a directory whose own read-only attribute blocks its removal on
+    # Windows) or from its parent (removing an entry from a directory requires write
+    # permission on that directory, regardless of the entry's own permissions, notably on
+    # POSIX). Instead of reasoning about which one it was, just grant write permission
+    # everywhere in the tree, so the next rmtree() retry is not blocked by either.
+    for root, dirs, files in os.walk(path):
+        for name in dirs + files:
+            entry = os.path.join(root, name)
             try:
-                shutil.rmtree(path, onerror=_change_permissions)
-                break
-            except OSError as err:
-                if i == retries - 1:
-                    raise ConanException(f"Couldn't remove folder: {path}\n{str(err)}\n"
-                                         "Folder might be busy or open. "
-                                         "Close any app using it and retry.")
+                os.chmod(entry, os.stat(entry).st_mode | stat.S_IWUSR)
+            except OSError:
+                pass
+    try:
+        os.chmod(path, os.stat(path).st_mode | stat.S_IWUSR)
+    except OSError:
+        pass
+
+
+def rmdir(path):
+    if not os.path.isdir(path):
+        return
+
+    retries = 4  # one extra attempt reserved for a permission fix, if one is needed
+    delay = 0.5
+    for i in range(retries):
+        try:
+            shutil.rmtree(path)
+            return
+        except OSError as err:
+            if i == retries - 1:
+                raise ConanException(f"Couldn't remove folder: {path}\n{str(err)}\n"
+                                     "Folder might be busy or open. "
+                                     "Close any app using it and retry.")
+            if isinstance(err, PermissionError):
+                _grant_write_permission(path)
+            else:
                 time.sleep(delay)
 
 
+if platform.system() == "Windows":
     def renamedir(old_path, new_path):
         retries = 3
         delay = 0.5
@@ -218,16 +231,6 @@ if platform.system() == "Windows":
                                          "Close any app using it and retry.")
                 time.sleep(delay)
 else:
-    def rmdir(path):
-        if not os.path.isdir(path):
-            return
-        try:
-            shutil.rmtree(path, onerror=_change_permissions)
-        except OSError as err:
-            raise ConanException(f"Couldn't remove folder: {path}\n{str(err)}\n"
-                                 "Folder might be busy or open. "
-                                 "Close any app using it and retry.")
-
     def renamedir(old_path, new_path):
         try:
             shutil.move(old_path, new_path)

--- a/test/integration/command/remove_test.py
+++ b/test/integration/command/remove_test.py
@@ -69,7 +69,8 @@ class TestRemoveWithoutUserChannel:
 
 def test_remove_package_with_readonly_folder():
     """ removing a package that contains a read-only directory must not fail with a
-    permission error
+    permission error, be it on Windows (the directory's own read-only attribute blocks its
+    removal) or on POSIX (removing an entry needs write permission on its parent directory)
     https://github.com/conan-io/conan/issues/20241
     """
     conanfile = textwrap.dedent("""

--- a/test/integration/command/remove_test.py
+++ b/test/integration/command/remove_test.py
@@ -1,6 +1,8 @@
 import json
 import os
 import shutil
+import stat
+import textwrap
 
 import pytest
 
@@ -63,6 +65,32 @@ class TestRemoveWithoutUserChannel:
 
         client.run("install --requires=lib/1.0@", assert_error=True)
         assert "Unable to find 'lib/1.0' in remotes" in client.out
+
+
+def test_remove_package_with_readonly_folder():
+    """ removing a package that contains a read-only directory must not fail with a
+    permission error
+    https://github.com/conan-io/conan/issues/20241
+    """
+    conanfile = textwrap.dedent("""
+        import os, stat
+        from conan import ConanFile
+        from conan.tools.files import save
+
+        class Pkg(ConanFile):
+            name = "pkg"
+            version = "1.0"
+            def package(self):
+                d = os.path.join(self.package_folder, "readonlydir")
+                save(self, os.path.join(d, "inside.txt"), "inside!!")
+                os.chmod(d, stat.S_IREAD | stat.S_IEXEC)
+        """)
+    client = TestClient()
+    client.save({"conanfile.py": conanfile})
+    client.run("create .")
+    pkg_layout = client.created_layout()
+    client.run("remove pkg/1.0 -c")
+    assert not os.path.exists(pkg_layout.base_folder)
 
 
 class TestRemovePackageRevisions:

--- a/test/unittests/util/files/test_rmdir.py
+++ b/test/unittests/util/files/test_rmdir.py
@@ -1,0 +1,23 @@
+import os
+import platform
+import stat
+
+import pytest
+
+from conan.test.utils.test_files import temp_folder
+from conan.internal.util.files import rmdir, save
+
+
+@pytest.mark.skipif(platform.system() != "Windows",
+                    reason="The read-only directory attribute is only relevant on Windows")
+def test_rmdir_readonly_subfolder():
+    """ rmdir() must be able to remove a folder that contains a read-only sub-directory
+    https://github.com/conan-io/conan/issues/20241
+    """
+    folder = temp_folder()
+    readonly_dir = os.path.join(folder, "readonlydir")
+    save(os.path.join(readonly_dir, "inside.txt"), "content")
+    os.chmod(readonly_dir, stat.S_IREAD | stat.S_IEXEC)
+
+    rmdir(folder)
+    assert not os.path.exists(folder)

--- a/test/unittests/util/files/test_rmdir.py
+++ b/test/unittests/util/files/test_rmdir.py
@@ -1,17 +1,15 @@
 import os
-import platform
 import stat
-
-import pytest
 
 from conan.test.utils.test_files import temp_folder
 from conan.internal.util.files import rmdir, save
 
 
-@pytest.mark.skipif(platform.system() != "Windows",
-                    reason="The read-only directory attribute is only relevant on Windows")
 def test_rmdir_readonly_subfolder():
-    """ rmdir() must be able to remove a folder that contains a read-only sub-directory
+    """ rmdir() must be able to remove a folder that contains a read-only sub-directory.
+    On Windows this fails because the sub-directory's own read-only attribute blocks its
+    removal; on POSIX it fails because removing an entry from a directory requires write
+    permission on that directory, unrelated to the entry's own permissions.
     https://github.com/conan-io/conan/issues/20241
     """
     folder = temp_folder()


### PR DESCRIPTION
Changelog: Bugfix: Fix internal ``rmdir`` function to not fail for Windows folders with read-only permissions (``os.access(path, os.W_OK)`` always return True for folders in Windows).
Docs: Omit
