### PR TITLE
[POC][CMakeConfigDeps] Multi-CONFIG CMake files mechanism

### DIFF
--- a/conan/internal/model/cpp_info.py
+++ b/conan/internal/model/cpp_info.py
@@ -797,9 +797,13 @@ class CppInfo:
             opened = new_open
         return result
 
-    def aggregated_components(self):
+    def aggregated_components(self, components=None):
         """Aggregates all the components as global values, returning a new CppInfo
         Used by many generators to obtain a unified, aggregated view of all components
+
+        :param components: if not ``None``, restrict the aggregation to only these
+         component names (used to compute the aggregated view of a subset of components,
+         e.g. the ones grouped in a single CMake config file).
         """
         # This method had caching before, but after a ``--deployer``, the package changes
         # location, and this caching was invalid, still pointing to the Conan cache instead of
@@ -807,7 +811,9 @@ class CppInfo:
         if self.has_components:
             result = _Component()
             # Reversed to make more dependant first
-            for component in reversed(self.get_sorted_components().values()):
+            for cmp_name, component in reversed(self.get_sorted_components().items()):
+                if components is not None and cmp_name not in components:
+                    continue
                 result.merge(component)
             # NOTE: The properties are not aggregated because they might refer only to the
             # component like "cmake_target_name" describing the target name FOR THE component

--- a/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
+++ b/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
@@ -120,13 +120,12 @@ class CMakeConfigDeps:
 
             if require.direct:
                 direct_deps.append((require, dep))
-            full_cpp_info = dep.cpp_info.deduce_full_cpp_info(dep)
             # A dependency might be split into several CMake config files (root +
             # cmake_file_name dict groups). Shared files (config, config-version, targets)
             # have a context-independent filename. When the same package is both requires and
             # tool_requires, keep the host-context version so legacy variables (<pkg>_LIBRARIES,
             # ...) are preserved.
-            for cmake_filename, cmake_file_info in self.get_cmake_filenames_info(dep, full_cpp_info).items():
+            for cmake_filename, cmake_file_info in self.get_cmake_filenames_info(dep).items():
                 context_gen = _CMakeContextGenerator(self, require, dep, cmake_filename, cmake_file_info)
                 config_version_filename, config_version_context = context_gen.get_config_version_info()
                 if config_version_filename not in ret:
@@ -210,7 +209,7 @@ class CMakeConfigDeps:
             if comp is not None:
                 return comp.get_property(prop, check_type=check_type)
 
-    def get_cmake_filenames_info(self, dep, full_cpp_info=None):
+    def get_cmake_filenames_info(self, dep):
         """
         Get the name of the files for the find_package(XXX) for the root and the rest of
         the components.
@@ -228,11 +227,11 @@ class CMakeConfigDeps:
               still generate a root config file named after the recipe.
         """
         ret = {}
-        components = full_cpp_info.components if full_cpp_info else dep.cpp_info.components
-        left_components_in_dep = list(components.keys())
-        default_components = dep.cpp_info.default_components or []
         cmake_file_name = self.get_property("cmake_file_name", dep)
-        if isinstance(cmake_file_name, dict):
+        components = dep.cpp_info.deduce_full_cpp_info(dep).components
+        if isinstance(cmake_file_name, dict):  # multiple CMake config files way
+            left_components_in_dep = list(components.keys())
+            default_components = dep.cpp_info.default_components or []
             for filename, file_info in cmake_file_name.items():
                 cmps_per_file = file_info.get("components", [])
                 for name in cmps_per_file:
@@ -246,18 +245,16 @@ class CMakeConfigDeps:
                     else:
                         left_components_in_dep.remove(name)
                 ret[filename] = {"components": cmps_per_file,
-                                 "full_cpp_info": full_cpp_info,
                                  "properties": file_info.get("properties", {}),
                                  "is_root": False}
             root_filename = dep.ref.name
-        else:
-            root_filename = cmake_file_name or dep.ref.name
-        # Root filename (if needed)
-        if not dep.cpp_info.has_components or left_components_in_dep:
-            if root_filename not in ret:
+            if left_components_in_dep and root_filename not in ret:
                 ret[root_filename] = {"components": left_components_in_dep,
-                                      "full_cpp_info": full_cpp_info,
                                       "is_root": True}
+        else:  # cmake_file_name is a string and behaves as usual
+            root_filename = cmake_file_name or dep.ref.name
+            ret[root_filename] = {"components": list(components.keys()),
+                                  "is_root": True}
         return ret
 
 
@@ -269,14 +266,14 @@ class _CMakeContextGenerator:
         self.consumer_conanfile = cmakedeps._conanfile
         self.require = require
         self.dep = dep
-        self.full_cpp_info = cmake_file_info.get("full_cpp_info") or dep.cpp_info.deduce_full_cpp_info(dep)
+        self.full_cpp_info = dep.cpp_info.deduce_full_cpp_info(dep)
         self.base_filename = cmake_filename
         # Whether this is the "root" config file for the dependency (as opposed to one of the
         # per-group files declared through the ``cmake_file_name`` dict property), and
         # which components (or leftover components, for the root file) it covers.
         self.is_root = cmake_file_info["is_root"]
         self.file_components = cmake_file_info["components"]
-        self.custom_props = cmake_file_info.get("properties")
+        self.custom_props = cmake_file_info.get("properties", {})
         self.is_build_context = require.build
         # Prepared to filter transitive tool-requires with visible=True
         self.transitive_reqs = get_transitive_requires(self.consumer_conanfile, dep)

--- a/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
+++ b/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
@@ -831,39 +831,6 @@ class _PathGenerator:
             paths[req.ref.name] = cppinfo_dirs
         return [d for dirs in paths.values() for d in dirs]
 
-    def _get_cmake_extra_variants(self, dep, cmake_filename, cmake_file_info):
-        custom_props = cmake_file_info.get("properties")
-        extra_variants = self._cmakedeps.get_property("cmake_file_name_variants", dep,
-                                                       custom_props=custom_props,
-                                                       check_type=list) or []
-        lowercase_variants = {variant.lower() for variant in extra_variants}
-        if len(lowercase_variants) > 1:
-            raise ConanException(
-                f"'{dep.ref}' 'cmake_file_name_variants' property contains different words. "
-                "They should be the same with different upper/lower cases only.")
-        if lowercase_variants:
-            if cmake_filename.lower() not in lowercase_variants:
-                cmake_file_name_prop = self._cmakedeps.get_property(
-                    "cmake_file_name", dep, custom_props=custom_props)
-                is_cmake_filename_defined = (
-                    isinstance(cmake_file_name_prop, str)
-                    or (isinstance(cmake_file_name_prop, dict)
-                        and cmake_filename in cmake_file_name_prop)
-                )
-                if is_cmake_filename_defined:
-                    extra_variants = []
-                    msg = (f"'{dep.ref}' 'cmake_file_name_variants' property contains names "
-                           f"with different casings than the defined name '{cmake_filename}'. "
-                           f"The specified 'cmake_file_name'='{cmake_filename}' property "
-                           f"will be used as the only name and the variants will be ignored.")
-                    self._conanfile.output.warning(msg)
-                else:
-                    msg = (f"'{dep.ref}' 'cmake_file_name_variants' property contains entries "
-                           f"that differ from the default 'cmake_file_name'='{cmake_filename}'. "
-                           f"They should be the same with different upper/lower cases only.")
-                    raise ConanException(msg)
-        return extra_variants
-
     def generate(self):
         template = textwrap.dedent("""\
         set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
@@ -926,8 +893,35 @@ class _PathGenerator:
             # A dependency might be split into several CMake config files (root +
             # cmake_file_name dict groups), each one needs its own _DIR entry.
             for cmake_filename, cmake_file_info in self._cmakedeps.get_cmake_filenames_info(dep).items():
-                pkg_names = set([cmake_filename] +
-                                self._get_cmake_extra_variants(dep, cmake_filename, cmake_file_info))
+                extra_variants = self._cmakedeps.get_property("cmake_file_name_variants", dep,
+                                                              custom_props=cmake_file_info.get("properties"),
+                                                              check_type=list) or []
+                lowercase_variants = {variant.lower() for variant in extra_variants}
+                if len(lowercase_variants) > 1:
+                    raise ConanException(f"'{dep.ref}' 'cmake_file_name_variants' property contains different words. "
+                                         "They should be the same with different upper/lower cases only.")
+                if lowercase_variants:
+                    if cmake_filename.lower() not in lowercase_variants:
+                        cmake_file_name_prop = self._cmakedeps.get_property(
+                            "cmake_file_name", dep, custom_props=cmake_file_info.get("properties"))
+                        is_cmake_filename_defined = (
+                            isinstance(cmake_file_name_prop, str)
+                            or (isinstance(cmake_file_name_prop, dict)
+                                and cmake_filename in cmake_file_name_prop)
+                        )
+                        if is_cmake_filename_defined:
+                            extra_variants = []
+                            msg = (f"'{dep.ref}' 'cmake_file_name_variants' property contains names "
+                                   f"with different casings than the defined name '{cmake_filename}'. "
+                                   f"The specified 'cmake_file_name'='{cmake_filename}' property "
+                                   f"will be used as the only name and the variants will be ignored.")
+                            self._conanfile.output.warning(msg)
+                        else:
+                            msg = (f"'{dep.ref}' 'cmake_file_name_variants' property contains entries "
+                                   f"that differ from the default 'cmake_file_name'='{cmake_filename}'. "
+                                   f"They should be the same with different upper/lower cases only.")
+                            raise ConanException(msg)
+                pkg_names = set([cmake_filename] + extra_variants)
                 # https://cmake.org/cmake/help/v3.22/guide/using-dependencies/index.html
                 if cmake_find_mode == FIND_MODE_NONE:
                     cps = glob.glob(os.path.join(dep.package_folder, f"**/{cmake_filename}.cps"),

--- a/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
+++ b/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
@@ -521,7 +521,6 @@ class _CMakeContextGenerator:
             components_per_file = self._ctx.file_components
             if full_cpp_info.has_components:
                 for name in components_per_file:
-                    component = full_cpp_info.components[name]
                     requires[name] = self._get_component_requires(
                         full_cpp_info.components[name], full_cpp_info.components)
             else:
@@ -632,7 +631,6 @@ class _CMakeContextGenerator:
             if cpp_info.has_components:
                 # Only the components belonging to this particular CMake config file
                 for name in self._ctx.file_components:
-                    component = cpp_info.components[name]
                     target_name = self._ctx.get_cmake_target_name(comp_name=name)
                     target = self._get_cmake_lib(cpp_info.components[name], cpp_info_requires,
                                                  comp_name=name)

--- a/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
+++ b/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
@@ -197,14 +197,52 @@ class CMakeConfigDeps:
             if comp is not None:
                 return comp.get_property(prop, check_type=check_type)
 
-    def get_cmake_filename(self, dep):
-        # Get the name of the file for the find_package(XXX)
-        # This is used by CMakeDeps to determine:
-        # - The filename to generate (XXX-config.cmake or FindXXX.cmake)
-        # - The name of the defined XXX_DIR variables
-        # - The name of transitive dependencies for calls to find_dependency
-        ret = self.get_property("cmake_file_name", dep)
-        return ret or dep.ref.name
+    def get_cmake_filenames_info(self, dep, full_cpp_info=None):
+        """
+        Get the name of the files for the find_package(XXX) for the root and the rest of
+        the components.
+        This is used by CMakeConfigDeps to determine:
+            - The filename to generate (XXX-config.cmake or FindXXX.cmake)
+            - The name of the defined XXX_DIR variables
+            - The name of transitive dependencies for calls to find_dependency
+
+        This method creates a map for the root/components belonging to each XXX-config file.
+        It also reads the properties:
+            - cmake_file_component_names: dict mapping each CMake package file name to a dict with
+              ``components`` (list of component names) and optional ``properties`` (per-file
+              overrides for CMakeConfigDeps global properties).
+            - cmake_file_name: name for the root config file.
+        """
+        ret = {}
+        components = full_cpp_info.components if full_cpp_info else dep.cpp_info.components
+        left_components_in_dep = list(components.keys())
+        default_components = dep.cpp_info.default_components or []
+        components_file_info = self.get_property("cmake_file_component_names", dep) or {}
+        for filename, global_cpp_info in components_file_info.items():
+            cmps_per_file = global_cpp_info.get("components", [])
+            for name in cmps_per_file:
+                if name in default_components:
+                    raise ConanException(f"The default component '{name}' is defined in "
+                                         f"another CMake Config file. Check the "
+                                         f"'cmake_file_component_names' property.")
+                elif name not in left_components_in_dep:
+                    raise ConanException(f"Component '{name}' does not exist. Check the "
+                                         f"'cmake_file_component_names' property definition.")
+                else:
+                    left_components_in_dep.remove(name)  # total of components within the root Config file
+            ret[filename] = {"components": cmps_per_file,
+                             "full_cpp_info": full_cpp_info,
+                             "properties": global_cpp_info.get("properties", {}),
+                             "is_root": False}
+        # Root filename (if needed)
+        if not dep.cpp_info.has_components or left_components_in_dep:
+            # Then let's add the root global cmake_file_name
+            root_filename = self.get_property("cmake_file_name", dep) or dep.ref.name
+            if root_filename not in ret:
+                ret[root_filename] = {"components": left_components_in_dep,
+                                      "full_cpp_info": full_cpp_info,
+                                      "is_root": True}
+        return ret
 
 
 class _CMakeContextGenerator:

--- a/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
+++ b/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
@@ -227,7 +227,7 @@ class CMakeConfigDeps:
         Get the name of the files for the find_package(XXX) for the root and the rest of
         the components.
         This is used by CMakeConfigDeps to determine:
-            - The filename to generate (XXX-config.cmake or FindXXX.cmake)
+            - The filename to generate (XXX-config.cmake)
             - The name of the defined XXX_DIR variables
             - The name of transitive dependencies for calls to find_dependency
 
@@ -235,43 +235,48 @@ class CMakeConfigDeps:
         It reads two properties:
             - ``cmake_file_names``: a dict mapping each CMake package file name to a dict with
               ``components`` (list of component names) and optional ``properties`` (per-file
-              overrides for CMakeConfigDeps global properties). Remaining components (if any)
-              still generate a root config file named after the recipe.
+              overrides for CMakeConfigDeps global properties). Every component must belong to
+              one of those files, and no root config file named after the recipe is generated.
             - ``cmake_file_name``: a string with the name for the root config file
               (default: recipe name). If both properties are set, ``cmake_file_names``
               takes precedence and ``cmake_file_name`` is ignored.
         """
         ret = {}
         cmake_file_names = self.get_property("cmake_file_names", dep)
-        components = self._get_full_cpp_info(dep).components
+        full_cpp_info = self._get_full_cpp_info(dep)
+        components = list(full_cpp_info.components.keys())
         if cmake_file_names is not None:  # multiple CMake config files way
             if not isinstance(cmake_file_names, dict):
                 raise ConanException("cmake_file_names property must be a dict")
-            left_components_in_dep = list(components.keys())
-            default_components = dep.cpp_info.default_components or []
             for filename, file_info in cmake_file_names.items():
-                cmps_per_file = file_info.get("components", [])
-                for name in cmps_per_file:
-                    if name in default_components:
-                        raise ConanException(f"The default component '{name}' is defined in "
-                                             f"another CMake Config file. Check the "
-                                             f"'cmake_file_names' property.")
-                    elif name not in left_components_in_dep:
+                cmps_per_file = []
+                for name in file_info.get("components", []):
+                    if name not in components:
                         raise ConanException(f"Component '{name}' does not exist. Check the "
                                              f"'cmake_file_names' property definition.")
-                    else:
-                        left_components_in_dep.remove(name)
+                    components.remove(name)
+                    cmps_per_file.append(name)
+                    # A component with several libs was expanded by deduce_full_cpp_info() into
+                    # internal per-lib components. They belong to the same file as their parent.
+                    # The declared (not deduced) libs are needed, the parent ones were emptied.
+                    declared_libs = dep.cpp_info.components[name].libs or []
+                    if len(declared_libs) > 1:
+                        # FIXME: alternative to hardcoded "_{name}_{lib}"? check deduce_full_cpp_info
+                        for c in [f"_{name}_{lib}" for lib in declared_libs]:
+                            cmps_per_file.append(c)
+                            components.remove(c)
                 ret[filename] = {"components": cmps_per_file,
                                  "properties": file_info.get("properties", {}),
                                  "is_root": False}
-            root_filename = dep.ref.name
-            if left_components_in_dep and root_filename not in ret:
-                ret[root_filename] = {"components": left_components_in_dep,
-                                      "is_root": True}
+            if components:
+                missing = "', '".join(components)
+                raise ConanException(f"{dep}: components '{missing}' are not defined in any "
+                                     f"CMake config file. Check the 'cmake_file_names' "
+                                     f"property definition.")
         else:  # Read cmake_file_name as usual
             cmake_file_name = self.get_property("cmake_file_name", dep)
             root_filename = cmake_file_name or dep.ref.name
-            ret[root_filename] = {"components": list(components.keys()),
+            ret[root_filename] = {"components": components,
                                   "is_root": True}
         return ret
 
@@ -288,7 +293,7 @@ class _CMakeContextGenerator:
         self.base_filename = cmake_filename
         # Whether this is the "root" config file for the dependency (as opposed to one of the
         # per-group files declared through the ``cmake_file_names`` property), and
-        # which components (or leftover components, for the root file) it covers.
+        # which components it covers.
         self.is_root = cmake_file_info["is_root"]
         self.file_components = cmake_file_info["components"]
         self.custom_props = cmake_file_info.get("properties", {})
@@ -734,20 +739,20 @@ class _CMakeContextGenerator:
             on all other library targets (not exes)
             It will not be added if there exists already a pkgname::pkgname target
             (Or an alias exists).
+            Only the root config file gets this aggregated target. Packages split into several
+            config files with ``cmake_file_names`` don't have a root file, so consumers must
+            always link the specific component targets.
             """
+            if not self._ctx.is_root:
+                return
             root_target_name = self._ctx.get_cmake_target_name()
             cpp_info = self._ctx.full_cpp_info
             # TODO: What if an exe target is called like the pkg_name::pkg_name
-            # Only the root config file gets the aggregated pkgname::pkgname interface target;
-            # a component group declared through cmake_file_names does not.
-            if self._ctx.is_root and libs and root_target_name not in libs:
+            if libs and root_target_name not in libs:
                 # Add a generic interface target for the package depending on the others
                 if cpp_info.default_components is not None:
                     all_requires = {}
-                    file_components = set(self._ctx.file_components)
                     for defaultc in cpp_info.default_components:
-                        if defaultc not in file_components:
-                            continue
                         comp_name = self._ctx.get_cmake_target_name(comp_name=defaultc)
                         link_feature = self._ctx.get_property("cmake_link_feature",
                                                          comp_name=defaultc)

--- a/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
+++ b/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
@@ -563,10 +563,8 @@ class _CMakeContextGenerator:
                     dep_target = self._ctx.get_cmake_target_name(comp_name=required_comp)
                     link_feature = self._ctx.get_property("cmake_link_feature",
                                                      comp_name=required_comp)
-                    link = not (pkg_type is PackageType.SHARED and
-                               dep_comp.type is PackageType.SHARED)
                     result[dep_target] = {
-                        "link": link,
+                        "link": True,  # Components of same package have PUBLIC dependency
                         "link_feature": link_feature,
                         "dependency": (dep, required_comp)
                     }

--- a/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
+++ b/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
@@ -122,7 +122,7 @@ class CMakeConfigDeps:
                 direct_deps.append((require, dep))
             full_cpp_info = dep.cpp_info.deduce_full_cpp_info(dep)
             # A dependency might be split into several CMake config files (root +
-            # cmake_file_component_names groups). Shared files (config, config-version, targets)
+            # cmake_file_name dict groups). Shared files (config, config-version, targets)
             # have a context-independent filename. When the same package is both requires and
             # tool_requires, keep the host-context version so legacy variables (<pkg>_LIBRARIES,
             # ...) are preserved.
@@ -220,37 +220,40 @@ class CMakeConfigDeps:
             - The name of transitive dependencies for calls to find_dependency
 
         This method creates a map for the root/components belonging to each XXX-config file.
-        It also reads the properties:
-            - cmake_file_component_names: dict mapping each CMake package file name to a dict with
+        It also reads the ``cmake_file_name`` property, which can be:
+            - a string: name for the root config file (default: recipe name).
+            - a dict mapping each CMake package file name to a dict with
               ``components`` (list of component names) and optional ``properties`` (per-file
-              overrides for CMakeConfigDeps global properties).
-            - cmake_file_name: name for the root config file.
+              overrides for CMakeConfigDeps global properties). Remaining components (if any)
+              still generate a root config file named after the recipe.
         """
         ret = {}
         components = full_cpp_info.components if full_cpp_info else dep.cpp_info.components
         left_components_in_dep = list(components.keys())
         default_components = dep.cpp_info.default_components or []
-        components_file_info = self.get_property("cmake_file_component_names", dep) or {}
-        for filename, global_cpp_info in components_file_info.items():
-            cmps_per_file = global_cpp_info.get("components", [])
-            for name in cmps_per_file:
-                if name in default_components:
-                    raise ConanException(f"The default component '{name}' is defined in "
-                                         f"another CMake Config file. Check the "
-                                         f"'cmake_file_component_names' property.")
-                elif name not in left_components_in_dep:
-                    raise ConanException(f"Component '{name}' does not exist. Check the "
-                                         f"'cmake_file_component_names' property definition.")
-                else:
-                    left_components_in_dep.remove(name)  # total of components within the root Config file
-            ret[filename] = {"components": cmps_per_file,
-                             "full_cpp_info": full_cpp_info,
-                             "properties": global_cpp_info.get("properties", {}),
-                             "is_root": False}
+        cmake_file_name = self.get_property("cmake_file_name", dep)
+        if isinstance(cmake_file_name, dict):
+            for filename, file_info in cmake_file_name.items():
+                cmps_per_file = file_info.get("components", [])
+                for name in cmps_per_file:
+                    if name in default_components:
+                        raise ConanException(f"The default component '{name}' is defined in "
+                                             f"another CMake Config file. Check the "
+                                             f"'cmake_file_name' property.")
+                    elif name not in left_components_in_dep:
+                        raise ConanException(f"Component '{name}' does not exist. Check the "
+                                             f"'cmake_file_name' property definition.")
+                    else:
+                        left_components_in_dep.remove(name)
+                ret[filename] = {"components": cmps_per_file,
+                                 "full_cpp_info": full_cpp_info,
+                                 "properties": file_info.get("properties", {}),
+                                 "is_root": False}
+            root_filename = dep.ref.name
+        else:
+            root_filename = cmake_file_name or dep.ref.name
         # Root filename (if needed)
         if not dep.cpp_info.has_components or left_components_in_dep:
-            # Then let's add the root global cmake_file_name
-            root_filename = self.get_property("cmake_file_name", dep) or dep.ref.name
             if root_filename not in ret:
                 ret[root_filename] = {"components": left_components_in_dep,
                                       "full_cpp_info": full_cpp_info,
@@ -269,7 +272,7 @@ class _CMakeContextGenerator:
         self.full_cpp_info = cmake_file_info.get("full_cpp_info") or dep.cpp_info.deduce_full_cpp_info(dep)
         self.base_filename = cmake_filename
         # Whether this is the "root" config file for the dependency (as opposed to one of the
-        # per-group files declared through the ``cmake_file_component_names`` property), and
+        # per-group files declared through the ``cmake_file_name`` dict property), and
         # which components (or leftover components, for the root file) it covers.
         self.is_root = cmake_file_info["is_root"]
         self.file_components = cmake_file_info["components"]
@@ -289,7 +292,7 @@ class _CMakeContextGenerator:
 
     def get_property(self, prop, dep=None, comp_name=None, check_type=None):
         target_dep = dep if dep is not None else self.dep
-        # Per-file property overrides (the "properties" entry of cmake_file_component_names)
+        # Per-file property overrides (the "properties" entry of the cmake_file_name dict)
         # only apply to the dependency's own, package-level properties, not to other deps
         # or to a specific component.
         custom_props = self.custom_props if (target_dep is self.dep and comp_name is None) else None
@@ -359,7 +362,7 @@ class _CMakeContextGenerator:
                 parsed_extra_variables[key] = parse_extra_variable("cmake_extra_variables",
                                                                    key, value)
 
-            # Component groups declared through cmake_file_component_names don't advertise
+            # Component groups declared through cmake_file_name (dict) don't advertise
             # find_package(XXX COMPONENTS ...): that mechanism only applies to the root config.
             cmake_components = (self._ctx.get_property("cmake_components", check_type=list)
                                 if self._ctx.is_root else "")
@@ -490,7 +493,7 @@ class _CMakeContextGenerator:
             The cmake filename(s) of ``dep`` that need a find_dependency() call to satisfy a
             requirement pointing to ``comp`` (or to the default/root interface target when
             ``comp`` is ``None``). A dependency might be split into several CMake config files
-            through cmake_file_component_names, so the specific component determines which of
+            through cmake_file_name (dict), so the specific component determines which of
             those files is the right one (the root file, for the default interface target).
             """
             filenames = []
@@ -724,7 +727,7 @@ class _CMakeContextGenerator:
             cpp_info = self._ctx.full_cpp_info
             # TODO: What if an exe target is called like the pkg_name::pkg_name
             # Only the root config file gets the aggregated pkgname::pkgname interface target;
-            # a component group declared through cmake_file_component_names does not.
+            # a component group declared through cmake_file_name (dict) does not.
             if self._ctx.is_root and libs and root_target_name not in libs:
                 # Add a generic interface target for the package depending on the others
                 if cpp_info.default_components is not None:
@@ -843,8 +846,13 @@ class _PathGenerator:
                 "They should be the same with different upper/lower cases only.")
         if lowercase_variants:
             if cmake_filename.lower() not in lowercase_variants:
-                is_cmake_filename_defined = self._cmakedeps.get_property(
-                    "cmake_file_name", dep, custom_props=custom_props) is not None
+                cmake_file_name_prop = self._cmakedeps.get_property(
+                    "cmake_file_name", dep, custom_props=custom_props)
+                is_cmake_filename_defined = (
+                    isinstance(cmake_file_name_prop, str)
+                    or (isinstance(cmake_file_name_prop, dict)
+                        and cmake_filename in cmake_file_name_prop)
+                )
                 if is_cmake_filename_defined:
                     extra_variants = []
                     msg = (f"'{dep.ref}' 'cmake_file_name_variants' property contains names "
@@ -919,7 +927,7 @@ class _PathGenerator:
             cmake_find_mode = cmake_find_mode.lower()
 
             # A dependency might be split into several CMake config files (root +
-            # cmake_file_component_names groups), each one needs its own _DIR entry.
+            # cmake_file_name dict groups), each one needs its own _DIR entry.
             for cmake_filename, cmake_file_info in self._cmakedeps.get_cmake_filenames_info(dep).items():
                 pkg_names = set([cmake_filename] +
                                 self._get_cmake_extra_variants(dep, cmake_filename, cmake_file_info))

--- a/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
+++ b/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
@@ -120,25 +120,29 @@ class CMakeConfigDeps:
 
             if require.direct:
                 direct_deps.append((require, dep))
-            # Shared files (config, config-version, targets) have a context-independent
-            # filename. When the same package is both requires and tool_requires, keep the
-            # host-context version so legacy variables (<pkg>_LIBRARIES, ...) are preserved.
-            context_gen = _CMakeContextGenerator(self, require, dep)
-            config_version_filename, config_version_context = context_gen.get_config_version_info()
-            if config_version_filename not in ret:
-                config_version = ConfigVersionTemplate2(config_version_filename, config_version_context)
-                ret[config_version.filename] = config_version.content()
-            config_filename, config_context = context_gen.get_config_info()
-            if config_filename not in ret:
-                config = ConfigTemplate2(config_filename, config_context)
-                ret[config.filename] = config.content()
-            targets_filename, targets_context = context_gen.get_targets_info()
-            if targets_filename not in ret:
-                targets = TargetsTemplate2(targets_filename, targets_context)
-                ret[targets.filename] = targets.content()
-            target_filename, target_context = context_gen.get_target_configuration_info()
-            target_configuration = TargetConfigurationTemplate2(target_filename, target_context)
-            ret[target_configuration.filename] = target_configuration.content()
+            full_cpp_info = dep.cpp_info.deduce_full_cpp_info(dep)
+            # A dependency might be split into several CMake config files (root +
+            # cmake_file_component_names groups). Shared files (config, config-version, targets)
+            # have a context-independent filename. When the same package is both requires and
+            # tool_requires, keep the host-context version so legacy variables (<pkg>_LIBRARIES,
+            # ...) are preserved.
+            for cmake_filename, cmake_file_info in self.get_cmake_filenames_info(dep, full_cpp_info).items():
+                context_gen = _CMakeContextGenerator(self, require, dep, cmake_filename, cmake_file_info)
+                config_version_filename, config_version_context = context_gen.get_config_version_info()
+                if config_version_filename not in ret:
+                    config_version = ConfigVersionTemplate2(config_version_filename, config_version_context)
+                    ret[config_version.filename] = config_version.content()
+                config_filename, config_context = context_gen.get_config_info()
+                if config_filename not in ret:
+                    config = ConfigTemplate2(config_filename, config_context)
+                    ret[config.filename] = config.content()
+                targets_filename, targets_context = context_gen.get_targets_info()
+                if targets_filename not in ret:
+                    targets = TargetsTemplate2(targets_filename, targets_context)
+                    ret[targets.filename] = targets.content()
+                target_filename, target_context = context_gen.get_target_configuration_info()
+                target_configuration = TargetConfigurationTemplate2(target_filename, target_context)
+                ret[target_configuration.filename] = target_configuration.content()
 
         self._print_help(direct_deps)
         return ret
@@ -150,7 +154,8 @@ class CMakeConfigDeps:
             for (require, dep) in direct_deps:
                 note = " # Optional. This is a tool-require, can't link its targets" \
                     if require.build else ""
-                msg.append(f"    find_package({self.get_cmake_filename(dep)}){note}")
+                for cmake_filename in self.get_cmake_filenames_info(dep).keys():
+                    msg.append(f"    find_package({cmake_filename}){note}")
                 if not require.build and not dep.cpp_info.exe:
                     target_name = self.get_property("cmake_target_name", dep)
                     link_targets.append(target_name or f"{dep.ref.name}::{dep.ref.name}")
@@ -174,7 +179,17 @@ class CMakeConfigDeps:
         build_suffix = "&build" if build_context else ""
         self._properties.setdefault(f"{dep}{build_suffix}", {}).update({prop: value})
 
-    def get_property(self, prop, dep, comp_name=None, check_type=None):
+    def get_property(self, prop, dep, comp_name=None, check_type=None, custom_props=None):
+        def _check_type(v):
+            if check_type is not None and not isinstance(v, check_type):
+                raise ConanException(f'The expected type for {prop} is "{check_type.__name__}", '
+                                     f'but "{type(v).__name__}" was found')
+
+        if custom_props is not None and prop in custom_props:
+            value = custom_props[prop]
+            _check_type(value)
+            return value
+
         dep_name = dep.ref.name
         # Find the requirement that points to this "dep".
         # TODO: It would probably be more explicit if it was an argument as "dep", but to keep
@@ -184,9 +199,7 @@ class CMakeConfigDeps:
         dep_comp = f"{str(dep_name)}::{comp_name}" if comp_name else f"{str(dep_name)}"
         try:
             value = self._properties[f"{dep_comp}{build_suffix}"][prop]
-            if check_type is not None and not isinstance(value, check_type):
-                raise ConanException(f'The expected type for {prop} is "{check_type.__name__}", '
-                                     f'but "{type(value).__name__}" was found')
+            _check_type(value)
             return value
         except KeyError:
             # Here we are not using the cpp_info = deduce_cpp_info(dep) because it is not
@@ -248,13 +261,19 @@ class CMakeConfigDeps:
 class _CMakeContextGenerator:
     """Builds filenames and Jinja contexts for one dependency requirement."""
 
-    def __init__(self, cmakedeps, require, dep):
+    def __init__(self, cmakedeps, require, dep, cmake_filename, cmake_file_info):
         self.cmakedeps = cmakedeps
         self.consumer_conanfile = cmakedeps._conanfile
         self.require = require
         self.dep = dep
-        self.full_cpp_info = dep.cpp_info.deduce_full_cpp_info(dep)
-        self.base_filename = cmakedeps.get_cmake_filename(dep)
+        self.full_cpp_info = cmake_file_info.get("full_cpp_info") or dep.cpp_info.deduce_full_cpp_info(dep)
+        self.base_filename = cmake_filename
+        # Whether this is the "root" config file for the dependency (as opposed to one of the
+        # per-group files declared through the ``cmake_file_component_names`` property), and
+        # which components (or leftover components, for the root file) it covers.
+        self.is_root = cmake_file_info["is_root"]
+        self.file_components = cmake_file_info["components"]
+        self.custom_props = cmake_file_info.get("properties")
         self.is_build_context = require.build
         # Prepared to filter transitive tool-requires with visible=True
         self.transitive_reqs = get_transitive_requires(self.consumer_conanfile, dep)
@@ -266,15 +285,16 @@ class _CMakeContextGenerator:
         config_folder = f"_{self.config}" if self.config else ""
         build_suffix = "_BUILD" if self.is_build_context else ""
         self.pkg_folder = dep.package_folder.replace("\\", "/")
-        self.pkg_folder_var = f"{dep.ref.name}_PACKAGE_FOLDER{config_folder}{build_suffix}"
+        self.pkg_folder_var = f"{cmake_filename}_PACKAGE_FOLDER{config_folder}{build_suffix}"
 
     def get_property(self, prop, dep=None, comp_name=None, check_type=None):
-        return self.cmakedeps.get_property(prop, dep or self.dep, comp_name, check_type)
-
-    def get_cmake_filename(self, dep=None):
-        if dep is None:
-            return self.base_filename
-        return self.cmakedeps.get_cmake_filename(dep)
+        target_dep = dep if dep is not None else self.dep
+        # Per-file property overrides (the "properties" entry of cmake_file_component_names)
+        # only apply to the dependency's own, package-level properties, not to other deps
+        # or to a specific component.
+        custom_props = self.custom_props if (target_dep is self.dep and comp_name is None) else None
+        return self.cmakedeps.get_property(prop, target_dep, comp_name, check_type,
+                                           custom_props=custom_props)
 
     def get_cmake_target_name(self, dep=None, comp_name=None):
         dep = dep or self.dep
@@ -339,7 +359,10 @@ class _CMakeContextGenerator:
                 parsed_extra_variables[key] = parse_extra_variable("cmake_extra_variables",
                                                                    key, value)
 
-            cmake_components = self._ctx.get_property("cmake_components", check_type=list)
+            # Component groups declared through cmake_file_component_names don't advertise
+            # find_package(XXX COMPONENTS ...): that mechanism only applies to the root config.
+            cmake_components = (self._ctx.get_property("cmake_components", check_type=list)
+                                if self._ctx.is_root else "")
             if cmake_components is None:
                 cmake_components = []
                 # This assumes cmake_components is only defined with not multi .libs=[lib1, lib2]
@@ -381,9 +404,13 @@ class _CMakeContextGenerator:
                                               check_type=list) or []
             prefixes = [self._ctx.base_filename] + prefixes
 
+            version = (self._ctx.get_property("component_version") or self._ctx.dep.ref.version)
+
             include_dirs = definitions = libraries = None
             if not self._ctx.is_build_context:  # try_compile and legacy globals
-                aggregated_cppinfo = self._ctx.full_cpp_info.aggregated_components()
+                # Restrict to the components covered by this particular CMake config file
+                components = self._ctx.file_components
+                aggregated_cppinfo = self._ctx.full_cpp_info.aggregated_components(components=components)
                 # FIXME: Proper escaping of paths for CMake
                 incdirs = [relativize_path(i.replace("\\", "/"), self._ctx.consumer_conanfile,
                                            "${CMAKE_CURRENT_LIST_DIR}")
@@ -393,14 +420,14 @@ class _CMakeContextGenerator:
                                        for d in aggregated_cppinfo.defines)
                 libs = []
                 if self._ctx.full_cpp_info.has_components:
-                    for component in self._ctx.full_cpp_info.components.keys():
+                    for component in components:
                         libs.append(self._ctx.get_cmake_target_name(comp_name=component))
                 else:
                     libs.append(self._ctx.get_cmake_target_name())
                 libraries = " ".join(libs) if libs else ""
 
             return {"additional_variables_prefixes": prefixes,
-                    "version": self._ctx.dep.ref.version,
+                    "version": version,
                     "include_dirs": include_dirs,
                     "definitions": definitions,
                     "libraries": libraries}
@@ -413,7 +440,9 @@ class _CMakeContextGenerator:
 
         def info(self):
             f = self._ctx.base_filename
-            return f"{f}Targets.cmake", {"filename": f, "ref": str(self._ctx.dep.ref)}
+            ref = (str(self._ctx.dep.ref) if self._ctx.is_root
+                   else ",".join(self._ctx.file_components))
+            return f"{f}Targets.cmake", {"filename": f, "ref": ref}
 
     class _TargetConfiguration:
         """Filename + context for TargetConfigurationTemplate2."""
@@ -450,28 +479,59 @@ class _CMakeContextGenerator:
             filename = f"{self._ctx.base_filename}-Targets{build}-{config_name}.cmake"
             return filename, context
 
+        def _get_dep_find_mode(self, d):
+            find_mode = self._ctx.get_property("cmake_find_mode", d)
+            if find_mode is None:
+                find_mode = FIND_MODE_CONFIG
+            return "" if find_mode.lower() in (FIND_MODE_NONE, FIND_MODE_BOTH) else find_mode.upper()
+
+        def _resolve_dependency_filenames(self, dep, comp):
+            """
+            The cmake filename(s) of ``dep`` that need a find_dependency() call to satisfy a
+            requirement pointing to ``comp`` (or to the default/root interface target when
+            ``comp`` is ``None``). A dependency might be split into several CMake config files
+            through cmake_file_component_names, so the specific component determines which of
+            those files is the right one (the root file, for the default interface target).
+            """
+            filenames = []
+            for cmake_filename, file_info in self._ctx.cmakedeps.get_cmake_filenames_info(dep).items():
+                if comp is None:
+                    if file_info["is_root"]:
+                        filenames.append(cmake_filename)
+                elif comp in file_info["components"]:
+                    filenames.append(cmake_filename)
+            return filenames
+
         def _get_dependencies_and_requires(self):
-            transitive_reqs = self._ctx.transitive_reqs
-            def _get_dep_find_mode(d):
-                find_mode = self._ctx.get_property("cmake_find_mode", d)
-
-                if find_mode is None:
-                    find_mode = FIND_MODE_CONFIG
-
-                return "" if find_mode.lower() in (FIND_MODE_NONE, FIND_MODE_BOTH) else find_mode.upper()
-            dependencies = {self._ctx.get_cmake_filename(d): _get_dep_find_mode(d)
-                            for d in transitive_reqs.values()}
-            extra_mods = self._ctx.get_property("cmake_extra_dependencies", check_type=list) or []
-            dependencies.update({extra_mod: "" for extra_mod in extra_mods})
-
             requires = {}
             full_cpp_info = self._ctx.full_cpp_info
+            components_per_file = self._ctx.file_components
             if full_cpp_info.has_components:
-                for name, component in full_cpp_info.components.items():
+                for name in components_per_file:
+                    component = full_cpp_info.components[name]
                     requires[name] = self._get_component_requires(
                         component, full_cpp_info.components)
             else:
                 requires[None] = self._get_component_requires(full_cpp_info, None)
+
+            dependencies = {}
+            if self._ctx.is_root:
+                # Preserve the historic behavior: the root config file gets a find_dependency()
+                # for every transitive requirement, regardless of whether some specific
+                # component links to it or not.
+                for d in self._ctx.transitive_reqs.values():
+                    for cmake_filename in self._resolve_dependency_filenames(d, None):
+                        dependencies[cmake_filename] = self._get_dep_find_mode(d)
+            for comp_requires in requires.values():
+                for info in comp_requires.values():
+                    dep, comp = info["dependency"]
+                    if dep is self._ctx.dep and comp is not None and comp in components_per_file:
+                        continue  # Requirement resolved within this same CMake config file
+                    for cmake_filename in self._resolve_dependency_filenames(dep, comp):
+                        dependencies[cmake_filename] = self._get_dep_find_mode(dep)
+
+            extra_mods = self._ctx.get_property("cmake_extra_dependencies", check_type=list) or []
+            dependencies.update({extra_mod: "" for extra_mod in extra_mods})
             return dependencies, requires
 
         def _get_component_requires(self, info, components):
@@ -491,7 +551,8 @@ class _CMakeContextGenerator:
                     link_feature = self._ctx.get_property("cmake_link_feature", d)
                     result[dep_target] = {
                         "link": req.libs,
-                        "link_feature": link_feature
+                        "link_feature": link_feature,
+                        "dependency": (d, None)
                     }
                 return result
 
@@ -502,9 +563,12 @@ class _CMakeContextGenerator:
                     dep_target = self._ctx.get_cmake_target_name(comp_name=required_comp)
                     link_feature = self._ctx.get_property("cmake_link_feature",
                                                      comp_name=required_comp)
+                    link = not (pkg_type is PackageType.SHARED and
+                               dep_comp.type is PackageType.SHARED)
                     result[dep_target] = {
-                        "link": True,  # Components of same package have PUBLIC dependency
-                        "link_feature": link_feature
+                        "link": link,
+                        "link_feature": link_feature,
+                        "dependency": (dep, required_comp)
                     }
                 else:  # Different package
                     try:
@@ -546,7 +610,8 @@ class _CMakeContextGenerator:
 
                         result[dep_target] = {
                             "link": link,
-                            "link_feature": link_feature
+                            "link_feature": link_feature,
+                            "dependency": (transitive_dep, comp)
                         }
             return result
 
@@ -554,7 +619,9 @@ class _CMakeContextGenerator:
             libs = {}
             cpp_info = self._ctx.full_cpp_info
             if cpp_info.has_components:
-                for name, component in cpp_info.components.items():
+                # Only the components belonging to this particular CMake config file
+                for name in self._ctx.file_components:
+                    component = cpp_info.components[name]
                     target_name = self._ctx.get_cmake_target_name(comp_name=name)
                     target = self._get_cmake_lib(component, cpp_info_requires, comp_name=name)
                     if target is not None:
@@ -656,7 +723,9 @@ class _CMakeContextGenerator:
             root_target_name = self._ctx.get_cmake_target_name()
             cpp_info = self._ctx.full_cpp_info
             # TODO: What if an exe target is called like the pkg_name::pkg_name
-            if libs and root_target_name not in libs:
+            # Only the root config file gets the aggregated pkgname::pkgname interface target;
+            # a component group declared through cmake_file_component_names does not.
+            if self._ctx.is_root and libs and root_target_name not in libs:
                 # Add a generic interface target for the package depending on the others
                 if cpp_info.default_components is not None:
                     all_requires = {}
@@ -684,7 +753,8 @@ class _CMakeContextGenerator:
             exes = {}
             cpp_info = self._ctx.full_cpp_info
             if cpp_info.has_components:
-                for name, comp in cpp_info.components.items():
+                for name in self._ctx.file_components:
+                    comp = cpp_info.components[name]
                     if comp.exe or comp.type is PackageType.APP:
                         target = self._ctx.get_cmake_target_name(comp_name=name)
                         exes[target] = self._cmake_pkg_path(comp.location)
@@ -696,10 +766,10 @@ class _CMakeContextGenerator:
 
         def _validate_lib_aliases(self, libs):
             seen_aliases = set()
-            root_target_name = self._ctx.get_cmake_target_name()
+            root_target_name = self._ctx.get_cmake_target_name() if self._ctx.is_root else None
             for lib in libs.values():
                 for alias in lib.get("cmake_target_aliases", []):
-                    if alias == root_target_name:
+                    if root_target_name and alias == root_target_name:
                         raise ConanException(
                             f"Can't define an alias '{alias}' for the "
                             f"root target '{root_target_name}' in {self._ctx.dep}. "
@@ -761,6 +831,34 @@ class _PathGenerator:
             paths[req.ref.name] = cppinfo_dirs
         return [d for dirs in paths.values() for d in dirs]
 
+    def _get_cmake_extra_variants(self, dep, cmake_filename, cmake_file_info):
+        custom_props = cmake_file_info.get("properties")
+        extra_variants = self._cmakedeps.get_property("cmake_file_name_variants", dep,
+                                                       custom_props=custom_props,
+                                                       check_type=list) or []
+        lowercase_variants = {variant.lower() for variant in extra_variants}
+        if len(lowercase_variants) > 1:
+            raise ConanException(
+                f"'{dep.ref}' 'cmake_file_name_variants' property contains different words. "
+                "They should be the same with different upper/lower cases only.")
+        if lowercase_variants:
+            if cmake_filename.lower() not in lowercase_variants:
+                is_cmake_filename_defined = self._cmakedeps.get_property(
+                    "cmake_file_name", dep, custom_props=custom_props) is not None
+                if is_cmake_filename_defined:
+                    extra_variants = []
+                    msg = (f"'{dep.ref}' 'cmake_file_name_variants' property contains names "
+                           f"with different casings than the defined name '{cmake_filename}'. "
+                           f"The specified 'cmake_file_name'='{cmake_filename}' property "
+                           f"will be used as the only name and the variants will be ignored.")
+                    self._conanfile.output.warning(msg)
+                else:
+                    msg = (f"'{dep.ref}' 'cmake_file_name_variants' property contains entries "
+                           f"that differ from the default 'cmake_file_name'='{cmake_filename}'. "
+                           f"They should be the same with different upper/lower cases only.")
+                    raise ConanException(msg)
+        return extra_variants
+
     def generate(self):
         template = textwrap.dedent("""\
         set(CMAKE_FIND_PACKAGE_PREFER_CONFIG ON)
@@ -820,67 +918,49 @@ class _PathGenerator:
             cmake_find_mode = cmake_find_mode or FIND_MODE_CONFIG
             cmake_find_mode = cmake_find_mode.lower()
 
-            cmake_filename = self._cmakedeps.get_cmake_filename(dep)
-            extra_variants = self._cmakedeps.get_property("cmake_file_name_variants", dep,
-                                                          check_type=list) or []
-            lowercase_variants = {variant.lower() for variant in extra_variants}
-            if len(lowercase_variants) > 1:
-                raise ConanException(f"'{dep.ref}' 'cmake_file_name_variants' property contains different words. "
-                                     "They should be the same with different upper/lower cases only.")
-            if lowercase_variants:
-                if cmake_filename.lower() not in lowercase_variants:
-                    is_cmake_filename_defined = self._cmakedeps.get_property("cmake_file_name", dep) is not None
-                    if is_cmake_filename_defined:
-                        extra_variants = []
-                        msg = (f"'{dep.ref}' 'cmake_file_name_variants' property contains names "
-                               f"with different casings than the defined name '{cmake_filename}'. "
-                               f"The specified 'cmake_file_name'='{cmake_filename}' property "
-                               f"will be used as the only name and the variants will be ignored.")
-                        self._conanfile.output.warning(msg)
-                    else:
-                        msg = (f"'{dep.ref}' 'cmake_file_name_variants' property contains entries "
-                               f"that differ from the default 'cmake_file_name'='{cmake_filename}'. "
-                               f"They should be the same with different upper/lower cases only.")
-                        raise ConanException(msg)
-            pkg_names = set([cmake_filename] + extra_variants)
-            # https://cmake.org/cmake/help/v3.22/guide/using-dependencies/index.html
-            if cmake_find_mode == FIND_MODE_NONE:
-                cps = glob.glob(os.path.join(dep.package_folder, f"**/{cmake_filename}.cps"),
-                                recursive=True)
-                if cps:
-                    loc = os.path.dirname(os.path.join(dep.package_folder, cps[0]))
-                    loc = loc.replace("\\", "/")
-                    relative_path = relativize_path(loc, self._conanfile,
-                                                    "${CMAKE_CURRENT_LIST_DIR}")
-                    for pkg_name in pkg_names:
-                        pkg_paths[pkg_name] = relative_path
-                    continue
-
-                try:
-                    # This is irrespective of the components, it should be in the root cpp_info
-                    # To define the location of the pkg-config.cmake file
-                    build_dir = dep.cpp_info.builddirs[0]
-                except IndexError:
-                    build_dir = dep.package_folder
-                pkg_folder = build_dir.replace("\\", "/") if build_dir else None
-                if pkg_folder:
-                    if any(os.path.isfile(os.path.join(pkg_folder, f + ext)) for f in pkg_names
-                           for ext in ("-config.cmake", "Config.cmake")):
-                        relative_path = relativize_path(pkg_folder, self._conanfile,
+            # A dependency might be split into several CMake config files (root +
+            # cmake_file_component_names groups), each one needs its own _DIR entry.
+            for cmake_filename, cmake_file_info in self._cmakedeps.get_cmake_filenames_info(dep).items():
+                pkg_names = set([cmake_filename] +
+                                self._get_cmake_extra_variants(dep, cmake_filename, cmake_file_info))
+                # https://cmake.org/cmake/help/v3.22/guide/using-dependencies/index.html
+                if cmake_find_mode == FIND_MODE_NONE:
+                    cps = glob.glob(os.path.join(dep.package_folder, f"**/{cmake_filename}.cps"),
+                                    recursive=True)
+                    if cps:
+                        loc = os.path.dirname(os.path.join(dep.package_folder, cps[0]))
+                        loc = loc.replace("\\", "/")
+                        relative_path = relativize_path(loc, self._conanfile,
                                                         "${CMAKE_CURRENT_LIST_DIR}")
                         for pkg_name in pkg_names:
                             pkg_paths[pkg_name] = relative_path
+                        continue
 
-                    for pkg_name in pkg_names:
-                        existing_paths = pkg_paths_multi.setdefault(pkg_name, [])
-                        if pkg_folder not in existing_paths:
-                            existing_paths.append(pkg_folder)
-                continue
+                    try:
+                        # This is irrespective of the components, it should be in the root cpp_info
+                        # To define the location of the pkg-config.cmake file
+                        build_dir = dep.cpp_info.builddirs[0]
+                    except IndexError:
+                        build_dir = dep.package_folder
+                    pkg_folder = build_dir.replace("\\", "/") if build_dir else None
+                    if pkg_folder:
+                        if any(os.path.isfile(os.path.join(pkg_folder, f + ext)) for f in pkg_names
+                               for ext in ("-config.cmake", "Config.cmake")):
+                            relative_path = relativize_path(pkg_folder, self._conanfile,
+                                                            "${CMAKE_CURRENT_LIST_DIR}")
+                            for pkg_name in pkg_names:
+                                pkg_paths[pkg_name] = relative_path
 
-            # If CMakeDeps generated, the folder is this one
-            # content.append(f'set({pkg_name}_ROOT "{gen_folder}")')
-            for pkg_name in pkg_names:
-                pkg_paths[pkg_name] = "${CMAKE_CURRENT_LIST_DIR}"
+                        for pkg_name in pkg_names:
+                            existing_paths = pkg_paths_multi.setdefault(pkg_name, [])
+                            if pkg_folder not in existing_paths:
+                                existing_paths.append(pkg_folder)
+                    continue
+
+                # If CMakeDeps generated, the folder is this one
+                # content.append(f'set({pkg_name}_ROOT "{gen_folder}")')
+                for pkg_name in pkg_names:
+                    pkg_paths[pkg_name] = "${CMAKE_CURRENT_LIST_DIR}"
 
         # CMAKE_PROGRAM_PATH | CMAKE_LIBRARY_PATH | CMAKE_INCLUDE_PATH
         cmake_program_path = self._get_cmake_paths([(req, dep) for req, dep in all_reqs if req.direct], "bindirs")

--- a/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
+++ b/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
@@ -232,29 +232,33 @@ class CMakeConfigDeps:
             - The name of transitive dependencies for calls to find_dependency
 
         This method creates a map for the root/components belonging to each XXX-config file.
-        It also reads the ``cmake_file_name`` property, which can be:
-            - a string: name for the root config file (default: recipe name).
-            - a dict mapping each CMake package file name to a dict with
+        It reads two properties:
+            - ``cmake_file_names``: a dict mapping each CMake package file name to a dict with
               ``components`` (list of component names) and optional ``properties`` (per-file
               overrides for CMakeConfigDeps global properties). Remaining components (if any)
               still generate a root config file named after the recipe.
+            - ``cmake_file_name``: a string with the name for the root config file
+              (default: recipe name). If both properties are set, ``cmake_file_names``
+              takes precedence and ``cmake_file_name`` is ignored.
         """
         ret = {}
-        cmake_file_name = self.get_property("cmake_file_name", dep)
+        cmake_file_names = self.get_property("cmake_file_names", dep)
         components = self._get_full_cpp_info(dep).components
-        if isinstance(cmake_file_name, dict):  # multiple CMake config files way
+        if cmake_file_names is not None:  # multiple CMake config files way
+            if not isinstance(cmake_file_names, dict):
+                raise ConanException("cmake_file_names property must be a dict")
             left_components_in_dep = list(components.keys())
             default_components = dep.cpp_info.default_components or []
-            for filename, file_info in cmake_file_name.items():
+            for filename, file_info in cmake_file_names.items():
                 cmps_per_file = file_info.get("components", [])
                 for name in cmps_per_file:
                     if name in default_components:
                         raise ConanException(f"The default component '{name}' is defined in "
                                              f"another CMake Config file. Check the "
-                                             f"'cmake_file_name' property.")
+                                             f"'cmake_file_names' property.")
                     elif name not in left_components_in_dep:
                         raise ConanException(f"Component '{name}' does not exist. Check the "
-                                             f"'cmake_file_name' property definition.")
+                                             f"'cmake_file_names' property definition.")
                     else:
                         left_components_in_dep.remove(name)
                 ret[filename] = {"components": cmps_per_file,
@@ -264,7 +268,8 @@ class CMakeConfigDeps:
             if left_components_in_dep and root_filename not in ret:
                 ret[root_filename] = {"components": left_components_in_dep,
                                       "is_root": True}
-        else:  # cmake_file_name is a string and behaves as usual
+        else:  # Read cmake_file_name as usual
+            cmake_file_name = self.get_property("cmake_file_name", dep)
             root_filename = cmake_file_name or dep.ref.name
             ret[root_filename] = {"components": list(components.keys()),
                                   "is_root": True}
@@ -282,7 +287,7 @@ class _CMakeContextGenerator:
         self.full_cpp_info = full_cpp_info
         self.base_filename = cmake_filename
         # Whether this is the "root" config file for the dependency (as opposed to one of the
-        # per-group files declared through the ``cmake_file_name`` dict property), and
+        # per-group files declared through the ``cmake_file_names`` property), and
         # which components (or leftover components, for the root file) it covers.
         self.is_root = cmake_file_info["is_root"]
         self.file_components = cmake_file_info["components"]
@@ -302,7 +307,7 @@ class _CMakeContextGenerator:
 
     def get_property(self, prop, dep=None, comp_name=None, check_type=None):
         target_dep = dep if dep is not None else self.dep
-        # Per-file property overrides (the "properties" entry of the cmake_file_name dict)
+        # Per-file property overrides (the "properties" entry of the cmake_file_names dict)
         # only apply to the dependency's own, package-level properties, not to other deps
         # or to a specific component.
         custom_props = self.custom_props if (target_dep is self.dep and comp_name is None) else None
@@ -372,7 +377,7 @@ class _CMakeContextGenerator:
                 parsed_extra_variables[key] = parse_extra_variable("cmake_extra_variables",
                                                                    key, value)
 
-            # Component groups declared through cmake_file_name (dict) don't advertise
+            # Component groups declared through cmake_file_names don't advertise
             # find_package(XXX COMPONENTS ...): that mechanism only applies to the root config.
             cmake_components = (self._ctx.get_property("cmake_components", check_type=list)
                                 if self._ctx.is_root else "")
@@ -503,7 +508,7 @@ class _CMakeContextGenerator:
             The cmake filename(s) of ``dep`` that need a find_dependency() call to satisfy a
             requirement pointing to ``comp`` (or to the default/root interface target when
             ``comp`` is ``None``). A dependency might be split into several CMake config files
-            through cmake_file_name (dict), so the specific component determines which of
+            through cmake_file_names, so the specific component determines which of
             those files is the right one (the root file, for the default interface target).
             """
             filenames = []
@@ -734,7 +739,7 @@ class _CMakeContextGenerator:
             cpp_info = self._ctx.full_cpp_info
             # TODO: What if an exe target is called like the pkg_name::pkg_name
             # Only the root config file gets the aggregated pkgname::pkgname interface target;
-            # a component group declared through cmake_file_name (dict) does not.
+            # a component group declared through cmake_file_names does not.
             if self._ctx.is_root and libs and root_target_name not in libs:
                 # Add a generic interface target for the package depending on the others
                 if cpp_info.default_components is not None:
@@ -904,7 +909,7 @@ class _PathGenerator:
             cmake_find_mode = cmake_find_mode.lower()
 
             # A dependency might be split into several CMake config files (root +
-            # cmake_file_name dict groups), each one needs its own _DIR entry.
+            # cmake_file_names groups), each one needs its own _DIR entry.
             for cmake_filename, cmake_file_info in self._cmakedeps.get_cmake_filename(dep).items():
                 extra_variants = self._cmakedeps.get_property("cmake_file_name_variants", dep,
                                                               custom_props=cmake_file_info.get("properties"),
@@ -915,13 +920,13 @@ class _PathGenerator:
                                          "They should be the same with different upper/lower cases only.")
                 if lowercase_variants:
                     if cmake_filename.lower() not in lowercase_variants:
-                        cmake_file_name_prop = self._cmakedeps.get_property(
-                            "cmake_file_name", dep, custom_props=cmake_file_info.get("properties"))
-                        is_cmake_filename_defined = (
-                            isinstance(cmake_file_name_prop, str)
-                            or (isinstance(cmake_file_name_prop, dict)
-                                and cmake_filename in cmake_file_name_prop)
-                        )
+                        cmake_file_names = self._cmakedeps.get_property("cmake_file_names", dep)
+                        if cmake_file_names is not None:
+                            is_cmake_filename_defined = cmake_filename in cmake_file_names
+                        else:
+                            is_cmake_filename_defined = self._cmakedeps.get_property(
+                                "cmake_file_name", dep,
+                                custom_props=cmake_file_info.get("properties")) is not None
                         if is_cmake_filename_defined:
                             extra_variants = []
                             msg = (f"'{dep.ref}' 'cmake_file_name_variants' property contains names "

--- a/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
+++ b/conan/tools/cmake/cmakeconfigdeps/cmakeconfigdeps.py
@@ -43,6 +43,7 @@ class CMakeConfigDeps:
 
         self._properties = {}
         self._full_cpp_infos = {}
+        self._cmake_filenames = {}
 
     @property
     def build_context_activated(self):
@@ -232,6 +233,10 @@ class CMakeConfigDeps:
             - The name of transitive dependencies for calls to find_dependency
 
         This method creates a map for the root/components belonging to each XXX-config file.
+        Each one reports its components twice: ``components`` are the ones declared by the
+        recipe, the public grouping, and ``deduced_components`` are those plus the internal
+        ones that ``deduce_full_cpp_info()`` derived from them, which need a target of their
+        own in the same file.
         It reads two properties:
             - ``cmake_file_names``: a dict mapping each CMake package file name to a dict with
               ``components`` (list of component names) and optional ``properties`` (per-file
@@ -241,31 +246,40 @@ class CMakeConfigDeps:
               (default: recipe name). If both properties are set, ``cmake_file_names``
               takes precedence and ``cmake_file_name`` is ignored.
         """
+        key = dep.ref.name
+        if key in self._cmake_filenames:
+            return self._cmake_filenames[key]
+
+        def _get_deduced_components(cmp_name):
+            # A component with several libs was expanded by deduce_full_cpp_info() into
+            # internal per-lib components. They belong to the same file as their parent.
+            # The declared (not deduced) libs are needed, the parent ones were emptied.
+            # FIXME: alternative to hardcoded "_{name}_{lib}"? check deduce_full_cpp_info
+            cs = []
+            declared_libs = dep.cpp_info.components[cmp_name].libs or []
+            if len(declared_libs) > 1:
+                for c in [f"_{cmp_name}_{lib}" for lib in declared_libs]:
+                    cs.append(c)
+            return cs
+
         ret = {}
         cmake_file_names = self.get_property("cmake_file_names", dep)
-        full_cpp_info = self._get_full_cpp_info(dep)
-        components = list(full_cpp_info.components.keys())
+        components = list(dep.cpp_info.components)
         if cmake_file_names is not None:  # multiple CMake config files way
             if not isinstance(cmake_file_names, dict):
                 raise ConanException("cmake_file_names property must be a dict")
             for filename, file_info in cmake_file_names.items():
                 cmps_per_file = []
+                deduced_components = []
                 for name in file_info.get("components", []):
                     if name not in components:
                         raise ConanException(f"Component '{name}' does not exist. Check the "
                                              f"'cmake_file_names' property definition.")
                     components.remove(name)
                     cmps_per_file.append(name)
-                    # A component with several libs was expanded by deduce_full_cpp_info() into
-                    # internal per-lib components. They belong to the same file as their parent.
-                    # The declared (not deduced) libs are needed, the parent ones were emptied.
-                    declared_libs = dep.cpp_info.components[name].libs or []
-                    if len(declared_libs) > 1:
-                        # FIXME: alternative to hardcoded "_{name}_{lib}"? check deduce_full_cpp_info
-                        for c in [f"_{name}_{lib}" for lib in declared_libs]:
-                            cmps_per_file.append(c)
-                            components.remove(c)
+                    deduced_components.extend(_get_deduced_components(name))
                 ret[filename] = {"components": cmps_per_file,
+                                 "deduced_components": deduced_components + cmps_per_file,
                                  "properties": file_info.get("properties", {}),
                                  "is_root": False}
             if components:
@@ -276,8 +290,11 @@ class CMakeConfigDeps:
         else:  # Read cmake_file_name as usual
             cmake_file_name = self.get_property("cmake_file_name", dep)
             root_filename = cmake_file_name or dep.ref.name
+            full_cpp_info = self._get_full_cpp_info(dep)
             ret[root_filename] = {"components": components,
+                                  "deduced_components": list(full_cpp_info.components.keys()),
                                   "is_root": True}
+        self._cmake_filenames[key] = ret
         return ret
 
 
@@ -293,9 +310,11 @@ class _CMakeContextGenerator:
         self.base_filename = cmake_filename
         # Whether this is the "root" config file for the dependency (as opposed to one of the
         # per-group files declared through the ``cmake_file_names`` property), and
-        # which components it covers.
+        # which components it covers: the ones declared by the recipe, and those plus the
+        # internal ones deduced from them, which get a target of their own.
         self.is_root = cmake_file_info["is_root"]
-        self.file_components = cmake_file_info["components"]
+        self.file_declared_components = cmake_file_info["components"]
+        self.file_deduced_components = cmake_file_info["deduced_components"]
         self.custom_props = cmake_file_info.get("properties", {})
         self.is_build_context = require.build
         # Prepared to filter transitive tool-requires with visible=True
@@ -382,14 +401,10 @@ class _CMakeContextGenerator:
                 parsed_extra_variables[key] = parse_extra_variable("cmake_extra_variables",
                                                                    key, value)
 
-            # Component groups declared through cmake_file_names don't advertise
-            # find_package(XXX COMPONENTS ...): that mechanism only applies to the root config.
-            cmake_components = (self._ctx.get_property("cmake_components", check_type=list)
-                                if self._ctx.is_root else "")
+            cmake_components = self._ctx.get_property("cmake_components", check_type=list)
             if cmake_components is None:
                 cmake_components = []
-                # This assumes cmake_components is only defined with not multi .libs=[lib1, lib2]
-                for name in self._ctx.file_components:
+                for name in self._ctx.file_declared_components:
                     if name.startswith("_"):  # Skip private components
                         continue
                     comp_components = self._ctx.get_property("cmake_components", comp_name=name,
@@ -432,7 +447,7 @@ class _CMakeContextGenerator:
             include_dirs = definitions = libraries = None
             if not self._ctx.is_build_context:  # try_compile and legacy globals
                 # Restrict to the components covered by this particular CMake config file
-                components = self._ctx.file_components
+                components = self._ctx.file_deduced_components
                 aggregated_cppinfo = self._ctx.full_cpp_info.aggregated_components(components=components)
                 # FIXME: Proper escaping of paths for CMake
                 incdirs = [relativize_path(i.replace("\\", "/"), self._ctx.consumer_conanfile,
@@ -464,7 +479,7 @@ class _CMakeContextGenerator:
         def info(self):
             f = self._ctx.base_filename
             ref = (str(self._ctx.dep.ref) if self._ctx.is_root
-                   else ",".join(self._ctx.file_components))
+                   else ",".join(self._ctx.file_deduced_components))
             return f"{f}Targets.cmake", {"filename": f, "ref": ref}
 
     class _TargetConfiguration:
@@ -528,7 +543,7 @@ class _CMakeContextGenerator:
         def _get_dependencies_and_requires(self):
             requires = {}
             full_cpp_info = self._ctx.full_cpp_info
-            components_per_file = self._ctx.file_components
+            components_per_file = self._ctx.file_deduced_components
             if full_cpp_info.has_components:
                 for name in components_per_file:
                     requires[name] = self._get_component_requires(
@@ -556,6 +571,22 @@ class _CMakeContextGenerator:
             dependencies.update({extra_mod: "" for extra_mod in extra_mods})
             return dependencies, requires
 
+        def _missing_root_target_error(self, required_dep):
+            """A cmake_file_names package has no pkg::pkg root target. Callers must
+            declare a specific component in cpp_info.requires."""
+            cmake_file_names = self._ctx.cmakedeps.get_cmake_filename(required_dep)
+            if any(info["is_root"] for info in cmake_file_names.values()):
+                return
+            available = [name for info in cmake_file_names.values()
+                         for name in info["components"]]
+            pkg = required_dep.ref.name
+            available_str = ", ".join(available) if available else "(none)"
+            raise ConanException(f"{self._ctx.dep} recipe cpp_info does not declare which "
+                                 f"component of '{pkg}' to link. '{pkg}' defines 'cmake_file_names' "
+                                 f"and has no root target '{pkg}::{pkg}'. Add "
+                                 f"self.cpp_info.requires = [\"{pkg}::<component>\"] in "
+                                 f"package_info(). Available components: {available_str}")
+
         def _get_component_requires(self, info, components):
             result = {}
             requires = info.parsed_requires()
@@ -569,6 +600,7 @@ class _CMakeContextGenerator:
                 for req, d in transitive_reqs.items():
                     if d.package_type is PackageType.APP:
                         continue
+                    self._missing_root_target_error(d)
                     dep_target = self._ctx.get_cmake_target_name(d)
                     link_feature = self._ctx.get_property("cmake_link_feature", d)
                     result[dep_target] = {
@@ -608,6 +640,7 @@ class _CMakeContextGenerator:
                                 raise ConanException(msg)
                             if transitive_dep.package_type is PackageType.APP:
                                 continue  # It doesn't make sense to link a package that is an App
+                            self._missing_root_target_error(transitive_dep)
                             comp = None
                             # replace_requires
                             default_target = (f"{transitive_dep.ref.name}::"
@@ -640,7 +673,7 @@ class _CMakeContextGenerator:
             cpp_info = self._ctx.full_cpp_info
             if cpp_info.has_components:
                 # Only the components belonging to this particular CMake config file
-                for name in self._ctx.file_components:
+                for name in self._ctx.file_deduced_components:
                     target_name = self._ctx.get_cmake_target_name(comp_name=name)
                     target = self._get_cmake_lib(cpp_info.components[name], cpp_info_requires,
                                                  comp_name=name)
@@ -776,7 +809,7 @@ class _CMakeContextGenerator:
             exes = {}
             cpp_info = self._ctx.full_cpp_info
             if cpp_info.has_components:
-                for name in self._ctx.file_components:
+                for name in self._ctx.file_deduced_components:
                     comp = cpp_info.components[name]
                     if comp.exe or comp.type is PackageType.APP:
                         target = self._ctx.get_cmake_target_name(comp_name=name)

--- a/test/functional/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps_multi_config.py
+++ b/test/functional/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps_multi_config.py
@@ -6,9 +6,9 @@ from conan.test.utils.tools import TestClient
 
 
 @pytest.mark.tool("cmake")
-def test_cmake_file_component_names_spirv_tools():
+def test_cmake_file_name_spirv_tools():
     """
-    Test a simple example imitating the spirv-tools library (cmake_file_component_names).
+    Test a simple example imitating the spirv-tools library (cmake_file_name).
     """
     c = TestClient()
 
@@ -40,7 +40,7 @@ def test_cmake_file_component_names_spirv_tools():
         }
     """)
 
-    # --- spirv-tools: multiple components split via cmake_file_component_names ---
+    # --- spirv-tools: multiple components split via cmake_file_name ---
     spirv_tools_conanfile = textwrap.dedent("""
         import os
         from conan import ConanFile
@@ -71,7 +71,7 @@ def test_cmake_file_component_names_spirv_tools():
 
             def package_info(self):
                 # Split into separate config files per CMake package name
-                self.cpp_info.set_property("cmake_file_component_names", {
+                self.cpp_info.set_property("cmake_file_name", {
                     "SPIRV-Tools": {"components": ["spirv-tools-core"]},
                     "SPIRV-Tools-opt": {"components": ["spirv-tools-opt"]},
                     "SPIRV-Tools-link": {"components": ["spirv-tools-link"]},

--- a/test/functional/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps_multi_config.py
+++ b/test/functional/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps_multi_config.py
@@ -71,7 +71,7 @@ def test_cmake_file_name_spirv_tools():
 
             def package_info(self):
                 # Split into separate config files per CMake package name
-                self.cpp_info.set_property("cmake_file_name", {
+                self.cpp_info.set_property("cmake_file_names", {
                     "SPIRV-Tools": {"components": ["spirv-tools-core"]},
                     "SPIRV-Tools-opt": {"components": ["spirv-tools-opt"]},
                     "SPIRV-Tools-link": {"components": ["spirv-tools-link"]},

--- a/test/functional/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps_multi_config.py
+++ b/test/functional/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps_multi_config.py
@@ -1,0 +1,245 @@
+import textwrap
+
+import pytest
+
+from conan.test.utils.tools import TestClient
+
+
+@pytest.mark.tool("cmake")
+def test_cmake_file_component_names_spirv_tools():
+    """
+    Test a simple example imitating the spirv-tools library (cmake_file_component_names).
+    """
+    c = TestClient()
+
+    # --- spirv-headers: header-only dependency (like real spirv-headers) ---
+    spirv_headers = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+        from conan.tools.files import copy
+
+        class SpirvHeadersConan(ConanFile):
+            name = "spirv-headers"
+            version = "1.0"
+            package_type = "header-library"
+            settings = "os", "arch", "compiler", "build_type"
+            exports_sources = "include/*"
+
+            def package(self):
+                copy(self, "*", src=os.path.join(self.source_folder, "include"),
+                     dst=os.path.join(self.package_folder, "include"))
+
+            def package_info(self):
+                self.cpp_info.components["spirv-headers"].includedirs = ["include"]
+    """)
+
+    spirv_header_h = textwrap.dedent("""
+        #pragma once
+        namespace spv {
+            int get_version();
+        }
+    """)
+
+    # --- spirv-tools: multiple components split via cmake_file_component_names ---
+    spirv_tools_conanfile = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+        from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
+
+        class SpirvToolsConan(ConanFile):
+            name = "spirv-tools"
+            version = "1.0"
+            package_type = "library"
+            settings = "os", "arch", "compiler", "build_type"
+            options = {"shared": [True, False]}
+            default_options = {"shared": False}
+            requires = "spirv-headers/1.0"
+            generators = "CMakeConfigDeps", "CMakeToolchain"
+            exports_sources = "src/*", "include/*", "CMakeLists.txt"
+
+            def layout(self):
+                cmake_layout(self)
+
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+                cmake.build()
+
+            def package(self):
+                cmake = CMake(self)
+                cmake.install()
+
+            def package_info(self):
+                # Split into separate config files per CMake package name
+                self.cpp_info.set_property("cmake_file_component_names", {
+                    "SPIRV-Tools": {"components": ["spirv-tools-core"]},
+                    "SPIRV-Tools-opt": {"components": ["spirv-tools-opt"]},
+                    "SPIRV-Tools-link": {"components": ["spirv-tools-link"]},
+                })
+
+                lib_ext = "lib" if self.settings.os == "Windows" else "a"
+                lib_prefix = "" if self.settings.os == "Windows" else "lib"
+
+                # spirv-tools-core
+                self.cpp_info.components["spirv-tools-core"].set_property("cmake_target_name", "SPIRV-Tools")
+                self.cpp_info.components["spirv-tools-core"].libs = ["SPIRV-Tools"]
+                self.cpp_info.components["spirv-tools-core"].type = "static-library"
+                self.cpp_info.components["spirv-tools-core"].includedirs = ["include"]
+                self.cpp_info.components["spirv-tools-core"].location = os.path.join("lib", f"{lib_prefix}SPIRV-Tools.{lib_ext}")
+                self.cpp_info.components["spirv-tools-core"].requires = ["spirv-headers::spirv-headers"]
+
+                # spirv-tools-opt
+                self.cpp_info.components["spirv-tools-opt"].set_property("cmake_target_name", "SPIRV-Tools-opt")
+                self.cpp_info.components["spirv-tools-opt"].libs = ["SPIRV-Tools-opt"]
+                self.cpp_info.components["spirv-tools-opt"].type = "static-library"
+                self.cpp_info.components["spirv-tools-opt"].includedirs = ["include"]
+                self.cpp_info.components["spirv-tools-opt"].location = os.path.join("lib", f"{lib_prefix}SPIRV-Tools-opt.{lib_ext}")
+                self.cpp_info.components["spirv-tools-opt"].requires = ["spirv-tools-core", "spirv-headers::spirv-headers"]
+
+                # spirv-tools-link
+                self.cpp_info.components["spirv-tools-link"].set_property("cmake_target_name", "SPIRV-Tools-link")
+                self.cpp_info.components["spirv-tools-link"].libs = ["SPIRV-Tools-link"]
+                self.cpp_info.components["spirv-tools-link"].type = "static-library"
+                self.cpp_info.components["spirv-tools-link"].includedirs = ["include"]
+                self.cpp_info.components["spirv-tools-link"].location = os.path.join("lib", f"{lib_prefix}SPIRV-Tools-link.{lib_ext}")
+                self.cpp_info.components["spirv-tools-link"].requires = ["spirv-tools-core", "spirv-tools-opt"]
+    """)
+
+    # Minimal C++ sources
+    core_cpp = textwrap.dedent("""
+        #include "spirv_tools/core.h"
+        #include "spirv/header.h"
+        namespace spv { int get_version() { return 100; } }
+        int spirv_tools_core_version() { return spv::get_version(); }
+    """)
+    opt_cpp = textwrap.dedent("""
+        #include "spirv_tools/opt.h"
+        #include "spirv_tools/core.h"
+        int spirv_tools_opt_optimize() { return spirv_tools_core_version() + 1; }
+    """)
+    link_cpp = textwrap.dedent("""
+        #include "spirv_tools/link.h"
+        #include "spirv_tools/opt.h"
+        int spirv_tools_link() { return spirv_tools_opt_optimize() + 1; }
+    """)
+
+    core_h = textwrap.dedent("""
+        #pragma once
+        int spirv_tools_core_version();
+    """)
+    opt_h = textwrap.dedent("""
+        #pragma once
+        int spirv_tools_opt_optimize();
+    """)
+    link_h = textwrap.dedent("""
+        #pragma once
+        int spirv_tools_link();
+    """)
+
+    spirv_tools_cmake = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.15)
+        project(spirv-tools CXX)
+
+        find_package(spirv-headers REQUIRED)
+
+        add_library(SPIRV-Tools STATIC src/core.cpp)
+        target_include_directories(SPIRV-Tools PUBLIC include)
+        target_link_libraries(SPIRV-Tools PUBLIC spirv-headers::spirv-headers)
+
+        add_library(SPIRV-Tools-opt STATIC src/opt.cpp)
+        target_include_directories(SPIRV-Tools-opt PUBLIC include)
+        target_link_libraries(SPIRV-Tools-opt PUBLIC SPIRV-Tools)
+
+        add_library(SPIRV-Tools-link STATIC src/link.cpp)
+        target_include_directories(SPIRV-Tools-link PUBLIC include)
+        target_link_libraries(SPIRV-Tools-link PUBLIC SPIRV-Tools SPIRV-Tools-opt)
+
+        install(TARGETS SPIRV-Tools SPIRV-Tools-opt SPIRV-Tools-link
+                RUNTIME DESTINATION bin
+                LIBRARY DESTINATION lib
+                ARCHIVE DESTINATION lib)
+        install(DIRECTORY include/ DESTINATION include)
+    """)
+
+    # --- Save spirv-headers ---
+    c.save({
+        "spirv-headers/conanfile.py": spirv_headers,
+        "spirv-headers/include/spirv/header.h": spirv_header_h,
+    })
+    c.run("create spirv-headers")
+
+    # --- Save spirv-tools ---
+    c.save({
+        "spirv-tools/conanfile.py": spirv_tools_conanfile,
+        "spirv-tools/CMakeLists.txt": spirv_tools_cmake,
+        "spirv-tools/src/core.cpp": core_cpp,
+        "spirv-tools/src/opt.cpp": opt_cpp,
+        "spirv-tools/src/link.cpp": link_cpp,
+        "spirv-tools/include/spirv_tools/core.h": core_h,
+        "spirv-tools/include/spirv_tools/opt.h": opt_h,
+        "spirv-tools/include/spirv_tools/link.h": link_h,
+    }, clean_first=True)
+
+    c.run("create spirv-tools")
+
+    # --- Verify generated config files ---
+    c.run("install --requires=spirv-tools/1.0 -g CMakeConfigDeps")
+    assert c.load("SPIRV-ToolsConfig.cmake")
+    assert c.load("SPIRV-Tools-optConfig.cmake")
+    assert c.load("SPIRV-Tools-linkConfig.cmake")
+    paths = c.load("conan_cmakedeps_paths.cmake")
+    assert "set(SPIRV-Tools_DIR" in paths
+    assert "set(SPIRV-Tools-opt_DIR" in paths
+    assert "set(SPIRV-Tools-link_DIR" in paths
+
+    # --- Consumer with test_package that builds ---
+    consumer_conanfile = textwrap.dedent("""
+        import os
+        from conan import ConanFile
+        from conan.tools.cmake import CMake, cmake_layout
+
+        class ConsumerConan(ConanFile):
+            settings = "os", "arch", "compiler", "build_type"
+            requires = "spirv-tools/1.0"
+            generators = "CMakeConfigDeps", "CMakeToolchain"
+            exports_sources = "src/*", "CMakeLists.txt"
+
+            def layout(self):
+                cmake_layout(self)
+
+            def build(self):
+                cmake = CMake(self)
+                cmake.configure()
+                cmake.build()
+                # Check the result
+                self.run(os.path.join(self.cpp.build.bindirs[0], "example"))
+    """)
+
+    consumer_cmake = textwrap.dedent("""
+        cmake_minimum_required(VERSION 3.15)
+        project(example CXX)
+
+        find_package(SPIRV-Tools-link REQUIRED CONFIG)
+
+        add_executable(example src/main.cpp)
+        target_link_libraries(example PRIVATE SPIRV-Tools-link)
+    """)
+
+    consumer_main = textwrap.dedent("""
+        #include <iostream>
+        #include "spirv_tools/link.h"
+        int main() {
+            std::cout << "spirv-tools link result: " << spirv_tools_link() << std::endl;
+            return 0;
+        }
+    """)
+
+    c.save({
+        "consumer/conanfile.py": consumer_conanfile,
+        "consumer/CMakeLists.txt": consumer_cmake,
+        "consumer/src/main.cpp": consumer_main,
+    }, clean_first=True)
+
+    c.run("build consumer")
+    # Check the output
+    assert "spirv-tools link result: 102" in c.out

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -1317,10 +1317,10 @@ def test_find_mode_none():
 
 
 class TestCmakeConfigProperties:
-    """Tests for cmake_file_component_names — components grouped per CMake config file."""
+    """Tests for cmake_file_name — components grouped per CMake config file."""
 
     def test_generates_multiple_config_files(self):
-        """Package with cmake_file_component_names generates separate config files per group."""
+        """Package with cmake_file_name generates separate config files per group."""
         tc = TestClient()
         dep = textwrap.dedent("""
             from conan import ConanFile
@@ -1332,7 +1332,7 @@ class TestCmakeConfigProperties:
 
                 def package_info(self):
                     # CMake File names for components
-                    self.cpp_info.set_property("cmake_file_component_names", {
+                    self.cpp_info.set_property("cmake_file_name", {
                         "greetings": {
                             "components": ["hello", "hello-helpers"],
                             "properties": {},
@@ -1388,11 +1388,11 @@ class TestCmakeConfigProperties:
         assert "# Requirement pkg::bye -> greet (Full link: False)" in adieu_targets
         assert "# Requirement pkg::bye -> pkg::bye-helpers (Full link: True)" in adieu_targets
 
-        # No root pkg config when all components are listed in cmake_file_component_names
+        # No root pkg config when all components are listed in cmake_file_name
         assert not os.path.exists(os.path.join(tc.current_folder, "pkg-config.cmake"))
 
     def test_paths_include_cmake_file_names(self):
-        """conan_cmakedeps_paths.cmake sets DIR for each cmake file from cmake_file_component_names."""
+        """conan_cmakedeps_paths.cmake sets DIR for each cmake file from cmake_file_name."""
         tc = TestClient()
         dep = textwrap.dedent("""
             from conan import ConanFile
@@ -1409,7 +1409,7 @@ class TestCmakeConfigProperties:
                     self.cpp_info.components["compB"].libs = ["b"]
                     self.cpp_info.components["compB"].type = "static-library"
                     self.cpp_info.components["compB"].location = "lib/libb.a"
-                    self.cpp_info.set_property("cmake_file_component_names", {
+                    self.cpp_info.set_property("cmake_file_name", {
                         "MyLib": {"components": ["compA", "compB"]},
                     })
         """)
@@ -1419,11 +1419,11 @@ class TestCmakeConfigProperties:
 
         paths = tc.load("conan_cmakedeps_paths.cmake")
         assert "set(MyLib_DIR" in paths
-        # pkg_DIR should not exist when all components are in cmake_file_component_names
+        # pkg_DIR should not exist when all components are in cmake_file_name
         assert "set(pkg_DIR" not in paths
 
     def test_error_nonexistent_component(self):
-        """Using a non-existent component in cmake_file_component_names raises ConanException."""
+        """Using a non-existent component in cmake_file_name raises ConanException."""
         tc = TestClient()
         dep = textwrap.dedent("""
             from conan import ConanFile
@@ -1437,7 +1437,7 @@ class TestCmakeConfigProperties:
                     self.cpp_info.components["compA"].libs = ["a"]
                     self.cpp_info.components["compA"].type = "static-library"
                     self.cpp_info.components["compA"].location = "lib/liba.a"
-                    self.cpp_info.set_property("cmake_file_component_names", {
+                    self.cpp_info.set_property("cmake_file_name", {
                         "MyLib": {"components": ["compA", "nonexistent"]},
                     })
         """)
@@ -1446,10 +1446,10 @@ class TestCmakeConfigProperties:
         tc.run(f"install --requires=pkg/1.0 -g CMakeConfigDeps",
                assert_error=True)
         assert "Component 'nonexistent' does not exist" in tc.out
-        assert "cmake_file_component_names" in tc.out
+        assert "cmake_file_name" in tc.out
 
     def test_error_default_component_in_another_file(self):
-        """Default component in cmake_file_component_names raises ConanException."""
+        """Default component in cmake_file_name raises ConanException."""
         tc = TestClient()
         dep = textwrap.dedent("""
             from conan import ConanFile
@@ -1467,7 +1467,7 @@ class TestCmakeConfigProperties:
                     self.cpp_info.components["compB"].type = "static-library"
                     self.cpp_info.components["compB"].location = "lib/libb.a"
                     self.cpp_info.default_components = ["compA"]
-                    self.cpp_info.set_property("cmake_file_component_names", {
+                    self.cpp_info.set_property("cmake_file_name", {
                         "MyLib": {"components": ["compA", "compB"]},
                     })
         """)
@@ -1476,10 +1476,10 @@ class TestCmakeConfigProperties:
         tc.run(f"install --requires=pkg/1.0 -g CMakeConfigDeps",
                assert_error=True)
         assert "default component 'compA' is defined in another CMake Config file" in tc.out
-        assert "cmake_file_component_names" in tc.out
+        assert "cmake_file_name" in tc.out
 
     def test_mixed_root_and_component_files(self):
-        """Some components in cmake_file_component_names, rest in root config file."""
+        """Some components in cmake_file_name, rest in root config file."""
         tc = TestClient()
         dep = textwrap.dedent("""
             from conan import ConanFile
@@ -1496,7 +1496,7 @@ class TestCmakeConfigProperties:
                     self.cpp_info.components["extra"].libs = ["extra"]
                     self.cpp_info.components["extra"].type = "static-library"
                     self.cpp_info.components["extra"].location = "lib/libextra.a"
-                    self.cpp_info.set_property("cmake_file_component_names", {
+                    self.cpp_info.set_property("cmake_file_name", {
                         "Extra": {"components": ["extra"]},
                     })
         """)
@@ -1519,7 +1519,7 @@ class TestCmakeConfigProperties:
         assert "set(Extra_DIR" in paths
 
     def test_find_dependency_uses_correct_names(self):
-        """Transitive find_dependency uses cmake file name from cmake_file_component_names."""
+        """Transitive find_dependency uses cmake file name from cmake_file_name."""
         tc = TestClient()
         dep = textwrap.dedent("""
             from conan import ConanFile
@@ -1533,7 +1533,7 @@ class TestCmakeConfigProperties:
                     self.cpp_info.components["lib"].libs = ["dep"]
                     self.cpp_info.components["lib"].type = "static-library"
                     self.cpp_info.components["lib"].location = "lib/libdep.a"
-                    self.cpp_info.set_property("cmake_file_component_names", {
+                    self.cpp_info.set_property("cmake_file_name", {
                         "DepLib": {"components": ["lib"]},
                     })
         """)
@@ -1576,7 +1576,7 @@ class TestCmakeConfigProperties:
                     save(self, os.path.join(self.package_folder, "lib", "libw.a"), "")
 
                 def package_info(self):
-                    self.cpp_info.set_property("cmake_file_component_names", {
+                    self.cpp_info.set_property("cmake_file_name", {
                         "widgets": {
                             "components": ["widgets"],
                             "properties": {
@@ -1616,7 +1616,7 @@ class TestCmakeConfigProperties:
                          "# hook for tests\n")
 
                 def package_info(self):
-                    self.cpp_info.set_property("cmake_file_component_names", {
+                    self.cpp_info.set_property("cmake_file_name", {
                         "CoreKit": {
                             "components": ["core"],
                             "properties": {
@@ -1651,7 +1651,7 @@ class TestCmakeConfigProperties:
                 settings = "os", "compiler", "build_type", "arch"
 
                 def package_info(self):
-                    self.cpp_info.set_property("cmake_file_component_names", {
+                    self.cpp_info.set_property("cmake_file_name", {
                         "PartA": {
                             "components": ["a"],
                             "properties": {"cmake_extra_dependencies": ["Protoc"]},

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -1,3 +1,4 @@
+import os
 import re
 import textwrap
 
@@ -1313,3 +1314,361 @@ def test_find_mode_none():
     target_dependency = tc.load("liba-Targets-release.cmake")
     # The dependency should not have CONFIG requirement
     assert "find_dependency(dep REQUIRED )" in target_dependency
+
+
+class TestCmakeConfigProperties:
+    """Tests for cmake_file_component_names — components grouped per CMake config file."""
+
+    def test_generates_multiple_config_files(self):
+        """Package with cmake_file_component_names generates separate config files per group."""
+        tc = TestClient()
+        dep = textwrap.dedent("""
+            from conan import ConanFile
+
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "1.0"
+                settings = "os", "compiler", "build_type", "arch"
+
+                def package_info(self):
+                    # CMake File names for components
+                    self.cpp_info.set_property("cmake_file_component_names", {
+                        "greetings": {
+                            "components": ["hello", "hello-helpers"],
+                            "properties": {},
+                        },
+                        "adieu": {
+                            "components": ["bye", "bye-helpers"],
+                        },
+                    })
+
+                    self.cpp_info.components["hello"].libs = ["hello"]
+                    self.cpp_info.components["hello"].set_property("cmake_target_name", "greet")
+                    self.cpp_info.components["hello"].type = "shared-library"
+                    self.cpp_info.components["hello"].location = "lib/libhello.so"
+
+                    self.cpp_info.components["hello-helpers"].defines = ["HELLO_HELPERS"]
+
+                    self.cpp_info.components["bye"].libs = ["bye"]
+                    self.cpp_info.components["bye"].type = "shared-library"
+                    self.cpp_info.components["bye"].location = "lib/libbye.so"
+                    self.cpp_info.components["bye"].requires = ["hello", "bye-helpers"]
+
+                    self.cpp_info.components["bye-helpers"].defines = ["BYE_HELPERS"]
+        """)
+        tc.save({"conanfile.py": dep})
+        tc.run("create .")
+        tc.run(f"install --requires=pkg/1.0 -g CMakeConfigDeps")
+        # Each group gets its own config, targets and config-version files
+        # greetings
+        assert os.path.exists(os.path.join(tc.current_folder, "greetings-config.cmake"))
+        assert os.path.exists(os.path.join(tc.current_folder, "greetings-Targets-release.cmake"))
+        assert os.path.exists(os.path.join(tc.current_folder, "greetings-config-version.cmake"))
+        # Targets contain the expected components
+        greetings_config = tc.load("greetings-config.cmake")
+        assert "set(greetings_LIBRARIES greet pkg::hello-helpers )" in greetings_config
+        # Targets contain the expected components
+        greetings_targets = tc.load("greetings-Targets-release.cmake")
+        assert "add_library(greet SHARED IMPORTED)" in greetings_targets
+        assert "add_library(pkg::hello-helpers INTERFACE IMPORTED)" in greetings_targets
+        assert "find_dependency" not in greetings_targets
+
+        # adieu
+        assert os.path.exists(os.path.join(tc.current_folder, "adieu-config.cmake"))
+        assert os.path.exists(os.path.join(tc.current_folder, "adieu-Targets-release.cmake"))
+        assert os.path.exists(os.path.join(tc.current_folder, "adieu-config-version.cmake"))
+        # Targets contain the expected components
+        adieu_config = tc.load("adieu-config.cmake")
+        assert "set(adieu_LIBRARIES pkg::bye pkg::bye-helpers )" in adieu_config
+        # Targets contain the expected components
+        adieu_targets = tc.load("adieu-Targets-release.cmake")
+        assert "find_dependency(greetings REQUIRED CONFIG)" in adieu_targets
+        assert "add_library(pkg::bye SHARED IMPORTED)" in adieu_targets
+        assert "add_library(pkg::bye-helpers INTERFACE IMPORTED)" in adieu_targets
+        assert "# Requirement pkg::bye -> greet (Full link: False)" in adieu_targets
+        assert "# Requirement pkg::bye -> pkg::bye-helpers (Full link: True)" in adieu_targets
+
+        # No root pkg config when all components are listed in cmake_file_component_names
+        assert not os.path.exists(os.path.join(tc.current_folder, "pkg-config.cmake"))
+
+    def test_paths_include_cmake_file_names(self):
+        """conan_cmakedeps_paths.cmake sets DIR for each cmake file from cmake_file_component_names."""
+        tc = TestClient()
+        dep = textwrap.dedent("""
+            from conan import ConanFile
+
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "1.0"
+                settings = "os", "compiler", "build_type", "arch"
+
+                def package_info(self):
+                    self.cpp_info.components["compA"].libs = ["a"]
+                    self.cpp_info.components["compA"].type = "static-library"
+                    self.cpp_info.components["compA"].location = "lib/liba.a"
+                    self.cpp_info.components["compB"].libs = ["b"]
+                    self.cpp_info.components["compB"].type = "static-library"
+                    self.cpp_info.components["compB"].location = "lib/libb.a"
+                    self.cpp_info.set_property("cmake_file_component_names", {
+                        "MyLib": {"components": ["compA", "compB"]},
+                    })
+        """)
+        tc.save({"conanfile.py": dep})
+        tc.run("create .")
+        tc.run(f"install --requires=pkg/1.0 -g CMakeConfigDeps")
+
+        paths = tc.load("conan_cmakedeps_paths.cmake")
+        assert "set(MyLib_DIR" in paths
+        # pkg_DIR should not exist when all components are in cmake_file_component_names
+        assert "set(pkg_DIR" not in paths
+
+    def test_error_nonexistent_component(self):
+        """Using a non-existent component in cmake_file_component_names raises ConanException."""
+        tc = TestClient()
+        dep = textwrap.dedent("""
+            from conan import ConanFile
+
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "1.0"
+                settings = "os", "compiler", "build_type", "arch"
+
+                def package_info(self):
+                    self.cpp_info.components["compA"].libs = ["a"]
+                    self.cpp_info.components["compA"].type = "static-library"
+                    self.cpp_info.components["compA"].location = "lib/liba.a"
+                    self.cpp_info.set_property("cmake_file_component_names", {
+                        "MyLib": {"components": ["compA", "nonexistent"]},
+                    })
+        """)
+        tc.save({"conanfile.py": dep})
+        tc.run("create .")
+        tc.run(f"install --requires=pkg/1.0 -g CMakeConfigDeps",
+               assert_error=True)
+        assert "Component 'nonexistent' does not exist" in tc.out
+        assert "cmake_file_component_names" in tc.out
+
+    def test_error_default_component_in_another_file(self):
+        """Default component in cmake_file_component_names raises ConanException."""
+        tc = TestClient()
+        dep = textwrap.dedent("""
+            from conan import ConanFile
+
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "1.0"
+                settings = "os", "compiler", "build_type", "arch"
+
+                def package_info(self):
+                    self.cpp_info.components["compA"].libs = ["a"]
+                    self.cpp_info.components["compA"].type = "static-library"
+                    self.cpp_info.components["compA"].location = "lib/liba.a"
+                    self.cpp_info.components["compB"].libs = ["b"]
+                    self.cpp_info.components["compB"].type = "static-library"
+                    self.cpp_info.components["compB"].location = "lib/libb.a"
+                    self.cpp_info.default_components = ["compA"]
+                    self.cpp_info.set_property("cmake_file_component_names", {
+                        "MyLib": {"components": ["compA", "compB"]},
+                    })
+        """)
+        tc.save({"conanfile.py": dep})
+        tc.run("create .")
+        tc.run(f"install --requires=pkg/1.0 -g CMakeConfigDeps",
+               assert_error=True)
+        assert "default component 'compA' is defined in another CMake Config file" in tc.out
+        assert "cmake_file_component_names" in tc.out
+
+    def test_mixed_root_and_component_files(self):
+        """Some components in cmake_file_component_names, rest in root config file."""
+        tc = TestClient()
+        dep = textwrap.dedent("""
+            from conan import ConanFile
+
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "1.0"
+                settings = "os", "compiler", "build_type", "arch"
+
+                def package_info(self):
+                    self.cpp_info.components["core"].libs = ["core"]
+                    self.cpp_info.components["core"].type = "static-library"
+                    self.cpp_info.components["core"].location = "lib/libcore.a"
+                    self.cpp_info.components["extra"].libs = ["extra"]
+                    self.cpp_info.components["extra"].type = "static-library"
+                    self.cpp_info.components["extra"].location = "lib/libextra.a"
+                    self.cpp_info.set_property("cmake_file_component_names", {
+                        "Extra": {"components": ["extra"]},
+                    })
+        """)
+        tc.save({"conanfile.py": dep})
+        tc.run("create .")
+        tc.run(f"install --requires=pkg/1.0 -g CMakeConfigDeps")
+
+        # Root pkg config with core component
+        assert tc.load("pkg-config.cmake")
+        pkg_targets = tc.load("pkg-Targets-release.cmake")
+        assert "pkg::core" in pkg_targets
+
+        # Extra config with extra component
+        assert tc.load("ExtraConfig.cmake")
+        extra_targets = tc.load("Extra-Targets-release.cmake")
+        assert "pkg::extra" in extra_targets
+
+        paths = tc.load("conan_cmakedeps_paths.cmake")
+        assert "set(pkg_DIR" in paths
+        assert "set(Extra_DIR" in paths
+
+    def test_find_dependency_uses_correct_names(self):
+        """Transitive find_dependency uses cmake file name from cmake_file_component_names."""
+        tc = TestClient()
+        dep = textwrap.dedent("""
+            from conan import ConanFile
+
+            class Dep(ConanFile):
+                name = "dep"
+                version = "1.0"
+                settings = "os", "compiler", "build_type", "arch"
+
+                def package_info(self):
+                    self.cpp_info.components["lib"].libs = ["dep"]
+                    self.cpp_info.components["lib"].type = "static-library"
+                    self.cpp_info.components["lib"].location = "lib/libdep.a"
+                    self.cpp_info.set_property("cmake_file_component_names", {
+                        "DepLib": {"components": ["lib"]},
+                    })
+        """)
+        consumer = textwrap.dedent("""
+            from conan import ConanFile
+
+            class Consumer(ConanFile):
+                name = "consumer"
+                version = "1.0"
+                settings = "os", "compiler", "build_type", "arch"
+                requires = "dep/1.0"
+
+                def package_info(self):
+                    self.cpp_info.requires = ["dep::lib"]
+        """)
+        tc.save({"dep/conanfile.py": dep, "consumer/conanfile.py": consumer})
+        tc.run("create dep")
+        tc.run("create consumer")
+        tc.run(f"install --requires=consumer/1.0 -g CMakeConfigDeps")
+
+        # Consumer targets should use find_dependency(DepLib) not find_dependency(dep)
+        consumer_targets = tc.load("consumer-Targets-release.cmake")
+        assert "find_dependency(DepLib" in consumer_targets
+        assert "find_dependency(dep " not in consumer_targets
+
+    def test_cmake_component_properties_version_and_compat(self):
+        """Per-file ``properties`` can override config-version (system_package_version, compat)."""
+        tc = TestClient()
+        dep = textwrap.dedent("""
+            import os
+            from conan import ConanFile
+            from conan.tools.files import save
+
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "1.0"
+                settings = "os", "compiler", "build_type", "arch"
+
+                def package(self):
+                    save(self, os.path.join(self.package_folder, "lib", "libw.a"), "")
+
+                def package_info(self):
+                    self.cpp_info.set_property("cmake_file_component_names", {
+                        "widgets": {
+                            "components": ["widgets"],
+                            "properties": {
+                                "system_package_version": "88.1.2",
+                                "cmake_config_version_compat": "ExactVersion",
+                            },
+                        },
+                    })
+                    self.cpp_info.components["widgets"].libs = ["w"]
+                    self.cpp_info.components["widgets"].type = "static-library"
+                    self.cpp_info.components["widgets"].location = "lib/libw.a"
+        """)
+        tc.save({"conanfile.py": dep})
+        tc.run("create .")
+        tc.run("install --requires=pkg/1.0 -g CMakeConfigDeps")
+        ver = tc.load("widgets-config-version.cmake")
+        assert 'set(PACKAGE_VERSION "88.1.2")' in ver
+        assert "PACKAGE_FIND_VERSION_MAJOR STREQUAL CVF_VERSION_MAJOR" in ver
+
+    def test_cmake_component_properties_build_modules_extra_variables_prefixes(self):
+        """Per-file ``properties``: build modules, extra CMake variables, legacy prefixes."""
+        tc = TestClient()
+        dep = textwrap.dedent(r"""
+            import os
+            from conan import ConanFile
+            from conan.tools.files import save
+
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "1.0"
+                settings = "os", "compiler", "build_type", "arch"
+
+                def package(self):
+                    p = self.package_folder
+                    save(self, os.path.join(p, "lib", "libcore.a"), "")
+                    save(self, os.path.join(p, "share", "cmake", "pkg_hook.cmake"),
+                         "# hook for tests\n")
+
+                def package_info(self):
+                    self.cpp_info.set_property("cmake_file_component_names", {
+                        "CoreKit": {
+                            "components": ["core"],
+                            "properties": {
+                                "cmake_build_modules": ["share/cmake/pkg_hook.cmake"],
+                                "cmake_extra_variables": {"PKG_HOOK_FLAG": 1},
+                                "cmake_additional_variables_prefixes": ["CoreLegacy"],
+                            },
+                        },
+                    })
+                    self.cpp_info.components["core"].libs = ["core"]
+                    self.cpp_info.components["core"].type = "static-library"
+                    self.cpp_info.components["core"].location = "lib/libcore.a"
+        """)
+        tc.save({"conanfile.py": dep})
+        tc.run("create .")
+        tc.run("install --requires=pkg/1.0 -g CMakeConfigDeps")
+        cfg = tc.load("CoreKitConfig.cmake")
+        assert "pkg_hook.cmake" in cfg
+        assert "set(PKG_HOOK_FLAG 1)" in cfg
+        assert 'set(CoreLegacy_VERSION_STRING "1.0")' in cfg
+        assert 'set(CoreKit_VERSION_STRING "1.0")' in cfg
+
+    def test_cmake_component_properties_extra_dependencies(self):
+        """Per-file ``properties``: cmake_extra_dependencies only affects that config's targets."""
+        tc = TestClient()
+        dep = textwrap.dedent("""
+            from conan import ConanFile
+
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "1.0"
+                settings = "os", "compiler", "build_type", "arch"
+
+                def package_info(self):
+                    self.cpp_info.set_property("cmake_file_component_names", {
+                        "PartA": {
+                            "components": ["a"],
+                            "properties": {"cmake_extra_dependencies": ["Protoc"]},
+                        },
+                        "PartB": {"components": ["b"], "properties": {}},
+                    })
+                    self.cpp_info.components["a"].libs = ["a"]
+                    self.cpp_info.components["a"].type = "static-library"
+                    self.cpp_info.components["a"].location = "lib/liba.a"
+                    self.cpp_info.components["b"].libs = ["b"]
+                    self.cpp_info.components["b"].type = "static-library"
+                    self.cpp_info.components["b"].location = "lib/libb.a"
+        """)
+        tc.save({"conanfile.py": dep})
+        tc.run("create .")
+        tc.run("install --requires=pkg/1.0 -g CMakeConfigDeps")
+        part_a = tc.load("PartA-Targets-release.cmake")
+        part_b = tc.load("PartB-Targets-release.cmake")
+        assert "find_dependency(Protoc" in part_a
+        assert "find_dependency(Protoc" not in part_b

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -1384,7 +1384,7 @@ class TestCmakeConfigProperties:
         assert "find_dependency(greetings REQUIRED CONFIG)" in adieu_targets
         assert "add_library(pkg::bye SHARED IMPORTED)" in adieu_targets
         assert "add_library(pkg::bye-helpers INTERFACE IMPORTED)" in adieu_targets
-        assert "# Requirement pkg::bye -> greet (Full link: False)" in adieu_targets
+        assert "# Requirement pkg::bye -> greet (Full link: True)" in adieu_targets
         assert "# Requirement pkg::bye -> pkg::bye-helpers (Full link: True)" in adieu_targets
 
         # No root pkg config when all components are listed in cmake_file_name

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -1335,7 +1335,6 @@ class TestCmakeConfigProperties:
                     self.cpp_info.set_property("cmake_file_name", {
                         "greetings": {
                             "components": ["hello", "hello-helpers"],
-                            "properties": {},
                         },
                         "adieu": {
                             "components": ["bye", "bye-helpers"],

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -1466,38 +1466,8 @@ class TestCmakeConfigProperties:
         tc.run("install --requires=pkg/1.0 -g CMakeConfigDeps", assert_error=True)
         assert "cmake_file_names property must be a dict" in tc.out
 
-    def test_error_default_component_in_another_file(self):
-        """Default component in cmake_file_names raises ConanException."""
-        tc = TestClient()
-        dep = textwrap.dedent("""
-            from conan import ConanFile
-
-            class Pkg(ConanFile):
-                name = "pkg"
-                version = "1.0"
-                settings = "os", "compiler", "build_type", "arch"
-
-                def package_info(self):
-                    self.cpp_info.components["compA"].libs = ["a"]
-                    self.cpp_info.components["compA"].type = "static-library"
-                    self.cpp_info.components["compA"].location = "lib/liba.a"
-                    self.cpp_info.components["compB"].libs = ["b"]
-                    self.cpp_info.components["compB"].type = "static-library"
-                    self.cpp_info.components["compB"].location = "lib/libb.a"
-                    self.cpp_info.default_components = ["compA"]
-                    self.cpp_info.set_property("cmake_file_names", {
-                        "MyLib": {"components": ["compA", "compB"]},
-                    })
-        """)
-        tc.save({"conanfile.py": dep})
-        tc.run("create .")
-        tc.run(f"install --requires=pkg/1.0 -g CMakeConfigDeps",
-               assert_error=True)
-        assert "default component 'compA' is defined in another CMake Config file" in tc.out
-        assert "cmake_file_names" in tc.out
-
-    def test_mixed_root_and_component_files(self):
-        """Some components in cmake_file_names, rest in root config file."""
+    def test_error_components_not_in_any_file(self):
+        """Every component must belong to one of the cmake_file_names files."""
         tc = TestClient()
         dep = textwrap.dedent("""
             from conan import ConanFile
@@ -1520,21 +1490,54 @@ class TestCmakeConfigProperties:
         """)
         tc.save({"conanfile.py": dep})
         tc.run("create .")
-        tc.run(f"install --requires=pkg/1.0 -g CMakeConfigDeps")
+        tc.run("install --requires=pkg/1.0 -g CMakeConfigDeps", assert_error=True)
+        assert ("pkg/1.0: components 'core' are not defined in any CMake config file. Check the "
+                "'cmake_file_names' property definition." in tc.out)
+        # No root config file is generated for a package split with cmake_file_names
+        assert not os.path.exists(os.path.join(tc.current_folder, "pkg-config.cmake"))
 
-        # Root pkg config with core component
-        assert tc.load("pkg-config.cmake")
-        pkg_targets = tc.load("pkg-Targets-release.cmake")
-        assert "pkg::core" in pkg_targets
+    def test_component_with_several_libs(self):
+        """A component declaring several libs keeps its internal targets in its own file."""
+        tc = TestClient()
+        dep = textwrap.dedent("""
+            import os
+            from conan import ConanFile
+            from conan.tools.files import save
 
-        # Extra config with extra component
-        assert tc.load("ExtraConfig.cmake")
-        extra_targets = tc.load("Extra-Targets-release.cmake")
-        assert "pkg::extra" in extra_targets
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "1.0"
+                settings = "os", "compiler", "build_type", "arch"
 
-        paths = tc.load("conan_cmakedeps_paths.cmake")
-        assert "set(pkg_DIR" in paths
-        assert "set(Extra_DIR" in paths
+                def package(self):
+                    for lib in ("core1", "core2"):
+                        save(self, os.path.join(self.package_folder, "lib", f"lib{lib}.a"), "")
+
+                def package_info(self):
+                    self.cpp_info.components["core"].libs = ["core1", "core2"]
+                    self.cpp_info.components["core"].type = "static-library"
+                    self.cpp_info.components["extra"].libs = ["extra"]
+                    self.cpp_info.components["extra"].type = "static-library"
+                    self.cpp_info.components["extra"].location = "lib/libextra.a"
+                    self.cpp_info.set_property("cmake_file_names", {
+                        "Core": {"components": ["core"]},
+                        "Extra": {"components": ["extra"]},
+                    })
+        """)
+        tc.save({"conanfile.py": dep})
+        tc.run("create .")
+        tc.run("install --requires=pkg/1.0 -g CMakeConfigDeps")
+
+        # The 2 libs are expanded into internal targets, all of them in the "Core" file
+        core_targets = tc.load("Core-Targets-release.cmake")
+        assert "add_library(pkg::core INTERFACE IMPORTED)" in core_targets
+        assert "add_library(pkg::_core_core1 STATIC IMPORTED)" in core_targets
+        assert "add_library(pkg::_core_core2 STATIC IMPORTED)" in core_targets
+        assert "# Requirement pkg::core -> pkg::_core_core1 (Full link: True)" in core_targets
+        assert "# Requirement pkg::core -> pkg::_core_core2 (Full link: True)" in core_targets
+        # The internal targets don't leak to the other file, no find_dependency needed either
+        assert "_core_" not in tc.load("Extra-Targets-release.cmake")
+        assert "find_dependency" not in core_targets
 
     def test_cmake_file_names_ignores_cmake_file_name(self):
         """When both properties are set, cmake_file_names wins and cmake_file_name is ignored."""
@@ -1556,6 +1559,7 @@ class TestCmakeConfigProperties:
                     self.cpp_info.components["extra"].location = "lib/libextra.a"
                     self.cpp_info.set_property("cmake_file_name", "MyPkg")
                     self.cpp_info.set_property("cmake_file_names", {
+                        "Core": {"components": ["core"]},
                         "Extra": {"components": ["extra"]},
                     })
         """)
@@ -1563,21 +1567,18 @@ class TestCmakeConfigProperties:
         tc.run("create .")
         tc.run("install --requires=pkg/1.0 -g CMakeConfigDeps")
 
-        # cmake_file_name is ignored: leftover components stay in the recipe-named root file
-        assert tc.load("pkg-config.cmake")
-        pkg_targets = tc.load("pkg-Targets-release.cmake")
-        assert "pkg::core" in pkg_targets
+        # cmake_file_name is ignored, and no root config file is generated
         assert not os.path.exists(os.path.join(tc.current_folder, "MyPkgConfig.cmake"))
         assert not os.path.exists(os.path.join(tc.current_folder, "MyPkg-config.cmake"))
+        assert not os.path.exists(os.path.join(tc.current_folder, "pkg-config.cmake"))
 
-        # cmake_file_names still generates the Extra config
-        assert tc.load("ExtraConfig.cmake")
-        extra_targets = tc.load("Extra-Targets-release.cmake")
-        assert "pkg::extra" in extra_targets
+        assert "pkg::core" in tc.load("Core-Targets-release.cmake")
+        assert "pkg::extra" in tc.load("Extra-Targets-release.cmake")
 
         paths = tc.load("conan_cmakedeps_paths.cmake")
-        assert "set(pkg_DIR" in paths
+        assert "set(Core_DIR" in paths
         assert "set(Extra_DIR" in paths
+        assert "set(pkg_DIR" not in paths
         assert "set(MyPkg_DIR" not in paths
 
     def test_find_dependency_uses_correct_names(self):
@@ -1620,6 +1621,105 @@ class TestCmakeConfigProperties:
         consumer_targets = tc.load("consumer-Targets-release.cmake")
         assert "find_dependency(DepLib" in consumer_targets
         assert "find_dependency(dep " not in consumer_targets
+
+    def test_consuming_only_the_required_transitive_components(self):
+        """Requiring one component only links the components it transitively depends on."""
+        c = TestClient()
+        liba = textwrap.dedent("""
+            import os
+            from conan import ConanFile
+            from conan.tools.files import save
+
+            class Liba(ConanFile):
+                name = "liba"
+                version = "1.0"
+                settings = "os", "compiler", "build_type", "arch"
+
+                def package(self):
+                    for lib in ("a1", "a2"):
+                        save(self, os.path.join(self.package_folder, "lib", f"lib{lib}.a"), "")
+
+                def package_info(self):
+                    self.cpp_info.components["acomp1"].libs = ["a1"]
+                    self.cpp_info.components["acomp1"].type = "static-library"
+                    self.cpp_info.components["acomp2"].libs = ["a2"]
+                    self.cpp_info.components["acomp2"].type = "static-library"
+            """)
+        libb = textwrap.dedent("""
+            import os
+            from conan import ConanFile
+            from conan.tools.files import save
+
+            class Libb(ConanFile):
+                name = "libb"
+                version = "1.0"
+                settings = "os", "compiler", "build_type", "arch"
+                requires = "liba/1.0"
+
+                def package(self):
+                    for lib in ("b1", "b2"):
+                        save(self, os.path.join(self.package_folder, "lib", f"lib{lib}.a"), "")
+
+                def package_info(self):
+                    self.cpp_info.set_property("cmake_file_names", {
+                        "BLib1": {"components": ["bcomp1"]},
+                        "BLib2": {"components": ["bcomp2"]},
+                    })
+                    self.cpp_info.components["bcomp1"].libs = ["b1"]
+                    self.cpp_info.components["bcomp1"].type = "static-library"
+                    self.cpp_info.components["bcomp1"].requires = ["liba::acomp1"]
+                    self.cpp_info.components["bcomp2"].libs = ["b2"]
+                    self.cpp_info.components["bcomp2"].type = "static-library"
+                    self.cpp_info.components["bcomp2"].requires = ["liba::acomp2"]
+            """)
+        consumer = textwrap.dedent("""
+            from conan import ConanFile
+
+            class Consumer(ConanFile):
+                name = "consumer"
+                version = "1.0"
+                settings = "os", "compiler", "build_type", "arch"
+                requires = "libb/1.0"
+
+                def package_info(self):
+                    self.cpp_info.requires = ["libb::bcomp1"]
+            """)
+        c.save({"liba/conanfile.py": liba,
+                "libb/conanfile.py": libb,
+                "consumer/conanfile.py": consumer})
+        c.run("create liba")
+        c.run("create libb")
+        c.run("create consumer")
+        c.run("install --requires=consumer/1.0 -g CMakeConfigDeps")
+
+        # The consumer only links the required component, not the whole libb::libb target.
+        # Since libb splits its components with cmake_file_names, find_dependency uses the
+        # cmake file name (BLib1) that owns bcomp1, not the package name (libb).
+        consumer_targets = c.load("consumer-Targets-release.cmake")
+        assert "find_dependency(BLib1 REQUIRED CONFIG)" in consumer_targets
+        assert "find_dependency(libb" not in consumer_targets
+        assert "find_dependency(BLib2" not in consumer_targets
+        assert "# Requirement consumer::consumer -> libb::bcomp1 (Full link: True)" in consumer_targets
+        assert "libb::bcomp2" not in consumer_targets
+        assert "libb::libb" not in consumer_targets
+        # liba is only reached through libb::bcomp1
+        assert "liba::" not in consumer_targets
+
+        # No root libb config file is generated: all components are split across
+        # BLib1/BLib2 by cmake_file_names.
+        assert not os.path.exists(os.path.join(c.current_folder, "libb-Targets-release.cmake"))
+
+        # Each libb component (now split into its own cmake file) links only its own
+        # liba component.
+        blib1_targets = c.load("BLib1-Targets-release.cmake")
+        assert "find_dependency(liba REQUIRED CONFIG)" in blib1_targets
+        assert "# Requirement libb::bcomp1 -> liba::acomp1 (Full link: True)" in blib1_targets
+        assert "# Requirement libb::bcomp1 -> liba::acomp2" not in blib1_targets
+
+        blib2_targets = c.load("BLib2-Targets-release.cmake")
+        assert "find_dependency(liba REQUIRED CONFIG)" in blib2_targets
+        assert "# Requirement libb::bcomp2 -> liba::acomp2 (Full link: True)" in blib2_targets
+        assert "# Requirement libb::bcomp2 -> liba::acomp1" not in blib2_targets
 
     def test_cmake_component_properties_version_and_compat(self):
         """Per-file ``properties`` can override config-version (system_package_version, compat)."""

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -1317,10 +1317,10 @@ def test_find_mode_none():
 
 
 class TestCmakeConfigProperties:
-    """Tests for cmake_file_name — components grouped per CMake config file."""
+    """Tests for cmake_file_names — components grouped per CMake config file."""
 
     def test_generates_multiple_config_files(self):
-        """Package with cmake_file_name generates separate config files per group."""
+        """Package with cmake_file_names generates separate config files per group."""
         tc = TestClient()
         dep = textwrap.dedent("""
             from conan import ConanFile
@@ -1332,7 +1332,7 @@ class TestCmakeConfigProperties:
 
                 def package_info(self):
                     # CMake File names for components
-                    self.cpp_info.set_property("cmake_file_name", {
+                    self.cpp_info.set_property("cmake_file_names", {
                         "greetings": {
                             "components": ["hello", "hello-helpers"],
                         },
@@ -1387,11 +1387,11 @@ class TestCmakeConfigProperties:
         assert "# Requirement pkg::bye -> greet (Full link: True)" in adieu_targets
         assert "# Requirement pkg::bye -> pkg::bye-helpers (Full link: True)" in adieu_targets
 
-        # No root pkg config when all components are listed in cmake_file_name
+        # No root pkg config when all components are listed in cmake_file_names
         assert not os.path.exists(os.path.join(tc.current_folder, "pkg-config.cmake"))
 
     def test_paths_include_cmake_file_names(self):
-        """conan_cmakedeps_paths.cmake sets DIR for each cmake file from cmake_file_name."""
+        """conan_cmakedeps_paths.cmake sets DIR for each cmake file from cmake_file_names."""
         tc = TestClient()
         dep = textwrap.dedent("""
             from conan import ConanFile
@@ -1408,7 +1408,7 @@ class TestCmakeConfigProperties:
                     self.cpp_info.components["compB"].libs = ["b"]
                     self.cpp_info.components["compB"].type = "static-library"
                     self.cpp_info.components["compB"].location = "lib/libb.a"
-                    self.cpp_info.set_property("cmake_file_name", {
+                    self.cpp_info.set_property("cmake_file_names", {
                         "MyLib": {"components": ["compA", "compB"]},
                     })
         """)
@@ -1418,11 +1418,11 @@ class TestCmakeConfigProperties:
 
         paths = tc.load("conan_cmakedeps_paths.cmake")
         assert "set(MyLib_DIR" in paths
-        # pkg_DIR should not exist when all components are in cmake_file_name
+        # pkg_DIR should not exist when all components are in cmake_file_names
         assert "set(pkg_DIR" not in paths
 
     def test_error_nonexistent_component(self):
-        """Using a non-existent component in cmake_file_name raises ConanException."""
+        """Using a non-existent component in cmake_file_names raises ConanException."""
         tc = TestClient()
         dep = textwrap.dedent("""
             from conan import ConanFile
@@ -1436,7 +1436,7 @@ class TestCmakeConfigProperties:
                     self.cpp_info.components["compA"].libs = ["a"]
                     self.cpp_info.components["compA"].type = "static-library"
                     self.cpp_info.components["compA"].location = "lib/liba.a"
-                    self.cpp_info.set_property("cmake_file_name", {
+                    self.cpp_info.set_property("cmake_file_names", {
                         "MyLib": {"components": ["compA", "nonexistent"]},
                     })
         """)
@@ -1445,10 +1445,29 @@ class TestCmakeConfigProperties:
         tc.run(f"install --requires=pkg/1.0 -g CMakeConfigDeps",
                assert_error=True)
         assert "Component 'nonexistent' does not exist" in tc.out
-        assert "cmake_file_name" in tc.out
+        assert "cmake_file_names" in tc.out
+
+    def test_error_cmake_file_names_not_dict(self):
+        """cmake_file_names that is not a dict raises ConanException."""
+        tc = TestClient()
+        dep = textwrap.dedent("""
+            from conan import ConanFile
+
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "1.0"
+                settings = "os", "compiler", "build_type", "arch"
+
+                def package_info(self):
+                    self.cpp_info.set_property("cmake_file_names", "MyLib")
+        """)
+        tc.save({"conanfile.py": dep})
+        tc.run("create .")
+        tc.run("install --requires=pkg/1.0 -g CMakeConfigDeps", assert_error=True)
+        assert "cmake_file_names property must be a dict" in tc.out
 
     def test_error_default_component_in_another_file(self):
-        """Default component in cmake_file_name raises ConanException."""
+        """Default component in cmake_file_names raises ConanException."""
         tc = TestClient()
         dep = textwrap.dedent("""
             from conan import ConanFile
@@ -1466,7 +1485,7 @@ class TestCmakeConfigProperties:
                     self.cpp_info.components["compB"].type = "static-library"
                     self.cpp_info.components["compB"].location = "lib/libb.a"
                     self.cpp_info.default_components = ["compA"]
-                    self.cpp_info.set_property("cmake_file_name", {
+                    self.cpp_info.set_property("cmake_file_names", {
                         "MyLib": {"components": ["compA", "compB"]},
                     })
         """)
@@ -1475,10 +1494,10 @@ class TestCmakeConfigProperties:
         tc.run(f"install --requires=pkg/1.0 -g CMakeConfigDeps",
                assert_error=True)
         assert "default component 'compA' is defined in another CMake Config file" in tc.out
-        assert "cmake_file_name" in tc.out
+        assert "cmake_file_names" in tc.out
 
     def test_mixed_root_and_component_files(self):
-        """Some components in cmake_file_name, rest in root config file."""
+        """Some components in cmake_file_names, rest in root config file."""
         tc = TestClient()
         dep = textwrap.dedent("""
             from conan import ConanFile
@@ -1495,7 +1514,7 @@ class TestCmakeConfigProperties:
                     self.cpp_info.components["extra"].libs = ["extra"]
                     self.cpp_info.components["extra"].type = "static-library"
                     self.cpp_info.components["extra"].location = "lib/libextra.a"
-                    self.cpp_info.set_property("cmake_file_name", {
+                    self.cpp_info.set_property("cmake_file_names", {
                         "Extra": {"components": ["extra"]},
                     })
         """)
@@ -1517,8 +1536,52 @@ class TestCmakeConfigProperties:
         assert "set(pkg_DIR" in paths
         assert "set(Extra_DIR" in paths
 
+    def test_cmake_file_names_ignores_cmake_file_name(self):
+        """When both properties are set, cmake_file_names wins and cmake_file_name is ignored."""
+        tc = TestClient()
+        dep = textwrap.dedent("""
+            from conan import ConanFile
+
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "1.0"
+                settings = "os", "compiler", "build_type", "arch"
+
+                def package_info(self):
+                    self.cpp_info.components["core"].libs = ["core"]
+                    self.cpp_info.components["core"].type = "static-library"
+                    self.cpp_info.components["core"].location = "lib/libcore.a"
+                    self.cpp_info.components["extra"].libs = ["extra"]
+                    self.cpp_info.components["extra"].type = "static-library"
+                    self.cpp_info.components["extra"].location = "lib/libextra.a"
+                    self.cpp_info.set_property("cmake_file_name", "MyPkg")
+                    self.cpp_info.set_property("cmake_file_names", {
+                        "Extra": {"components": ["extra"]},
+                    })
+        """)
+        tc.save({"conanfile.py": dep})
+        tc.run("create .")
+        tc.run("install --requires=pkg/1.0 -g CMakeConfigDeps")
+
+        # cmake_file_name is ignored: leftover components stay in the recipe-named root file
+        assert tc.load("pkg-config.cmake")
+        pkg_targets = tc.load("pkg-Targets-release.cmake")
+        assert "pkg::core" in pkg_targets
+        assert not os.path.exists(os.path.join(tc.current_folder, "MyPkgConfig.cmake"))
+        assert not os.path.exists(os.path.join(tc.current_folder, "MyPkg-config.cmake"))
+
+        # cmake_file_names still generates the Extra config
+        assert tc.load("ExtraConfig.cmake")
+        extra_targets = tc.load("Extra-Targets-release.cmake")
+        assert "pkg::extra" in extra_targets
+
+        paths = tc.load("conan_cmakedeps_paths.cmake")
+        assert "set(pkg_DIR" in paths
+        assert "set(Extra_DIR" in paths
+        assert "set(MyPkg_DIR" not in paths
+
     def test_find_dependency_uses_correct_names(self):
-        """Transitive find_dependency uses cmake file name from cmake_file_name."""
+        """Transitive find_dependency uses cmake file name from cmake_file_names."""
         tc = TestClient()
         dep = textwrap.dedent("""
             from conan import ConanFile
@@ -1532,7 +1595,7 @@ class TestCmakeConfigProperties:
                     self.cpp_info.components["lib"].libs = ["dep"]
                     self.cpp_info.components["lib"].type = "static-library"
                     self.cpp_info.components["lib"].location = "lib/libdep.a"
-                    self.cpp_info.set_property("cmake_file_name", {
+                    self.cpp_info.set_property("cmake_file_names", {
                         "DepLib": {"components": ["lib"]},
                     })
         """)
@@ -1575,7 +1638,7 @@ class TestCmakeConfigProperties:
                     save(self, os.path.join(self.package_folder, "lib", "libw.a"), "")
 
                 def package_info(self):
-                    self.cpp_info.set_property("cmake_file_name", {
+                    self.cpp_info.set_property("cmake_file_names", {
                         "widgets": {
                             "components": ["widgets"],
                             "properties": {
@@ -1615,7 +1678,7 @@ class TestCmakeConfigProperties:
                          "# hook for tests\n")
 
                 def package_info(self):
-                    self.cpp_info.set_property("cmake_file_name", {
+                    self.cpp_info.set_property("cmake_file_names", {
                         "CoreKit": {
                             "components": ["core"],
                             "properties": {
@@ -1650,7 +1713,7 @@ class TestCmakeConfigProperties:
                 settings = "os", "compiler", "build_type", "arch"
 
                 def package_info(self):
-                    self.cpp_info.set_property("cmake_file_name", {
+                    self.cpp_info.set_property("cmake_file_names", {
                         "PartA": {
                             "components": ["a"],
                             "properties": {"cmake_extra_dependencies": ["Protoc"]},

--- a/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
+++ b/test/integration/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps.py
@@ -1834,3 +1834,105 @@ class TestCmakeConfigProperties:
         part_b = tc.load("PartB-Targets-release.cmake")
         assert "find_dependency(Protoc" in part_a
         assert "find_dependency(Protoc" not in part_b
+
+    def test_cmake_components_per_cmake_file_name(self):
+        """Each cmake_file_names config advertises find_package COMPONENTS, not only the root."""
+        tc = TestClient()
+        dep = textwrap.dedent("""
+            from conan import ConanFile
+
+            class Pkg(ConanFile):
+                name = "pkg"
+                version = "1.0"
+                settings = "os", "compiler", "build_type", "arch"
+
+                def package_info(self):
+                    self.cpp_info.set_property("cmake_file_names", {
+                        "CoreKit": {
+                            "components": ["core", "helpers", "_private"],
+                        },
+                        "ExtraKit": {
+                            "components": ["extra"],
+                            "properties": {"cmake_components": ["ExtraFoo", "ExtraBar"]},
+                        },
+                    })
+                    self.cpp_info.components["core"].libs = ["core"]
+                    self.cpp_info.components["core"].type = "static-library"
+                    self.cpp_info.components["core"].location = "lib/libcore.a"
+                    self.cpp_info.components["core"].set_property("cmake_target_name", "pkg::Core")
+                    self.cpp_info.components["helpers"].defines = ["HELPERS"]
+                    self.cpp_info.components["helpers"].set_property("cmake_components",
+                                                                    ["HelpersComp"])
+                    self.cpp_info.components["_private"].defines = ["PRIVATE"]
+                    self.cpp_info.components["extra"].libs = ["extra"]
+                    self.cpp_info.components["extra"].type = "static-library"
+                    self.cpp_info.components["extra"].location = "lib/libextra.a"
+        """)
+        tc.save({"conanfile.py": dep})
+        tc.run("create .")
+        tc.run("install --requires=pkg/1.0 -g CMakeConfigDeps")
+
+        core = tc.load("CoreKitConfig.cmake")
+        extra = tc.load("ExtraKitConfig.cmake")
+        # Declared components of this file: target name / per-component cmake_components.
+        # Private components starting with '_' are not advertised.
+        assert "set(CoreKit_PACKAGE_PROVIDED_COMPONENTS Core HelpersComp)" in core
+        # Per-file cmake_components overrides the default listing
+        assert "set(ExtraKit_PACKAGE_PROVIDED_COMPONENTS ExtraFoo ExtraBar)" in extra
+        assert "Core" not in extra
+
+    def test_implicit_root_of_cmake_file_names_dep(self):
+        """A library that requires a cmake_file_names package without cpp_info.requires
+        must fail at generate time: there is no pkg::pkg root target to link.
+        """
+        tc = TestClient()
+        spirv_tools = textwrap.dedent("""
+            from conan import ConanFile
+
+            class SpirvTools(ConanFile):
+                name = "spirv-tools"
+                version = "1.3.290.0"
+                settings = "os", "compiler", "build_type", "arch"
+
+                def package_info(self):
+                    components = {
+                        "spirv-tools-core": [],
+                        "spirv-tools-opt": ["spirv-tools-core"],
+                        "spirv-tools-link": ["spirv-tools-core", "spirv-tools-opt"],
+                    }
+                    self.cpp_info.set_property("cmake_file_names", {
+                        "SPIRV-Tools": {"components": ["spirv-tools-core"]},
+                        "SPIRV-Tools-opt": {"components": ["spirv-tools-opt"]},
+                        "SPIRV-Tools-link": {"components": ["spirv-tools-link"]},
+                    })
+                    for name, reqs in components.items():
+                        self.cpp_info.components[name].libs = [name]
+                        self.cpp_info.components[name].type = "static-library"
+                        self.cpp_info.components[name].location = f"lib/lib{name}.a"
+                        if reqs:
+                            self.cpp_info.components[name].requires = reqs
+        """)
+        vvl = textwrap.dedent("""
+            from conan import ConanFile
+
+            class VulkanValidationLayers(ConanFile):
+                name = "vulkan-validationlayers"
+                version = "1.3.290.0"
+                settings = "os", "compiler", "build_type", "arch"
+                requires = "spirv-tools/1.3.290.0"
+
+                def package_info(self):
+                    self.cpp_info.libs = ["vulkan_validationlayers"]
+                    self.cpp_info.type = "static-library"
+                    self.cpp_info.location = "lib/libvulkan_validationlayers.a"
+        """)
+        tc.save({"spirv-tools/conanfile.py": spirv_tools,
+                 "vvl/conanfile.py": vvl})
+        tc.run("create spirv-tools")
+        tc.run("create vvl")
+        tc.run("install --requires=vulkan-validationlayers/1.3.290.0 -g CMakeConfigDeps",
+               assert_error=True)
+        assert ("vulkan-validationlayers/1.3.290.0 recipe cpp_info does not declare which "
+                "component of 'spirv-tools' to link") in tc.out
+        assert "self.cpp_info.requires = [\"spirv-tools::<component>\"]" in tc.out
+        assert "Available components: spirv-tools-core, spirv-tools-opt, spirv-tools-link" in tc.out


### PR DESCRIPTION
Changelog: Feature: Multi-CONFIG CMake files mechanism in CMakeConfigDeps.
Changelog: Feature: New property `cmake_file_names` that accepts a dict object read by CMakeConfigDeps.
Changelog: Feature: Add an optional `components` kwarg to the `aggregated_components` function to restrict the aggregation to the passed list of components.
Docs: https://github.com/conan-io/docs/pull/XXXX
Closes: https://github.com/conan-io/conan/issues/19407

### Other details

If `cmake_file_names` is used:

* `default_components` are ignored 
* Target interface is not created per CONFIG file (legacy root interface target appending all the targets).
* Raise an exception if any component is not added to any CONFIG file.


### Checked on CCI repo

**spirv-tools**

Applying this diff, it should work locally on your native env (if `cmake_file_names` is present, `cmake_file_name` is ignored):
```diff
diff --git a/recipes/spirv-tools/all/conanfile.py b/recipes/spirv-tools/all/conanfile.py
index 63ee667a0a..d9dcdb9749 100644
--- a/recipes/spirv-tools/all/conanfile.py
+++ b/recipes/spirv-tools/all/conanfile.py
@@ -146,7 +146,14 @@ class SpirvtoolsConan(ConanFile):
             rm(self, "*SPIRV-Tools-shared*", os.path.join(self.package_folder, "lib"))

     def package_info(self):
         self.cpp_info.set_property("cmake_file_name", "SPIRV-Tools")
+        self.cpp_info.set_property("cmake_file_names", {
+            "SPIRV-Tools": {"components": ["spirv-tools-core"]},
+            "SPIRV-Tools-opt": {"components": ["spirv-tools-opt"]},
+            "SPIRV-Tools-link": {"components": ["spirv-tools-link"]},
+            "SPIRV-Tools-reduce": {"components": ["spirv-tools-reduce"]},
+            "SPIRV-Tools-lint": {"components": ["spirv-tools-lint"]},
+            "SPIRV-Tools-diff": {"components": ["spirv-tools-diff"]},
+        })
         self.cpp_info.set_property("pkg_config_name", "SPIRV-Tools-shared" if self.options.shared else "SPIRV-Tools")

         # SPIRV-Tools
diff --git a/recipes/spirv-tools/all/test_package/CMakeLists.txt b/recipes/spirv-tools/all/test_package/CMakeLists.txt
index 8e5e8c835..8f599056f 100644
--- a/recipes/spirv-tools/all/test_package/CMakeLists.txt
+++ b/recipes/spirv-tools/all/test_package/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.15)
 project(test_package)

 find_package(SPIRV-Tools REQUIRED CONFIG)
+find_package(SPIRV-Tools-opt REQUIRED CONFIG)

 add_executable(${PROJECT_NAME}_c test_package.c)
 if(TARGET SPIRV-Tools-shared)
diff --git a/recipes/spirv-tools/all/test_package/conanfile.py b/recipes/spirv-tools/all/test_package/conanfile.py
index d8eaf2ab1..98a5e384f 100644
--- a/recipes/spirv-tools/all/test_package/conanfile.py
+++ b/recipes/spirv-tools/all/test_package/conanfile.py
@@ -6,7 +6,7 @@ import os

 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
-    generators = "CMakeToolchain", "CMakeDeps", "VirtualRunEnv"
+    generators = "CMakeToolchain", "CMakeConfigDeps", "VirtualRunEnv"
     test_type = "explicit"

     def layout(self):
```

```bash
-- Conan: Configuring Targets for spirv-tools-opt
-- Conan: Configuring Targets for spirv-tools-core
-- Conan: Target declared imported STATIC library 'SPIRV-Tools-static'
-- Conan: Target declared alias 'SPIRV-Tools' for 'SPIRV-Tools-static'
-- Conan: Target declared imported STATIC library 'SPIRV-Tools-opt'
-- Configuring done (0.8s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/frannchuti/develop/conan-center-index/recipes/spirv-tools/all/test_package/build/apple-clang-17-armv8-gnu17-release

spirv-tools/1.4.350.0 (test package): Running CMake.build()
spirv-tools/1.4.350.0 (test package): RUN: cmake --build "/Users/frannchuti/develop/conan-center-index/recipes/spirv-tools/all/test_package/build/apple-clang-17-armv8-gnu17-release" -- -j14
[ 25%] Building C object CMakeFiles/test_package_c.dir/test_package.c.o
[ 50%] Building CXX object CMakeFiles/test_package_cpp.dir/test_package.cpp.o
[ 75%] Linking C executable test_package_c
[ 75%] Built target test_package_c
[100%] Linking CXX executable test_package_cpp
ld: warning: ignoring duplicate libraries: '-lc++'
[100%] Built target test_package_cpp


======== Testing the package: Executing test ========
spirv-tools/1.4.350.0 (test package): Running test()
spirv-tools/1.4.350.0 (test package): RUN: ./test_package_c

spirv-tools/1.4.350.0 (test package): RUN: ./test_package_cpp
OpCapability Linkage
OpCapability Shader
OpMemoryModel Logical GLSL450
%int = OpTypeInt 32 1
%int_42 = OpConstant %int 42
```
```bash
$ tree
tree
.
├── . . . 
├── SPIRV-Tools-diff-Targets-release.cmake
├── SPIRV-Tools-diffConfig.cmake
├── SPIRV-Tools-diffConfigVersion.cmake
├── SPIRV-Tools-diffTargets.cmake
├── SPIRV-Tools-link-Targets-release.cmake
├── SPIRV-Tools-linkConfig.cmake
├── SPIRV-Tools-linkConfigVersion.cmake
├── SPIRV-Tools-linkTargets.cmake
├── SPIRV-Tools-lint-Targets-release.cmake
├── SPIRV-Tools-lintConfig.cmake
├── SPIRV-Tools-lintConfigVersion.cmake
├── SPIRV-Tools-lintTargets.cmake
├── SPIRV-Tools-opt-Targets-release.cmake
├── SPIRV-Tools-optConfig.cmake
├── SPIRV-Tools-optConfigVersion.cmake
├── SPIRV-Tools-optTargets.cmake
├── SPIRV-Tools-reduce-Targets-release.cmake
├── SPIRV-Tools-reduceConfig.cmake
├── SPIRV-Tools-reduceConfigVersion.cmake
├── SPIRV-Tools-reduceTargets.cmake
├── SPIRV-Tools-Targets-release.cmake
├── SPIRV-ToolsConfig.cmake
├── SPIRV-ToolsConfigVersion.cmake
└── SPIRV-ToolsTargets.cmake
```
