### PR TITLE
Prioritize host and visible nodes in workspace monolithic builds when ambiguity arises

### DIFF
--- a/conan/api/subapi/workspace.py
+++ b/conan/api/subapi/workspace.py
@@ -424,7 +424,13 @@ class WorkspaceAPI:
                 else:
                     require = existing.require
                     require.aggregate(r)
-                    root.transitive_deps[require] = TransitiveRequirement(require, t.node)
+                    # Prefer host node if they are different
+                    n = t.node
+                    if t.node.context != existing.node.context and existing.node.context == CONTEXT_HOST:
+                        n = existing.node
+                        ConanOutput().warning(f"Workspace has dependencies to the same package {require} in different contexts, "
+                                              f"which can cause problems. Using the host context node")
+                    root.transitive_deps[require] = TransitiveRequirement(require, n)
 
         # The graph edges must be defined too
         for r, t in root.transitive_deps.items():

--- a/conan/api/subapi/workspace.py
+++ b/conan/api/subapi/workspace.py
@@ -423,13 +423,17 @@ class WorkspaceAPI:
                     root.transitive_deps[r] = t
                 else:
                     require = existing.require
-                    require.aggregate(r)
                     # Prefer host node if they are different
                     n = t.node
                     if t.node.context != existing.node.context and existing.node.context == CONTEXT_HOST:
                         n = existing.node
                         ConanOutput().warning(f"Workspace has dependencies to the same package {require} in different contexts, "
                                               f"which can cause problems. Using the host context node")
+                    elif require.visible != r.visible and require.visible:
+                        n = existing.node
+                        ConanOutput().warning(f"Workspace has dependencies to the same package {require} with different visibility, "
+                                              f"which can cause problems. Using the visible node")
+                    require.aggregate(r)
                     root.transitive_deps[require] = TransitiveRequirement(require, n)
 
         # The graph edges must be defined too

--- a/test/functional/workspace/test_workspace.py
+++ b/test/functional/workspace/test_workspace.py
@@ -1,9 +1,11 @@
 import os
 import platform
 import shutil
+import textwrap
 
 import pytest
 
+from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.mocks import ConanFileMock
 from conan.test.utils.tools import TestClient
 from conan.tools.files import replace_in_file
@@ -92,3 +94,300 @@ def test_super_build_different_layouts():
     assert "Adding project: liba" in c.out
     assert "Adding project: libb" in c.out
     assert "Adding project: app1" in c.out
+
+
+# The workspace CMake needs at least 3.25 for find_package to work
+@pytest.mark.tool("cmake", "3.27")
+def test_super_build_private_version_ambiguous():
+    """
+    https://github.com/conan-io/conan/issues/20304
+    Known, accepted trade-off (not a bug to fix): "core" and "other" are two
+    unrelated editables, each with its own *private* (visible=False) dependency on a
+    different version of "leaf". This proves, at the real CMake/find_package level
+    (not just by inspecting Conan-generated file content), what test_workspace.py's
+    test_link_libraries_editable_private_version_ambiguous shows at the graph level:
+    the monolithic build's top-level CMakeLists.txt pulls "core" and "other" in as
+    source via the same FetchContent_Declare(..., OVERRIDE_FIND_PACKAGE) mechanism
+    "conan new workspace" scaffolds (see "Adding project" below), but "leaf" itself is
+    a regular, non-editable dependency resolved via a single, shared, generated
+    find_package() config - there is only one CMAKE_PREFIX_PATH for the whole
+    monolithic build. So both "core" and "other" end up calling find_package(leaf)
+    from their own CMakeLists.txt and get back the exact same version, even though
+    they each declared a different one.
+    """
+    c = TestClient()
+    workspace = textwrap.dedent("""
+        from conan import ConanFile, Workspace
+        from conan.tools.cmake import CMakeConfigDeps, CMakeToolchain, cmake_layout
+        from conan.tools.files import save
+
+
+        class MyWs(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+
+            def generate(self):
+                CMakeConfigDeps(self).generate()
+                CMakeToolchain(self).generate()
+
+            def layout(self):
+                cmake_layout(self)
+
+
+        class MyWorkspace(Workspace):
+            def root_conanfile(self):
+                return MyWs
+
+            def packages(self):
+                return [{"path": "core", "ref": "core/1.0"},
+                        {"path": "other", "ref": "other/1.0"}]
+
+            def build_order(self, order):
+                super().build_order(order)
+                pkglist = " ".join([f'{it["ref"].name}:{it["folder"]}'
+                                    for level in order for it in level])
+                save(self, "build/conanws_build_order.cmake",
+                    f"set(CONAN_WS_BUILD_ORDER {pkglist})")
+        """)
+    # Same FetchContent_Declare(..., OVERRIDE_FIND_PACKAGE) loop that "conan new
+    # workspace" scaffolds: it is how a real monolithic build brings editable sources
+    # into one shared CMake project.
+    root_cmake = textwrap.dedent("""\
+        cmake_minimum_required(VERSION 3.25)
+        project(monorepo CXX)
+
+        include(FetchContent)
+
+        function(add_project PACKAGE_NAME SUBFOLDER)
+            message(STATUS "Adding project: ${PACKAGE_NAME}. Folder: ${SUBFOLDER}")
+            FetchContent_Declare(
+                ${PACKAGE_NAME}
+                SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/${SUBFOLDER}
+                SYSTEM
+                OVERRIDE_FIND_PACKAGE
+            )
+            FetchContent_MakeAvailable(${PACKAGE_NAME})
+        endfunction()
+
+        include(build/conanws_build_order.cmake)
+
+        foreach(pair ${CONAN_WS_BUILD_ORDER})
+            string(FIND "${pair}" ":" pos)
+            string(SUBSTRING "${pair}" 0 "${pos}" pkg)
+            math(EXPR pos "${pos} + 1")  # Skip the separator
+            string(SUBSTRING "${pair}" "${pos}" -1 folder)
+
+            add_project(${pkg} ${folder})
+            get_target_property(target_type ${pkg} TYPE)
+            if (NOT target_type STREQUAL "EXECUTABLE")
+                add_library(${pkg}::${pkg} ALIAS ${pkg})
+            endif()
+        endforeach()
+        """)
+
+    def pkg_cmake(name):
+        # Each editable independently does its own find_package(leaf) and reports
+        # what it got, so the mismatch is visible directly in the cmake configure log.
+        return textwrap.dedent(f"""\
+            cmake_minimum_required(VERSION 3.25)
+            project({name} CXX)
+
+            find_package(leaf REQUIRED)
+            message(STATUS "{name.upper()} sees leaf version: ${{leaf_VERSION_STRING}}")
+
+            add_library({name} INTERFACE)
+            target_link_libraries({name} INTERFACE leaf::leaf)
+            """)
+
+    def pkg_conanfile(name, leaf_version):
+        return textwrap.dedent(f"""\
+            from conan import ConanFile
+            from conan.tools.cmake import cmake_layout
+
+
+            class Pkg(ConanFile):
+                name = "{name}"
+                version = "1.0"
+                settings = "os", "compiler", "build_type", "arch"
+                exports_sources = "CMakeLists.txt"
+
+                def layout(self):
+                    cmake_layout(self)
+
+                def requirements(self):
+                    self.requires("leaf/{leaf_version}", visible=False)
+            """)
+
+    c.save({"leaf/conanfile.py": GenConanfile("leaf"),
+            "core/conanfile.py": pkg_conanfile("core", "1.0"),
+            "core/CMakeLists.txt": pkg_cmake("core"),
+            "other/conanfile.py": pkg_conanfile("other", "2.0"),
+            "other/CMakeLists.txt": pkg_cmake("other"),
+            "conanws.py": workspace,
+            "CMakeLists.txt": root_cmake})
+    c.run("create leaf --version=1.0")
+    c.run("create leaf --version=2.0")
+    c.run("workspace super-install")
+
+    config_preset = "conan-default" if platform.system() == "Windows" else "conan-release"
+    c.run_command(f"cmake --preset {config_preset}")
+    # Both editables are genuinely pulled in as source via FetchContent
+    assert "Adding project: core" in c.out
+    assert "Adding project: other" in c.out
+
+    # "core" declared leaf/1.0 and "other" declared leaf/2.0, but there is only one
+    # find_package(leaf) resolution for the whole monolithic build: both report the
+    # same (wrong, for one of them) version.
+    assert "CORE sees leaf version: 2.0" in c.out
+    assert "OTHER sees leaf version: 2.0" in c.out
+
+
+# The workspace CMake needs at least 3.25 for find_package to work
+@pytest.mark.tool("cmake", "3.27")
+def test_super_build_two_editables_same_name():
+    """
+    https://github.com/conan-io/conan/issues/20304
+    Unlike test_super_build_private_version_ambiguous above (silent wrong version, no
+    warning), having TWO editables share the same name is not silently resolved: it
+    crashes. A plain "workspace super-install" fails immediately ("Duplicated
+    requirement") before reaching any of this, because every editable is a top-level
+    requirement by default - see test_two_editables_same_name_different_version in
+    test/integration/workspace/test_workspace.py. But that guard is incidental: using
+    --pkg to select only "core" and "other" as top-level requirements sidesteps it, and
+    Conan then accepts both editable "leaf/1.0" and "leaf/2.0" (reached only
+    transitively, through "core"'s and "other"'s own private requirements) silently,
+    side by side in the graph. The failure only shows up once the "conan new
+    workspace"-style FetchContent build order tries to add BOTH "leaf" editables (from
+    two different folders) as source into the one monolithic CMake project: the second
+    one crashes CMake outright, with an error that says nothing about Conan,
+    workspaces, or the actual duplicate-name root cause.
+    """
+    c = TestClient()
+    workspace = textwrap.dedent("""
+        from conan import ConanFile, Workspace
+        from conan.tools.cmake import CMakeConfigDeps, CMakeToolchain, cmake_layout
+        from conan.tools.files import save
+
+
+        class MyWs(ConanFile):
+            settings = "os", "compiler", "build_type", "arch"
+
+            def generate(self):
+                CMakeConfigDeps(self).generate()
+                CMakeToolchain(self).generate()
+
+            def layout(self):
+                cmake_layout(self)
+
+
+        class MyWorkspace(Workspace):
+            def root_conanfile(self):
+                return MyWs
+
+            def packages(self):
+                return [{"path": "leaf_v1", "ref": "leaf/1.0"},
+                        {"path": "leaf_v2", "ref": "leaf/2.0"},
+                        {"path": "core", "ref": "core/1.0"},
+                        {"path": "other", "ref": "other/1.0"}]
+
+            def build_order(self, order):
+                super().build_order(order)
+                pkglist = " ".join([f'{it["ref"].name}:{it["folder"]}'
+                                    for level in order for it in level])
+                save(self, "build/conanws_build_order.cmake",
+                    f"set(CONAN_WS_BUILD_ORDER {pkglist})")
+        """)
+    # Same FetchContent_Declare(..., OVERRIDE_FIND_PACKAGE) loop "conan new workspace"
+    # scaffolds - see test_super_build_private_version_ambiguous above.
+    root_cmake = textwrap.dedent("""\
+        cmake_minimum_required(VERSION 3.25)
+        project(monorepo CXX)
+
+        include(FetchContent)
+
+        function(add_project PACKAGE_NAME SUBFOLDER)
+            message(STATUS "Adding project: ${PACKAGE_NAME}. Folder: ${SUBFOLDER}")
+            FetchContent_Declare(
+                ${PACKAGE_NAME}
+                SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/${SUBFOLDER}
+                SYSTEM
+                OVERRIDE_FIND_PACKAGE
+            )
+            FetchContent_MakeAvailable(${PACKAGE_NAME})
+        endfunction()
+
+        include(build/conanws_build_order.cmake)
+
+        foreach(pair ${CONAN_WS_BUILD_ORDER})
+            string(FIND "${pair}" ":" pos)
+            string(SUBSTRING "${pair}" 0 "${pos}" pkg)
+            math(EXPR pos "${pos} + 1")  # Skip the separator
+            string(SUBSTRING "${pair}" "${pos}" -1 folder)
+
+            add_project(${pkg} ${folder})
+            get_target_property(target_type ${pkg} TYPE)
+            if (NOT target_type STREQUAL "EXECUTABLE")
+                add_library(${pkg}::${pkg} ALIAS ${pkg})
+            endif()
+        endforeach()
+        """)
+    leaf_cmake = textwrap.dedent("""\
+        cmake_minimum_required(VERSION 3.25)
+        project(leaf CXX)
+
+        add_library(leaf INTERFACE)
+        """)
+
+    def pkg_cmake(name):
+        return textwrap.dedent(f"""\
+            cmake_minimum_required(VERSION 3.25)
+            project({name} CXX)
+
+            find_package(leaf REQUIRED)
+
+            add_library({name} INTERFACE)
+            target_link_libraries({name} INTERFACE leaf::leaf)
+            """)
+
+    def pkg_conanfile(name, leaf_version):
+        return textwrap.dedent(f"""\
+            from conan import ConanFile
+            from conan.tools.cmake import cmake_layout
+
+
+            class Pkg(ConanFile):
+                name = "{name}"
+                version = "1.0"
+                settings = "os", "compiler", "build_type", "arch"
+                exports_sources = "CMakeLists.txt"
+
+                def layout(self):
+                    cmake_layout(self)
+
+                def requirements(self):
+                    self.requires("leaf/{leaf_version}", visible=False)
+            """)
+
+    c.save({"leaf_v1/conanfile.py": GenConanfile("leaf", "1.0"),
+            "leaf_v1/CMakeLists.txt": leaf_cmake,
+            "leaf_v2/conanfile.py": GenConanfile("leaf", "2.0"),
+            "leaf_v2/CMakeLists.txt": leaf_cmake,
+            "core/conanfile.py": pkg_conanfile("core", "1.0"),
+            "core/CMakeLists.txt": pkg_cmake("core"),
+            "other/conanfile.py": pkg_conanfile("other", "2.0"),
+            "other/CMakeLists.txt": pkg_cmake("other"),
+            "conanws.py": workspace,
+            "CMakeLists.txt": root_cmake})
+    # --pkg selects only "core"/"other" as top-level requirements, sidestepping the
+    # "Duplicated requirement" guard a plain "workspace super-install" would hit
+    # immediately (both "leaf" editables are still reached transitively and end up in
+    # the build order regardless).
+    c.run("workspace super-install --pkg=core/1.0 --pkg=other/1.0")
+
+    config_preset = "conan-default" if platform.system() == "Windows" else "conan-release"
+    c.run_command(f"cmake --preset {config_preset}", assert_error=True)
+    assert "Adding project: leaf. Folder: leaf_v1" in c.out
+    assert "Adding project: leaf. Folder: leaf_v2" in c.out
+    # CMake wraps this message at a column that can vary, so check the two halves
+    # separately rather than one exact substring.
+    assert 'add_library cannot create ALIAS target "leaf::leaf" because another' in c.out
+    assert "the same name already exists" in c.out

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -1344,6 +1344,47 @@ class TestMeta:
         # It no longer crashes
         assert "Install finished successfully" in c.out
 
+    def test_link_libraries_diamond_workspace(self):
+        # https://github.com/conan-io/conan/issues/20304
+        # CMakeConfigDeps can silently drop the INTERFACE_LINK_LIBRARIES entry of a
+        # regular (non-editable) package's own dependency ("wrapper" -> "leaf"), when
+        # "leaf" is *also* reachable from an editable workspace member ("core") that
+        # is required in 2 different contexts: as a host requirement (implicit,
+        # because "workspace super-install" requires every editable at the top level)
+        # and as a build requirement (tool_requires from another editable, "app").
+        c = TestClient()
+        workspace = textwrap.dedent("""
+            from conan import ConanFile, Workspace
+            from conan.tools.cmake import CMakeConfigDeps
+
+            class MyWs(ConanFile):
+                settings = "build_type"
+                def generate(self):
+                    CMakeConfigDeps(self).generate()
+
+            class MyWorkspace(Workspace):
+                def root_conanfile(self):
+                    return MyWs
+                def packages(self):
+                    return [{"path": "core", "ref": "core/1.0"},
+                            {"path": "app", "ref": "app/1.0"}]
+            """)
+        c.save({"leaf/conanfile.py": GenConanfile("leaf", "1.0"),
+                "wrapper/conanfile.py": GenConanfile("wrapper", "1.0").with_requires("leaf/1.0"),
+                "core/conanfile.py": GenConanfile("core", "1.0").with_requires("leaf/1.0"),
+                "app/conanfile.py": GenConanfile("app", "1.0")
+                                    .with_requires("wrapper/1.0")
+                                    .with_tool_requires("core/1.0"),
+                "conanws.py": workspace})
+        c.run("create leaf")
+        c.run("create wrapper")
+        c.run("workspace super-install")
+
+        # "wrapper" is a regular (non-editable) package that requires "leaf" directly,
+        # so its generated target file must link against it
+        wrapper_targets = c.load("wrapper-Targets-release.cmake")
+        assert "leaf::leaf" in wrapper_targets
+
 
 def test_workspace_with_local_recipes_index():
     c3i_folder = temp_folder()

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -1344,14 +1344,9 @@ class TestMeta:
         # It no longer crashes
         assert "Install finished successfully" in c.out
 
-    def test_link_libraries_diamond_workspace(self):
+    def test_link_libraries_workspace_different_context(self):
         # https://github.com/conan-io/conan/issues/20304
-        # CMakeConfigDeps can silently drop the INTERFACE_LINK_LIBRARIES entry of a
-        # regular (non-editable) package's own dependency ("wrapper" -> "leaf"), when
-        # "leaf" is *also* reachable from an editable workspace member ("core") that
-        # is required in 2 different contexts: as a host requirement (implicit,
-        # because "workspace super-install" requires every editable at the top level)
-        # and as a build requirement (tool_requires from another editable, "app").
+        # Ensure that host context is preferred when both host and build context are present in the workspace
         c = TestClient()
         workspace = textwrap.dedent("""
             from conan import ConanFile, Workspace
@@ -1379,11 +1374,46 @@ class TestMeta:
         c.run("create leaf")
         c.run("create wrapper")
         c.run("workspace super-install")
+        assert "Using the host context node" in c.out
 
         # "wrapper" is a regular (non-editable) package that requires "leaf" directly,
         # so its generated target file must link against it
         wrapper_targets = c.load("wrapper-Targets-release.cmake")
         assert "leaf::leaf" in wrapper_targets
+
+    def test_link_libraries_different_visibility(self):
+        c = TestClient()
+        workspace = textwrap.dedent("""
+                    from conan import ConanFile, Workspace
+                    from conan.tools.cmake import CMakeConfigDeps
+
+                    class MyWs(ConanFile):
+                        settings = "build_type"
+                        def generate(self):
+                            CMakeConfigDeps(self).generate()
+
+                    class MyWorkspace(Workspace):
+                        def root_conanfile(self):
+                            return MyWs
+                        def packages(self):
+                            return [{"path": "app", "ref": "app/1.0"},
+                                    {"path": "core", "ref": "core/1.0"}]
+                    """)
+        c.save({"leaf/conanfile.py": GenConanfile("leaf"),
+                "wrapper/conanfile.py": GenConanfile("wrapper", "1.0").with_requirement("leaf/1.0"),
+                "core/conanfile.py": GenConanfile("core", "1.0").with_requirement("leaf/2.0", visible=False),
+                "app/conanfile.py": GenConanfile("app", "1.0")
+               .with_requires("wrapper/1.0")
+               .with_requires("core/1.0"),
+                "conanws.py": workspace})
+        c.run("create leaf --version=1.0")
+        c.run("create leaf --version=2.0")
+        c.run("create wrapper")
+        c.run("workspace super-install")
+        assert "Using the visible node" in c.out
+
+        leaf_config = c.load("leaf-config.cmake")
+        assert 'leaf_VERSION_STRING "1.0"' in leaf_config
 
 
 def test_workspace_with_local_recipes_index():

--- a/test/integration/workspace/test_workspace.py
+++ b/test/integration/workspace/test_workspace.py
@@ -1415,6 +1415,103 @@ class TestMeta:
         leaf_config = c.load("leaf-config.cmake")
         assert 'leaf_VERSION_STRING "1.0"' in leaf_config
 
+    def test_link_libraries_editable_private_version_ambiguous(self):
+        # https://github.com/conan-io/conan/issues/20304
+        # Known, accepted trade-off (not a bug to fix): "core" and "other" are two
+        # unrelated editables, each with its own *private* (visible=False) dependency
+        # on a different version of "leaf". Neither requirement is "the visible one",
+        # so the visible-vs-invisible tie-break does not apply here: there is no rule
+        # at all, whichever happens to be processed last silently wins, and (unlike the
+        # visible-vs-invisible and host-vs-build cases) NO warning is emitted. The
+        # monolithic build still only generates ONE find_package() resolution for
+        # "leaf", so one of "core"/"other" is silently pointed at the wrong version of
+        # its own private dependency. See test_super_build_private_version_ambiguous in
+        # test/functional/workspace/test_workspace.py for this same scenario proven at
+        # the actual CMake/find_package level.
+        c = TestClient()
+        workspace = textwrap.dedent("""
+            from conan import ConanFile, Workspace
+            from conan.tools.cmake import CMakeConfigDeps
+
+            class MyWs(ConanFile):
+                settings = "build_type"
+                def generate(self):
+                    CMakeConfigDeps(self).generate()
+
+            class MyWorkspace(Workspace):
+                def root_conanfile(self):
+                    return MyWs
+                def packages(self):
+                    return [{"path": "core", "ref": "core/1.0"},
+                            {"path": "other", "ref": "other/1.0"}]
+            """)
+        c.save({"leaf/conanfile.py": GenConanfile("leaf"),
+                "core/conanfile.py": GenConanfile("core", "1.0").with_requirement("leaf/1.0", visible=False),
+                "other/conanfile.py": GenConanfile("other", "1.0").with_requirement("leaf/2.0", visible=False),
+                "conanws.py": workspace})
+        c.run("create leaf --version=1.0")
+        c.run("create leaf --version=2.0")
+        c.run("workspace super-install")
+        # Neither tie-break condition applies: no warning at all is emitted, unlike the
+        # visible-vs-invisible and host-vs-build cases above.
+        assert "Using the visible node" not in c.out
+        assert "Using the host context node" not in c.out
+
+        # Only ONE find_package(leaf) resolution exists for the whole monolithic
+        # build. "other" happens to win here (an accident of processing order, not a
+        # deliberate rule): "core"'s own private "leaf/1.0" silently disappears, and if
+        # "core" itself called find_package(leaf), it would get "2.0" instead.
+        leaf_config = c.load("leaf-config.cmake")
+        assert 'leaf_VERSION_STRING "2.0"' in leaf_config
+        assert 'leaf_VERSION_STRING "1.0"' not in leaf_config
+
+    def test_two_editables_same_name_different_version(self):
+        # https://github.com/conan-io/conan/issues/20304
+        # Unlike the ambiguous-private-dependency case above, having TWO editables
+        # share the same name ("leaf", at different versions, required privately by
+        # "core" and "other" respectively) is NOT silently resolved: it is rejected
+        # loudly. "workspace super-install" always requires every editable at the top
+        # level, so "leaf/1.0" and "leaf/2.0" collide as top-level requirements
+        # immediately, before any collapsing or generation even happens.
+        c = TestClient()
+        workspace = textwrap.dedent("""
+            from conan import ConanFile, Workspace
+            from conan.tools.cmake import CMakeConfigDeps
+
+            class MyWs(ConanFile):
+                settings = "build_type"
+                def generate(self):
+                    CMakeConfigDeps(self).generate()
+
+            class MyWorkspace(Workspace):
+                def root_conanfile(self):
+                    return MyWs
+                def packages(self):
+                    return [{"path": "leaf_v1", "ref": "leaf/1.0"},
+                            {"path": "leaf_v2", "ref": "leaf/2.0"},
+                            {"path": "core", "ref": "core/1.0"},
+                            {"path": "other", "ref": "other/1.0"}]
+            """)
+        c.save({"leaf_v1/conanfile.py": GenConanfile("leaf", "1.0"),
+                "leaf_v2/conanfile.py": GenConanfile("leaf", "2.0"),
+                "core/conanfile.py": GenConanfile("core", "1.0").with_requirement("leaf/1.0", visible=False),
+                "other/conanfile.py": GenConanfile("other", "1.0").with_requirement("leaf/2.0", visible=False),
+                "conanws.py": workspace})
+        c.run("workspace super-install", assert_error=True)
+        assert "Duplicated requirement: leaf/2.0" in c.out
+
+        # But that guard is an accident of how the top-level requires happen to be
+        # built, not a deliberate check: filtering which packages become top-level
+        # requirements sidesteps it, since "leaf" is then only reached transitively
+        # (once via "core", once via "other"). Conan accepts this silently: both
+        # editable "leaf" nodes coexist in the graph side by side, with no warning at
+        # all. It is the FetchContent-based monolithic CMakeLists.txt that ultimately
+        # can't cope with it - see test_super_build_two_editables_same_name in
+        # test/functional/workspace/test_workspace.py.
+        c.run("workspace super-install --pkg=core/1.0 --pkg=other/1.0")
+        assert "leaf/1.0 - Editable" in c.out
+        assert "leaf/2.0 - Editable" in c.out
+
 
 def test_workspace_with_local_recipes_index():
     c3i_folder = temp_folder()


### PR DESCRIPTION
Changelog: Fix: Prioritize host and visible nodes in workspace monolithic builds when ambiguity arises
Docs: https://github.com/conan-io/docs/pull/4546

Closes https://github.com/conan-io/conan/issues/20304

This use case is quite problematic, as the monolithic build does not support crossbuilding, and only 1 node will be present. While it's true that CMakeConfigDeps has some ways to reconcile differences like this, workspaces should ideally stick to only having packages in one context, as there's only one destination for find_package in the collapsed build
