### PR TITLE
[docs] Improve visualization for architecture_bits

### DIFF
--- a/conan/tools/build/flags.py
+++ b/conan/tools/build/flags.py
@@ -98,7 +98,7 @@ def architecture_bits(conanfile):
     Detect the architecture bits based on the ``conanfile.settings.arch`` and those known architectures in Conan.
 
     :param conanfile: The current recipe object. Always use ``self``.
-    :return: ``"64"`` for 64-bit architectures, ``"32"`` for 32-bit architectures, or ``None`` if the architecture is unknown.
+    :return: ``"64"`` string for 64-bit architectures, ``"32"`` string for 32-bit architectures, or ``None`` if the architecture is unknown.
     """
     arch = conanfile.settings.get_safe("arch")
     if arch in ["x86_64", "ppc64le", "ppc64", "armv8", "armv8.3", "arm64ec", "sparcv9",

--- a/conan/tools/build/flags.py
+++ b/conan/tools/build/flags.py
@@ -98,7 +98,7 @@ def architecture_bits(conanfile):
     Detect the architecture bits based on the ``conanfile.settings.arch`` and those known architectures in Conan.
 
     :param conanfile: The current recipe object. Always use ``self``.
-    :return: "64" for 64-bit architectures, "32" for 32-bit architectures, or None if the architecture is unknown.
+    :return: ``"64"`` for 64-bit architectures, ``"32"`` for 32-bit architectures, or ``None`` if the architecture is unknown.
     """
     arch = conanfile.settings.get_safe("arch")
     if arch in ["x86_64", "ppc64le", "ppc64", "armv8", "armv8.3", "arm64ec", "sparcv9",


### PR DESCRIPTION
Hello!

This PR is a tweak to improve the [architecture_bits](https://docs.conan.io/2/reference/tools/build.html#conan-tools-build-architecture-bits) result description:

<img width="1476" height="1022" alt="Screenshot 2026-09-03 at 09-03-15 conan tools build — conan 2 32 0 documentation" src="https://github.com/user-attachments/assets/09759053-dd56-4116-a360-3e85fc9d2f92" />

It misses the word emphasis for those result values, like for `can_run`.

The Conan documentation extracts the method docstring to generate its reference. 

Changelog: Omit
Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [x] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
