### PR TITLE
Add CPE, supplier, publisher support to CycloneDX SBOM generators

### DIFF
--- a/conan/internal/model/conan_file.py
+++ b/conan/internal/model/conan_file.py
@@ -32,6 +32,9 @@ class ConanFile:
     description = None
     topics = None
     homepage = None
+    cpe = None  # str: CPE 2.3 formatted string (or CPE 2.2 URI), "*" as version placeholder
+    supplier = None  # str: name of the organization that supplied the component
+    publisher = None  # str: person(s)/organization(s) that published the component
 
     build_policy = None
     upload_policy = None
@@ -141,7 +144,8 @@ class ConanFile:
         result = {}
 
         for a in ("name", "user", "channel", "url", "license",
-                  "author", "description", "homepage", "build_policy", "upload_policy",
+                  "author", "description", "homepage", "cpe", "supplier", "publisher",
+                  "build_policy", "upload_policy",
                   "revision_mode", "provides", "deprecated", "win_bash", "win_bash_run",
                   "default_options", "options_description"):
             v = getattr(self, a, None)

--- a/conan/tools/sbom/cyclonedx.py
+++ b/conan/tools/sbom/cyclonedx.py
@@ -1,7 +1,9 @@
 from conan import conan_version
+from conan.errors import ConanException
+from conan.internal.model.recipe_ref import ref_matches
 
 
-def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, **kwargs):
+def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, cpes=None, **kwargs):
     """
     (Experimental) Generate cyclone 1.4 SBOM with JSON format
 
@@ -14,6 +16,10 @@ def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, **kwar
         name (str, optional): Custom name for the metadata field.
         add_build (bool, optional, default=False): Include build dependencies.
         add_tests (bool, optional, default=False): Include test dependencies.
+        cpes (dict, optional): Mapping of reference patterns (as understood by
+            ``RecipeReference.matches()``, e.g. ``"openssl/*"``) to CPE 2.3/2.2 strings, used to
+            override or provide the ``cpe`` field of matching components. A value of ``None``
+            for a matching pattern suppresses any ``cpe`` declared in the recipe.
 
     Returns:
         The generated CycloneDX 1.4 document as a string.
@@ -61,6 +67,7 @@ def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, **kwar
         **({"components": [{
             "author": node.conanfile.author or "Unknown",
             "bom-ref": _calculate_bomref(node),
+            **_cpe_field(node.ref, node.conanfile, cpes),
             **({"description": node.conanfile.description} if node.conanfile.description else {}),
             **({"externalReferences": [{
                 "type": "website",
@@ -68,7 +75,11 @@ def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, **kwar
             }]} if node.conanfile.homepage else {}),
             **({"licenses": _calculate_licenses(node)} if node.conanfile.license else {}),
             "name": node.name,
+            **({"publisher": node.conanfile.publisher} if getattr(node.conanfile, "publisher",
+                                                                  None) else {}),
             "purl": f"pkg:conan/{node.name}@{node.ref.version}",
+            **({"supplier": {"name": node.conanfile.supplier}}
+               if getattr(node.conanfile, "supplier", None) else {}),
             "type": "application" if node.conanfile.package_type == "application" else "library",
             "version": str(node.ref.version),
         } for node in nodes]} if nodes else {}),
@@ -77,7 +88,12 @@ def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, **kwar
             "component": {
                 "author": conanfile.author or "Unknown",
                 "bom-ref": special_id if has_special_root_node else _calculate_bomref(conanfile),
+                **(_cpe_field(conanfile.ref, conanfile, cpes) if not has_special_root_node else {}),
                 "name": name if name else name_default,
+                **({"publisher": conanfile.publisher} if getattr(conanfile, "publisher", None)
+                   else {}),
+                **({"supplier": {"name": conanfile.supplier}}
+                   if getattr(conanfile, "supplier", None) else {}),
                 "type": "application" if conanfile.package_type == "application" else "library",
             },
             "timestamp": f"{datetime.fromtimestamp(time.time(), tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}",
@@ -97,7 +113,7 @@ def cyclonedx_1_4(conanfile, name=None, add_build=False, add_tests=False, **kwar
     return sbom_cyclonedx_1_4
 
 
-def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, **kwargs):
+def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, cpes=None, **kwargs):
     """
     (Experimental) Generate cyclone 1.6 SBOM with JSON format
 
@@ -110,6 +126,10 @@ def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, **kwar
         name (str, optional): Custom name for the metadata field.
         add_build (bool, optional, default=False): Include build dependencies.
         add_tests (bool, optional, default=False): Include test dependencies.
+        cpes (dict, optional): Mapping of reference patterns (as understood by
+            ``RecipeReference.matches()``, e.g. ``"openssl/*"``) to CPE 2.3/2.2 strings, used to
+            override or provide the ``cpe`` field of matching components. A value of ``None``
+            for a matching pattern suppresses any ``cpe`` declared in the recipe.
 
     Returns:
         The generated CycloneDX 1.6 document as a string.
@@ -158,6 +178,7 @@ def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, **kwar
         **({"components": [{
             **({"authors": [{"name": node.conanfile.author}]} if node.conanfile.author else {}),
             "bom-ref": _calculate_bomref(node),
+            **_cpe_field(node.ref, node.conanfile, cpes),
             **({"description": node.conanfile.description} if node.conanfile.description else {}),
             **({"externalReferences": [{
                 "type": "website",
@@ -165,7 +186,11 @@ def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, **kwar
             }]} if node.conanfile.homepage else {}),
             **({"licenses": _calculate_licenses(node)} if node.conanfile.license else {}),
             "name": node.name,
+            **({"publisher": node.conanfile.publisher} if getattr(node.conanfile, "publisher",
+                                                                  None) else {}),
             "purl": f"pkg:conan/{node.name}@{node.ref.version}",
+            **({"supplier": {"name": node.conanfile.supplier}}
+               if getattr(node.conanfile, "supplier", None) else {}),
             "type": "application" if node.conanfile.package_type == "application" else "library",
             "version": str(node.ref.version),
         } for node in nodes]} if nodes else {}),
@@ -174,7 +199,12 @@ def cyclonedx_1_6(conanfile, name=None, add_build=False, add_tests=False, **kwar
             "component": {
                 **({"authors": [{"name": conanfile.author}]} if conanfile.author else {}),
                 "bom-ref": special_id if has_special_root_node else _calculate_bomref(conanfile),
+                **(_cpe_field(conanfile.ref, conanfile, cpes) if not has_special_root_node else {}),
                 "name": name if name else name_default,
+                **({"publisher": conanfile.publisher} if getattr(conanfile, "publisher", None)
+                   else {}),
+                **({"supplier": {"name": conanfile.supplier}}
+                   if getattr(conanfile, "supplier", None) else {}),
                 "type": "application" if conanfile.package_type == "application" else "library"
             },
             "timestamp": f"{datetime.fromtimestamp(time.time(), tz=timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')}",
@@ -216,6 +246,51 @@ def _calculate_licenses(component):
             field = "name"
         result.append({"license": {field: lic}})
     return result
+
+
+def _cpe_field(ref, conanfile, cpes):
+    cpe = _calculate_cpe(ref, conanfile, cpes)
+    return {"cpe": cpe} if cpe else {}
+
+
+def _calculate_cpe(ref, conanfile, cpes):
+    matched = False
+    cpe = None
+    if cpes:
+        for pattern, value in cpes.items():
+            if ref_matches(ref, pattern, is_consumer=False):
+                matched = True
+                cpe = value
+                break
+    if not matched:
+        cpe = getattr(conanfile, "cpe", None)
+    if not cpe:
+        return None
+    return _normalize_cpe(cpe, ref.version, ref)
+
+
+def _normalize_cpe(cpe, version, ref):
+    if not isinstance(cpe, str):
+        raise ConanException(f"Invalid 'cpe' for '{ref}': expected a string, "
+                              f"got '{type(cpe).__name__}'")
+    if cpe.startswith("cpe:2.3:"):
+        parts = cpe.split(":")
+        if len(parts) != 13:
+            raise ConanException(f"Invalid CPE 2.3 string for '{ref}': '{cpe}' must have "
+                                  "13 colon-separated components "
+                                  "('cpe:2.3:part:vendor:product:version:update:edition:"
+                                  "language:sw_edition:target_sw:target_hw:other')")
+        if parts[5] == "*":
+            parts[5] = _cpe_escape(str(version))
+        return ":".join(parts)
+    if cpe.startswith("cpe:/"):
+        return cpe
+    raise ConanException(f"Invalid 'cpe' for '{ref}': '{cpe}' must start with "
+                          "'cpe:2.3:' or 'cpe:/'")
+
+
+def _cpe_escape(value):
+    return "".join(c if (c.isalnum() or c in "._-") else f"\\{c}" for c in value)
 
 
 def _calculate_bomref(component):

--- a/test/integration/sbom/test_cyclonedx.py
+++ b/test/integration/sbom/test_cyclonedx.py
@@ -329,6 +329,89 @@ class TestCyclonedx:
             assert content_json["components"][0]["authors"][0]["name"] == 'conan-dev'
             assert content_json["components"][0]["type"] == 'application'
 
+    def test_cyclonedx_cpe_from_recipe(self, hook_setup_post_package):
+        tc = hook_setup_post_package
+        tc.save({"dep/conanfile.py": GenConanfile("dep", "1.0")
+                .with_class_attribute('cpe = "cpe:2.3:a:dep_vendor:dep:*:*:*:*:*:*:*:*"'),
+                 "conanfile.py": GenConanfile("foo", "1.0").with_requires("dep/1.0")})
+        tc.run("create dep")
+        tc.run("create .")
+        create_layout = tc.created_layout()
+        cyclone_path = os.path.join(create_layout.metadata(), "sbom.cdx.json")
+        content_json = json.loads(tc.load(cyclone_path))
+        dep_component = next(c for c in content_json["components"] if c["name"] == "dep")
+        assert dep_component["cpe"] == "cpe:2.3:a:dep_vendor:dep:1.0:*:*:*:*:*:*:*"
+        foo_component = next((c for c in content_json["components"] if c["name"] == "foo"), None)
+        assert foo_component is None or "cpe" not in foo_component
+
+    def test_cyclonedx_no_cpe_when_not_declared(self, hook_setup_post_package):
+        tc = hook_setup_post_package
+        tc.save({"dep/conanfile.py": GenConanfile("dep", "1.0"),
+                 "conanfile.py": GenConanfile("foo", "1.0").with_requires("dep/1.0")})
+        tc.run("create dep")
+        tc.run("create .")
+        create_layout = tc.created_layout()
+        cyclone_path = os.path.join(create_layout.metadata(), "sbom.cdx.json")
+        content_json = json.loads(tc.load(cyclone_path))
+        assert all("cpe" not in c for c in content_json["components"])
+
+    def test_cyclonedx_supplier_publisher(self, hook_setup_post_package):
+        tc = hook_setup_post_package
+        tc.save({"dep/conanfile.py": GenConanfile("dep", "1.0")
+                .with_class_attribute('supplier = "Dep Org"')
+                .with_class_attribute('publisher = "Dep Publisher"'),
+                 "conanfile.py": GenConanfile("foo", "1.0").with_requires("dep/1.0")})
+        tc.run("create dep")
+        tc.run("create .")
+        create_layout = tc.created_layout()
+        cyclone_path = os.path.join(create_layout.metadata(), "sbom.cdx.json")
+        content_json = json.loads(tc.load(cyclone_path))
+        dep_component = next(c for c in content_json["components"] if c["name"] == "dep")
+        assert dep_component["supplier"] == {"name": "Dep Org"}
+        assert dep_component["publisher"] == "Dep Publisher"
+
+    def test_cyclonedx_invalid_cpe_raises(self, hook_setup_post_package):
+        tc = hook_setup_post_package
+        tc.save({"conanfile.py": GenConanfile("foo", "1.0")
+                .with_class_attribute('cpe = "not-a-cpe"')})
+        tc.run("create .", assert_error=True)
+        assert "Invalid 'cpe'" in tc.out
+
+    def test_cyclonedx_cpes_override(self, cyclone_version):
+        tc = TestClient(light=True)
+        hook_path = os.path.join(tc.paths.hooks_path, "hook_sbom.py")
+        override_hook = textwrap.dedent(f"""
+            import json
+            import os
+            from conan.api.output import ConanOutput
+            from conan.tools.sbom import {cyclone_version}
+
+            def post_package(conanfile):
+                sbom = {cyclone_version}(conanfile, cpes={{
+                    "dep/*": "cpe:2.3:a:override_vendor:override_product:*:*:*:*:*:*:*:*",
+                    "foo/*": None,
+                }})
+                metadata_folder = conanfile.package_metadata_folder
+                with open(os.path.join(metadata_folder, "sbom.cdx.json"), 'w') as f:
+                    json.dump(sbom, f, indent=4)
+                ConanOutput().success("CYCLONEDX CREATED")
+        """)
+        save(hook_path, override_hook)
+        tc.save({"dep/conanfile.py": GenConanfile("dep", "1.0")
+                .with_class_attribute('cpe = "cpe:2.3:a:recipe_vendor:recipe_product:*:*:*:*:*:*:*:*"'),
+                 "conanfile.py": GenConanfile("foo", "1.0")
+                .with_class_attribute('cpe = "cpe:2.3:a:foo_vendor:foo_product:*:*:*:*:*:*:*:*"')
+                .with_requires("dep/1.0")})
+        tc.run("create dep")
+        tc.run("create .")
+        create_layout = tc.created_layout()
+        cyclone_path = os.path.join(create_layout.metadata(), "sbom.cdx.json")
+        content_json = json.loads(tc.load(cyclone_path))
+        dep_component = next(c for c in content_json["components"] if c["name"] == "dep")
+        assert dep_component["cpe"] == "cpe:2.3:a:override_vendor:override_product:1.0:*:*:*:*:*:*:*"
+        foo_component = next((c for c in content_json["components"] if c["name"] == "foo"), None)
+        assert foo_component is None or "cpe" not in foo_component
+
     def test_sbom_test_requires_skipped(self, cyclone_version):
         tc = TestClient(light=True)
         hook_path = os.path.join(tc.paths.hooks_path, "hook_sbom.py")

--- a/test/unittests/tools/sbom/test_cpe.py
+++ b/test/unittests/tools/sbom/test_cpe.py
@@ -1,0 +1,94 @@
+import pytest
+
+from conan.api.model import RecipeReference
+from conan.errors import ConanException
+from conan.test.utils.mocks import ConanFileMock
+from conan.tools.sbom.cyclonedx import _calculate_cpe, _cpe_field, _normalize_cpe
+
+
+@pytest.mark.parametrize(
+    "cpe, version, expected",
+    [
+        ("cpe:2.3:a:openssl:openssl:*:*:*:*:*:*:*:*", "3.0.5",
+         "cpe:2.3:a:openssl:openssl:3.0.5:*:*:*:*:*:*:*"),
+        ("cpe:2.3:a:openssl:openssl:1.0.0:*:*:*:*:*:*:*", "3.0.5",
+         "cpe:2.3:a:openssl:openssl:1.0.0:*:*:*:*:*:*:*"),
+        ("cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*", "1.2.3+build",
+         "cpe:2.3:a:vendor:product:1.2.3\\+build:*:*:*:*:*:*:*"),
+        ("cpe:/a:openssl:openssl:3.0.5", "3.0.5", "cpe:/a:openssl:openssl:3.0.5"),
+    ],
+)
+def test_normalize_cpe(cpe, version, expected):
+    assert _normalize_cpe(cpe, version, "openssl/3.0.5") == expected
+
+
+@pytest.mark.parametrize(
+    "cpe, error",
+    [
+        ("bogus", "must start with 'cpe:2.3:' or 'cpe:/'"),
+        ("cpe:2.3:a:vendor:product", "must have 13 colon-separated components"),
+        ("cpe:2.3:a:vendor:product:1:2:3:4:5:6:7:8:9:10", "must have 13 colon-separated components"),
+    ],
+)
+def test_normalize_cpe_invalid_string(cpe, error):
+    with pytest.raises(ConanException, match=error):
+        _normalize_cpe(cpe, "1.0", "pkg/1.0")
+
+
+def test_normalize_cpe_invalid_type():
+    with pytest.raises(ConanException, match="expected a string"):
+        _normalize_cpe(123, "1.0", "pkg/1.0")
+
+
+def test_calculate_cpe_from_recipe_attribute():
+    ref = RecipeReference.loads("openssl/3.0.5")
+    conanfile = ConanFileMock()
+    conanfile.cpe = "cpe:2.3:a:openssl:openssl:*:*:*:*:*:*:*:*"
+    assert _calculate_cpe(ref, conanfile, None) == \
+        "cpe:2.3:a:openssl:openssl:3.0.5:*:*:*:*:*:*:*"
+
+
+def test_calculate_cpe_no_attribute_no_override():
+    ref = RecipeReference.loads("openssl/3.0.5")
+    conanfile = ConanFileMock()
+    assert _calculate_cpe(ref, conanfile, None) is None
+
+
+def test_calculate_cpe_override_takes_precedence():
+    ref = RecipeReference.loads("openssl/3.0.5")
+    conanfile = ConanFileMock()
+    conanfile.cpe = "cpe:2.3:a:wrong:wrong:*:*:*:*:*:*:*:*"
+    cpes = {"openssl/*": "cpe:2.3:a:openssl:openssl:*:*:*:*:*:*:*:*"}
+    assert _calculate_cpe(ref, conanfile, cpes) == \
+        "cpe:2.3:a:openssl:openssl:3.0.5:*:*:*:*:*:*:*"
+
+
+def test_calculate_cpe_override_none_suppresses_recipe_attribute():
+    ref = RecipeReference.loads("fmt/10.0")
+    conanfile = ConanFileMock()
+    conanfile.cpe = "cpe:2.3:a:some:guess:*:*:*:*:*:*:*:*"
+    cpes = {"fmt/*": None}
+    assert _calculate_cpe(ref, conanfile, cpes) is None
+
+
+def test_calculate_cpe_override_no_match_falls_back_to_recipe_attribute():
+    ref = RecipeReference.loads("openssl/3.0.5")
+    conanfile = ConanFileMock()
+    conanfile.cpe = "cpe:2.3:a:openssl:openssl:*:*:*:*:*:*:*:*"
+    cpes = {"zlib/*": "cpe:2.3:a:zlib:zlib:*:*:*:*:*:*:*:*"}
+    assert _calculate_cpe(ref, conanfile, cpes) == \
+        "cpe:2.3:a:openssl:openssl:3.0.5:*:*:*:*:*:*:*"
+
+
+def test_cpe_field_empty_when_no_cpe():
+    ref = RecipeReference.loads("openssl/3.0.5")
+    conanfile = ConanFileMock()
+    assert _cpe_field(ref, conanfile, None) == {}
+
+
+def test_cpe_field_with_cpe():
+    ref = RecipeReference.loads("openssl/3.0.5")
+    conanfile = ConanFileMock()
+    conanfile.cpe = "cpe:2.3:a:openssl:openssl:*:*:*:*:*:*:*:*"
+    assert _cpe_field(ref, conanfile, None) == \
+        {"cpe": "cpe:2.3:a:openssl:openssl:3.0.5:*:*:*:*:*:*:*"}


### PR DESCRIPTION
## Summary
- Adds `cpe`, `supplier`, `publisher` attributes to `ConanFile`, mapped to
  CycloneDX's `component.cpe`/`component.supplier`/`component.publisher`
  fields in both `cyclonedx_1_4` and `cyclonedx_1_6`.
- Adds a `cpes=` override argument to both generators (ref-pattern → CPE
  string or `None`) so consumers can inject/suppress CPEs for third-party
  recipes without a recipe change.
- A `*` in the version position of a CPE 2.3 string is substituted with the
  package's version at generation time; invalid CPE strings raise
  `ConanException` instead of silently producing a broken/misleading value.
- No built-in vendor/product mapping table is shipped. CPE data is either
  declared explicitly by the recipe or supplied explicitly by the consumer
  via `cpes=`, never guessed from the package name.

Fixes #18810

## Test plan
- [x] `test/unittests/tools/sbom/test_cpe.py` normalization, version
      substitution/escaping, override precedence, invalid-CPE errors
- [x] `test/integration/sbom/test_cyclonedx.py` recipe-attribute CPE,
      absence when undeclared, supplier/publisher output, invalid CPE aborts
      `conan create`, `cpes=` override (including suppression)
- [x] Full `test/integration/sbom/` + `test/unittests/tools/sbom/` suite green
      (76 tests)
- [x] `test/integration/command/test_inspect.py` green (unchanged `serialize()`
      output when attributes are unset)
- [x] `test/integration/graph/` green (583 tests, no regression from the
      `ConanFile.serialize()` change)