### PR TITLE
lockfiles timestamp stability

### DIFF
--- a/conan/cli/commands/lock.py
+++ b/conan/cli/commands/lock.py
@@ -170,6 +170,8 @@ def lock_update(conan_api, parser, subparser, *args):
     args = parser.parse_args(*args)
 
     lockfile = conan_api.lockfile.get_lockfile(lockfile=args.lockfile, partial=True)
+    if lockfile is None:
+        raise ConanException("No lockfile to update")
     lockfile.update(requires=args.requires, build_requires=args.build_requires,
                     python_requires=args.python_requires, config_requires=args.config_requires)
     conan_api.lockfile.save_lockfile(lockfile, args.lockfile_out)

--- a/conan/internal/model/lockfile.py
+++ b/conan/internal/model/lockfile.py
@@ -49,12 +49,22 @@ class _LockRequires:
 
     def add(self, ref, package_ids=None):
         if ref.revision is not None:
+            # Timestamp doesn't affect equality/hash (see RecipeReference.__eq__), so this
+            # finds the previously locked entry for the exact same revision, if any
+            old_ref = next((r for r in self._requires if r == ref), None)
             old_package_ids = self._requires.pop(ref, None)  # Get existing one
             if old_package_ids is not None:
                 if package_ids is not None:
                     assert isinstance(old_package_ids, dict)
                     old_package_ids.update(package_ids)
                 package_ids = old_package_ids
+            if old_ref is not None and old_ref.timestamp is not None:
+                # Same revision as before: keep the timestamp it already had locked, don't
+                # let it drift to the incoming one. Otherwise, re-exporting or re-downloading
+                # the very same, unchanged revision elsewhere (which still refreshes its
+                # "latest" timestamp) would leak into the lockfile as a confusing diff with
+                # no real content change. https://github.com/conan-io/conan/issues/17402
+                ref = old_ref
             self._requires[ref] = package_ids
         else:  # Manual addition of something without revision
             existing = {r: r for r in self._requires}.get(ref)

--- a/test/integration/lockfile/test_lock_merge.py
+++ b/test/integration/lockfile/test_lock_merge.py
@@ -1,3 +1,4 @@
+import json
 import textwrap
 
 import pytest
@@ -57,3 +58,26 @@ def test_merge_alias(requires):
     assert "ERROR: Package 'pkg/0.3' not resolved" in c.out
     c.run("install app -s build_type=Debug", assert_error=True)
     assert "ERROR: Package 'pkg/0.4' not resolved" in c.out
+
+
+def test_lock_merge_different_timestamps():
+    # Test that the first lockfile keeps its timestamp in case the same revision exists in the
+    # other ones
+    c = TestClient(light=True)
+    c.run("lock add --requires=math/1.0#rev1%123.0 --lockfile-out=conan1.lock")
+    new_lock = json.loads(c.load("conan1.lock"))
+    assert ["math/1.0#rev1%123.0"] == new_lock["requires"]
+
+    c.run("lock add --requires=math/1.0#rev1%124.0 --lockfile-out=conan2.lock")
+    new_lock = json.loads(c.load("conan2.lock"))
+    assert ["math/1.0#rev1%124.0"] == new_lock["requires"]
+
+    c.run("lock merge --lockfile=conan1.lock --lockfile=conan2.lock")
+    new_lock = json.loads(c.load("conan.lock"))
+    # keeps the conan1.lock one
+    assert ["math/1.0#rev1%123.0"] == new_lock["requires"]
+
+    c.run("lock merge --lockfile=conan2.lock --lockfile=conan1.lock")
+    new_lock = json.loads(c.load("conan.lock"))
+    # keeps the conan2.lock one
+    assert ["math/1.0#rev1%124.0"] == new_lock["requires"]

--- a/test/integration/lockfile/test_lock_requires.py
+++ b/test/integration/lockfile/test_lock_requires.py
@@ -635,6 +635,44 @@ def test_revision_timestamp():
     assert locked_ref.timestamp and locked_ref.timestamp != server_timestamp
 
 
+def test_partial_lockfile_unrelated_timestamp_change():
+    """
+    https://github.com/conan-io/conan/issues/17402
+
+    Updating a single package via a partial lockfile (removing its line from the
+    lockfile and letting ``--lockfile-partial`` fill it back in) should not touch the
+    locked entry of other, unrelated packages that were not really modified, as this
+    pollutes the lockfile diff with confusing, unrelated changes.
+    """
+    c = TestClient(light=True)
+    c.save({"pkga/conanfile.py": GenConanfile("pkga", "0.1"),
+            "pkgb/conanfile.py": GenConanfile("pkgb", "0.1").with_requires("pkga/0.1")})
+    c.run("create pkga")
+    c.run("create pkgb")
+    c.run("lock create --requires=pkgb/0.1 --lockfile-out=conan.lock")
+    lock1 = json.loads(c.load("conan.lock"))
+    pkga_ref1 = next(RecipeReference.loads(r) for r in lock1["requires"] if r.startswith("pkga/"))
+
+    # Simulate an unrelated rebuild happening elsewhere (e.g. in CI): pkga is re-created
+    # with the exact same content, producing the same revision, but Conan still bumps its
+    # cache timestamp ("already exported before, making it latest again")
+    time.sleep(1)
+    c.run("create pkga")
+
+    # The user updates pkgb: remove its line from the lockfile and let
+    # --lockfile-partial fill it back in, as described in the issue
+    c.run("lock remove --requires=pkgb/0.1 --lockfile=conan.lock --lockfile-out=conan.lock")
+    c.run("install --requires=pkgb/0.1 --lockfile=conan.lock --lockfile-partial "
+          "--lockfile-out=conan.lock")
+
+    lock2 = json.loads(c.load("conan.lock"))
+    pkga_ref2 = next(RecipeReference.loads(r) for r in lock2["requires"] if r.startswith("pkga/"))
+
+    # pkga was never touched by this update, it must keep its exact locked entry
+    assert pkga_ref1.revision == pkga_ref2.revision
+    assert pkga_ref1.timestamp == pkga_ref2.timestamp
+
+
 class TestLockfileUpdate:
     """
     Check that --update works

--- a/test/integration/lockfile/test_lock_requires.py
+++ b/test/integration/lockfile/test_lock_requires.py
@@ -817,3 +817,8 @@ def test_lock_error():
     c.run(f"install --requires={ref} {settings} --build={ref} "
           "--lockfile=recipes/consumer/conan.lock ")
 
+
+def test_lock_update_error():
+    c = TestClient(light=True)
+    c.run("lock update --requires=math/1.0#rev1%124.0", assert_error=True)
+    assert "No lockfile to update" in c.out

--- a/test/integration/lockfile/test_user_overrides.py
+++ b/test/integration/lockfile/test_user_overrides.py
@@ -202,9 +202,32 @@ def test_add_multiple_revisions():
            new_lock["requires"]
 
 
-def test_timestamps_are_updated():
-    """ When ``conan lock add`` adds a revision with a timestamp, or without it, it will be
-    updated in the lockfile-out to the resolved new timestamp
+def test_timestamps_without_value_are_updated():
+    """ When ``conan lock add`` adds a revision without a timestamp, it will be filled in the
+    lockfile-out with the resolved real timestamp, as there was no previous value to keep
+    """
+    c = TestClient(light=True)
+    c.save({"conanfile.txt": "[requires]\nmath/1.0",
+            "math/conanfile.py": GenConanfile("math", "1.0")})
+    c.run("create math")
+    rev = c.exported_recipe_revision()
+    # Create a new lockfile, wipe the previous
+    c.run(f"lock add --lockfile=\"\" --requires=math/1.0#{rev}")
+    lock = json.loads(c.load("conan.lock"))
+    assert lock["requires"] == [f"math/1.0#{rev}"]  # no timestamp yet
+
+    c.run("install . --lockfile=conan.lock --lockfile-out=conan.lock")
+    assert f" math/1.0#{rev} - Cache" in c.out
+    new_lock = json.loads(c.load("conan.lock"))
+    assert new_lock["requires"][0].startswith(f"math/1.0#{rev}%")  # timestamp filled in
+
+
+def test_timestamps_with_value_are_kept():
+    """ https://github.com/conan-io/conan/issues/17402
+    When ``conan lock add`` adds a revision with an explicit timestamp (even an arbitrary one),
+    that timestamp becomes part of the locked identity: resolving that same revision again
+    later (e.g. a plain ``install`` reusing the lockfile) must not silently rewrite it, or it
+    would pollute the lockfile with confusing, content-free diffs.
     """
     c = TestClient(light=True)
     c.save({"conanfile.txt": "[requires]\nmath/1.0",
@@ -216,7 +239,7 @@ def test_timestamps_are_updated():
     c.run("install . --lockfile=conan.lock --lockfile-out=conan.lock")
     assert f" math/1.0#{rev} - Cache" in c.out
     new_lock = c.load("conan.lock")
-    assert "%0.123" not in new_lock
+    assert "%0.123" in new_lock
 
 
 def test_lock_add_error():

--- a/test/integration/lockfile/test_user_overrides.py
+++ b/test/integration/lockfile/test_user_overrides.py
@@ -202,6 +202,23 @@ def test_add_multiple_revisions():
            new_lock["requires"]
 
 
+def test_add_same_revisions_newer_timestamps():
+    c = TestClient(light=True)
+    c.run("lock add --requires=math/1.0#rev1%123.0")
+    new_lock = json.loads(c.load("conan.lock"))
+    assert ["math/1.0#rev1%123.0"] == new_lock["requires"]
+
+    # This addition doesn't change anything, as the requires is already locked
+    c.run("lock add --requires=math/1.0#rev1%124.0")
+    new_lock = json.loads(c.load("conan.lock"))
+    assert ["math/1.0#rev1%123.0"] == new_lock["requires"]
+
+    # The update works
+    c.run("lock update --requires=math/1.0#rev1%124.0")
+    new_lock = json.loads(c.load("conan.lock"))
+    assert ["math/1.0#rev1%124.0"] == new_lock["requires"]
+
+
 def test_timestamps_without_value_are_updated():
     """ When ``conan lock add`` adds a revision without a timestamp, it will be filled in the
     lockfile-out with the resolved real timestamp, as there was no previous value to keep


### PR DESCRIPTION
Changelog: Fix: Lockfile timestamp stability for existing revisions
Docs: Omit

Close https://github.com/conan-io/conan/issues/17402
