### PR TITLE
[fix] Preserve transitive dependency options in build-order `build_args`

### DIFF
--- a/conan/internal/graph/graph_builder.py
+++ b/conan/internal/graph/graph_builder.py
@@ -470,8 +470,6 @@ class DepsGraphBuilder:
             else:
                 down_options = Options(options_values=node.conanfile.default_build_options)
 
-        # down_options is the real propagated one, so update consumer self_options for state
-        node.conanfile.self_options.update(down_options)
         return down_options
 
     @staticmethod

--- a/conan/internal/graph/install_graph.py
+++ b/conan/internal/graph/install_graph.py
@@ -8,7 +8,32 @@ from conan.internal.graph.graph import RECIPE_CONSUMER, RECIPE_VIRTUAL, BINARY_S
 from conan.errors import ConanException, ConanInvalidConfiguration
 from conan.api.model import PkgReference
 from conan.api.model import RecipeReference
+from conan.internal.model.recipe_ref import ref_matches
 from conan.internal.util.files import load
+
+
+def _reproducible_options(node):
+    """Recipe-defined downstream options needed to rebuild this node, split by context."""
+    options = set()
+    build_options = set()
+    down_options = node.conanfile._conan_down_options
+    for pattern, package_options in down_options._deps_package_options.items():
+        opened = [node]
+        visited = set()
+        while opened:
+            current = opened.pop()
+            if current in visited:
+                continue
+            visited.add(current)
+            is_consumer = current.conanfile._conan_is_consumer
+            if ref_matches(current.ref, pattern, is_consumer=is_consumer):
+                target = options if current.context == node.context else build_options
+                target.update(package_options.dumps(scope=pattern).splitlines())
+                if "*" not in pattern.split("/", 1)[0]:
+                    continue
+            if not current.conanfile.vendor:
+                opened.extend(edge.dst for edge in current.edges if edge.require.visible)
+    return sorted(options), sorted(build_options)
 
 
 class _InstallPackageReference:
@@ -25,6 +50,7 @@ class _InstallPackageReference:
         self.context = None  # Same PREF could be in both contexts, but only 1 context is enough to
         # be able to reproduce, typically host preferrably
         self.options = []  # to be able to fire a build, the options will be necessary
+        self.build_options = []
         self.filenames = []  # The build_order.json filenames e.g. "windows_build_order"
         # If some package, like ICU, requires itself, built for the "build" context architecture
         # to cross compile, there will be a dependency from the current "self" (host context)
@@ -50,8 +76,8 @@ class _InstallPackageReference:
         result.prev = node.pref.revision
         result.binary = node.binary
         result.context = node.context
-        # self_options are the minimum to reproduce state
-        result.options = node.conanfile.self_options.dumps().splitlines()
+        # Downstream recipe options are the minimum to reproduce state
+        result.options, result.build_options = _reproducible_options(node)
         result.nodes.append(node)
         result.overrides = node.overrides()
         result.info = node.conanfile.info.serialize()  # ConanInfo doesn't have deserialize
@@ -74,21 +100,26 @@ class _InstallPackageReference:
         if self.options:
             scope = "" if self.context == "host" else ":b"
             cmd += " " + " ".join(f'-o{scope}="{o}"' for o in self.options)
+        if self.build_options:
+            cmd += " " + " ".join(f'-o:b="{o}"' for o in self.build_options)
         if self.overrides:
             cmd += f' --lockfile-overrides="{self.overrides}"'
         return cmd
 
     def serialize(self):
-        return {"package_id": self.package_id,
-                "prev": self.prev,
-                "context": self.context,
-                "binary": self.binary,
-                "options": self.options,
-                "filenames": self.filenames,
-                "depends": self.depends,
-                "overrides": self.overrides.serialize(),
-                "build_args": self._build_args(),
-                "info": self.info}
+        result = {"package_id": self.package_id,
+                  "prev": self.prev,
+                  "context": self.context,
+                  "binary": self.binary,
+                  "options": self.options,
+                  "filenames": self.filenames,
+                  "depends": self.depends,
+                  "overrides": self.overrides.serialize(),
+                  "build_args": self._build_args(),
+                  "info": self.info}
+        if self.build_options:
+            result["build_options"] = self.build_options
+        return result
 
     @staticmethod
     def deserialize(data, filename, ref):
@@ -99,6 +130,7 @@ class _InstallPackageReference:
         result.binary = data["binary"]
         result.context = data["context"]
         result.options = data["options"]
+        result.build_options = data.get("build_options", [])
         result.filenames = data["filenames"] or [filename]
         result.depends = data["depends"]
         result.overrides = Overrides.deserialize(data["overrides"])
@@ -233,6 +265,7 @@ class _InstallConfiguration:
         self.context = None  # Same PREF could be in both contexts, but only 1 context is enough to
         # be able to reproduce, typically host preferrably
         self.options = []  # to be able to fire a build, the options will be necessary
+        self.build_options = []
         self.filenames = []  # The build_order.json filenames e.g. "windows_build_order"
         self.depends = []  # List of full prefs
         self.overrides = Overrides()
@@ -264,8 +297,8 @@ class _InstallConfiguration:
         result.prev = node.pref.revision
         result.binary = node.binary
         result.context = node.context
-        # self_options are the minimum to reproduce state
-        result.options = node.conanfile.self_options.dumps().splitlines()
+        # Downstream recipe options are the minimum to reproduce state
+        result.options, result.build_options = _reproducible_options(node)
         result.overrides = node.overrides()
         result.info = node.conanfile.info.serialize()
 
@@ -298,24 +331,28 @@ class _InstallConfiguration:
         if self.options:
             scope = "" if self.context == "host" else ":b"
             cmd += " " + " ".join(f'-o{scope}="{o}"' for o in self.options)
+        if self.build_options:
+            cmd += " " + " ".join(f'-o:b="{o}"' for o in self.build_options)
         if self.overrides:
             cmd += f' --lockfile-overrides="{self.overrides}"'
         return cmd
 
     def serialize(self):
-        return {"ref": self.ref.repr_notime(),
-                "pref": self.pref.repr_notime(),
-                "package_id": self.pref.package_id,
-                "prev": self.pref.revision,
-                "context": self.context,
-                "binary": self.binary,
-                "options": self.options,
-                "filenames": self.filenames,
-                "depends": [d.repr_notime() for d in self.depends],
-                "overrides": self.overrides.serialize(),
-                "build_args": self._build_args(),
-                "info": self.info
-                }
+        result = {"ref": self.ref.repr_notime(),
+                  "pref": self.pref.repr_notime(),
+                  "package_id": self.pref.package_id,
+                  "prev": self.pref.revision,
+                  "context": self.context,
+                  "binary": self.binary,
+                  "options": self.options,
+                  "filenames": self.filenames,
+                  "depends": [d.repr_notime() for d in self.depends],
+                  "overrides": self.overrides.serialize(),
+                  "build_args": self._build_args(),
+                  "info": self.info}
+        if self.build_options:
+            result["build_options"] = self.build_options
+        return result
 
     @staticmethod
     def deserialize(data, filename):
@@ -326,6 +363,7 @@ class _InstallConfiguration:
         result.binary = data["binary"]
         result.context = data["context"]
         result.options = data["options"]
+        result.build_options = data.get("build_options", [])
         result.filenames = data["filenames"] or [filename]
         result.depends = [PkgReference.loads(p) for p in data["depends"]]
         result.overrides = Overrides.deserialize(data["overrides"])

--- a/conan/internal/methods.py
+++ b/conan/internal/methods.py
@@ -121,6 +121,7 @@ def run_configure_method(conanfile, down_options, profile_options, ref):
 
     result = conanfile.options.get_upstream_options(down_options, ref, is_consumer)
     self_options, up_options, private_up_options = result
+    conanfile._conan_down_options = down_options
     # self_options are the minimum to reproduce state, as defined from downstream (not profile)
     conanfile.self_options = self_options
     # up_options are the minimal options that should be propagated to dependencies

--- a/test/integration/command/info/test_info_build_order.py
+++ b/test/integration/command/info/test_info_build_order.py
@@ -947,3 +947,55 @@ def test_build_order_options():
     assert "55c609fe8808aa5308134cb5989d23d3caffccf2" in c.out
     # the built package is the static one, the option is not really propagated
     assert "shared: False" in c.out
+
+
+@pytest.mark.parametrize("order_by", ["recipe", "configuration"])
+def test_build_order_transitive_options(order_by):
+    # Reproduces https://github.com/conan-io/conan/issues/20314
+    c = TestClient(light=True)
+    c.save({
+        "leaf/conanfile.py": GenConanfile("leaf", "1.0").with_shared_option(False),
+        "tool/conanfile.py": GenConanfile("tool", "1.0").with_shared_option(False),
+        "middle/conanfile.py": GenConanfile("middle", "1.0").with_shared_option(False)
+                                                               .with_requires("leaf/1.0")
+                                                               .with_tool_requirement("tool/1.0",
+                                                                                      visible=True),
+        "app/conanfile.py": (
+            GenConanfile("app", "1.0").with_requires("middle/1.0")
+                                          .with_default_option("middle/*:shared", True)
+                                          .with_default_option("leaf/*:shared", True)
+                                          .with_default_option("tool/*:shared", True)),
+    })
+    for recipe in ("leaf", "tool", "middle"):
+        c.run(f"export {recipe}")
+
+    c.run(f"graph build-order app --build=missing --order-by={order_by} --format=json",
+          redirect_stdout="build-order.json")
+    c.run("graph build-order-merge --file=build-order.json --file=build-order.json --format=json")
+    order = json.loads(c.stdout)["order"]
+    middle = next(item for level in order for item in level
+                  if item["ref"].startswith("middle/"))
+    if order_by == "recipe":
+        middle_ref = middle["ref"]
+        middle = next(package for level in middle["packages"] for package in level)
+    else:
+        middle_ref = middle["ref"]
+
+    assert middle["options"] == ["leaf/*:shared=True", "middle/*:shared=True"]
+    assert middle["build_options"] == ["tool/*:shared=True"]
+    assert middle["build_args"] == ("--requires=middle/1.0 --build=middle/1.0 "
+                                    "-o=\"leaf/*:shared=True\" "
+                                    "-o=\"middle/*:shared=True\" "
+                                    "-o:b=\"tool/*:shared=True\"")
+
+    c.run(f"graph info {middle['build_args']} --format=json")
+    nodes = json.loads(c.stdout)["graph"]["nodes"].values()
+    isolated_middle = next(node for node in nodes if node.get("ref") == middle_ref)
+    leaf = next(node for node in nodes if node.get("ref", "").startswith("leaf/"))
+    tool = next(node for node in nodes if node.get("ref", "").startswith("tool/"))
+    assert isolated_middle["package_id"] == middle["package_id"]
+    assert isolated_middle["options"]["shared"] == "True"
+    assert leaf["context"] == "host"
+    assert leaf["options"]["shared"] == "True"
+    assert tool["context"] == "build"
+    assert tool["options"]["shared"] == "True"


### PR DESCRIPTION
Changelog: Bugfix: Preserve transitive dependency options in `graph build-order` `build_args`.
Docs: Omit

Fixes #20314

The original report and minimal reproducer are available in #20314.

## Context

Before `13b618b` (#19950), build-order preserved the complete downstream recipe-option state. That change correctly prevented options from leaking into hidden requirements, but attempted to recover build-order state with `Options.update()`. This method does not merge dependency-scoped options, so transitive options were dropped from `build_args`.

## Fix

Retain recipe-origin downstream options separately, then select the options that reach the package and its visible dependency graph. Profile and command-line options remain caller-supplied. Host and build options are emitted with the correct `-o` and `-o:b` scopes.

## Validation

The regression test covers both build-order modes, command replay with an identical package ID, visible tool requirements, and build-order merge.