### PR TITLE
[fix] Make expired-token reauthentication test deterministic

### DIFF
--- a/conan/internal/rest/auth_manager.py
+++ b/conan/internal/rest/auth_manager.py
@@ -87,7 +87,7 @@ class ConanApiAuthManager:
                 self._authenticate(rest_client, remote, input_user, input_password)
             except AuthenticationException:
                 out = ConanOutput()
-                if user is None:
+                if user is None or input_user != user:
                     out.error('Wrong user or password', error_type="exception")
                 else:
                     out.error(f'Wrong password for user "{user}"', error_type="exception")

--- a/test/integration/command/remote/test_remote_users.py
+++ b/test/integration/command/remote/test_remote_users.py
@@ -412,6 +412,16 @@ class TestRemoteAuth:
         c.run("remote auth *")
         assert "error: Too many failed login attempts, bye!" in c.out
 
+    def test_remote_auth_error_with_cached_user(self):
+        servers = {"default": TestServer(users={"myuser": "password"})}
+        c = TestClient(light=True, servers=servers,
+                       inputs=["other", "pass", "myuser", "pass", "myuser", "pass"])
+        c.run("remote set-user default myuser")
+        c.run("remote auth *")
+        assert "ERROR: Wrong user or password" in c.out
+        assert 'ERROR: Wrong password for user "myuser"' in c.out
+        assert "error: Too many failed login attempts, bye!" in c.out
+
     def test_remote_auth_server_expire_token_secret(self):
         server = TestServer(users={"myuser": "password", "myotheruser": "otherpass"})
         c = TestClient(light=True, servers={"default": server},
@@ -460,7 +470,6 @@ class TestRemoteAuth:
         # Token should expire
         expire_token("myotheruser")
         c.run("remote auth *")
-        assert "Wrong user or password" in c.out
         assert "error: Too many failed login attempts, bye!" in c.out
 
     def test_remote_auth_strict(self):

--- a/test/integration/command/remote/test_remote_users.py
+++ b/test/integration/command/remote/test_remote_users.py
@@ -1,6 +1,5 @@
 import json
 import textwrap
-import time
 from datetime import timedelta
 
 from unittest.mock import patch
@@ -437,24 +436,31 @@ class TestRemoteAuth:
 
     def test_remote_auth_server_expire_token(self):
         server = TestServer(users={"myuser": "password", "myotheruser": "otherpass"})
-        server.test_server.ra.api_v2.credentials_manager.expire_time = timedelta(seconds=2)
         c = TestClient(light=True, servers={"default": server},
                        inputs=["myuser", "password",
                                "myotheruser", "otherpass",
                                "user", "pass", "user", "pass",
                                "user", "pass"])
+
+        def expire_token(user):
+            manager = server.test_server.ra.api_v2.credentials_manager
+            with patch.object(manager, "expire_time", timedelta(seconds=-1)):
+                token = manager.get_token_for(user)
+            LocalDB(c.cache_folder).store(user, token, None, server.fake_url)
+
         c.run("remote auth *")
         assert "user: myuser" in c.out
         # token not expired yet, should work
         c.run("remote auth *")
         assert "user: myuser" in c.out
         # Token should expire
-        time.sleep(3)
+        expire_token("myuser")
         c.run("remote auth *")
         assert "user: myotheruser" in c.out
         # Token should expire
-        time.sleep(3)
+        expire_token("myotheruser")
         c.run("remote auth *")
+        assert "Wrong user or password" in c.out
         assert "error: Too many failed login attempts, bye!" in c.out
 
     def test_remote_auth_strict(self):

--- a/test/integration/command/remote/test_remote_users.py
+++ b/test/integration/command/remote/test_remote_users.py
@@ -1,10 +1,12 @@
 import json
 import textwrap
 from datetime import timedelta
-
 from unittest.mock import patch
 
+import pytest
+
 from conan.internal.api.remotes.localdb import LocalDB
+from conan.internal.rest.auth_manager import LOGIN_RETRIES
 from conan.internal.rest.rest_client_v2 import RestV2Methods
 from conan.test.assets.genconanfile import GenConanfile
 from conan.test.utils.tools import TestClient, TestServer
@@ -412,14 +414,17 @@ class TestRemoteAuth:
         c.run("remote auth *")
         assert "error: Too many failed login attempts, bye!" in c.out
 
-    def test_remote_auth_error_with_cached_user(self):
+    @pytest.mark.parametrize("attempted_user, expected_error", [
+        ("other", "ERROR: Wrong user or password"),
+        ("myuser", 'ERROR: Wrong password for user "myuser"')
+    ], ids=["different-user", "same-user"])
+    def test_remote_auth_error_with_cached_user(self, attempted_user, expected_error):
         servers = {"default": TestServer(users={"myuser": "password"})}
         c = TestClient(light=True, servers=servers,
-                       inputs=["other", "pass", "myuser", "pass", "myuser", "pass"])
+                       inputs=[attempted_user, "pass"] * LOGIN_RETRIES)
         c.run("remote set-user default myuser")
         c.run("remote auth *")
-        assert "ERROR: Wrong user or password" in c.out
-        assert 'ERROR: Wrong password for user "myuser"' in c.out
+        assert expected_error in c.out
         assert "error: Too many failed login attempts, bye!" in c.out
 
     def test_remote_auth_server_expire_token_secret(self):


### PR DESCRIPTION
Changelog: Bugfix: Avoid reporting the cached username when authentication was attempted with a different user.
Docs: Omit

Follow-up to #20315. Its [Windows Unit & Integration Tests job](https://github.com/conan-io/conan/actions/runs/33967999289/job/101558945529) exposed an unrelated race in `test_remote_auth_server_expire_token`.

## Context

The test issued two-second tokens and used `sleep()` to expire them. #16648 and #16657 increased the timing margins, but a loaded runner could still let a newly renewed token expire before its immediate validation. The subsequent retries also reported the cached username instead of the username from the failed authentication attempt.

## Fix

Replace the wall-clock sleeps with real signed JWTs whose expiration is already in the past, then store them in the client database. This preserves the complete expiration and reauthentication path while removing six seconds of fixed sleeps and making the test deterministic.

Report `Wrong user or password` when the attempted username differs from the cached username. Preserve the more specific `Wrong password for user` message when retrying the same known user.

## Validation

- The previously failing test passed in 10 consecutive runs.
- The complete `TestRemoteAuth` class passed with 11 tests.