### PR TITLE
cmakedeps/target_data: avoid writing no-op genexes

### DIFF
--- a/conan/tools/cmake/cmakedeps/templates/target_data.py
+++ b/conan/tools/cmake/cmakedeps/templates/target_data.py
@@ -146,13 +146,24 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
 
 
               # COMPOUND VARIABLES
-              set({{ pkg_name }}_COMPILE_OPTIONS{{ config_suffix }}
-                  "$<$<COMPILE_LANGUAGE:CXX>:{{ pkg_var(pkg_name, 'COMPILE_OPTIONS_CXX', config_suffix) }}>"
-                  "$<$<COMPILE_LANGUAGE:C>:{{ pkg_var(pkg_name, 'COMPILE_OPTIONS_C', config_suffix) }}>")
-              set({{ pkg_name }}_LINKER_FLAGS{{ config_suffix }}
-                  "$<$<STREQUAL{{ ':$' }}<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:{{ pkg_var(pkg_name, 'SHARED_LINK_FLAGS', config_suffix) }}>"
-                  "$<$<STREQUAL{{ ':$' }}<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>:{{ pkg_var(pkg_name, 'SHARED_LINK_FLAGS', config_suffix) }}>"
-                  "$<$<STREQUAL{{ ':$' }}<TARGET_PROPERTY:TYPE>,EXECUTABLE>:{{ pkg_var(pkg_name, 'EXE_LINK_FLAGS', config_suffix) }}>")
+              set({{ pkg_name }}_COMPILE_OPTIONS{{ config_suffix }})
+              if ("{{ pkg_var(pkg_name, 'COMPILE_OPTIONS_CXX', config_suffix) }}")
+                  list(APPEND {{ pkg_name }}_COMPILE_OPTIONS{{ config_suffix }}
+                      "$<$<COMPILE_LANGUAGE:CXX>:{{ pkg_var(pkg_name, 'COMPILE_OPTIONS_CXX', config_suffix) }}>")
+              endif ()
+              if ("{{ pkg_var(pkg_name, 'COMPILE_OPTIONS_C', config_suffix) }}")
+                  list(APPEND {{ pkg_name }}_COMPILE_OPTIONS{{ config_suffix }}
+                      "$<$<COMPILE_LANGUAGE:C>:{{ pkg_var(pkg_name, 'COMPILE_OPTIONS_C', config_suffix) }}>")
+              endif ()
+              set({{ pkg_name }}_LINKER_FLAGS{{ config_suffix }})
+              if ("{{ pkg_var(pkg_name, 'SHARED_LINK_FLAGS', config_suffix) }}")
+                  list(APPEND {{ pkg_name }}_LINKER_FLAGS{{ config_suffix }}
+                      "$<$<OR:$<STREQUAL{{ ':$' }}<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>,$<STREQUAL{{ ':$' }}<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>>:{{ pkg_var(pkg_name, 'SHARED_LINK_FLAGS', config_suffix) }}>")
+              endif ()
+              if ("{{ pkg_var(pkg_name, 'EXE_LINK_FLAGS', config_suffix) }}")
+                  list(APPEND {{ pkg_name }}_LINKER_FLAGS{{ config_suffix }}
+                      "$<$<STREQUAL{{ ':$' }}<TARGET_PROPERTY:TYPE>,EXECUTABLE>:{{ pkg_var(pkg_name, 'EXE_LINK_FLAGS', config_suffix) }}>")
+              endif ()
 
 
               set({{ pkg_name }}_COMPONENTS{{ config_suffix }} {{ components_names }})
@@ -181,14 +192,24 @@ class ConfigDataTemplate(CMakeDepsFileTemplate):
               set({{ pkg_name }}_{{ comp_variable_name }}_NO_SONAME_MODE{{ config_suffix }} {{ cpp.no_soname }})
 
               # COMPOUND VARIABLES
-              set({{ pkg_name }}_{{ comp_variable_name }}_LINKER_FLAGS{{ config_suffix }}
-                      $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>:{{ comp_var(pkg_name, comp_variable_name, 'SHARED_LINK_FLAGS', config_suffix) }}>
-                      $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>:{{ comp_var(pkg_name, comp_variable_name, 'SHARED_LINK_FLAGS', config_suffix) }}>
-                      $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:{{ comp_var(pkg_name, comp_variable_name, 'EXE_LINK_FLAGS', config_suffix) }}>
-              )
-              set({{ pkg_name }}_{{ comp_variable_name }}_COMPILE_OPTIONS{{ config_suffix }}
-                  "$<$<COMPILE_LANGUAGE:CXX>:{{ comp_var(pkg_name, comp_variable_name, 'COMPILE_OPTIONS_CXX', config_suffix) }}>"
-                  "$<$<COMPILE_LANGUAGE:C>:{{ comp_var(pkg_name, comp_variable_name, 'COMPILE_OPTIONS_C', config_suffix) }}>")
+              set({{ pkg_name }}_{{ comp_variable_name }}_LINKER_FLAGS{{ config_suffix }})
+              if ("{{ comp_var(pkg_name, comp_variable_name, 'SHARED_LINK_FLAGS', config_suffix) }}")
+                  list(APPEND {{ pkg_name }}_{{ comp_variable_name }}_LINKER_FLAGS{{ config_suffix }}
+                      $<$<OR:$<STREQUAL:$<TARGET_PROPERTY:TYPE>,SHARED_LIBRARY>,$<STREQUAL:$<TARGET_PROPERTY:TYPE>,MODULE_LIBRARY>>:{{ comp_var(pkg_name, comp_variable_name, 'SHARED_LINK_FLAGS', config_suffix) }}>)
+              endif ()
+              if ("{{ comp_var(pkg_name, comp_variable_name, 'SHARED_LINK_FLAGS', config_suffix) }}")
+                  list(APPEND {{ pkg_name }}_{{ comp_variable_name }}_LINKER_FLAGS{{ config_suffix }}
+                      $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>:{{ comp_var(pkg_name, comp_variable_name, 'EXE_LINK_FLAGS', config_suffix) }}>)
+              endif ()
+              set({{ pkg_name }}_{{ comp_variable_name }}_COMPILE_OPTIONS{{ config_suffix }})
+              if ("{{ comp_var(pkg_name, comp_variable_name, 'COMPILE_OPTIONS_CXX', config_suffix) }}")
+                  list(APPEND {{ pkg_name }}_{{ comp_variable_name }}_COMPILE_OPTIONS{{ config_suffix }}
+                      "$<$<COMPILE_LANGUAGE:CXX>:{{ comp_var(pkg_name, comp_variable_name, 'COMPILE_OPTIONS_CXX', config_suffix) }}>")
+              endif ()
+              if ("{{ comp_var(pkg_name, comp_variable_name, 'COMPILE_OPTIONS_C', config_suffix) }}")
+                  list(APPEND {{ pkg_name }}_{{ comp_variable_name }}_COMPILE_OPTIONS{{ config_suffix }}
+                      "$<$<COMPILE_LANGUAGE:C>:{{ comp_var(pkg_name, comp_variable_name, 'COMPILE_OPTIONS_C', config_suffix) }}>")
+              endif ()
 
               {%- endfor %}
           """)


### PR DESCRIPTION
In projects with oodles of targets linking to oodles of Conan dependencies, considerable time is spent in generation evaluating genexes of the form:

    $<$<STREQUAL:$<TARGET_PROPERTY:TYPE>,???>:>

which is always the empty string. Detect when this is the case and avoid using the genex at all.

Use the `if (var) list(APPEND) endif ()` pattern so that the CMake variable is still the single-source of truth instead of generate-time state being baked in. This allows users to add, say, a shared linker flag by hand and the semantics continue to be correct.

---
Changelog: (Feature | Fix | Bugfix): Fix; see commit message above.
Docs: https://github.com/conan-io/docs/pull/XXXX

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.