### PR TITLE
[fix] Preserve package configuration order during installation

### DIFF
--- a/conan/api/subapi/install.py
+++ b/conan/api/subapi/install.py
@@ -40,9 +40,9 @@ class InstallAPI:
         """
         installer = BinaryInstaller(self._conan_api, self._helpers.global_conf,
                                     self._helpers.hook_manager)
-        install_graph = InstallGraph(deps_graph)
+        install_graph = InstallGraph(deps_graph, order_by="configuration")
         install_graph.raise_errors()
-        install_order = install_graph.install_order()
+        install_order = install_graph.install_order_grouped_by_recipe()
         installer.install_system_requires(deps_graph, install_order=install_order)
         try:  # To be able to capture the output, report or save graph.json, then raise later
             installer.install(deps_graph, remotes, install_order=install_order)

--- a/conan/internal/graph/install_graph.py
+++ b/conan/internal/graph/install_graph.py
@@ -487,6 +487,21 @@ class InstallGraph:
             return [r for level in levels for r in level]
         return levels
 
+    def install_order_grouped_by_recipe(self):
+        assert self._order == "configuration"
+        levels = []
+        for configuration_level in self.install_order():
+            recipes = {}
+            for configuration in configuration_level:
+                for node in configuration.nodes:
+                    recipe = recipes.get(node.ref)
+                    if recipe is None:
+                        recipes[node.ref] = _InstallRecipeReference.create(node)
+                    else:
+                        recipe.add(node)
+            levels.append(list(recipes.values()))
+        return levels
+
     @staticmethod
     def _raise_loop_detected(nodes):
         """

--- a/conan/internal/graph/installer.py
+++ b/conan/internal/graph/installer.py
@@ -203,8 +203,8 @@ class BinaryInstaller:
     @staticmethod
     def install_system_requires(graph, only_info=False, install_order=None):
         if install_order is None:
-            install_graph = InstallGraph(graph)
-            install_order = install_graph.install_order()
+            install_graph = InstallGraph(graph, order_by="configuration")
+            install_order = install_graph.install_order_grouped_by_recipe()
 
         def _install_build(cfile):
             if hasattr(cfile, "build_system_requirements"):
@@ -242,8 +242,8 @@ class BinaryInstaller:
         _install_build(conanfile)
 
     def install_sources(self, graph, remotes):
-        install_graph = InstallGraph(graph)
-        install_order = install_graph.install_order()
+        install_graph = InstallGraph(graph, order_by="configuration")
+        install_order = install_graph.install_order_grouped_by_recipe()
 
         for level in install_order:
             for install_reference in level:
@@ -253,9 +253,9 @@ class BinaryInstaller:
     def install(self, deps_graph, remotes, install_order=None):
         assert not deps_graph.error, "This graph cannot be installed: {}".format(deps_graph)
         if install_order is None:
-            install_graph = InstallGraph(deps_graph)
+            install_graph = InstallGraph(deps_graph, order_by="configuration")
             install_graph.raise_errors()
-            install_order = install_graph.install_order()
+            install_order = install_graph.install_order_grouped_by_recipe()
 
         ConanOutput().title("Installing packages")
 

--- a/test/integration/graph/ux/loop_detection_test.py
+++ b/test/integration/graph/ux/loop_detection_test.py
@@ -38,8 +38,10 @@ def test_install_order_infinite_loop():
     c.run("install tool -pr:h=tool_profile -b=missing",
           assert_error=True)
     assert "ERROR: There is a loop in the graph" in c.out
-    assert "fmt/1.0 (Build) -> ['tool/1.0']" in c.out
-    assert "tool/1.0 (Build) -> ['fmt/1.0']" in c.out
+    assert "fmt/1.0:da39a3ee5e6b4b0d3255bfef95601890afd80709 (Build) -> " \
+           "['tool/1.0:044d18636d2b7da86d3aa46a2aabf1400db525b1']" in c.out
+    assert "tool/1.0:044d18636d2b7da86d3aa46a2aabf1400db525b1 (Build) -> " \
+           "['fmt/1.0:da39a3ee5e6b4b0d3255bfef95601890afd80709']" in c.out
 
     # Graph build-order fails in the same way
     c.run("graph build-order tool -pr:h=tool_profile -b=missing --order-by=recipe",
@@ -55,6 +57,35 @@ def test_install_order_infinite_loop():
            "['tool/1.0:044d18636d2b7da86d3aa46a2aabf1400db525b1']" in c.out
     assert "tool/1.0:044d18636d2b7da86d3aa46a2aabf1400db525b1 (Build) -> " \
            "['fmt/1.0:da39a3ee5e6b4b0d3255bfef95601890afd80709']" in c.out
+
+
+def test_install_order_recipe_cycle_from_distinct_configurations():
+    c = TestClient(light=True)
+    c.save({
+        "clang-bootstrap/conanfile.py": GenConanfile("clang-bootstrap", "1.0")
+        .with_package_type("application").with_settings("os").with_build_msg("BUILD BOOTSTRAP"),
+        "clang-hybrid/conanfile.py": GenConanfile("clang-hybrid", "1.0")
+        .with_package_type("application").with_settings("os").with_requires("z3/1.0")
+        .with_build_msg("BUILD HYBRID"),
+        "z3/conanfile.py": GenConanfile("z3", "1.0")
+        .with_package_type("static-library").with_settings("os").with_build_msg("BUILD Z3"),
+        "app/conanfile.txt": "[requires]\nz3/1.0",
+        "profile_build": "[settings]\nos=Linux\n\n[tool_requires]\n"
+                         "!clang-bootstrap/*: clang-bootstrap/1.0",
+        "profile_host": "[settings]\nos=Windows\n\n[tool_requires]\n*: clang-hybrid/1.0"
+    })
+    c.run("export clang-bootstrap")
+    c.run("export z3")
+    c.run("export clang-hybrid")
+
+    args = "app -pr:b=profile_build -pr:h=profile_host --build=missing -nr"
+    c.run(f"graph info {args}")
+    c.run(f"install {args}")
+    bootstrap = c.out.index("BUILD BOOTSTRAP")
+    first_z3 = c.out.index("BUILD Z3")
+    hybrid = c.out.index("BUILD HYBRID")
+    second_z3 = c.out.rindex("BUILD Z3")
+    assert bootstrap < first_z3 < hybrid < second_z3
 
 
 def test_build_require_undetected_loop():

--- a/test/integration/graph/ux/loop_detection_test.py
+++ b/test/integration/graph/ux/loop_detection_test.py
@@ -59,24 +59,37 @@ def test_install_order_infinite_loop():
            "['fmt/1.0:da39a3ee5e6b4b0d3255bfef95601890afd80709']" in c.out
 
 
-def test_install_order_recipe_cycle_from_distinct_configurations():
-    c = TestClient(light=True)
+def _compiler_bootstrap_client(host_compiler_version):
+    c = TestClient()
     c.save({
         "clang-bootstrap/conanfile.py": GenConanfile("clang-bootstrap", "1.0")
-        .with_package_type("application").with_settings("os").with_build_msg("BUILD BOOTSTRAP"),
+        .with_package_type("application").with_settings("os", "arch")
+        .with_build_msg("BUILD BOOTSTRAP"),
         "clang-hybrid/conanfile.py": GenConanfile("clang-hybrid", "1.0")
-        .with_package_type("application").with_settings("os").with_requires("z3/1.0")
+        .with_package_type("application").with_settings("os", "arch", "compiler", "build_type")
+        .with_requires("z3/1.0")
         .with_build_msg("BUILD HYBRID"),
         "z3/conanfile.py": GenConanfile("z3", "1.0")
-        .with_package_type("static-library").with_settings("os").with_build_msg("BUILD Z3"),
+        .with_package_type("static-library").with_settings("os", "arch", "compiler", "build_type")
+        .with_build_msg("BUILD Z3"),
         "app/conanfile.txt": "[requires]\nz3/1.0",
-        "profile_build": "[settings]\nos=Linux\n\n[tool_requires]\n"
+        "profile_build": "[settings]\nos=Linux\narch=x86_64\ncompiler=clang\n"
+                         "compiler.version=21\ncompiler.libcxx=libstdc++11\nbuild_type=Release\n\n"
+                         "[tool_requires]\n"
                          "!clang-bootstrap/*: clang-bootstrap/1.0",
-        "profile_host": "[settings]\nos=Windows\n\n[tool_requires]\n*: clang-hybrid/1.0"
+        "profile_host": "[settings]\nos=Linux\narch=x86_64\ncompiler=clang\n"
+                        f"compiler.version={host_compiler_version}\n"
+                        "compiler.libcxx=libstdc++11\nbuild_type=Release\n\n"
+                        "[tool_requires]\n*: clang-hybrid/1.0"
     })
     c.run("export clang-bootstrap")
     c.run("export z3")
     c.run("export clang-hybrid")
+    return c
+
+
+def test_install_order_recipe_cycle_from_distinct_configurations():
+    c = _compiler_bootstrap_client("22")
 
     args = "app -pr:b=profile_build -pr:h=profile_host --build=missing -nr"
     c.run(f"graph info {args}")
@@ -86,6 +99,15 @@ def test_install_order_recipe_cycle_from_distinct_configurations():
     hybrid = c.out.index("BUILD HYBRID")
     second_z3 = c.out.rindex("BUILD Z3")
     assert bootstrap < first_z3 < hybrid < second_z3
+
+
+def test_install_order_cycle_from_same_configuration():
+    c = _compiler_bootstrap_client("21")
+    args = "app -pr:b=profile_build -pr:h=profile_host --build=missing -nr"
+    c.run(f"graph info {args}", assert_error=True)
+    assert "ERROR: There is a loop in the graph" in c.out
+    c.run(f"install {args}", assert_error=True)
+    assert "ERROR: There is a loop in the graph" in c.out
 
 
 def test_build_require_undetected_loop():


### PR DESCRIPTION
Changelog: Bugfix: Allow acyclic graphs with interleaved package configurations to be installed.
Docs: Omit

Fixes #20321

The original report and minimal reproducer are available in #20321.

## Context

Installation currently groups the complete graph by recipe revision before computing its order. When configurations of the same recipe must be processed at different stages, this merges their distinct dependencies and can introduce an artificial recipe-level cycle into an acyclic package graph.

## Fix

Compute the installation order using full package configurations, then group the configurations that are ready in each level by recipe. This preserves the recipe-shaped batches expected by `BinaryInstaller` while allowing the same recipe revision to appear in multiple installation levels.

Build-order serialization and `graph build-order --order-by=recipe` retain their existing behavior.

## Validation

The regression test reproduces #20321, verifies that `graph info` succeeds, and confirms that one `install --build=missing` processes the configurations in dependency order. The existing loop-detection test confirms that a real configuration cycle is still rejected.

Relevant install, system-requirements, graph-info, build-order, and loop-detection tests passed locally with 99 tests.