### PR TITLE
Add header marker for skipped binaries

### DIFF
--- a/conan/cli/printers/graph.py
+++ b/conan/cli/printers/graph.py
@@ -110,7 +110,7 @@ def print_graph_packages(graph):
     requires = {}
     build_requires = {}
     test_requires = {}
-    skipped_requires = []
+    skipped_requires = {}
     tab = "    "
     for node in graph.nodes:
         if node.recipe in ("Consumer", "Cli"):
@@ -130,7 +130,7 @@ def print_graph_packages(graph):
         if existing[0] == "Skip":
             existing[0] = node.binary
 
-    def _format_requires(title, reqs_to_print, context="host"):
+    def _format_requires(title, reqs_to_print, context):
         if not reqs_to_print:
             return
         output.info(title, Color.BRIGHT_YELLOW)
@@ -138,7 +138,7 @@ def print_graph_packages(graph):
             name = pref.repr_notime() if status != "Platform" else str(pref.ref)
             msg = f"{tab}{name} - "
             if status == "Skip":
-                skipped_requires.append((str(pref.ref), context))
+                skipped_requires.setdefault(context, []).append(str(pref.ref))
                 output.verbose(f"{msg}{status}", Color.BRIGHT_CYAN)
             elif status == "Missing" or status == "Invalid":
                 output.write(msg, Color.BRIGHT_CYAN)
@@ -157,15 +157,12 @@ def print_graph_packages(graph):
                 for line in compact_dumps:
                     output.debug(f"{tab}{tab}{line}", Color.BRIGHT_GREEN)
 
-    _format_requires("Requirements", requires)
-    _format_requires("Test requirements", test_requires)
+    _format_requires("Requirements", requires, "host")
+    _format_requires("Test requirements", test_requires, "test")
     _format_requires("Build requirements", build_requires, "build")
 
-    if skipped_requires and not output.level_allowed(LEVEL_VERBOSE):
-        output.info("Skipped binaries", Color.BRIGHT_YELLOW)
-        output.info(tab)
-        for name, context in skipped_requires:
-            output.info(name, Color.BRIGHT_CYAN, newline=False)
-            if output.level_allowed(LEVEL_VERBOSE):
-                output.info(f" ({context})", Color.CYAN, newline=False)
-            output.info(",")
+    if not output.level_allowed(LEVEL_VERBOSE):
+        for context, names in skipped_requires.items():
+            output.info(f"Skipped {context} binaries", Color.BRIGHT_YELLOW)
+            output.info(tab, newline=False)
+            output.info(", ".join(names), Color.BRIGHT_CYAN)

--- a/conan/cli/printers/graph.py
+++ b/conan/cli/printers/graph.py
@@ -130,7 +130,7 @@ def print_graph_packages(graph):
         if existing[0] == "Skip":
             existing[0] = node.binary
 
-    def _format_requires(title, reqs_to_print, context):
+    def _format_requires(title, reqs_to_print, header):
         if not reqs_to_print:
             return
         output.info(title, Color.BRIGHT_YELLOW)
@@ -138,7 +138,7 @@ def print_graph_packages(graph):
             name = pref.repr_notime() if status != "Platform" else str(pref.ref)
             msg = f"{tab}{name} - "
             if status == "Skip":
-                skipped_requires.setdefault(context, []).append(str(pref.ref))
+                skipped_requires.setdefault(header, []).append(str(pref.ref))
                 output.verbose(f"{msg}{status}", Color.BRIGHT_CYAN)
             elif status == "Missing" or status == "Invalid":
                 output.write(msg, Color.BRIGHT_CYAN)
@@ -162,7 +162,7 @@ def print_graph_packages(graph):
     _format_requires("Build requirements", build_requires, "build")
 
     if not output.level_allowed(LEVEL_VERBOSE):
-        for context, names in skipped_requires.items():
-            output.info(f"Skipped {context} binaries", Color.BRIGHT_YELLOW)
+        for header, names in skipped_requires.items():
+            output.info(f"Skipped {header} binaries", Color.BRIGHT_YELLOW)
             output.info(tab, newline=False)
             output.info(", ".join(names), Color.BRIGHT_CYAN)

--- a/conan/cli/printers/graph.py
+++ b/conan/cli/printers/graph.py
@@ -130,7 +130,7 @@ def print_graph_packages(graph):
         if existing[0] == "Skip":
             existing[0] = node.binary
 
-    def _format_requires(title, reqs_to_print):
+    def _format_requires(title, reqs_to_print, context="host"):
         if not reqs_to_print:
             return
         output.info(title, Color.BRIGHT_YELLOW)
@@ -138,7 +138,7 @@ def print_graph_packages(graph):
             name = pref.repr_notime() if status != "Platform" else str(pref.ref)
             msg = f"{tab}{name} - "
             if status == "Skip":
-                skipped_requires.append(str(pref.ref))
+                skipped_requires.append((str(pref.ref), context))
                 output.verbose(f"{msg}{status}", Color.BRIGHT_CYAN)
             elif status == "Missing" or status == "Invalid":
                 output.write(msg, Color.BRIGHT_CYAN)
@@ -159,8 +159,13 @@ def print_graph_packages(graph):
 
     _format_requires("Requirements", requires)
     _format_requires("Test requirements", test_requires)
-    _format_requires("Build requirements", build_requires)
+    _format_requires("Build requirements", build_requires, "build")
 
     if skipped_requires and not output.level_allowed(LEVEL_VERBOSE):
         output.info("Skipped binaries", Color.BRIGHT_YELLOW)
-        output.info(f"{tab}{', '.join(skipped_requires)}", Color.BRIGHT_CYAN)
+        output.info(tab)
+        for name, context in skipped_requires:
+            output.info(name, Color.BRIGHT_CYAN, newline=False)
+            if output.level_allowed(LEVEL_VERBOSE):
+                output.info(f" ({context})", Color.CYAN, newline=False)
+            output.info(",")

--- a/test/functional/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps_new.py
+++ b/test/functional/toolchains/cmake/cmakeconfigdeps/test_cmakeconfigdeps_new.py
@@ -373,7 +373,7 @@ class TestLibsLinkageTraits:
         c.run("new cmake_exe -d name=game -d version=0.1 -d requires=engine/0.1")
         c.run(f"create . -o engine/*:shared=True -c tools.cmake.cmakedeps:new={new_value} "
               "-c tools.compilation:verbosity=verbose")
-        assert re.search(r"Skipped binaries(\s*)matrix/0.1", c.out)
+        assert re.search(r"Skipped host binaries(\s*)matrix/0.1", c.out)
         assert "matrix/0.1: Hello World Release!"
         assert "engine/0.1: Hello World Release!"
         assert "game/0.1: Hello World Release!"

--- a/test/integration/build_requires/build_requires_test.py
+++ b/test/integration/build_requires/build_requires_test.py
@@ -690,10 +690,10 @@ def test_build_missing_build_requires():
     c.run("remove tool*:* -c")
     c.run("install app")
     assert "- Build" not in c.out
-    assert re.search(r"Skipped binaries(\s*)tool/0.1 \(build\), tooldep/0.1 \(build\)", c.out)
+    assert re.search(r"Skipped build binaries(\s*)tool/0.1, tooldep/0.1", c.out)
     c.run("install app --build=missing")
     assert "- Build" not in c.out
-    assert re.search(r"Skipped binaries(\s*)tool/0.1 \(build\), tooldep/0.1 \(build\)", c.out)
+    assert re.search(r"Skipped build binaries(\s*)tool/0.1, tooldep/0.1", c.out)
 
 
 def test_requirement_in_wrong_method():

--- a/test/integration/build_requires/build_requires_test.py
+++ b/test/integration/build_requires/build_requires_test.py
@@ -690,10 +690,10 @@ def test_build_missing_build_requires():
     c.run("remove tool*:* -c")
     c.run("install app")
     assert "- Build" not in c.out
-    assert re.search(r"Skipped binaries(\s*)tool/0.1, tooldep/0.1", c.out)
+    assert re.search(r"Skipped binaries(\s*)tool/0.1 \(build\), tooldep/0.1 \(build\)", c.out)
     c.run("install app --build=missing")
     assert "- Build" not in c.out
-    assert re.search(r"Skipped binaries(\s*)tool/0.1, tooldep/0.1", c.out)
+    assert re.search(r"Skipped binaries(\s*)tool/0.1 \(build\), tooldep/0.1 \(build\)", c.out)
 
 
 def test_requirement_in_wrong_method():

--- a/test/integration/command/install/install_test.py
+++ b/test/integration/command/install/install_test.py
@@ -507,7 +507,7 @@ def test_upload_skip_build_missing():
     c.run("create pkg2")
     c.run("remove pkg1/*:* -c")  # remove binaries
     c.run("create pkg3 --build=missing")
-    assert re.search(r"Skipped binaries(\s*)pkg1/1.0", c.out)
+    assert re.search(r"Skipped host binaries(\s*)pkg1/1.0", c.out)
 
 
 def test_upload_skip_build_compatibles():

--- a/test/integration/graph/test_package_type_overrides.py
+++ b/test/integration/graph/test_package_type_overrides.py
@@ -93,7 +93,7 @@ def test_package_type_traits_run_transitive(package_type_traits):
     else:
         # Without "package_type_traits" the run trait is False, and as liba is a static-library
         # linked inside libb, Conan understands its binary is not necessary anymore and skips it
-        assert re.search(r"Skipped binaries(\s*)liba/0.1", c.out)
+        assert re.search(r"Skipped host binaries(\s*)liba/0.1", c.out)
         assert "MYSHARED RUNTIME!!" not in c.out
         assert _not_found(c.out)
         assert "Error in build() method" in c.out

--- a/test/integration/graph/test_repackaging.py
+++ b/test/integration/graph/test_repackaging.py
@@ -35,7 +35,7 @@ def test_repackage():
 
     client.save({"conanfile.py": GenConanfile().with_requires("repackager/1.0")}, clean_first=True)
     client.run("install .")
-    assert re.search(r"Skipped binaries(\s*)liba/1.0, libb/1.0", client.out)
+    assert re.search(r"Skipped binaries(\s*)liba/1.0 \(host\), libb/1.0 \(host\)", client.out)
     assert "repackager/1.0: Already installed!" in client.out
 
 
@@ -113,7 +113,7 @@ def test_repackage_library_self_multiple():
     c.run("create .")
 
     c.run("install --requires=liba/3.0 --deployer=full_deploy")
-    assert re.search(r"Skipped binaries(\s*)liba/1.0, liba/2.0", c.out)
+    assert re.search(r"Skipped binaries(\s*)liba/1.0 \(host\), liba/2.0 \(host\)", c.out)
     assert "liba/3.0: Already installed!" in c.out
     assert c.load("full_deploy/host/liba/3.0/a1.txt") == "A1.0!"
     assert c.load("full_deploy/host/liba/3.0/a2.txt") == "A2.0!"
@@ -146,6 +146,6 @@ def test_repackage_library_self_transitive():
     c.run("create .")
 
     c.run("install --requires=liba/3.0 --deployer=full_deploy")
-    assert re.search(r"Skipped binaries(\s*)liba/1.0, libb/1.0", c.out)
+    assert re.search(r"Skipped binaries(\s*)liba/1.0 \(host\), libb/1.0 \(host\)", c.out)
     assert "liba/3.0: Already installed!" in c.out
     assert c.load("full_deploy/host/liba/3.0/a1.txt") == "A1.0!"

--- a/test/integration/graph/test_repackaging.py
+++ b/test/integration/graph/test_repackaging.py
@@ -35,7 +35,7 @@ def test_repackage():
 
     client.save({"conanfile.py": GenConanfile().with_requires("repackager/1.0")}, clean_first=True)
     client.run("install .")
-    assert re.search(r"Skipped binaries(\s*)liba/1.0 \(host\), libb/1.0 \(host\)", client.out)
+    assert re.search(r"Skipped host binaries(\s*)liba/1.0, libb/1.0", client.out)
     assert "repackager/1.0: Already installed!" in client.out
 
 
@@ -63,7 +63,7 @@ def test_repackage_library_self():
     c.run("create .")
 
     c.run("install --requires=liba/2.0 --deployer=full_deploy")
-    assert re.search(r"Skipped binaries(\s*)liba/1.0", c.out)
+    assert re.search(r"Skipped host binaries(\s*)liba/1.0", c.out)
     assert "liba/2.0: Already installed!" in c.out
     assert c.load("full_deploy/host/liba/2.0/a.txt") == "A1.0!"
 
@@ -113,7 +113,7 @@ def test_repackage_library_self_multiple():
     c.run("create .")
 
     c.run("install --requires=liba/3.0 --deployer=full_deploy")
-    assert re.search(r"Skipped binaries(\s*)liba/1.0 \(host\), liba/2.0 \(host\)", c.out)
+    assert re.search(r"Skipped host binaries(\s*)liba/1.0, liba/2.0", c.out)
     assert "liba/3.0: Already installed!" in c.out
     assert c.load("full_deploy/host/liba/3.0/a1.txt") == "A1.0!"
     assert c.load("full_deploy/host/liba/3.0/a2.txt") == "A2.0!"
@@ -146,6 +146,6 @@ def test_repackage_library_self_transitive():
     c.run("create .")
 
     c.run("install --requires=liba/3.0 --deployer=full_deploy")
-    assert re.search(r"Skipped binaries(\s*)liba/1.0 \(host\), libb/1.0 \(host\)", c.out)
+    assert re.search(r"Skipped host binaries(\s*)liba/1.0, libb/1.0", c.out)
     assert "liba/3.0: Already installed!" in c.out
     assert c.load("full_deploy/host/liba/3.0/a1.txt") == "A1.0!"

--- a/test/integration/graph/test_require_same_pkg_versions.py
+++ b/test/integration/graph/test_require_same_pkg_versions.py
@@ -292,7 +292,7 @@ def test_require_different_versions_transitive():
     c.run("upload consumer/1.0 -r=default -c")
     c.run("remove * -c")
     c.run("install --requires=consumer/1.0")
-    assert re.search(r"Skipped binaries(\s*)myqemu/1.0 \(build\), myqemu/2.0 \(build\), snippy/1.0 \(build\), valgrind/1.0 \(build\)", c.out)
+    assert re.search(r"Skipped build binaries(\s*)myqemu/1.0, myqemu/2.0, snippy/1.0, valgrind/1.0", c.out)
 
 
 class TestTransitiveBuild:

--- a/test/integration/graph/test_require_same_pkg_versions.py
+++ b/test/integration/graph/test_require_same_pkg_versions.py
@@ -292,7 +292,7 @@ def test_require_different_versions_transitive():
     c.run("upload consumer/1.0 -r=default -c")
     c.run("remove * -c")
     c.run("install --requires=consumer/1.0")
-    assert re.search(r"Skipped binaries(\s*)myqemu/1.0, myqemu/2.0, snippy/1.0, valgrind/1.0", c.out)
+    assert re.search(r"Skipped binaries(\s*)myqemu/1.0 \(build\), myqemu/2.0 \(build\), snippy/1.0 \(build\), valgrind/1.0 \(build\)", c.out)
 
 
 class TestTransitiveBuild:

--- a/test/integration/graph/test_skip_binaries.py
+++ b/test/integration/graph/test_skip_binaries.py
@@ -195,7 +195,7 @@ def test_skip_visible_build():
     c.run("create libb")
     c.run("create libc")
     c.run("install app --format=json")
-    assert re.search(r"Skipped binaries(\s*)libb/0.1, liba/0.1", c.out)
+    assert re.search(r"Skipped binaries(\s*)libb/0.1 \(host\), liba/0.1 \(build\)", c.out)
 
 
 def test_skip_tool_requires_context():
@@ -323,7 +323,7 @@ def test_skip_intermediate_static_complex():
     c.run("remove libd:* -c")  # binary not necessary, can be skipped
     c.run("remove libc:* -c")  # binary not necessary, can be skipped
     c.run("install app")
-    assert re.search(r"Skipped binaries(\s*)libc/0.1, libd/0.1", c.out)
+    assert re.search(r"Skipped binaries(\s*)libc/0.1 \(host\), libd/0.1 \(host\)", c.out)
     assert "libd/0.1: Already installed!" not in c.out
     assert "libc/0.1: Already installed!" not in c.out
     for lib in ("a", "b", "e", "f", "g", "h", "i", "j"):

--- a/test/integration/graph/test_skip_binaries.py
+++ b/test/integration/graph/test_skip_binaries.py
@@ -83,7 +83,7 @@ def test_test_requires():
     client.save({"conanfile.py": GenConanfile().with_requires("pkg/1.0")})
     # Checking list of skipped binaries
     client.run("create . --name=app --version=1.0")
-    assert re.search(r"Skipped binaries(\s*)gtest/1.0", client.out)
+    assert re.search(r"Skipped test binaries(\s*)gtest/1.0", client.out)
     # Showing the complete information about the skipped binary
     client.run("create . --name=app --version=1.0 -v")
     client.assert_listed_binary({"gtest/1.0": (package_id, "Skip")}, test=True)
@@ -195,7 +195,8 @@ def test_skip_visible_build():
     c.run("create libb")
     c.run("create libc")
     c.run("install app --format=json")
-    assert re.search(r"Skipped binaries(\s*)libb/0.1 \(host\), liba/0.1 \(build\)", c.out)
+    assert re.search(r"Skipped host binaries(\s*)libb/0.1", c.out)
+    assert re.search(r"Skipped build binaries(\s*)liba/0.1", c.out)
 
 
 def test_skip_tool_requires_context():
@@ -281,7 +282,7 @@ def test_skip_intermediate_static():
     c.run("create libc")
     c.run("remove libb:* -c")  # binary not necessary, can be skipped
     c.run("install app")
-    assert re.search(r"Skipped binaries(\s*)libb/0.1", c.out)
+    assert re.search(r"Skipped host binaries(\s*)libb/0.1", c.out)
     assert "libb/0.1: Already installed!" not in c.out
     assert "liba/0.1: Already installed!" in c.out
     assert "libc/0.1: Already installed!" in c.out
@@ -323,7 +324,7 @@ def test_skip_intermediate_static_complex():
     c.run("remove libd:* -c")  # binary not necessary, can be skipped
     c.run("remove libc:* -c")  # binary not necessary, can be skipped
     c.run("install app")
-    assert re.search(r"Skipped binaries(\s*)libc/0.1 \(host\), libd/0.1 \(host\)", c.out)
+    assert re.search(r"Skipped host binaries(\s*)libc/0.1, libd/0.1", c.out)
     assert "libd/0.1: Already installed!" not in c.out
     assert "libc/0.1: Already installed!" not in c.out
     for lib in ("a", "b", "e", "f", "g", "h", "i", "j"):

--- a/test/integration/graph/test_skip_build.py
+++ b/test/integration/graph/test_skip_build.py
@@ -75,7 +75,7 @@ def test_skip():
     assert "pkga" in c.out
     assert "pkgb" in c.out
     # but pkga binary is not really necessary
-    assert re.search(r"Skipped binaries(\s*)pkga/1.0.0", c.out)
+    assert re.search(r"Skipped test binaries(\s*)pkga/1.0.0", c.out)
 
     # skipping all but the current one
     c.run("install pkgc -c &:tools.graph:skip_test=False")

--- a/test/integration/package_id/test_cache_compatibles.py
+++ b/test/integration/package_id/test_cache_compatibles.py
@@ -411,11 +411,11 @@ class TestDefaultCompat:
         c.run("create app ")
         c.run("remove tool:* -c")
         c.run("install --requires=dep/0.1  --build=missing")
-        assert re.search(r"Skipped binaries(\s*)tool/0.1", c.out)
+        assert re.search(r"Skipped build binaries(\s*)tool/0.1", c.out)
         c.run("graph info --requires=app/0.1 --build=missing")
-        assert re.search(r"Skipped binaries(\s*)tool/0.1", c.out)
+        assert re.search(r"Skipped build binaries(\s*)tool/0.1", c.out)
         c.run("install --requires=app/0.1  --build=missing")
-        assert re.search(r"Skipped binaries(\s*)tool/0.1", c.out)
+        assert re.search(r"Skipped build binaries(\s*)tool/0.1", c.out)
 
     def test_msvc_194_fallback(self):
         c = TestClient()

--- a/test/integration/remote/test_offline.py
+++ b/test/integration/remote/test_offline.py
@@ -76,4 +76,4 @@ def test_offline_build_requires():
 
     c.run("graph info --requires=pkg/0.1 -nr")
     assert "tool/0.1: WARN" not in c.out
-    assert re.search(r"Skipped binaries(\s*)tool/0.1", c.out)
+    assert re.search(r"Skipped build binaries(\s*)tool/0.1", c.out)

--- a/test/integration/test_components_error.py
+++ b/test/integration/test_components_error.py
@@ -147,7 +147,7 @@ def test_unused_requirement_not_propagated():
     t.run('create lib')
     t.run('create pkg')
     t.run("install app")
-    assert re.search(r"Skipped binaries(\s*)header/0.1", t.out)
+    assert re.search(r"Skipped host binaries(\s*)header/0.1", t.out)
 
 
 @pytest.mark.parametrize("component", [True, False])

--- a/test/integration/toolchains/apple/test_xcodedeps.py
+++ b/test/integration/toolchains/apple/test_xcodedeps.py
@@ -625,7 +625,7 @@ def test_skipped_not_included():
     client.run("create dep --name=dep --version=0.1")
     client.run("create pkg --name=pkg --version=0.1")
     client.run("install consumer -g XcodeDeps -s arch=x86_64 -s build_type=Release")
-    assert re.search(r"Skipped binaries\n\s+(.*?)", client.out, re.DOTALL)
+    assert re.search(r"Skipped host binaries\n\s+(.*?)", client.out, re.DOTALL)
     dep_xconfig = client.load("consumer/conan_pkg_pkg.xcconfig")
     assert "conan_dep.xcconfig" not in dep_xconfig
 


### PR DESCRIPTION
Changelog: Fix: Split skipped binaries summary per host/build/test group
Docs: Omit

In the extreme case, this would look like:
<img width="495" height="231" alt="image" src="https://github.com/user-attachments/assets/e20a5f71-6e04-4652-876c-6297e9d7303e" />
