### PR TITLE
qbs: fix requires when package has pkg_config_name

### DIFF
--- a/conan/tools/qbs/qbsdeps.py
+++ b/conan/tools/qbs/qbsdeps.py
@@ -132,8 +132,11 @@ class _QbsDepGenerator:
             if not requires:
                 # If no requires were found, let's try to get all the direct visible
                 # dependencies, e.g., requires = "other_pkg/1.0"
-                for deprequire, _ in self._dep.dependencies.direct_host.items():
-                    requires.append((deprequire.ref.name, deprequire.ref.version))
+                # Use _get_package_name so dependency names match generated JSON
+                # filenames when pkg_config_name / qbs_file_name is set
+                # (e.g. recipe "clipper" -> file "polyclipping.json").
+                for _, dep in self._dep.dependencies.direct_host.items():
+                    requires.append((_get_package_name(dep), dep.ref.version))
             file = _QbsDepsModuleFile(
                 self, self._dep, self._dep.cpp_info, requires, module_name
             )

--- a/test/integration/toolchains/qbs/test_qbsdeps.py
+++ b/test/integration/toolchains/qbs/test_qbsdeps.py
@@ -104,6 +104,44 @@ def test_pkg_config_name():
     assert os.path.exists(module_path)
 
 
+def test_dependency_uses_pkg_config_name():
+    # Recipe-level requires must reference the same name used for the JSON file
+    # when the dependency overrides pkg_config_name (clipper -> polyclipping).
+    dep = textwrap.dedent('''
+        from conan import ConanFile
+
+        class Dep(ConanFile):
+            name = "clipper"
+            version = "1.0"
+            def package_info(self):
+                self.cpp_info.set_property("pkg_config_name", "polyclipping")
+        ''')
+    consumer = textwrap.dedent('''
+        from conan import ConanFile
+
+        class Consumer(ConanFile):
+            name = "assimp"
+            version = "1.0"
+            requires = "clipper/1.0"
+        ''')
+    client = TestClient()
+    client.save({"conanfile.py": dep})
+    client.run("create .")
+    client.save({"conanfile.py": consumer}, clean_first=True)
+    client.run("create .")
+    client.run("install --requires=assimp/1.0@ -g QbsDeps")
+
+    dep_path = os.path.join(client.current_folder, "conan-qbs-deps", "polyclipping.json")
+    assert os.path.exists(dep_path)
+    assert not os.path.exists(os.path.join(client.current_folder, "conan-qbs-deps", "clipper.json"))
+
+    consumer_path = os.path.join(client.current_folder, "conan-qbs-deps", "assimp.json")
+    consumer_content = json.loads(load(consumer_path))
+    assert consumer_content.get("dependencies") == [
+        {"name": "polyclipping", "version": "1.0"}
+    ]
+
+
 def test_qbs_file_name():
     # Checks we can override module name using the "qbs_file_name" property
     conanfile = textwrap.dedent('''


### PR DESCRIPTION
Changelog: Bugfix: QbsDeps dependency names now match pkg_config_name / qbs_file_name
Docs: Omit

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [x] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop2/.github/CONTRIBUTING.md).
- [x] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one.
