### PR TITLE
add docker extra_file profile field

### DIFF
--- a/conan/internal/runner/docker.py
+++ b/conan/internal/runner/docker.py
@@ -19,6 +19,7 @@ from conan.internal.errors import conanfile_exception_formatter
 from conan.internal.graph.graph import CONTEXT_HOST
 from conan.internal.graph.profile_node_definer import initialize_conanfile_profile
 from conan.internal.runner.output import RunnerOutput
+from conan.tools.files import copy
 
 
 class _ContainerConfig(NamedTuple):
@@ -104,6 +105,7 @@ class DockerRunner:
         self.cache = str(host_profile.runner.get('cache', 'clean'))
         if self.cache not in ['clean', 'copy', 'shared']:
             raise ConanException(f'Invalid cache value: "{self.cache}". Valid values are: clean, copy, shared')
+        self.extra_files = [p.strip() for p in host_profile.runner.get('extra_files', '').split(',') if p.strip()]
         self.container = None
         self.raw_args = raw_args
         self.command = command
@@ -310,6 +312,12 @@ class DockerRunner:
                     self.logger.verbose(f"Copying {src_file} -> {self.abs_runner_home_path / file_name}")
                     shutil.copy(src_file, self.abs_runner_home_path / file_name)
 
+            if self.extra_files:
+                self.logger.verbose(f"Copying extra_files patterns {self.extra_files} to "
+                                    f"{self.abs_runner_home_path / 'extra'}")
+                copy(None, self.extra_files, self.conan_api.home_folder,
+                     str(self.abs_runner_home_path / 'extra'))
+
             if self.cache == 'copy':
                 tgz_path = self.abs_runner_home_path / 'local_cache_save.tgz'
                 self.logger.status(f'Save host cache in: {tgz_path}')
@@ -329,6 +337,8 @@ class DockerRunner:
             for file_name in ['global.conf', 'settings.yml', 'remotes.json']:
                 if (self.abs_runner_home_path / file_name).exists():
                     self._run_command('cp "'+self.abs_docker_path+'/.conanrunner/'+file_name+'" ${HOME}/.conan2/'+file_name, verbose=False)
+            if self.extra_files:
+                self._run_command('cp -r "'+self.abs_docker_path+'/.conanrunner/extra/." ${HOME}/.conan2/.', verbose=False)
             if self.cache in ['copy']:
                 self._run_command('conan cache restore "'+self.abs_docker_path+'/.conanrunner/local_cache_save.tgz"')
 

--- a/test/functional/command/runner_test.py
+++ b/test/functional/command/runner_test.py
@@ -178,7 +178,13 @@ def test_create_docker_runner_dockerfile_folder_path():
     copies extra home files into the container for both the ``copy`` and ``clean`` cache modes.
     """
     client = TestClient()
-    client.save_home({"extensions/greeting.txt": "hello from host"})
+    test_extension = textwrap.dedent("""\
+    from conan.api.output import ConanOutput
+
+    def profile_plugin(profile):
+        ConanOutput().info("my custom profile plugin running")
+    """)
+    client.save_home({"extensions/plugins/profile.py": test_extension})
     profile_build = textwrap.dedent(f"""\
     [settings]
     arch={{{{ detect_api.detect_arch() }}}}
@@ -230,20 +236,17 @@ def test_create_docker_runner_dockerfile_folder_path():
 
     client.save({"host_copy": profile_host_copy, "host_clean": profile_host_clean, "build": profile_build})
     client.run("new cmake_lib -d name=pkg -d version=0.2")
-    extra_file_copy = os.path.join(client.current_folder, ".conanrunner", "extra", "extensions", "greeting.txt")
-    client.run("create . -pr:h host_copy -pr:b build -v")
+    client.run("create . -pr:h host_copy -pr:b build")
 
-    assert "Copying extra_files patterns" in client.out
-    assert client.load(extra_file_copy) == "hello from host"
+    assert "my custom profile plugin running" in client.out
     assert "Restore: pkg/0.2" in client.out
     assert "Restore: pkg/0.2:8631cf963dbbb4d7a378a64a6fd1dc57558bc2fe" in client.out
     assert "Restore: pkg/0.2:8631cf963dbbb4d7a378a64a6fd1dc57558bc2fe metadata" in client.out
     assert "Removing container" in client.out
 
-    client.run("create . -pr:h host_clean -pr:b build -v")
+    client.run("create . -pr:h host_clean -pr:b build")
 
-    assert "Copying extra_files patterns" in client.out
-    assert client.load(extra_file_copy) == "hello from host"
+    assert "my custom profile plugin running" in client.out
     assert "Restore: pkg/0.2" in client.out
     assert "Restore: pkg/0.2:8631cf963dbbb4d7a378a64a6fd1dc57558bc2fe" in client.out
     assert "Restore: pkg/0.2:8631cf963dbbb4d7a378a64a6fd1dc57558bc2fe metadata" in client.out

--- a/test/functional/command/runner_test.py
+++ b/test/functional/command/runner_test.py
@@ -174,9 +174,11 @@ def test_create_docker_runner_cache_shared_profile_folder():
 @pytest.mark.skipif(docker_skip(), reason="Only docker running")
 def test_create_docker_runner_dockerfile_folder_path():
     """
-    Tests the ``conan create . ``
+    Tests the ``conan create . ``, also checking the ``extra_files`` [runner] setting
+    copies extra home files into the container for both the ``copy`` and ``clean`` cache modes.
     """
     client = TestClient()
+    client.save_home({"extensions/greeting.txt": "hello from host"})
     profile_build = textwrap.dedent(f"""\
     [settings]
     arch={{{{ detect_api.detect_arch() }}}}
@@ -204,6 +206,7 @@ def test_create_docker_runner_dockerfile_folder_path():
     image=conan-runner-default-test
     cache=copy
     remove=True
+    extra_files=extensions/*
     """)
 
     profile_host_clean = textwrap.dedent(f"""\
@@ -222,19 +225,25 @@ def test_create_docker_runner_dockerfile_folder_path():
     image=conan-runner-default-test
     cache=clean
     remove=True
+    extra_files=extensions/*
     """)
 
     client.save({"host_copy": profile_host_copy, "host_clean": profile_host_clean, "build": profile_build})
     client.run("new cmake_lib -d name=pkg -d version=0.2")
-    client.run("create . -pr:h host_copy -pr:b build")
+    extra_file_copy = os.path.join(client.current_folder, ".conanrunner", "extra", "extensions", "greeting.txt")
+    client.run("create . -pr:h host_copy -pr:b build -v")
 
+    assert "Copying extra_files patterns" in client.out
+    assert client.load(extra_file_copy) == "hello from host"
     assert "Restore: pkg/0.2" in client.out
     assert "Restore: pkg/0.2:8631cf963dbbb4d7a378a64a6fd1dc57558bc2fe" in client.out
     assert "Restore: pkg/0.2:8631cf963dbbb4d7a378a64a6fd1dc57558bc2fe metadata" in client.out
     assert "Removing container" in client.out
 
-    client.run("create . -pr:h host_clean -pr:b build")
+    client.run("create . -pr:h host_clean -pr:b build -v")
 
+    assert "Copying extra_files patterns" in client.out
+    assert client.load(extra_file_copy) == "hello from host"
     assert "Restore: pkg/0.2" in client.out
     assert "Restore: pkg/0.2:8631cf963dbbb4d7a378a64a6fd1dc57558bc2fe" in client.out
     assert "Restore: pkg/0.2:8631cf963dbbb4d7a378a64a6fd1dc57558bc2fe metadata" in client.out


### PR DESCRIPTION
Changelog: Feature: Add `extra_files` setting to the `[runner]` profile section (Docker runner), allowing to copy extra host files/folders into the container, opt-in and disabled by default.
Docs: https://github.com/conan-io/docs/pull/XXXX
Closes: #20281

Adds a new opt-in `extra_files` key to the `[runner]` profile section, accepting a comma-separated list of fnmatch patterns relative to the Conan home folder, e.g.:

```
[runner]
type=docker
extra_files=extensions/*
```

It's opt-in and empty by default, so existing profiles/behavior are unaffected.