### PR TITLE
Only spawn ``min(threads, download_count)`` threads in parallel downloads

### DIFF
--- a/conan/internal/graph/installer.py
+++ b/conan/internal/graph/installer.py
@@ -301,9 +301,10 @@ class BinaryInstaller:
         ConanOutput().subtitle(f"Downloading {download_count} package{plural}")
         parallel = self._global_conf.get("core.download:parallel", check_type=int,
                                          default=cpu_count())
-        if parallel:  # User can define core.download:parallel=0 to deactivate parallelism
-            ConanOutput().info("Downloading binary packages in %s parallel threads" % parallel)
-            thread_pool = ThreadPool(parallel)
+        if parallel and download_count:  # User can define core.download:parallel=0 to deactivate parallelism
+            thread_count = min(parallel, download_count)
+            ConanOutput().info(f"Downloading binary packages in {thread_count} parallel threads")
+            thread_pool = ThreadPool(thread_count)
             thread_pool.map(self._download_pkg, downloads)
             thread_pool.close()
             thread_pool.join()

--- a/test/integration/command/install/install_parallel_test.py
+++ b/test/integration/command/install/install_parallel_test.py
@@ -1,12 +1,14 @@
+import pytest
+
 from conan.test.utils.tools import GenConanfile, TestClient
 
 
 class TestInstallParallel:
 
-    def test_basic_parallel_install(self):
+    @pytest.mark.parametrize("counter", [2, 8])
+    def test_basic_parallel_install(self, counter):
         client = TestClient(default_server_user=True)
         threads = 4
-        counter = 8
 
         client.save_home({"global.conf": f"core.download:parallel={threads}"})
         client.save({"conanfile.py": GenConanfile()})
@@ -24,6 +26,6 @@ class TestInstallParallel:
 
         client.save({"conanfile.txt": conanfile_txt}, clean_first=True)
         client.run("install .")
-        assert "Downloading binary packages in %s parallel threads" % threads in client.out
+        assert "Downloading binary packages in %s parallel threads" % min(threads, counter) in client.out
         for i in range(counter):
             assert "pkg%s/0.1@user/testing: Package installed" % i in client.out


### PR DESCRIPTION
Changelog: Fix: Only spawn ``min(threads, download_count)`` threads in parallel downloads
Docs: Omit

Incidental PR while I was investigating an unrelated fix. ThreadPool instantiates all threads on initialization