### PR TITLE
Use server latest prev when it's present in the cache with newer ones after it

### DIFF
--- a/conan/internal/cache/cache.py
+++ b/conan/internal/cache/cache.py
@@ -201,6 +201,13 @@ class PkgCache:
         assert ref.timestamp
         self._db.update_recipe_timestamp(ref)
 
+    def update_package_timestamp(self, pref: PkgReference, path=None, build_id=None):
+        """ when the package already exists in cache, but we get a new timestamp from a server
+        that would affect its order in our cache """
+        assert pref.revision
+        assert pref.timestamp
+        self._db.update_package_timestamp(pref, path=path, build_id=build_id)
+
     def search_recipes(self, pattern=None):
         # Conan references in main storage
         if pattern:
@@ -268,7 +275,7 @@ class PkgCache:
             # TODO: The relpath would be the same as the previous one, it shouldn't be ncessary to
             #  update it, the update_package_timestamp() can be simplified and path dropped
             relpath = os.path.relpath(layout.base_folder, self._base_folder)
-            self._db.update_package_timestamp(pref, path=relpath, build_id=build_id)
+            self.update_package_timestamp(pref, path=relpath, build_id=build_id)
 
     def assign_rrev(self, layout: RecipeLayout):
         """ called at export, once the exported recipe revision has been computed, it

--- a/conan/internal/graph/graph_binaries.py
+++ b/conan/internal/graph/graph_binaries.py
@@ -432,7 +432,6 @@ class GraphBinariesAnalyzer:
                     if self._cache.exists_prev(node.pref):
                         # The server gave us a newer prev, but we already have it in cache
                         # so we don't need to download it. Update its timestamp to match the server's
-                        node.binary = BINARY_CACHE
                         cache_latest_prev = node.pref
                         self._cache.update_package_timestamp(node.pref)
                     else:

--- a/conan/internal/graph/graph_binaries.py
+++ b/conan/internal/graph/graph_binaries.py
@@ -429,9 +429,16 @@ class GraphBinariesAnalyzer:
                 cache_time = cache_latest_prev.timestamp
                 # TODO: cache 2.0 should we update the date if the prev is the same?
                 if cache_time < node.pref_timestamp and cache_latest_prev != node.pref:
-                    node.binary = BINARY_UPDATE
-                    output.info("Current package revision is older than the remote one")
-                    return
+                    if self._cache.exists_prev(node.pref):
+                        # The server gave us a newer prev, but we already have it in cache
+                        # so we don't need to download it. Update its timestamp to match the server's
+                        node.binary = BINARY_CACHE
+                        cache_latest_prev = node.pref
+                        self._cache.update_package_timestamp(node.pref)
+                    else:
+                        node.binary = BINARY_UPDATE
+                        output.info("Current package revision is older than the remote one")
+                        return
                 if cache_time > node.pref_timestamp:
                     output.info("Current package revision is newer than the remote one")
 

--- a/test/integration/command/install/install_update_test.py
+++ b/test/integration/command/install/install_update_test.py
@@ -1,3 +1,4 @@
+import json
 import os
 import textwrap
 from time import sleep
@@ -245,3 +246,102 @@ class TestUpdateOldPolicy:
         c.run("lock create pkg --lockfile base.lock --lockfile-out full.lock --build=* --update")
         # it doesn't crash
         assert "Generated lockfile" in c.out
+
+
+def test_update_remote_not_latest_in_cache():
+    """
+    rrev1 is present in the remote and in the cache, but then we create a new rev locally,
+    if we now try to install using --update, the newer local cache one should be used,
+    not the remote one which is older
+    """
+    tc = TestClient(default_server_user=True, light=True)
+    conanfile = textwrap.dedent("""
+    from conan import ConanFile
+    import time
+    import os
+
+    class Pkg(ConanFile):
+        name = "pkg"
+        version = "0.1"
+
+        def package(self):
+            with open(os.path.join(self.package_folder, "file.txt"), "w") as f:
+                f.write(str(time.time()))
+    """)
+    # Different revisions for the same recipe
+    tc.save({"rrev1/conanfile.py": GenConanfile("pkg", "0.1"),
+             "rrev2/conanfile.py": conanfile})
+    tc.run("create rrev1")
+    rrev1 = tc.exported_recipe_revision()
+    tc.run("upload pkg/0.1 -r=default -c")
+
+    tc.run("create rrev2")
+    old_rrev2_layout = tc.created_layout()
+    rrev2 = old_rrev2_layout.reference.ref.revision
+    tc.run("install --requires=pkg/0.1 --update")
+    assert rrev1 not in tc.out
+    assert rrev2 in tc.out
+
+    tc.run("upload pkg/0.1 -r=default -c")
+    tc.run("list pkg/0.1#latest:*#latest -r=default")
+    assert rrev2 in tc.out
+    assert old_rrev2_layout.reference.revision in tc.out
+
+    # Now with package revisions, the behavior is the same
+    tc.run("create rrev2")
+    new_rrev2_layout = tc.created_layout()
+    assert old_rrev2_layout.reference.ref.revision == new_rrev2_layout.reference.ref.revision
+    assert old_rrev2_layout.reference.revision != new_rrev2_layout.reference.revision
+
+    tc.run("install --requires=pkg/0.1 --update")
+    tc.assert_listed_binary({str(new_rrev2_layout.reference.ref): (new_rrev2_layout.reference.package_id, "Cache")})
+
+
+def test_package_revision_timestamp_mismatch():
+    """
+    Updating from a remote whose latest prev is older than the local newer one failed
+    if the remote's prev was also present in the local cache
+    see https://github.com/conan-io/conan/issues/20333
+    """
+    tc = TestClient(default_server_user=True, light=True)
+    conanfile = textwrap.dedent("""
+        from conan import ConanFile
+        import time
+        import os
+
+        class Pkg(ConanFile):
+            name = "pkg"
+            version = "0.1"
+
+            def package(self):
+                with open(os.path.join(self.package_folder, "file.txt"), "w") as f:
+                    f.write(str(time.time()))
+        """)
+    tc.save({"conanfile.py": conanfile})
+    tc.run("create")
+    old_layout = tc.created_layout()
+
+    tc.run("create")
+    new_layout = tc.created_layout()
+    assert old_layout.reference.revision != new_layout.reference.revision
+
+    tc.run("list pkg/0.1#latest:*#latest -f=json", redirect_stdout="local.json")
+    local_list = json.loads(tc.load("local.json"))
+    local_timestamp = local_list["Local Cache"]["pkg/0.1"]["revisions"][new_layout.reference.ref.revision]["packages"][new_layout.reference.package_id]["revisions"][new_layout.reference.revision]["timestamp"]
+
+    # We're uploading the old package revision, which locally has an older timestamp than the new one,
+    # but not remotely
+    tc.run(f"upload {old_layout.reference.repr_notime()} -r=default -c")
+    assert f"{old_layout.reference.revision} (Uploaded)" in tc.out
+
+    tc.run("list pkg/0.1#latest:*#latest -r=default -f=json", redirect_stdout="remote.json")
+    remote_json = json.loads(tc.load("remote.json"))
+    remote_timestamp = remote_json["default"]["pkg/0.1"]["revisions"][old_layout.reference.ref.revision]["packages"][old_layout.reference.package_id]["revisions"][old_layout.reference.revision]["timestamp"]
+    # Note that the local latest prev has an older timestamp than the remote's,
+    # as the remote updates the timestamp when uploading
+    assert remote_timestamp > local_timestamp
+
+    # This currently fails
+    tc.run("install --requires=pkg/0.1 --update")
+    assert old_layout.reference.revision in tc.out
+    assert new_layout.reference.revision not in tc.out

--- a/test/integration/command/install/install_update_test.py
+++ b/test/integration/command/install/install_update_test.py
@@ -255,46 +255,34 @@ def test_update_remote_not_latest_in_cache():
     not the remote one which is older
     """
     tc = TestClient(default_server_user=True, light=True)
-    conanfile = textwrap.dedent("""
-    from conan import ConanFile
-    import time
-    import os
 
-    class Pkg(ConanFile):
-        name = "pkg"
-        version = "0.1"
-
-        def package(self):
-            with open(os.path.join(self.package_folder, "file.txt"), "w") as f:
-                f.write(str(time.time()))
-    """)
     # Different revisions for the same recipe
-    tc.save({"rrev1/conanfile.py": GenConanfile("pkg", "0.1"),
-             "rrev2/conanfile.py": conanfile})
+    tc.save({"rrev1/conanfile.py": GenConanfile("pkg", "0.1").with_build_msg("rrev1"),
+             "rrev2/conanfile.py": GenConanfile("pkg", "0.1").with_build_msg("rrev2")})
     tc.run("create rrev1")
-    rrev1 = tc.exported_recipe_revision()
-    tc.run("upload pkg/0.1 -r=default -c")
+    old_rrev1_layout = tc.created_layout()
+
+    tc.run("list pkg/0.1#latest:*#latest -f=json", redirect_stdout="local.json")
+    local_json = json.loads(tc.load("local.json"))
+    local_timestamp = local_json["Local Cache"]["pkg/0.1"]["revisions"][old_rrev1_layout.reference.ref.revision]["timestamp"]
 
     tc.run("create rrev2")
-    old_rrev2_layout = tc.created_layout()
-    rrev2 = old_rrev2_layout.reference.ref.revision
-    tc.run("install --requires=pkg/0.1 --update")
-    assert rrev1 not in tc.out
-    assert rrev2 in tc.out
 
-    tc.run("upload pkg/0.1 -r=default -c")
-    tc.run("list pkg/0.1#latest:*#latest -r=default")
-    assert rrev2 in tc.out
-    assert old_rrev2_layout.reference.revision in tc.out
+    tc.run(f"upload {old_rrev1_layout.reference.repr_notime()} -r=default -c")
 
-    # Now with package revisions, the behavior is the same
-    tc.run("create rrev2")
-    new_rrev2_layout = tc.created_layout()
-    assert old_rrev2_layout.reference.ref.revision == new_rrev2_layout.reference.ref.revision
-    assert old_rrev2_layout.reference.revision != new_rrev2_layout.reference.revision
+    tc.run("list pkg/0.1#latest:*#latest -r=default -f=json", redirect_stdout="remote.json")
+    remote_json = json.loads(tc.load("remote.json"))
+    remote_timestamp = remote_json["default"]["pkg/0.1"]["revisions"][old_rrev1_layout.reference.ref.revision]["timestamp"]
 
     tc.run("install --requires=pkg/0.1 --update")
-    tc.assert_listed_binary({str(new_rrev2_layout.reference.ref): (new_rrev2_layout.reference.package_id, "Cache")})
+    tc.assert_listed_binary({str(old_rrev1_layout.reference.ref): (old_rrev1_layout.reference.package_id, "Cache")})
+
+    # This rrev is now the newer one
+    tc.run("list pkg/0.1#latest -f=json", redirect_stdout="local.json")
+    local_json = json.loads(tc.load("local.json"))
+    new_local_timestamp = local_json["Local Cache"]["pkg/0.1"]["revisions"][old_rrev1_layout.reference.ref.revision]["timestamp"]
+    assert new_local_timestamp > local_timestamp
+    assert new_local_timestamp == remote_timestamp
 
 
 def test_package_revision_timestamp_mismatch():
@@ -345,3 +333,10 @@ def test_package_revision_timestamp_mismatch():
     tc.run("install --requires=pkg/0.1 --update")
     assert old_layout.reference.revision in tc.out
     assert new_layout.reference.revision not in tc.out
+
+    # Now old_layout should have the latest timestamp, server rules
+    tc.run("list pkg/0.1#latest:*#latest -f=json", redirect_stdout="local.json")
+    local_list = json.loads(tc.load("local.json"))
+    after_local_timestamp = local_list["Local Cache"]["pkg/0.1"]["revisions"][old_layout.reference.ref.revision]["packages"][old_layout.reference.package_id]["revisions"][old_layout.reference.revision]["timestamp"]
+    assert after_local_timestamp == remote_timestamp
+    assert after_local_timestamp > local_timestamp


### PR DESCRIPTION
Changelog: Bugfix: Latest package revisions found in servers using ``--update`` are now considered latest even if the same prev is not latest in the local cache
Docs: Omit

Closes https://github.com/conan-io/conan/issues/20333